### PR TITLE
feat(sample-apps): add Navigation API feature detection

### DIFF
--- a/apps/README.md
+++ b/apps/README.md
@@ -51,7 +51,8 @@ shared `router.config.ts`:
 **Auto-detection**: When `navigation` preference is set, the app automatically
 selects the best available plugin:
 
-1. Navigation API when supported 🧑‍🔬 _experimental_
+1. Navigation API when supported, via the 🧑‍🔬 _experimental_
+   [navigation plugin](../packages/navigation-location-plugin/)
 2. Push State as fallback for unsupported browsers
 
 **Override options** (in priority order):

--- a/apps/README.md
+++ b/apps/README.md
@@ -37,6 +37,32 @@ Everything else — the contacts/mymessages/prefs features, router
 configuration, transition hooks, data sources, dialogs, styles, and the
 simulated REST fixtures in `public/` — is imported from `sample-app-shared`.
 
+## Location plugin selection
+
+Both apps support three location strategies via `locationPluginConfig` in the
+shared `router.config.ts`:
+
+| Plugin       | URL Format | Browser Support        |
+| ------------ | ---------- | ---------------------- |
+| `hash`       | `/#/path`  | All browsers           |
+| `pushState`  | `/path`    | Modern browsers        |
+| `navigation` | `/path`    | Chrome 102+, Edge 102+ |
+
+**Auto-detection**: When `navigation` preference is set, the app automatically
+selects the best available plugin:
+
+1. Navigation API when supported 🧑‍🔬 _experimental_
+2. Push State as fallback for unsupported browsers
+
+**Override options** (in priority order):
+
+1. URL parameter: `?feature-location-plugin=hash`
+2. Session storage: Set via Feature Flags panel in Prefs
+3. Environment variable: `VITE_SAMPLE_APP_LOCATION_PLUGIN=pushState`
+
+The Feature Flags panel shows browser compatibility indicators for each plugin
+option.
+
 ## End-to-end tests
 
 `sample-app-lit-e2e` runs the same Cypress specs against both apps:

--- a/apps/README.md
+++ b/apps/README.md
@@ -42,11 +42,11 @@ simulated REST fixtures in `public/` — is imported from `sample-app-shared`.
 Both apps support three location strategies via `locationPluginConfig` in the
 shared `router.config.ts`:
 
-| Plugin       | URL Format | Browser Support        |
-| ------------ | ---------- | ---------------------- |
-| `hash`       | `/#/path`  | All browsers           |
-| `pushState`  | `/path`    | Modern browsers        |
-| `navigation` | `/path`    | Chrome 102+, Edge 102+ |
+| Plugin       | URL Format | Browser Support                              |
+| ------------ | ---------- | -------------------------------------------- |
+| `hash`       | `/#/path`  | All browsers                                 |
+| `pushState`  | `/path`    | Modern browsers                              |
+| `navigation` | `/path`    | Chrome/Edge 102+, Firefox 147+, Safari 26.2+ |
 
 **Auto-detection**: When `navigation` preference is set, the app automatically
 selects the best available plugin:

--- a/apps/sample-app-lit-e2e/src/integration/feature_flags_panel.cy.js
+++ b/apps/sample-app-lit-e2e/src/integration/feature_flags_panel.cy.js
@@ -1,0 +1,39 @@
+import { visitWithFeatures } from '../support/e2e';
+
+const EMAIL_ADDRESS = 'myself@angular.dev';
+
+const readStoredFlags = (win) =>
+  JSON.parse(win.sessionStorage.getItem('featureFlags') ?? '{}');
+
+describe('feature flags panel', () => {
+  beforeEach(() => {
+    window.sessionStorage.clear();
+    visitWithFeatures('/login');
+    cy.get('select').contains('myself').parent('select').select(EMAIL_ADDRESS);
+    cy.get('button').contains('Log in').click();
+    cy.url().should('include', '/home');
+
+    cy.get('button.btn').contains('Preferences').click();
+    cy.contains('Reset All Data');
+    cy.get('feature-flags-panel')
+      .shadow()
+      .find('select')
+      .first()
+      .as('pluginSelect');
+  });
+
+  it('stores an explicit location plugin selection', () => {
+    cy.get('@pluginSelect').select('Hash');
+    cy.window().then((win) => {
+      expect(readStoredFlags(win)['location-plugin']).to.equal('hash');
+    });
+  });
+
+  it('removes the stored preference when Auto-detect is selected', () => {
+    cy.get('@pluginSelect').select('Hash');
+    cy.get('@pluginSelect').select('Auto-detect');
+    cy.window().then((win) => {
+      expect(readStoredFlags(win)).to.not.have.property('location-plugin');
+    });
+  });
+});

