### PR TITLE
docs: add Open Graph and Twitter Card meta tags

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -33,7 +33,9 @@ export default defineConfig({
       description = config.description;
       pageUrl = baseUrl;
     } else {
-      title = pageData.frontmatter.title || pageData.title || config.title;
+      title = pageData.frontmatter.title || pageData.title;
+      title = title ? `${config.title} - ${title}` : config.title;
+
       description =
         pageData.frontmatter.description ||
         pageData.description ||


### PR DESCRIPTION
## Summary
- Added `transformHead` hook to generate social sharing meta tags for all docs pages
- Open Graph tags: title, description, image, image:alt, url, type, site_name
- Twitter Card tags: card, creator, title, description, image, image:alt
- Homepage uses site config values, other pages use frontmatter with fallbacks
- Clean URLs (no .html) for Cloudflare Pages compatibility

## Changes
- `docs/.vitepress/config.ts`: Added transformHead hook with 13 meta tags per page
