### PR TITLE
docs: add target=_self to sample app link in hellogalaxy

### DIFF
--- a/docs/tutorial/hellogalaxy.md
+++ b/docs/tutorial/hellogalaxy.md
@@ -455,7 +455,7 @@ You've now learned the core concepts of lit-ui-router:
 
 ## What's Next?
 
-Explore the [Sample App](/app) to see a more complete example with:
+Explore the <a href="/app" target="_self">Sample App</a> to see a more complete example with:
 
 - Authentication and protected routes
 - Lazy-loaded states


### PR DESCRIPTION
## Summary
- Add `target="_self"` attribute to the Sample App link in the Hello Galaxy tutorial
- Ensures navigation stays within the same tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)