### PR TITLE
fix: correct module entry point for npm package

### DIFF
--- a/packages/lit-ui-router/package.json
+++ b/packages/lit-ui-router/package.json
@@ -2,7 +2,7 @@
   "name": "lit-ui-router",
   "version": "0.0.1",
   "type": "module",
-  "module": "./src/index.js",
+  "module": "./dist/index.js",
   "sideEffects": [
     "**/ui-router.js",
     "**/ui-view.js"


### PR DESCRIPTION
## Summary
- Fix `module` field in package.json from `./src/index.js` to `./dist/index.js`
- The `src/` directory is not included in the published package (only `dist/**`)
- This would cause module resolution failures for bundlers using the `module` field

## Test plan
- [x] Verify with `npm pack --dry-run` that package contents are correct
- [ ] After merge, publish to npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)