### PR TITLE
ci: workflow refinements towards immutable releases

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -17,10 +17,20 @@ on:
         description: 'Other increment'
         required: false
         type: string
+      prBase:
+        description: 'GitHub PR base branch'
+        required: true
+        default: 'main'
+        type: string
+      branchPrefix:
+        description: 'GitHub PR branch prefix'
+        required: false
+        default: 'release/lit-ui-router/v'
+        type: string
 
 permissions:
   contents: write
-  pull-requests: write
+  # pull-requests: write # instead handled by GH_PERSONAL_ACCESS_TOKEN for downstream actions
 
 jobs:
   bump_version:
@@ -29,6 +39,8 @@ jobs:
     env:
       INCREMENT: ${{ inputs.increment }}
       OTHER_INCREMENT: ${{ inputs.other }}
+      PR_BASE: ${{ inputs.prBase }}
+      BRANCH_PREFIX: ${{ inputs.branchPrefix }}
       GH_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
 
     steps:
@@ -56,8 +68,8 @@ jobs:
       - name: Calculate bumped version
         run: echo "BUMPED_VERSION=$(pnpm --filter lit-ui-router exec release-it --release-version --increment "$ACTUAL_INCREMENT")" >> "$GITHUB_ENV"
       - name: Switch branches
-        run: git switch --create "release/lit-ui-router/v$BUMPED_VERSION"
+        run: git switch --create "$BRANCH_PREFIX$BUMPED_VERSION"
       - name: Bump version
         run: pnpm --filter lit-ui-router exec release-it --increment "$BUMPED_VERSION" --git.commit true --git.push true
       - name: Create PR
-        run: gh pr create --base main --head "release/lit-ui-router/v$BUMPED_VERSION" --fill-verbose
+        run: gh pr create --base "$PR_BASE" --head "$BRANCH_PREFIX$BUMPED_VERSION" --fill-verbose

--- a/.github/workflows/publish-gh.yml
+++ b/.github/workflows/publish-gh.yml
@@ -1,4 +1,4 @@
-name: Tag and Release
+name: Tag & push
 
 on:
   push:
@@ -11,7 +11,7 @@ permissions:
 jobs:
   publish_gh:
     runs-on: ubuntu-latest
-    environment: publish
+    environment: tag-release
     env:
       GITHUB_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
     steps:
@@ -36,6 +36,6 @@ jobs:
           cache: 'pnpm'
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-      - name: Tag & Release
-        run: pnpm --filter lit-ui-router exec release-it --no-increment --git.tag true --git.push true --github.release true
+      - name: Tag & push
+        run: pnpm --filter lit-ui-router exec release-it --no-increment --git.tag true --git.push true
         continue-on-error: true

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,22 +1,29 @@
 name: Publish to NPM
-
+# https://docs.npmjs.com/trusted-publishers
+# https://github.com/release-it/release-it/blob/19.2.2/docs/npm.md#trusted-publishing-oidc
 on:
   push:
     tags:
       - lit-ui-router@*
 
 permissions:
-  id-token: write  # Required for OIDC
-  contents: read
+  id-token: write
+  contents: write
+  attestations: write
+  artifact-metadata: write
 
 jobs:
   publish_npm:
     runs-on: ubuntu-latest
     environment: publish
-
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: 'Checkout code'
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
       - name: Setup pnpm
         uses: pnpm/action-setup@v2
         with:
@@ -26,10 +33,16 @@ jobs:
         with:
           node-version: '22.17.1'
           cache: 'pnpm'
-      - run: npm install -g npm@latest # Required for OIDC
+      - name: Update npm
+        run: npm install -g npm@latest # >= 11.5.1
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Build
         run: npm exec -- turbo run lit-ui-router#build
+      - name: Pack
+        run: pnpm --filter lit-ui-router pack --pack-destination packages/lit-ui-router
+      - uses: actions/attest-build-provenance@v3
+        with:
+          subject-path: 'packages/lit-ui-router/lit-ui-router-*.tgz'
       - name: Publish
-        run: pnpm --filter lit-ui-router exec release-it --no-increment --npm.publish true --npm.skipChecks true
+        run: pnpm --filter lit-ui-router exec release-it --no-increment --npm.publish true --npm.skipChecks true --github.release true --github.assets "lit-ui-router-*.tgz"

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@ certs/
 
 .turbo
 .claude
+
+lit-ui-router-*.tgz

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "lit-ui-router",
+  "name": "lit-ui-router-turborepo",
   "version": "0.0.0",
   "license": "MIT",
   "private": true,


### PR DESCRIPTION
- separate environments for trusted npm publish environment vs bump version vs create tag
- allow more granular permissions over manual workflow initiation
- add more bump version input options
- now the release happens at same time as npm publish, after tag pushed
- attestation + release asset
- rename root package.json