### PR TITLE
ci: enforce catalog for dependencies shared by 2+ packages

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -52,7 +52,7 @@ export default tseslint.config(
     },
   },
   {
-    files: ['**/*.js'],
+    files: ['**/*.js', '**/*.mjs'],
     languageOptions: {
       globals: {
         ...globals.browser,

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "private": true,
   "scripts": {
     "build": "turbo run build",
+    "check:catalog": "node scripts/check-catalog.mjs",
     "ci": "turbo run ci",
     "dev": "turbo run dev",
     "format": "turbo run format",
@@ -14,7 +15,8 @@
     "format:root": "prettier --write \"*.{md,ts,js,json,jsonc}\"",
     "lint": "turbo run lint",
     "lint:root": "eslint --format tap --ignore-pattern apps --ignore-pattern tools --ignore-pattern docs --ignore-pattern packages --ignore-pattern examples",
-    "test:coverage": "turbo run test:coverage"
+    "test:coverage": "turbo run test:coverage",
+    "test:root": "node --test \"scripts/**/*.test.mjs\""
   },
   "engines": {
     "node": ">=22.17.1"
@@ -22,6 +24,8 @@
   "packageManager": "pnpm@10.28.1",
   "devDependencies": {
     "@eslint/js": "^9.39.2",
+    "@pnpm/fs.find-packages": "catalog:",
+    "@pnpm/workspace.read-manifest": "catalog:",
     "cypress": "catalog:",
     "eslint": "^9.39.2",
     "eslint-config-prettier": "^10.1.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,12 @@ settings:
 
 catalogs:
   default:
+    '@pnpm/fs.find-packages':
+      specifier: ^1000.0.24
+      version: 1000.0.24
+    '@pnpm/workspace.read-manifest':
+      specifier: ^1000.3.1
+      version: 1000.3.1
     '@types/dom-navigation':
       specifier: ^1.0.6
       version: 1.0.6
@@ -83,6 +89,12 @@ importers:
       '@eslint/js':
         specifier: ^9.39.2
         version: 9.39.2
+      '@pnpm/fs.find-packages':
+        specifier: 'catalog:'
+        version: 1000.0.24(@pnpm/logger@1001.0.1)
+      '@pnpm/workspace.read-manifest':
+        specifier: 'catalog:'
+        version: 1000.3.1
       cypress:
         specifier: 'catalog:'
         version: 14.5.4
@@ -738,6 +750,10 @@ packages:
   '@github/catalyst@1.7.0':
     resolution: {integrity: sha512-qOAxrDdRZz9+v4y2WoAfh11rpRY/x4FRofPNmJyZFzAjubtzE3sCa/tAycWWufmQGoYiwwzL/qJBBgyg7avxPw==}
 
+  '@gwhitney/detect-indent@7.0.1':
+    resolution: {integrity: sha512-7bQW+gkKa2kKZPeJf6+c6gFK9ARxQfn+FKy9ScTBppyKRWH2KzsmweXUoklqeEiHiNVWaeP5csIdsNq6w7QhzA==}
+    engines: {node: '>=12.20'}
+
   '@hapi/address@5.1.1':
     resolution: {integrity: sha512-A+po2d/dVoY7cYajycYI43ZbYMXukuopIsqCjh5QzsBCipDtdofHntljDlpccMjIfTy6UOkg+5KPriwYch2bXA==}
     engines: {node: '>=14.0.0'}
@@ -1154,6 +1170,68 @@ packages:
   '@phun-ky/typeof@2.0.3':
     resolution: {integrity: sha512-oeQJs1aa8Ghke8JIK9yuq/+KjMiaYeDZ38jx7MhkXncXlUKjqQ3wEm2X3qCKyjo+ZZofZj+WsEEiqkTtRuE2xQ==}
     engines: {node: ^20.9.0 || >=22.0.0, npm: '>=10.8.2'}
+
+  '@pnpm/constants@1001.3.1':
+    resolution: {integrity: sha512-2hf0s4pVrVEH8RvdJJ7YRKjQdiG8m0iAT26TTqXnCbK30kKwJW69VLmP5tED5zstmDRXcOeH5eRcrpkdwczQ9g==}
+    engines: {node: '>=18.12'}
+
+  '@pnpm/core-loggers@1001.0.9':
+    resolution: {integrity: sha512-pW58m3ssrwVjwhlmTXDW1dh1sv2y6R2Gl5YvQInjM2d01/5mre/sYAY4MK3XfgEShZJQxv6wVXDUvyHHJ0oizg==}
+    engines: {node: '>=18.12'}
+    peerDependencies:
+      '@pnpm/logger': '>=1001.0.0 <1002.0.0'
+
+  '@pnpm/error@1000.1.0':
+    resolution: {integrity: sha512-Dqc2IJJPjUatwc9Letw+vG29rnaMrDGi5g6WCx1HiZYm0obXbTmLygeRafMbgf+sLKXrWE1shOeiayQuczBdoA==}
+    engines: {node: '>=18.12'}
+
+  '@pnpm/fs.find-packages@1000.0.24':
+    resolution: {integrity: sha512-6r2lpvoljgTvQ+CiJYz3jCunzO1PM6g1Cqc3xon49he8sgg8BatMsNxcGnuZWK//du80+ylS/uBXKxwuHMuHUw==}
+    engines: {node: '>=18.12'}
+
+  '@pnpm/graceful-fs@1000.1.0':
+    resolution: {integrity: sha512-EsMX4slK0qJN2AR0/AYohY5m0HQNYGMNe+jhN74O994zp22/WbX+PbkIKyw3UQn39yQm2+z6SgwklDxbeapsmQ==}
+    engines: {node: '>=18.12'}
+
+  '@pnpm/logger@1001.0.1':
+    resolution: {integrity: sha512-gdwlAMXC4Wc0s7Dmg/4wNybMEd/4lSd9LsXQxeg/piWY0PPXjgz1IXJWnVScx6dZRaaodWP3c1ornrw8mZdFZw==}
+    engines: {node: '>=18.12'}
+
+  '@pnpm/manifest-utils@1002.0.5':
+    resolution: {integrity: sha512-2DSwQ6pP73IuJS5mCCtPd5fibJwuAdufXKuSL/Oq1n6AggCqy8616Xea1X3RH3z5dL4mn7Z4EZ+vnX8jX3Wrfw==}
+    engines: {node: '>=18.12'}
+    peerDependencies:
+      '@pnpm/logger': ^1001.0.1
+
+  '@pnpm/read-project-manifest@1001.2.6':
+    resolution: {integrity: sha512-BcNO50lAkE4m9JaJ0WmG3m/DH/qLSvMgZywtmb/dfyyLVu5nDZfDqmOd8U+f1NhLcLMbBK6AnS3hyUqZYvw9Vg==}
+    engines: {node: '>=18.12'}
+    peerDependencies:
+      '@pnpm/logger': ^1001.0.1
+
+  '@pnpm/semver.peer-range@1000.0.0':
+    resolution: {integrity: sha512-r6VzkrdH7ZKjPmAogTNvxuV/UyS/xwHNme+ZuEFiG0UthZgqudDftYtKmG20fcfrjG1lgJbbWICA8KvZy7mmbw==}
+    engines: {node: '>=18.12'}
+
+  '@pnpm/text.comments-parser@1000.0.0':
+    resolution: {integrity: sha512-ivv/esrETOq9uMiKOC0ddVZ1BktEGsfsMQ9RWmrDpwPiqFSqWsIspnquxTBmm5GflC5N06fbqjGOpulZVYo3vQ==}
+    engines: {node: '>=18.12'}
+
+  '@pnpm/types@1001.3.0':
+    resolution: {integrity: sha512-NLTXheat/u7OEGg5M5vF6Z85zx8uKUZE0+whtX/sbFV2XL48RdnOWGPTKYuVVkv8M+launaLUTgGEXNs/ess2w==}
+    engines: {node: '>=18.12'}
+
+  '@pnpm/util.lex-comparator@3.0.2':
+    resolution: {integrity: sha512-blFO4Ws97tWv/SNE6N39ZdGmZBrocXnBOfVp0ln4kELmns4pGPZizqyRtR8EjfOLMLstbmNCTReBoDvLz1isVg==}
+    engines: {node: '>=18.12'}
+
+  '@pnpm/workspace.read-manifest@1000.3.1':
+    resolution: {integrity: sha512-ojO1Anf4ITL7OskuUYoLI3bldQ36XNLpG2cYQZ4F6LZbBZnRY8umW6TeWzb9h/aX8UFwYp9vWbQ8R/FaMtMEeg==}
+    engines: {node: '>=18.12'}
+
+  '@pnpm/write-project-manifest@1000.0.16':
+    resolution: {integrity: sha512-zG68fk03ryot7TWUl9S/ShQ91uHWzIL9sVr2aQCuNHJo8G9kjsG6S0p58Zj/voahdDQeakZYYBSJ0mjNZeiJnw==}
+    engines: {node: '>=18.12'}
 
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
@@ -1868,6 +1946,9 @@ packages:
   bluebird@3.7.2:
     resolution: {integrity: sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==}
 
+  bole@5.0.29:
+    resolution: {integrity: sha512-eYR9i2ubLv5/4TFGyZsQ1cVH4jF9+qLJA72Aow+E7ZZQfqHqQNUZeX3w+pVWF76PQyjl5eDKf2xylyOOX76ozA==}
+
   brace-expansion@1.1.12:
     resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
 
@@ -2218,6 +2299,9 @@ packages:
     resolution: {integrity: sha512-FDWG5cmEYf2Z00IkYRhbFrwIwvdFKH07uV8dvNy0omp/Qb1xcyCWp2UDtcwJF4QZZvk0sLudP6/hAu42TaqVhQ==}
     engines: {node: '>=0.12'}
 
+  error-ex@1.3.4:
+    resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
+
   error-stack-parser-es@1.0.5:
     resolution: {integrity: sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==}
 
@@ -2412,6 +2496,9 @@ packages:
 
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
+  fast-safe-stringify@2.1.1:
+    resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -2669,6 +2756,9 @@ packages:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
     engines: {node: '>=8'}
 
+  individual@3.0.0:
+    resolution: {integrity: sha512-rUY5vtT748NMRbEMrTNiFfy29BgGZwGXUi2NFUVMWQrogSLzlJvQV9eeMWi+g1aVaQ53tpyLAQtd5x/JH0Nh1g==}
+
   ini@2.0.0:
     resolution: {integrity: sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==}
     engines: {node: '>=10'}
@@ -2685,6 +2775,9 @@ packages:
   ip-address@10.1.0:
     resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
     engines: {node: '>= 12'}
+
+  is-arrayish@0.2.1:
+    resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
 
   is-binary-path@2.1.0:
     resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
@@ -2758,6 +2851,10 @@ packages:
     resolution: {integrity: sha512-oG7cgbmg5kLYae2N5IVd3jm2s+vldjxJzK1pcu9LfpGuQ93MQSzo0okvRna+7y5ifrD+20FE8FvjusyGaz14fw==}
     engines: {node: '>=18'}
 
+  is-windows@1.0.2:
+    resolution: {integrity: sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==}
+    engines: {node: '>=0.10.0'}
+
   is-wsl@3.1.0:
     resolution: {integrity: sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==}
     engines: {node: '>=16'}
@@ -2808,6 +2905,9 @@ packages:
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
 
+  json-parse-even-better-errors@2.3.1:
+    resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
+
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
 
@@ -2819,6 +2919,11 @@ packages:
 
   json-stringify-safe@5.0.1:
     resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
+
+  json5@2.2.3:
+    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
+    engines: {node: '>=6'}
+    hasBin: true
 
   jsonc-eslint-parser@2.4.2:
     resolution: {integrity: sha512-1e4qoRgnn448pRuMvKGsFFymUCquZV0mpGgOyIKNgD3JVDTsVJyRBGH/Fm0tBb8WsWGgmB1mDe6/yJMQM37DUA==}
@@ -2845,6 +2950,9 @@ packages:
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
+
+  lines-and-columns@1.2.4:
+    resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
   linkify-it@5.0.0:
     resolution: {integrity: sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==}
@@ -3153,6 +3261,10 @@ packages:
   ospath@1.2.2:
     resolution: {integrity: sha512-o6E5qJV5zkAbIDNhGSIlyOhScKXgQrSRMilfph0clDfM0nEnBOlKlH4sWDmG95BW/CvwNz0vmm7dJVtU2KlMiA==}
 
+  p-filter@2.1.0:
+    resolution: {integrity: sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw==}
+    engines: {node: '>=8'}
+
   p-limit@3.1.0:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
     engines: {node: '>=10'}
@@ -3160,6 +3272,10 @@ packages:
   p-locate@5.0.0:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
+
+  p-map@2.1.0:
+    resolution: {integrity: sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==}
+    engines: {node: '>=6'}
 
   p-map@4.0.0:
     resolution: {integrity: sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==}
@@ -3188,6 +3304,10 @@ packages:
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
+
+  parse-json@5.2.0:
+    resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
+    engines: {node: '>=8'}
 
   parse-path@7.1.0:
     resolution: {integrity: sha512-EuCycjZtfPcjWk7KTksnJ5xPMvWGA/6i4zrLYhRG0hGvC3GPU/jGUj3Cy+ZR0v30duV3e23R95T1lE2+lsndSw==}
@@ -3347,6 +3467,10 @@ packages:
   rc9@2.1.2:
     resolution: {integrity: sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg==}
 
+  read-yaml-file@2.1.0:
+    resolution: {integrity: sha512-UkRNRIwnhG+y7hpqnycCL/xbTk7+ia9VuVTC0S+zVbwd65DI9eUpRMfsWIGrCWxTU/mi+JW8cHQCrv+zfCbEPQ==}
+    engines: {node: '>=10.13'}
+
   readdirp@3.6.0:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
@@ -3442,6 +3566,11 @@ packages:
 
   semver@7.7.3:
     resolution: {integrity: sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  semver@7.8.1:
+    resolution: {integrity: sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -3549,6 +3678,10 @@ packages:
     resolution: {integrity: sha512-1POYv7uv2gXoyGFpBCmpDVSNV74IfsWlDW216UPjbWufNf+bSU6GdbDsxdcxtfwb4xlI3yxzOTKClUosxARYrQ==}
     engines: {node: '>=0.10.0'}
 
+  split2@4.2.0:
+    resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
+    engines: {node: '>= 10.x'}
+
   split@0.3.3:
     resolution: {integrity: sha512-wD2AeVmxXRBoX44wAycgjVpMhvbwdI2aZjCkvfNcH1YqHQvJVa1duWc73OyVGJUc05fhFaTZeQ/PYsrmyH0JVA==}
 
@@ -3597,6 +3730,13 @@ packages:
   strip-ansi@7.1.2:
     resolution: {integrity: sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==}
     engines: {node: '>=12'}
+
+  strip-bom@4.0.0:
+    resolution: {integrity: sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==}
+    engines: {node: '>=8'}
+
+  strip-comments-strings@1.2.0:
+    resolution: {integrity: sha512-zwF4bmnyEjZwRhaak9jUWNxc0DoeKBJ7lwSN/LEc8dQXZcUFG6auaaTQJokQWXopLdM3iTx01nQT8E4aL29DAQ==}
 
   strip-final-newline@2.0.0:
     resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
@@ -4090,6 +4230,14 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
+  write-file-atomic@5.0.1:
+    resolution: {integrity: sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+
+  write-yaml-file@5.0.0:
+    resolution: {integrity: sha512-FdNA4RyH1L43TlvGG8qOMIfcEczwA5ij+zLXUy3Z83CjxhLvcV7/Q/8pk22wnCgYw7PJhtK+7lhO+qqyT4NdvQ==}
+    engines: {node: '>=16.14'}
+
   ws@8.18.0:
     resolution: {integrity: sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==}
     engines: {node: '>=10.0.0'}
@@ -4559,6 +4707,8 @@ snapshots:
 
   '@github/catalyst@1.7.0': {}
 
+  '@gwhitney/detect-indent@7.0.1': {}
+
   '@hapi/address@5.1.1':
     dependencies:
       '@hapi/hoek': 11.0.7
@@ -4926,6 +5076,89 @@ snapshots:
       '@octokit/openapi-types': 27.0.0
 
   '@phun-ky/typeof@2.0.3': {}
+
+  '@pnpm/constants@1001.3.1': {}
+
+  '@pnpm/core-loggers@1001.0.9(@pnpm/logger@1001.0.1)':
+    dependencies:
+      '@pnpm/logger': 1001.0.1
+      '@pnpm/types': 1001.3.0
+
+  '@pnpm/error@1000.1.0':
+    dependencies:
+      '@pnpm/constants': 1001.3.1
+
+  '@pnpm/fs.find-packages@1000.0.24(@pnpm/logger@1001.0.1)':
+    dependencies:
+      '@pnpm/read-project-manifest': 1001.2.6(@pnpm/logger@1001.0.1)
+      '@pnpm/types': 1001.3.0
+      '@pnpm/util.lex-comparator': 3.0.2
+      p-filter: 2.1.0
+      tinyglobby: 0.2.15
+    transitivePeerDependencies:
+      - '@pnpm/logger'
+
+  '@pnpm/graceful-fs@1000.1.0':
+    dependencies:
+      graceful-fs: 4.2.11
+
+  '@pnpm/logger@1001.0.1':
+    dependencies:
+      bole: 5.0.29
+      split2: 4.2.0
+
+  '@pnpm/manifest-utils@1002.0.5(@pnpm/logger@1001.0.1)':
+    dependencies:
+      '@pnpm/core-loggers': 1001.0.9(@pnpm/logger@1001.0.1)
+      '@pnpm/error': 1000.1.0
+      '@pnpm/logger': 1001.0.1
+      '@pnpm/semver.peer-range': 1000.0.0
+      '@pnpm/types': 1001.3.0
+      semver: 7.8.1
+
+  '@pnpm/read-project-manifest@1001.2.6(@pnpm/logger@1001.0.1)':
+    dependencies:
+      '@gwhitney/detect-indent': 7.0.1
+      '@pnpm/error': 1000.1.0
+      '@pnpm/graceful-fs': 1000.1.0
+      '@pnpm/logger': 1001.0.1
+      '@pnpm/manifest-utils': 1002.0.5(@pnpm/logger@1001.0.1)
+      '@pnpm/text.comments-parser': 1000.0.0
+      '@pnpm/types': 1001.3.0
+      '@pnpm/write-project-manifest': 1000.0.16
+      fast-deep-equal: 3.1.3
+      is-windows: 1.0.2
+      json5: 2.2.3
+      parse-json: 5.2.0
+      read-yaml-file: 2.1.0
+      strip-bom: 4.0.0
+
+  '@pnpm/semver.peer-range@1000.0.0':
+    dependencies:
+      semver: 7.8.1
+
+  '@pnpm/text.comments-parser@1000.0.0':
+    dependencies:
+      strip-comments-strings: 1.2.0
+
+  '@pnpm/types@1001.3.0': {}
+
+  '@pnpm/util.lex-comparator@3.0.2': {}
+
+  '@pnpm/workspace.read-manifest@1000.3.1':
+    dependencies:
+      '@pnpm/constants': 1001.3.1
+      '@pnpm/error': 1000.1.0
+      '@pnpm/types': 1001.3.0
+      read-yaml-file: 2.1.0
+
+  '@pnpm/write-project-manifest@1000.0.16':
+    dependencies:
+      '@pnpm/text.comments-parser': 1000.0.0
+      '@pnpm/types': 1001.3.0
+      json5: 2.2.3
+      write-file-atomic: 5.0.1
+      write-yaml-file: 5.0.0
 
   '@polka/url@1.0.0-next.29': {}
 
@@ -5656,6 +5889,11 @@ snapshots:
 
   bluebird@3.7.2: {}
 
+  bole@5.0.29:
+    dependencies:
+      fast-safe-stringify: 2.1.1
+      individual: 3.0.0
+
   brace-expansion@1.1.12:
     dependencies:
       balanced-match: 1.0.2
@@ -6017,6 +6255,10 @@ snapshots:
 
   entities@7.0.0: {}
 
+  error-ex@1.3.4:
+    dependencies:
+      is-arrayish: 0.2.1
+
   error-stack-parser-es@1.0.5: {}
 
   es-define-property@1.0.1: {}
@@ -6286,6 +6528,8 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
+  fast-safe-stringify@2.1.1: {}
+
   fastq@1.20.1:
     dependencies:
       reusify: 1.1.0
@@ -6550,6 +6794,8 @@ snapshots:
 
   indent-string@4.0.0: {}
 
+  individual@3.0.0: {}
+
   ini@2.0.0: {}
 
   inquirer@12.11.1(@types/node@25.0.9):
@@ -6565,6 +6811,8 @@ snapshots:
       '@types/node': 25.0.9
 
   ip-address@10.1.0: {}
+
+  is-arrayish@0.2.1: {}
 
   is-binary-path@2.1.0:
     dependencies:
@@ -6612,6 +6860,8 @@ snapshots:
   is-unicode-supported@2.1.0: {}
 
   is-what@5.5.0: {}
+
+  is-windows@1.0.2: {}
 
   is-wsl@3.1.0:
     dependencies:
@@ -6666,6 +6916,8 @@ snapshots:
 
   json-buffer@3.0.1: {}
 
+  json-parse-even-better-errors@2.3.1: {}
+
   json-schema-traverse@0.4.1: {}
 
   json-schema@0.4.0: {}
@@ -6673,6 +6925,8 @@ snapshots:
   json-stable-stringify-without-jsonify@1.0.1: {}
 
   json-stringify-safe@5.0.1: {}
+
+  json5@2.2.3: {}
 
   jsonc-eslint-parser@2.4.2:
     dependencies:
@@ -6706,6 +6960,8 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
       type-check: 0.4.0
+
+  lines-and-columns@1.2.4: {}
 
   linkify-it@5.0.0:
     dependencies:
@@ -7033,6 +7289,10 @@ snapshots:
 
   ospath@1.2.2: {}
 
+  p-filter@2.1.0:
+    dependencies:
+      p-map: 2.1.0
+
   p-limit@3.1.0:
     dependencies:
       yocto-queue: 0.1.0
@@ -7040,6 +7300,8 @@ snapshots:
   p-locate@5.0.0:
     dependencies:
       p-limit: 3.1.0
+
+  p-map@2.1.0: {}
 
   p-map@4.0.0:
     dependencies:
@@ -7077,6 +7339,13 @@ snapshots:
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
+
+  parse-json@5.2.0:
+    dependencies:
+      '@babel/code-frame': 7.28.6
+      error-ex: 1.3.4
+      json-parse-even-better-errors: 2.3.1
+      lines-and-columns: 1.2.4
 
   parse-path@7.1.0:
     dependencies:
@@ -7208,6 +7477,11 @@ snapshots:
     dependencies:
       defu: 6.1.4
       destr: 2.0.5
+
+  read-yaml-file@2.1.0:
+    dependencies:
+      js-yaml: 4.1.1
+      strip-bom: 4.0.0
 
   readdirp@3.6.0:
     dependencies:
@@ -7348,6 +7622,8 @@ snapshots:
   search-insights@2.17.3: {}
 
   semver@7.7.3: {}
+
+  semver@7.8.1: {}
 
   sharp@0.34.5:
     dependencies:
@@ -7501,6 +7777,8 @@ snapshots:
 
   speakingurl@14.0.1: {}
 
+  split2@4.2.0: {}
+
   split@0.3.3:
     dependencies:
       through: 2.3.8
@@ -7569,6 +7847,10 @@ snapshots:
   strip-ansi@7.1.2:
     dependencies:
       ansi-regex: 6.2.2
+
+  strip-bom@4.0.0: {}
+
+  strip-comments-strings@1.2.0: {}
 
   strip-final-newline@2.0.0: {}
 
@@ -8008,6 +8290,16 @@ snapshots:
       strip-ansi: 7.1.2
 
   wrappy@1.0.2: {}
+
+  write-file-atomic@5.0.1:
+    dependencies:
+      imurmurhash: 0.1.4
+      signal-exit: 4.1.0
+
+  write-yaml-file@5.0.0:
+    dependencies:
+      js-yaml: 4.1.1
+      write-file-atomic: 5.0.1
 
   ws@8.18.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,9 +5,9 @@ packages:
   - docs
   - examples
 
-catalogMode: prefer
-
 catalog:
+  '@pnpm/fs.find-packages': ^1000.0.24
+  '@pnpm/workspace.read-manifest': ^1000.3.1
   '@types/dom-navigation': ^1.0.6
   '@types/lodash': ^4.17.23
   '@uirouter/core': ^6.1.2
@@ -24,6 +24,8 @@ catalog:
   vite-plugin-static-copy: ^3.1.5
   vitest: ^4.0.17
   wrangler: ^4.59.2
+
+catalogMode: prefer
 
 catalogs:
   publishedPeer:

--- a/scripts/check-catalog.core.mjs
+++ b/scripts/check-catalog.core.mjs
@@ -1,0 +1,125 @@
+// Pure logic for the catalog-duplication check — no filesystem or pnpm SDK here,
+// so every unit is directly testable with plain fixtures (see check-catalog.test.mjs).
+// The IO (enumerating workspace members, reading the workspace manifest) lives in
+// check-catalog.mjs and feeds plain objects into these functions.
+
+export const DEP_FIELDS = [
+  'dependencies',
+  'devDependencies',
+  'peerDependencies',
+  'optionalDependencies',
+];
+
+// Specifier prefixes that are already "managed" — i.e. not an inline registry
+// range that could/should be hoisted into the catalog.
+const MANAGED_PREFIXES = [
+  'catalog:',
+  'workspace:',
+  'link:',
+  'file:',
+  'portal:',
+  'npm:',
+];
+
+/** True when `spec` is a plain registry range/tag (the kind a catalog would hold). */
+export function isInlineRegistryRange(spec) {
+  if (typeof spec !== 'string') return false;
+  const s = spec.trim();
+  if (s.length === 0) return false;
+  if (MANAGED_PREFIXES.some((p) => s.startsWith(p))) return false;
+  if (s.includes('://')) return false; // http(s)/git url
+  if (/^(git\+|git:|github:|gitlab:|bitbucket:)/.test(s)) return false;
+  return true;
+}
+
+/**
+ * Map each dependency to the workspace packages that declare it inline.
+ * @param {Array<{ name: string, dir: string, manifest: object }>} members
+ * @returns {Map<string, Map<string, Array<{ dir: string, field: string, spec: string }>>>}
+ *          dep name -> consumer package name -> declaration sites
+ */
+export function collectInlineUsage(members) {
+  const usage = new Map();
+  for (const { name, dir, manifest } of members) {
+    for (const field of DEP_FIELDS) {
+      for (const [dep, spec] of Object.entries(manifest?.[field] ?? {})) {
+        if (!isInlineRegistryRange(spec)) continue;
+        if (!usage.has(dep)) usage.set(dep, new Map());
+        const byConsumer = usage.get(dep);
+        if (!byConsumer.has(name)) byConsumer.set(name, []);
+        byConsumer.get(name).push({ dir, field, spec });
+      }
+    }
+  }
+  return usage;
+}
+
+/**
+ * Reduce usage to violations: deps declared inline by 2+ distinct packages.
+ * @returns {Array<{ dep: string, consumers: Map, specs: string[] }>} sorted by dep
+ */
+export function findViolations(usage) {
+  const violations = [];
+  for (const [dep, consumers] of usage) {
+    if (consumers.size < 2) continue;
+    const specs = [
+      ...new Set([...consumers.values()].flat().map((entry) => entry.spec)),
+    ];
+    violations.push({ dep, consumers, specs });
+  }
+  return violations.sort((a, b) => a.dep.localeCompare(b.dep));
+}
+
+/** Set of every dependency name defined in the default or any named catalog. */
+export function catalogDepNames(workspaceManifest) {
+  const names = new Set(Object.keys(workspaceManifest?.catalog ?? {}));
+  for (const catalog of Object.values(workspaceManifest?.catalogs ?? {})) {
+    for (const name of Object.keys(catalog ?? {})) names.add(name);
+  }
+  return names;
+}
+
+/**
+ * Render the human-readable report.
+ * @returns {{ ok: boolean, text: string }}
+ */
+export function formatReport(
+  violations,
+  { memberCount, catalogNames = new Set() } = {},
+) {
+  if (violations.length === 0) {
+    return {
+      ok: true,
+      text:
+        `✓ catalog check passed — ${memberCount} workspace packages, ` +
+        `no dependency declared inline by 2+ packages.`,
+    };
+  }
+
+  const lines = [
+    `✗ catalog check failed — dependencies declared inline by 2+ workspace ` +
+      `packages must use \`catalog:\` (pnpm-workspace.yaml):`,
+    '',
+  ];
+  for (const { dep, consumers, specs } of violations) {
+    const drift =
+      specs.length > 1
+        ? ` (versions drift: ${specs.join(', ')})`
+        : ` (${specs[0]})`;
+    lines.push(
+      `  ${dep} — declared inline by ${consumers.size} packages${drift}`,
+    );
+    for (const entries of consumers.values()) {
+      for (const { dir, field, spec } of entries) {
+        lines.push(`      • ${dir.padEnd(40)} ${field.padEnd(20)} ${spec}`);
+      }
+    }
+    lines.push(
+      catalogNames.has(dep)
+        ? `      → catalog already defines "${dep}" — replace each inline range with "catalog:".`
+        : `      → add "${dep}" to the \`catalog:\` in pnpm-workspace.yaml and replace each inline range with "catalog:".`,
+    );
+    lines.push('');
+  }
+  return { ok: false, text: lines.join('\n') };
+}

--- a/scripts/check-catalog.mjs
+++ b/scripts/check-catalog.mjs
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+// Enforce pnpm catalog usage for shared dependencies.
+//
+// Rule: any dependency declared with an inline registry range (e.g. "^1.2.3")
+// in two or more workspace packages must instead be hoisted to the `catalog:`
+// in pnpm-workspace.yaml and referenced as `catalog:` (or `catalog:<name>`).
+// `catalogMode: prefer` nudges new `pnpm add`s toward the catalog, but it is a
+// soft default; this check is the hard gate that keeps duplication from drifting
+// back in (e.g. via hand-edited package.json or a `--save-catalog`-less add).
+//
+// This file is the IO shell: it enumerates workspace members and reads the
+// workspace manifest via the pnpm SDK, then delegates all decisions to the pure,
+// unit-tested functions in ./check-catalog.core.mjs.
+//
+// Why the SDK (not the lockfile, not hand-parsed YAML): pnpm-lock.yaml has
+// already resolved `catalog:` refs to concrete versions, so it can't distinguish
+// a catalogued dep from an inline one — that lives only in package.json.
+// `findPackages` is pnpm's own workspace resolver, so we inherit its glob
+// handling, including that the standalone tutorials under examples/* are NOT
+// members (the glob is `examples`, not `examples/*`).
+
+import { findPackages } from '@pnpm/fs.find-packages';
+import { readWorkspaceManifest } from '@pnpm/workspace.read-manifest';
+import { dirname, join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  catalogDepNames,
+  collectInlineUsage,
+  findViolations,
+  formatReport,
+} from './check-catalog.core.mjs';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+/** Enumerate workspace members (incl. root) and the parsed workspace manifest. */
+export async function loadWorkspace(root) {
+  const workspaceManifest = await readWorkspaceManifest(root);
+  const projects = await findPackages(root, {
+    patterns: workspaceManifest?.packages,
+    includeRoot: true,
+  });
+  const members = projects.map((project) => {
+    const dir = relative(root, project.rootDir) || '<root>';
+    return {
+      name: project.manifest?.name ?? dir,
+      dir,
+      manifest: project.manifest,
+    };
+  });
+  return { members, workspaceManifest };
+}
+
+async function main() {
+  const { members, workspaceManifest } = await loadWorkspace(ROOT);
+  const violations = findViolations(collectInlineUsage(members));
+  const { ok, text } = formatReport(violations, {
+    memberCount: members.length,
+    catalogNames: catalogDepNames(workspaceManifest),
+  });
+  (ok ? console.log : console.error)(text);
+  if (!ok) process.exitCode = 1;
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/scripts/check-catalog.test.mjs
+++ b/scripts/check-catalog.test.mjs
@@ -1,0 +1,165 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+  catalogDepNames,
+  collectInlineUsage,
+  findViolations,
+  formatReport,
+  isInlineRegistryRange,
+} from './check-catalog.core.mjs';
+
+describe('isInlineRegistryRange', () => {
+  it('accepts plain registry ranges and tags', () => {
+    for (const spec of ['^1.2.3', '~2.0.0', '1.0.0', '>=3 <4', '*', 'latest']) {
+      assert.equal(isInlineRegistryRange(spec), true, spec);
+    }
+  });
+
+  it('rejects catalog, workspace, and other managed protocols', () => {
+    for (const spec of [
+      'catalog:',
+      'catalog:publishedPeer',
+      'workspace:*',
+      'link:../x',
+      'file:../x.tgz',
+      'portal:../x',
+      'npm:other@^1.0.0',
+    ]) {
+      assert.equal(isInlineRegistryRange(spec), false, spec);
+    }
+  });
+
+  it('rejects git/url specifiers and non-strings', () => {
+    for (const spec of [
+      'git+https://example.com/x.git',
+      'git://example.com/x.git',
+      'github:user/repo',
+      'https://example.com/x.tgz',
+    ]) {
+      assert.equal(isInlineRegistryRange(spec), false, spec);
+    }
+    for (const spec of ['', '   ', undefined, null, 42]) {
+      assert.equal(isInlineRegistryRange(spec), false, String(spec));
+    }
+  });
+});
+
+const members = [
+  {
+    name: 'a',
+    dir: 'apps/a',
+    manifest: {
+      dependencies: { lodash: '^4.17.21' },
+      devDependencies: { vite: 'catalog:' },
+    },
+  },
+  {
+    name: 'b',
+    dir: 'apps/b',
+    manifest: {
+      dependencies: { lodash: '^4.18.0' },
+      devDependencies: { vite: 'catalog:' },
+    },
+  },
+  {
+    name: 'c',
+    dir: 'packages/c',
+    // catalogued lodash must not count as an inline consumer
+    manifest: { dependencies: { lodash: 'catalog:', only: '^1.0.0' } },
+  },
+  {
+    name: 'd',
+    dir: 'packages/d',
+    // same package declaring a dep twice counts as ONE consumer
+    manifest: {
+      dependencies: { dup: '^1.0.0' },
+      peerDependencies: { dup: '^1.0.0' },
+    },
+  },
+];
+
+describe('collectInlineUsage + findViolations', () => {
+  const usage = collectInlineUsage(members);
+  const violations = findViolations(usage);
+  const byDep = new Map(violations.map((v) => [v.dep, v]));
+
+  it('flags a dep declared inline by 2+ distinct packages', () => {
+    assert.ok(byDep.has('lodash'));
+    assert.equal(byDep.get('lodash').consumers.size, 2);
+    assert.deepEqual(byDep.get('lodash').specs, ['^4.17.21', '^4.18.0']);
+  });
+
+  it('ignores catalog/workspace specifiers', () => {
+    // vite is catalog: everywhere, lodash@c is catalog: -> only a & b counted
+    assert.ok(!byDep.has('vite'));
+  });
+
+  it('does not flag single-consumer deps', () => {
+    assert.ok(!byDep.has('only'));
+  });
+
+  it('counts multiple fields in one package as a single consumer', () => {
+    assert.ok(!byDep.has('dup'));
+    assert.equal(usage.get('dup').size, 1);
+  });
+
+  it('sorts violations by dependency name', () => {
+    const sorted = [...violations.map((v) => v.dep)].sort((a, b) =>
+      a.localeCompare(b),
+    );
+    assert.deepEqual(
+      violations.map((v) => v.dep),
+      sorted,
+    );
+  });
+});
+
+describe('catalogDepNames', () => {
+  it('collects names from the default and named catalogs', () => {
+    const names = catalogDepNames({
+      catalog: { lit: '^3.0.0', lodash: '^4.0.0' },
+      catalogs: { publishedPeer: { '@uirouter/core': '^6.0.0' } },
+    });
+    assert.deepEqual([...names].sort(), ['@uirouter/core', 'lit', 'lodash']);
+  });
+
+  it('tolerates a missing/empty manifest', () => {
+    assert.equal(catalogDepNames(undefined).size, 0);
+    assert.equal(catalogDepNames({}).size, 0);
+  });
+});
+
+describe('formatReport', () => {
+  it('reports success with the member count', () => {
+    const { ok, text } = formatReport([], { memberCount: 8 });
+    assert.equal(ok, true);
+    assert.match(text, /✓ catalog check passed — 8 workspace packages/);
+  });
+
+  it('fails and suggests adding to the catalog when the dep is uncatalogued', () => {
+    const violations = findViolations(collectInlineUsage(members));
+    const { ok, text } = formatReport(violations, {
+      memberCount: 4,
+      catalogNames: new Set(),
+    });
+    assert.equal(ok, false);
+    assert.match(
+      text,
+      /lodash — declared inline by 2 packages \(versions drift: \^4\.17\.21, \^4\.18\.0\)/,
+    );
+    assert.match(text, /add "lodash" to the `catalog:`/);
+  });
+
+  it('suggests replacing inline ranges when the dep is already catalogued', () => {
+    const violations = findViolations(collectInlineUsage(members));
+    const { text } = formatReport(violations, {
+      memberCount: 4,
+      catalogNames: new Set(['lodash']),
+    });
+    assert.match(
+      text,
+      /catalog already defines "lodash" — replace each inline range/,
+    );
+  });
+});

--- a/turbo.json
+++ b/turbo.json
@@ -10,6 +10,7 @@
       "outputs": ["dist/**"]
     },
     "test": {
+      "with": ["//#test:root"],
       "dependsOn": ["^test"],
       "inputs": ["src/**/*.ts", "vitest.config.ts", "cypress.config.ts"]
     },
@@ -26,7 +27,25 @@
       "inputs": ["examples/**/*.{ts,js}", "eslint.config.js", "$TURBO_DEFAULT$"]
     },
     "ci": {
-      "dependsOn": ["build", "test", "test:coverage", "lint", "format:check"]
+      "dependsOn": [
+        "build",
+        "test",
+        "test:coverage",
+        "lint",
+        "format:check",
+        "//#check:catalog"
+      ]
+    },
+    "//#check:catalog": {
+      "inputs": [
+        "scripts/check-catalog.mjs",
+        "scripts/check-catalog.core.mjs",
+        "pnpm-workspace.yaml",
+        "**/package.json"
+      ]
+    },
+    "//#test:root": {
+      "inputs": ["scripts/**"]
     },
     "format": {
       "with": ["//#format:root"],


### PR DESCRIPTION
## What

Adds a hard CI gate that fails when a dependency is declared with an inline registry range (e.g. `^1.2.3`) in **two or more** workspace packages. Such deps must instead live in the `catalog:` in `pnpm-workspace.yaml` and be referenced as `catalog:`.

`catalogMode: prefer` only *softly* nudges new `pnpm add`s toward the catalog; this check is the hard backstop that keeps duplication from drifting back in via hand-edited `package.json` or a `--save-catalog`-less add.

## How

- **`scripts/check-catalog.core.mjs`** — pure logic, zero IO, so each unit is testable with plain fixtures: `isInlineRegistryRange`, `collectInlineUsage`, `findViolations`, `catalogDepNames`, `formatReport` (catalog-aware hint: "add X" vs "catalog already defines X").
- **`scripts/check-catalog.mjs`** — thin IO shell. Uses pnpm's own SDK (`@pnpm/fs.find-packages` + `@pnpm/workspace.read-manifest`) to enumerate workspace members and read the catalogs.
  - Not the **lockfile** — it has already resolved `catalog:` → concrete versions, erasing the inline-vs-catalogued distinction.
  - Not **hand-parsed YAML** — a YAML lib would still leave glob expansion hand-rolled; the SDK *is* pnpm's resolver, so `examples/*` tutorials are correctly excluded as non-members.
- **`scripts/check-catalog.test.mjs`** — 13 `node:test` unit tests (zero new test deps).

## Wiring

- `//#check:catalog` → `ci.dependsOn`.
- `//#test:root` (`node --test "scripts/**/*.test.mjs"`) attached to the `test` task via `with`, mirroring `lint:root`/`format:root` — so `turbo run test` and `turbo run ci` both run it, and any future `scripts/**/*.test.mjs` is auto-discovered.
- `eslint.config.js`: extended the node-globals block to `**/*.mjs`.

The single `turbo run ci --ui=stream` in CI covers both new tasks — no workflow edit.

## Notes

- Current repo **passes** (no dep is inline in 2+ members today).
- `catalogMode: prefer` auto-routed the two new `@pnpm/*` dev deps into the catalog (single-consumer, harmless).

## Test plan

- [x] `pnpm check:catalog` passes (8 members)
- [x] `pnpm test:root` — 13/13
- [x] Injecting a duplicate (`lodash` into two packages) fails with a drift-aware message
- [x] `turbo run check:catalog test:root lint` green; prettier + eslint clean