### PR TITLE
feat: TransitionController — reactive controller for UI-Router transitions

### DIFF
--- a/apps/sample-app-lit/src/app/main/App.ts
+++ b/apps/sample-app-lit/src/app/main/App.ts
@@ -1,7 +1,11 @@
-import { html, LitElement, PropertyValues } from 'lit';
+import { html, LitElement } from 'lit';
 import { styleMap } from 'lit/directives/style-map.js';
 import { customElement, property } from 'lit/decorators.js';
-import { UIViewInjectedProps, RoutedLitElement } from 'lit-ui-router';
+import {
+  TransitionController,
+  UIViewInjectedProps,
+  RoutedLitElement,
+} from 'lit-ui-router';
 
 import AuthService from '../global/authService.js';
 import './NavHeader.js';
@@ -22,28 +26,16 @@ export class App extends LitElement {
     this._uiViewProps = props;
   }
 
-  shouldUpdate(changedProperties: PropertyValues) {
-    const viewPropsChanged = changedProperties.has('_uiViewProps');
-    return viewPropsChanged || super.shouldUpdate(changedProperties);
-  }
-
-  override requestUpdate(
-    name?: PropertyKey,
-    oldValue?: unknown,
-    options?: unknown,
-  ) {
-    super.requestUpdate(name, oldValue, options as never);
-    const navHeader =
-      this.renderRoot?.querySelector<LitElement>('sample-nav-header');
-    navHeader?.requestUpdate();
-  }
+  // Re-renders this component after every successful transition, keeping the
+  // named ui-view visibility (displayActive) in sync with the active state.
+  transitions = new TransitionController(this);
 
   get stateService() {
     return this._uiViewProps.router.stateService;
   }
 
   isActive(glob: string) {
-    return this.stateService.includes(glob);
+    return this.transitions.includes(glob);
   }
 
   handleLogout = () => {

--- a/apps/sample-app-lit/src/app/main/NavHeader.ts
+++ b/apps/sample-app-lit/src/app/main/NavHeader.ts
@@ -1,7 +1,7 @@
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import { when } from 'lit/directives/when.js';
-import { uiSref, uiSrefActive } from 'lit-ui-router';
+import { TransitionController, uiSref, uiSrefActive } from 'lit-ui-router';
 
 import AppConfig from '../global/appConfig.js';
 import AuthService from '../global/authService.js';
@@ -11,6 +11,11 @@ export class NavHeader extends LitElement {
   createRenderRoot() {
     return this;
   }
+
+  // AuthService/AppConfig are plain singletons with no change notification,
+  // but auth changes always ride a transition (login/logout navigate), so
+  // re-rendering on every successful transition keeps this header fresh.
+  transitions = new TransitionController(this);
 
   handleLogout() {
     this.dispatchEvent(new Event('logout'));

--- a/apps/sample-app-lit/src/app/mymessages/Compose.ts
+++ b/apps/sample-app-lit/src/app/mymessages/Compose.ts
@@ -1,7 +1,7 @@
-import { html, LitElement, PropertyValues } from 'lit';
+import { html, LitElement } from 'lit';
 import { customElement, state, property } from 'lit/decorators.js';
 import { isEqual } from 'lodash';
-import { UIViewInjectedProps } from 'lit-ui-router';
+import { TransitionController, UIViewInjectedProps } from 'lit-ui-router';
 
 import { MessagesStorage } from '../global/dataSources.js';
 import AppConfig from '../global/appConfig.js';
@@ -34,52 +34,39 @@ export class Compose extends LitElement {
   constructor(_uiViewProps: UIViewInjectedProps<ComposeResolves>) {
     super();
     this._uiViewProps = _uiViewProps;
-    this.pristineMessage = this.buildPristineMessage();
-    this.message = { ...this.pristineMessage };
+    this.resetMessage(_uiViewProps?.resolves?.$stateParams?.message);
   }
 
-  buildPristineMessage(): Message {
-    return {
+  // Resets the draft whenever a transition lands on this state. Sticky
+  // instances survive between visits, so the constructor only runs once:
+  // - hostConnected: the element (re)entered the DOM, start a fresh draft.
+  // - onSuccess: a transition targeted this state while composing (Reply/
+  //   Forward/Edit, or a DSR redirect back here); reset only if the message
+  //   param actually changed, so an in-progress draft isn't clobbered.
+  // Params are read from the transition itself, which is authoritative even
+  // before <ui-view> pushes updated props. uiCanExit below still guards
+  // against silently discarding unsaved edits.
+  transitions = new TransitionController(this, {
+    criteria: { to: 'mymessages.compose' },
+    callback: (transition, reason) =>
+      this.resetMessage(
+        transition?.params().message as Partial<Message> | undefined,
+        { force: reason === 'hostConnected' },
+      ),
+  });
+
+  resetMessage(message: Partial<Message> = {}, { force = false } = {}) {
+    const pristineMessage = {
       body: '',
       to: '',
       subject: '',
-      ...this._uiViewProps?.resolves?.$stateParams?.message,
+      ...message,
       from: AppConfig.emailAddress,
     } as Message;
-  }
-
-  async willUpdate() {
-    let pristineMessage;
-    if (
-      this.pristineMessage &&
-      !isEqual(
-        this.pristineMessage,
-        (pristineMessage = this.buildPristineMessage()),
-      )
-    ) {
-      this.pristineMessage = pristineMessage;
-      this.message = { ...this.pristineMessage };
-    }
-  }
-
-  shouldUpdate(changedProperties: PropertyValues) {
-    // let pristineMessage;
-    // if (this.pristineMessage && !isEqual(this.pristineMessage, pristineMessage = this.buildPristineMessage())) {
-    //   this.pristineMessage = pristineMessage;
-    //   this.message = {...this.pristineMessage};
-    //   return true;
-    // }
-    return super.shouldUpdate(changedProperties);
-  }
-
-  uiOnParamsChanged(changedProperties: Record<string, unknown>) {
-    console.info(
-      'uiOnParamsChanged',
-      changedProperties,
-      this._uiViewProps?.resolves?.$stateParams,
-    );
-    // this.pristineMessage = { body: '', to: '', subject: '', ...this._uiViewProps.resolves.$stateParams.message, from: AppConfig.emailAddress };
-    // this.message = {...this.pristineMessage};
+    if (!force && isEqual(this.pristineMessage, pristineMessage)) return;
+    this.pristineMessage = pristineMessage;
+    this.message = { ...pristineMessage };
+    this.canExit = false;
   }
 
   /**

--- a/apps/sample-app-lit/src/app/mymessages/MessageList.ts
+++ b/apps/sample-app-lit/src/app/mymessages/MessageList.ts
@@ -3,6 +3,7 @@ import { customElement } from 'lit/decorators.js';
 import { UIViewInjectedProps } from 'lit-ui-router';
 
 import { MessagesStorage } from '../global/dataSources.js';
+import { StoreCommitController } from '../util/storeCommitController.js';
 import { Message } from './interface.js';
 import './MessageTable.js';
 
@@ -19,8 +20,9 @@ export class MessageList extends LitElement {
 
   constructor(public _uiViewProps: UIViewInjectedProps<MessageListResolves>) {
     super();
-    this.onCommit = this.onCommit.bind(this);
   }
+
+  commits = new StoreCommitController(this, MessagesStorage);
 
   get folder() {
     return this._uiViewProps.resolves!.folder;
@@ -28,20 +30,6 @@ export class MessageList extends LitElement {
 
   get messages() {
     return this._uiViewProps.resolves!.messages ?? [];
-  }
-
-  onCommit() {
-    this.requestUpdate();
-  }
-
-  connectedCallback() {
-    MessagesStorage.addEventListener('commit', this.onCommit);
-    super.connectedCallback();
-  }
-
-  disconnectedCallback() {
-    super.disconnectedCallback();
-    MessagesStorage.removeEventListener('commit', this.onCommit);
   }
 
   render() {

--- a/apps/sample-app-lit/src/app/mymessages/MessageTable.ts
+++ b/apps/sample-app-lit/src/app/mymessages/MessageTable.ts
@@ -40,7 +40,7 @@ export class MessageTable extends LitElement {
 
   @property({
     hasChanged(value, oldValue) {
-      return isEqual(value, oldValue);
+      return !isEqual(value, oldValue);
     },
     attribute: false,
   })
@@ -81,7 +81,7 @@ export class MessageTable extends LitElement {
         </td>`,
     );
     const tableBody = repeat(
-      messages.sort(orderBy(sort)),
+      [...messages].sort(orderBy(sort)),
       ({ _id }) => _id,
       (message) =>
         html`<tr

--- a/apps/sample-app-lit/src/app/util/storeCommitController.ts
+++ b/apps/sample-app-lit/src/app/util/storeCommitController.ts
@@ -1,0 +1,34 @@
+import { ReactiveController, ReactiveControllerHost } from 'lit';
+
+/** The event-emitting surface of a fake REST store (see ./sessionStorage.js) */
+interface CommitEventSource {
+  addEventListener: EventTarget['addEventListener'];
+  removeEventListener: EventTarget['removeEventListener'];
+}
+
+/**
+ * A ReactiveController that re-renders its host whenever a fake REST store
+ * commits data (message saved/deleted, marked read, etc).
+ *
+ * Route resolves only run during transitions, so data mutated between
+ * transitions needs a push-based refresh; this controller provides it with
+ * automatic subscribe/unsubscribe tied to the host's DOM lifecycle.
+ */
+export class StoreCommitController implements ReactiveController {
+  constructor(
+    private host: ReactiveControllerHost,
+    private store: CommitEventSource,
+  ) {
+    host.addController(this);
+  }
+
+  private onCommit = () => this.host.requestUpdate();
+
+  hostConnected() {
+    this.store.addEventListener('commit', this.onCommit);
+  }
+
+  hostDisconnected() {
+    this.store.removeEventListener('commit', this.onCommit);
+  }
+}

--- a/packages/lit-ui-router/README.md
+++ b/packages/lit-ui-router/README.md
@@ -35,6 +35,38 @@ router.start();
 | Template with props | Views needing params/resolves | `` (props) => html`...` `` |
 | LitElement class    | Complex views with lifecycle  | `MyComponent`              |
 
+## Reacting to Transitions
+
+Any element (routed or not) can stay synchronized with the router using the
+`TransitionController` reactive controller. It registers transition hooks when
+the host connects, calls `host.requestUpdate()` on matching transitions, and
+deregisters everything when the host disconnects — no manual `requestUpdate()`
+plumbing or leaked hooks.
+
+```ts
+import { TransitionController } from 'lit-ui-router';
+
+class NavHeader extends LitElement {
+  private transitions = new TransitionController(this);
+
+  render() {
+    // Re-evaluated after every successful transition
+    return html`Current state: ${this.transitions.current?.name}`;
+  }
+}
+```
+
+Scope it to specific states or react to parameter changes with a callback:
+
+```ts
+class UserDetail extends LitElement {
+  private transitions = new TransitionController(this, {
+    criteria: { to: 'users.detail' },
+    callback: () => this.loadUser(this.transitions.params.userId),
+  });
+}
+```
+
 ## Documentation
 
 Visit [lit-ui-router.dev](https://lit-ui-router.dev) for full documentation, tutorials, and API reference.

--- a/packages/lit-ui-router/src/index.ts
+++ b/packages/lit-ui-router/src/index.ts
@@ -1,5 +1,6 @@
 export * from './interface.js';
 export * from './core.js';
+export * from './transition-controller.js';
 export * from './ui-router.js';
 export * from './ui-view.js';
 export * from './ui-sref.js';

--- a/packages/lit-ui-router/src/specs/transition-controller.spec.ts
+++ b/packages/lit-ui-router/src/specs/transition-controller.spec.ts
@@ -1,0 +1,253 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
+import { Transition } from '@uirouter/core';
+
+import {
+  TransitionController,
+  TransitionControllerOptions,
+} from '../transition-controller.js';
+import { UIRouterLitElement } from '../ui-router.js';
+import { UIRouterLit } from '../core.js';
+import { LitStateDeclaration } from '../interface.js';
+import {
+  createTestRouter,
+  routerGo,
+  tick,
+  waitForUpdate,
+} from './test-utils.js';
+
+@customElement('test-transition-controller-host')
+class TransitionControllerHost extends LitElement {
+  controller?: TransitionController;
+
+  renderCount = 0;
+
+  createRenderRoot() {
+    return this;
+  }
+
+  render() {
+    this.renderCount++;
+    return html`<span>${this.controller?.current?.name ?? ''}</span>`;
+  }
+}
+
+const testStates: LitStateDeclaration[] = [
+  { name: 'a', url: '/a' },
+  { name: 'b', url: '/b/:id' },
+  { name: 'b.child', url: '/child' },
+];
+
+describe('TransitionController', () => {
+  let container: HTMLElement;
+  let router: UIRouterLit;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    router = createTestRouter(testStates);
+  });
+
+  afterEach(() => {
+    container.remove();
+  });
+
+  async function mountHost(
+    options?: TransitionControllerOptions,
+    { withContext = true }: { withContext?: boolean } = {},
+  ) {
+    const host = document.createElement(
+      'test-transition-controller-host',
+    ) as TransitionControllerHost;
+    host.controller = new TransitionController(host, options);
+
+    if (withContext) {
+      const uiRouterEl = document.createElement(
+        'ui-router',
+      ) as UIRouterLitElement;
+      uiRouterEl.uiRouter = router;
+      container.appendChild(uiRouterEl);
+      await waitForUpdate(uiRouterEl);
+      uiRouterEl.appendChild(host);
+    } else {
+      container.appendChild(host);
+    }
+
+    await waitForUpdate(host);
+    return host;
+  }
+
+  describe('router discovery', () => {
+    it('should discover the router from an ancestor ui-router', async () => {
+      const host = await mountHost();
+      expect(host.controller!.router).toBe(router);
+    });
+
+    it('should use an explicitly provided router without context', async () => {
+      const host = await mountHost({ router }, { withContext: false });
+      expect(host.controller!.router).toBe(router);
+
+      await routerGo(router, 'a');
+      await waitForUpdate(host);
+      expect(host.textContent).toContain('a');
+    });
+
+    it('should be a no-op without a router', async () => {
+      const host = await mountHost(undefined, { withContext: false });
+
+      expect(host.controller!.router).toBeUndefined();
+      expect(host.controller!.params).toEqual({});
+      expect(host.controller!.current).toBeUndefined();
+      expect(host.controller!.includes('a')).toBe(false);
+    });
+  });
+
+  describe('host updates', () => {
+    it('should request a host update on every successful transition', async () => {
+      const host = await mountHost();
+      const initialRenderCount = host.renderCount;
+
+      await routerGo(router, 'a');
+      await waitForUpdate(host);
+
+      expect(host.renderCount).toBeGreaterThan(initialRenderCount);
+      expect(host.textContent).toContain('a');
+
+      await routerGo(router, 'b', { id: '42' });
+      await waitForUpdate(host);
+
+      expect(host.textContent).toContain('b');
+    });
+
+    it('should synchronize once when the host connects', async () => {
+      await routerGo(router, 'a');
+
+      const callback = vi.fn();
+      const host = await mountHost({ callback });
+
+      expect(callback).toHaveBeenCalledTimes(1);
+      const [transition, reason] = callback.mock.calls[0];
+      expect(reason).toBe('hostConnected');
+      expect(transition).toBeInstanceOf(Transition);
+      expect(host.textContent).toContain('a');
+    });
+  });
+
+  describe('callback', () => {
+    it('should invoke the callback with the transition and reason', async () => {
+      const callback = vi.fn();
+      await mountHost({ callback });
+      callback.mockClear();
+
+      await routerGo(router, 'a');
+
+      expect(callback).toHaveBeenCalledTimes(1);
+      const [transition, reason] = callback.mock.calls[0];
+      expect(reason).toBe('onSuccess');
+      expect((transition as Transition).to().name).toBe('a');
+    });
+
+    it('should respect hook match criteria', async () => {
+      const callback = vi.fn();
+      await mountHost({ callback, criteria: { to: 'b' } });
+      callback.mockClear();
+
+      await routerGo(router, 'a');
+      expect(callback).not.toHaveBeenCalled();
+
+      await routerGo(router, 'b', { id: '1' });
+      expect(callback).toHaveBeenCalledTimes(1);
+    });
+
+    it('should observe additional transition events', async () => {
+      const callback = vi.fn();
+      await mountHost({ callback, events: ['onStart', 'onSuccess'] });
+      callback.mockClear();
+
+      await routerGo(router, 'a');
+
+      const reasons = callback.mock.calls.map(([, reason]) => reason);
+      expect(reasons).toEqual(['onStart', 'onSuccess']);
+    });
+
+    it('should allow onBefore callbacks to cancel a transition', async () => {
+      await routerGo(router, 'a');
+
+      await mountHost({
+        events: ['onBefore'],
+        criteria: { to: 'b' },
+        callback: () => false,
+      });
+
+      await router.stateService.go('b', { id: '1' }).catch(() => {});
+      await tick();
+
+      expect(router.globals.current.name).toBe('a');
+    });
+  });
+
+  describe('lifecycle cleanup', () => {
+    it('should deregister hooks when the host disconnects', async () => {
+      const callback = vi.fn();
+      const host = await mountHost({ callback });
+      callback.mockClear();
+
+      host.remove();
+      await tick();
+
+      await routerGo(router, 'a');
+      expect(callback).not.toHaveBeenCalled();
+    });
+
+    it('should re-register hooks and synchronize when the host reconnects', async () => {
+      const callback = vi.fn();
+      const host = await mountHost({ callback });
+      const parent = host.parentElement!;
+
+      host.remove();
+      await tick();
+      await routerGo(router, 'a');
+      callback.mockClear();
+
+      parent.appendChild(host);
+      await waitForUpdate(host);
+
+      // Synchronized with the transition that completed while disconnected
+      expect(callback).toHaveBeenCalledTimes(1);
+      const [transition, reason] = callback.mock.calls[0];
+      expect(reason).toBe('hostConnected');
+      expect((transition as Transition).to().name).toBe('a');
+
+      callback.mockClear();
+      await routerGo(router, 'b', { id: '7' });
+      expect(callback).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('accessors', () => {
+    it('should expose current state, params, and transition', async () => {
+      const host = await mountHost();
+
+      await routerGo(router, 'b', { id: '42' });
+
+      const controller = host.controller!;
+      expect(controller.current?.name).toBe('b');
+      expect(controller.params.id).toBe('42');
+      expect(controller.transition).toBeInstanceOf(Transition);
+      expect(controller.transition!.to().name).toBe('b');
+      expect(controller.globals).toBe(router.globals);
+    });
+
+    it('should delegate includes() to the state service', async () => {
+      const host = await mountHost();
+
+      await routerGo(router, 'b.child', { id: '42' });
+
+      const controller = host.controller!;
+      expect(controller.includes('b')).toBe(true);
+      expect(controller.includes('b.**')).toBe(true);
+      expect(controller.includes('a')).toBe(false);
+    });
+  });
+});

--- a/packages/lit-ui-router/src/transition-controller.ts
+++ b/packages/lit-ui-router/src/transition-controller.ts
@@ -1,0 +1,258 @@
+import {
+  HookMatchCriteria,
+  HookResult,
+  RawParams,
+  StateDeclaration,
+  StateOrName,
+  Transition,
+  UIRouter,
+  UIRouterGlobals,
+} from '@uirouter/core';
+import { ReactiveController, ReactiveControllerHost } from 'lit';
+
+import { UIRouterLitElement } from './ui-router.js';
+
+/** @internal */
+type DeregisterFn = () => void;
+
+/**
+ * Transition lifecycle events that a [[TransitionController]] can observe.
+ *
+ * Each value corresponds to a
+ * {@link https://ui-router.github.io/core/docs/latest/interfaces/transition.ihookregistry.html | TransitionService hook registry}
+ * method of the same name.
+ *
+ * @category controllers
+ */
+export type TransitionEventType =
+  | 'onBefore'
+  | 'onStart'
+  | 'onSuccess'
+  | 'onError';
+
+/**
+ * The reason a [[TransitionController]] invoked its callback.
+ *
+ * Either one of the observed [[TransitionEventType]] hooks fired, or the
+ * host element (re)connected to the DOM and the controller synchronized
+ * with the router's current state (`'hostConnected'`).
+ *
+ * @category controllers
+ */
+export type TransitionCallbackReason = TransitionEventType | 'hostConnected';
+
+/**
+ * A callback invoked by [[TransitionController]] whenever the host is
+ * synchronized with the router.
+ *
+ * For `'onBefore'` and `'onStart'` reasons, the returned value is passed
+ * back to UI-Router as a
+ * {@link https://ui-router.github.io/core/docs/latest/modules/transition.html#hookresult | HookResult},
+ * so the callback may cancel or redirect the pending transition.
+ *
+ * @param transition - The [[Transition]] which triggered the callback.
+ *   For the `'hostConnected'` reason this is the most recent successful
+ *   transition, or `undefined` when no transition has succeeded yet.
+ * @param reason - Why the callback was invoked (see [[TransitionCallbackReason]]).
+ *
+ * @category controllers
+ */
+export type TransitionCallback = (
+  transition: Transition | undefined,
+  reason: TransitionCallbackReason,
+) => unknown;
+
+/**
+ * Options for [[TransitionController]].
+ *
+ * @category controllers
+ */
+export interface TransitionControllerOptions {
+  /**
+   * The [[UIRouter]] instance to observe.
+   *
+   * When omitted, the controller discovers the router from an ancestor
+   * <code>&lt;ui-router&gt;</code> (or <code>&lt;ui-view&gt;</code>) via the
+   * `ui-router-context` event when the host connects.
+   */
+  router?: UIRouter;
+
+  /**
+   * {@link https://ui-router.github.io/core/docs/latest/interfaces/transition.hookmatchcriteria.html | HookMatchCriteria}
+   * limiting which transitions notify the host.
+   *
+   * Defaults to `{}` (all transitions).
+   */
+  criteria?: HookMatchCriteria;
+
+  /**
+   * The transition lifecycle events to observe.
+   *
+   * Defaults to `['onSuccess']`.
+   */
+  events?: TransitionEventType[];
+
+  /**
+   * Invoked before `host.requestUpdate()` whenever an observed event fires,
+   * and once each time the host connects (see [[TransitionCallbackReason]]).
+   */
+  callback?: TransitionCallback;
+}
+
+/**
+ * A zero-dependency Lit
+ * {@link https://lit.dev/docs/composition/controllers/ | ReactiveController}
+ * that keeps its host element synchronized with UI-Router transitions.
+ *
+ * The controller registers [[TransitionService]] hooks (by default
+ * `onSuccess`) when the host connects and calls `host.requestUpdate()`
+ * whenever a matching transition event fires — no manual `requestUpdate()`
+ * plumbing, no leaked hooks. All registered hooks are deregistered in
+ * `hostDisconnected()`, so the controller is garbage-collection safe for
+ * elements that come and go from the DOM (including `sticky` routed
+ * components).
+ *
+ * On (re)connect the controller also synchronizes once with the router's
+ * current state, so hosts render fresh data even when they connect after
+ * a transition has already completed.
+ *
+ * @example Re-render on every successful transition
+ * ```ts
+ * class NavHeader extends LitElement {
+ *   private transitions = new TransitionController(this);
+ *
+ *   render() {
+ *     // Re-evaluated after every successful transition
+ *     return html`Current state: ${this.transitions.current?.name}`;
+ *   }
+ * }
+ * ```
+ *
+ * @example React to parameter changes on a specific state
+ * ```ts
+ * class UserDetail extends LitElement {
+ *   private transitions = new TransitionController(this, {
+ *     criteria: { to: 'users.detail' },
+ *     callback: () => this.loadUser(this.transitions.params.userId),
+ *   });
+ * }
+ * ```
+ *
+ * @example With an explicit router instance
+ * ```ts
+ * const controller = new TransitionController(host, { router });
+ * ```
+ *
+ * @category controllers
+ */
+export class TransitionController implements ReactiveController {
+  private host: ReactiveControllerHost & Element;
+
+  private options: TransitionControllerOptions;
+
+  private deregisterFns: DeregisterFn[] = [];
+
+  private _router?: UIRouter;
+
+  private _transition?: Transition;
+
+  constructor(
+    host: ReactiveControllerHost & Element,
+    options: TransitionControllerOptions = {},
+  ) {
+    this.host = host;
+    this.options = options;
+    this._router = options.router;
+    host.addController(this);
+  }
+
+  /**
+   * The observed [[UIRouter]] instance.
+   *
+   * `undefined` until provided via [[TransitionControllerOptions.router]] or
+   * discovered from an ancestor <code>&lt;ui-router&gt;</code> on connect.
+   */
+  get router(): UIRouter | undefined {
+    return this._router;
+  }
+
+  /** The router's [[UIRouterGlobals]], if a router has been discovered. */
+  get globals(): UIRouterGlobals | undefined {
+    return this._router?.globals;
+  }
+
+  /** The current parameter values (`globals.params`). */
+  get params(): RawParams {
+    return this.globals?.params ?? {};
+  }
+
+  /** The current [[StateDeclaration]] (`globals.current`). */
+  get current(): StateDeclaration | undefined {
+    return this.globals?.current;
+  }
+
+  /**
+   * The most recent [[Transition]] observed by this controller
+   * (set by observed events and on host connect).
+   */
+  get transition(): Transition | undefined {
+    return this._transition;
+  }
+
+  /**
+   * Delegates to [[StateService.includes]]: is the state (or glob pattern,
+   * e.g. `'admin.**'`) included in the current active state?
+   *
+   * Returns `false` when no router has been discovered.
+   */
+  includes(stateOrName: StateOrName, params?: RawParams): boolean {
+    return this._router?.stateService.includes(stateOrName, params) ?? false;
+  }
+
+  /** @internal */
+  hostConnected() {
+    this._router ??=
+      this.options.router ?? UIRouterLitElement.seekRouter(this.host);
+
+    const router = this._router;
+    if (!router) {
+      return;
+    }
+
+    const criteria = this.options.criteria ?? {};
+    const events = this.options.events ?? ['onSuccess'];
+
+    for (const event of events) {
+      this.deregisterFns.push(
+        router.transitionService[event](
+          criteria,
+          (transition) => this.notify(transition, event) as HookResult,
+        ) as DeregisterFn,
+      );
+    }
+
+    // Synchronize with the router's current state: the host may have
+    // (re)connected after the transition that put it on screen succeeded.
+    this.notify(
+      router.globals.successfulTransitions.peekTail(),
+      'hostConnected',
+    );
+  }
+
+  /** @internal */
+  hostDisconnected() {
+    while (this.deregisterFns.length) {
+      this.deregisterFns.shift()?.();
+    }
+  }
+
+  private notify(
+    transition: Transition | undefined,
+    reason: TransitionCallbackReason,
+  ): unknown {
+    this._transition = transition ?? this._transition;
+    const result = this.options.callback?.(transition, reason);
+    this.host.requestUpdate();
+    return result;
+  }
+}

--- a/packages/lit-ui-router/src/transition-controller.ts
+++ b/packages/lit-ui-router/src/transition-controller.ts
@@ -19,7 +19,7 @@ type DeregisterFn = () => void;
  * Transition lifecycle events that a [[TransitionController]] can observe.
  *
  * Each value corresponds to a
- * {@link https://ui-router.github.io/core/docs/latest/interfaces/transition.ihookregistry.html | TransitionService hook registry}
+ * {@link https://ui-router.github.io/core/docs/latest/interfaces/_transition_interface_.ihookregistry.html | TransitionService hook registry}
  * method of the same name.
  *
  * @category controllers
@@ -47,7 +47,7 @@ export type TransitionCallbackReason = TransitionEventType | 'hostConnected';
  *
  * For `'onBefore'` and `'onStart'` reasons, the returned value is passed
  * back to UI-Router as a
- * {@link https://ui-router.github.io/core/docs/latest/modules/transition.html#hookresult | HookResult},
+ * {@link https://ui-router.github.io/core/docs/latest/modules/_transition_interface_.html#hookresult | HookResult},
  * so the callback may cancel or redirect the pending transition.
  *
  * @param transition - The [[Transition]] which triggered the callback.
@@ -78,7 +78,7 @@ export interface TransitionControllerOptions {
   router?: UIRouter;
 
   /**
-   * {@link https://ui-router.github.io/core/docs/latest/interfaces/transition.hookmatchcriteria.html | HookMatchCriteria}
+   * {@link https://ui-router.github.io/core/docs/latest/interfaces/_transition_interface_.hookmatchcriteria.html | HookMatchCriteria}
    * limiting which transitions notify the host.
    *
    * Defaults to `{}` (all transitions).

--- a/packages/lit-ui-router/typedoc.json
+++ b/packages/lit-ui-router/typedoc.json
@@ -12,7 +12,14 @@
   "excludeInternal": true,
   "excludePrivate": true,
   "categorizeByGroup": false,
-  "categoryOrder": ["core", "components", "directives", "controllers", "hooks", "types"],
+  "categoryOrder": [
+    "core",
+    "components",
+    "directives",
+    "controllers",
+    "hooks",
+    "types"
+  ],
   "readme": "none",
   "githubPages": false,
   "entryFileName": "index",

--- a/packages/lit-ui-router/typedoc.json
+++ b/packages/lit-ui-router/typedoc.json
@@ -15,8 +15,8 @@
   "categoryOrder": [
     "core",
     "components",
-    "directives",
     "controllers",
+    "directives",
     "hooks",
     "types"
   ],

--- a/packages/lit-ui-router/typedoc.json
+++ b/packages/lit-ui-router/typedoc.json
@@ -12,7 +12,7 @@
   "excludeInternal": true,
   "excludePrivate": true,
   "categorizeByGroup": false,
-  "categoryOrder": ["core", "components", "directives", "hooks", "types"],
+  "categoryOrder": ["core", "components", "directives", "controllers", "hooks", "types"],
   "readme": "none",
   "githubPages": false,
   "entryFileName": "index",

--- a/packages/lit-ui-router/typedoc.json
+++ b/packages/lit-ui-router/typedoc.json
@@ -35,6 +35,42 @@
   },
   "sort": ["alphabetical", "source-order"],
   "router": "category",
+  "externalSymbolLinkMappings": {
+    "@uirouter/core": {
+      "UIRouter": "https://ui-router.github.io/core/docs/latest/classes/_router_.uirouter.html",
+      "UIRouterGlobals": "https://ui-router.github.io/core/docs/latest/classes/_globals_.uirouterglobals.html",
+      "Transition": "https://ui-router.github.io/core/docs/latest/classes/_transition_transition_.transition.html",
+      "TransitionOptions": "https://ui-router.github.io/core/docs/latest/interfaces/_transition_interface_.transitionoptions.html",
+      "TargetState": "https://ui-router.github.io/core/docs/latest/classes/_state_targetstate_.targetstate.html",
+      "StateDeclaration": "https://ui-router.github.io/core/docs/latest/interfaces/_state_interface_.statedeclaration.html",
+      "StateOrName": "https://ui-router.github.io/core/docs/latest/modules/_state_interface_.html#stateorname",
+      "RawParams": "https://ui-router.github.io/core/docs/latest/interfaces/_params_interface_.rawparams.html",
+      "HookMatchCriteria": "https://ui-router.github.io/core/docs/latest/interfaces/_transition_interface_.hookmatchcriteria.html",
+      "HookResult": "https://ui-router.github.io/core/docs/latest/modules/_transition_interface_.html#hookresult"
+    },
+    "lit": {
+      "LitElement": "https://lit.dev/docs/api/LitElement/",
+      "TemplateResult": "https://lit.dev/docs/api/templates/#TemplateResult",
+      "ReactiveController": "https://lit.dev/docs/api/controllers/#ReactiveController",
+      "ReactiveControllerHost": "https://lit.dev/docs/api/controllers/#ReactiveControllerHost",
+      "AsyncDirective": "https://lit.dev/docs/api/custom-directives/#AsyncDirective",
+      "DirectiveResult": "https://lit.dev/docs/api/custom-directives/#DirectiveResult",
+      "ElementPart": "https://lit.dev/docs/api/custom-directives/#ElementPart"
+    },
+    "@lit/reactive-element": {
+      "ReactiveController": "https://lit.dev/docs/api/controllers/#ReactiveController",
+      "ReactiveControllerHost": "https://lit.dev/docs/api/controllers/#ReactiveControllerHost"
+    },
+    "lit-element": {
+      "LitElement": "https://lit.dev/docs/api/LitElement/"
+    },
+    "lit-html": {
+      "TemplateResult": "https://lit.dev/docs/api/templates/#TemplateResult",
+      "AsyncDirective": "https://lit.dev/docs/api/custom-directives/#AsyncDirective",
+      "DirectiveResult": "https://lit.dev/docs/api/custom-directives/#DirectiveResult",
+      "ElementPart": "https://lit.dev/docs/api/custom-directives/#ElementPart"
+    }
+  },
   "formatWithPrettier": true,
   "prettierConfigFile": "../../.prettierrc",
   "sidebar": {

--- a/tools/typedoc-plugin-lit-ui-router/src/index.ts
+++ b/tools/typedoc-plugin-lit-ui-router/src/index.ts
@@ -31,6 +31,7 @@ type Category =
   | 'core'
   | 'components'
   | 'directives'
+  | 'controllers'
   | 'hooks'
   | 'types'
   | 'other';
@@ -49,6 +50,12 @@ const SYMBOL_CATEGORIES: Record<string, Category> = {
   uiSrefActive: 'directives',
   UiSrefDirective: 'directives',
   UiSrefActiveDirective: 'directives',
+  // Controllers
+  TransitionController: 'controllers',
+  TransitionControllerOptions: 'controllers',
+  TransitionEventType: 'controllers',
+  TransitionCallback: 'controllers',
+  TransitionCallbackReason: 'controllers',
   // Hooks
   UiOnExit: 'hooks',
   UiOnParamsChanged: 'hooks',
@@ -97,6 +104,10 @@ const CATEGORY_META: Record<Category, { title: string; description: string }> =
     directives: {
       title: 'Directives',
       description: 'Lit directives for navigation and active state styling.',
+    },
+    controllers: {
+      title: 'Controllers',
+      description: 'Reactive controllers binding hosts to router transitions.',
     },
     hooks: {
       title: 'Hooks',
@@ -220,6 +231,7 @@ function generateCategoryIndexFiles(outDir: string, app: Application): void {
     'core',
     'components',
     'directives',
+    'controllers',
     'hooks',
     'types',
     'other',
@@ -275,7 +287,11 @@ function updateSidebarJson(outDir: string, app: Application): void {
   const sidebar = JSON.parse(fs.readFileSync(sidebarPath, 'utf-8'));
   for (const item of sidebar) {
     const category: Category = item.text;
-    item.text = CATEGORY_META[category].title;
+    // Fall back to title-casing so an uncharted @category tag renders
+    // instead of crashing the docs build.
+    item.text =
+      CATEGORY_META[category]?.title ??
+      category.charAt(0).toUpperCase() + category.slice(1);
     item.link = `/api/reference/${category}`;
     delete item.collapsed;
     if (category === 'types') {


### PR DESCRIPTION
## Summary

- Adds `TransitionController`, a zero-dependency Lit ReactiveController in `packages/lit-ui-router` that binds a host element to `@uirouter/core` transition hooks: it discovers the router from the `<ui-router>` context on `hostConnected`, registers the configured hooks (default `onSuccess`; `onBefore`/`onStart`/`onError` opt-in, with `HookMatchCriteria` support), calls `host.requestUpdate()` per matching transition, and deregisters everything on `hostDisconnected`. On (re)connect it synchronizes from the last successful transition so sticky components never render stale state.
- Eliminates all manual refresh crutches in the sample app: `App` and `Compose` use `TransitionController` (active-section visibility, draft reset from route params with draft-preservation semantics), `NavHeader`/`MessageList` use a small `StoreCommitController` for data-store commits, and `MessageTable`'s broken `hasChanged` comparator is fixed.
- README gains a "Reacting to Transitions" section.

## Test plan

- 13 new browser-mode vitest specs for the controller (discovery, explicit router, per-event registration, cancellation via `onBefore`, disconnect/reconnect lifecycle, accessors) — full suite passes in chromium/firefox/webkit
- Cypress e2e suite passes against the built docs deploy