--- a/apps/sample-app-shared/src/app/prefs/FeatureFlagsPanel.ts
+++ b/apps/sample-app-shared/src/app/prefs/FeatureFlagsPanel.ts
@@ -3,6 +3,7 @@ import { customElement, state } from 'lit/decorators.js';
 import {
   featureFlags,
   FeatureFlagDefinitions,
+  canUseNavigationAPI,
 } from '../util/featureDetection.js';
 
 interface FlagConfig {
@@ -13,6 +14,10 @@ interface FlagConfig {
   options?: { value: string | undefined; label: string }[];
 }
 
+const navigationApiLabel = canUseNavigationAPI()
+  ? 'Navigation API (Available)'
+  : 'Navigation API (Not supported)';
+
 const FLAG_CONFIGS: FlagConfig[] = [
   {
     key: 'location-plugin',
@@ -20,10 +25,10 @@ const FLAG_CONFIGS: FlagConfig[] = [
     description: 'Router location strategy (requires page reload)',
     type: 'select',
     options: [
-      { value: undefined, label: 'None' },
+      { value: undefined, label: 'Auto-detect' },
       { value: 'hash', label: 'Hash' },
       { value: 'pushState', label: 'Push State' },
-      { value: 'navigation', label: 'Navigation API' },
+      { value: 'navigation', label: navigationApiLabel },
     ],
   },
   {
@@ -120,7 +125,11 @@ export class FeatureFlagsPanel extends LitElement {
 
   private _handleSelectChange(flag: keyof FeatureFlagDefinitions, e: Event) {
     const value = (e.target as HTMLSelectElement).value;
-    featureFlags.set(flag, value as FeatureFlagDefinitions[typeof flag]);
+    if (value === '') {
+      featureFlags.reset(flag);
+    } else {
+      featureFlags.set(flag, value as FeatureFlagDefinitions[typeof flag]);
+    }
     this._flags = featureFlags.getAll();
   }
 
@@ -161,7 +170,7 @@ export class FeatureFlagsPanel extends LitElement {
         >
           ${config.options.map(
             (opt) => html`
-              <option value=${opt.value} ?selected=${value === opt.value}>
+              <option value=${opt.value ?? ''} ?selected=${value === opt.value}>
                 ${opt.label}
               </option>
             `,

--- a/packages/navigation-location-plugin/README.md
+++ b/packages/navigation-location-plugin/README.md
@@ -6,7 +6,7 @@
 [![codecov](https://codecov.io/gh/simshanith/lit-ui-router/graph/badge.svg?component=navigation-location-plugin)](https://app.codecov.io/gh/simshanith/lit-ui-router?components%5B0%5D=navigation-location-plugin)
 [![Can I Use Navigation API](https://img.shields.io/badge/caniuse-Navigation%20API-orange)](https://caniuse.com/mdn-api_navigation)
 
-> **Experimental**: This plugin uses the [Navigation API](https://developer.mozilla.org/en-US/docs/Web/API/Navigation_API), which has limited browser support.
+> **Experimental**: this plugin is a new implementation without the production mileage of the battle-tested `pushState`/`hash` location services. The underlying [Navigation API](https://developer.mozilla.org/en-US/docs/Web/API/Navigation_API) is also only recently cross-engine (Firefox 147+, Safari 26.2+), so non-Chromium behavior is lightly exercised.
 
 A UI-Router location plugin that uses the modern browser Navigation API for URL management.
 
@@ -90,18 +90,18 @@ interface UIRouterNavigateInfo {
 
 ## Browser Compatibility
 
-The Navigation API has limited browser support:
+The Navigation API is supported in all modern engines:
 
-| Browser | Support       |
-| ------- | ------------- |
-| Chrome  | 102+          |
-| Edge    | 102+          |
-| Firefox | Not supported |
-| Safari  | Not supported |
+| Browser | Support |
+| ------- | ------- |
+| Chrome  | 102+    |
+| Edge    | 102+    |
+| Firefox | 147+    |
+| Safari  | 26.2+   |
 
 Check [caniuse.com](https://caniuse.com/mdn-api_navigation) for current support status.
 
-For broader browser support, consider using:
+For older browsers, consider using:
 
 - `pushStateLocationPlugin` - History API based (wide support)
 - `hashLocationPlugin` - Hash-based URLs (universal support)
@@ -112,7 +112,8 @@ For broader browser support, consider using:
 | ------------------ | -------------- | --------- | --------- |
 | Modern standard    | Yes            | No        | No        |
 | Event interception | Yes            | No        | No        |
-| Browser support    | Limited        | Wide      | Universal |
+| Browser support    | Modern engines | Wide      | Universal |
+| Production mileage | New            | Wide      | Wide      |
 | SEO friendly       | Yes            | Yes       | No        |
 | Clean URLs         | Yes            | Yes       | No        |
 


### PR DESCRIPTION
## Summary

- Add `canUseNavigationAPI()` utility for browser capability detection
- Update `resolveLocationPlugin()` to auto-select Navigation API when available, falling back to pushState
- Show "(Available)" / "(Not supported)" indicators in Feature Flags panel
- Change default dropdown option to "Auto-detect"
- Document location plugin selection in README

## Test plan

- [x] Build passes: `turbo sample-app-lit#build`
- [x] E2E tests pass: `turbo sample-app-lit-e2e#test` (16/16 passing)
- [ ] Manual: Open in Chrome - verify Navigation API auto-selected
- [ ] Manual: Open in Firefox/Safari - verify pushState fallback
- [ ] Manual: Test `?feature-location-plugin=hash` override

Closes lit-ui-router-uko

## Rebase over #163 (sample-app-shared)

Rebuilt on main after the shared-package extraction: the per-app `featureDetection.ts` and `FeatureFlagsPanel.ts` changes (which were byte-identical between the two apps) now land once in `apps/sample-app-shared`, the location-plugin docs moved from the vanilla app's README to `apps/README.md`, and the original four commits collapsed into one (the mobx-port commit no longer has anything to port). Verified against warm dev servers of both apps: new `feature_flags_panel` spec 2/2 each, plus `sample_app` 13/13 and `location_plugins` 3/3 under the new pushState default.


## Docs: browser support refresh + experimental reframing

The Navigation API went cross-engine since this PR was drafted (Firefox 147, Safari 26.2 — see [caniuse](https://caniuse.com/mdn-api_navigation)), so the compat tables in `apps/README.md` and the plugin README are updated. The plugin's **Experimental** caveat is reframed around what's actually experimental: the plugin is a new implementation without the production mileage of the battle-tested pushState/hash location services (and non-Chromium engines only recently shipped the API). The plugin README change warrants a patch release after merge so npm carries the corrected caveat.
