### PR TITLE
ci: provision node/pnpm/turbo via mise-action

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -22,15 +22,8 @@ jobs:
     steps:
       - name: 'Checkout code'
         uses: actions/checkout@v4
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: 10.13.1
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '22.17.1' # Specify Node.js version
-          cache: 'pnpm' # Use pnpm cache instead of npm
+      - name: Setup mise
+        uses: jdx/mise-action@v4
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Add workspace binaries to PATH

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -70,15 +70,8 @@ jobs:
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: 10.13.1
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '22.17.1'
-          cache: 'pnpm'
+      - name: Setup mise
+        uses: jdx/mise-action@v4
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Set branch prefix

--- a/.github/workflows/publish-gh.yml
+++ b/.github/workflows/publish-gh.yml
@@ -36,15 +36,8 @@ jobs:
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: 10.13.1
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '22.17.1'
-          cache: 'pnpm'
+      - name: Setup mise
+        uses: jdx/mise-action@v4
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Tag & push

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -35,15 +35,8 @@ jobs:
           PACKAGE_NAME="${TAG%@*}"
           echo "$PACKAGE_NAME"
           echo "PACKAGE_NAME=$PACKAGE_NAME" >> "$GITHUB_ENV"
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: 10.13.1
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '22.17.1'
-          cache: 'pnpm'
+      - name: Setup mise
+        uses: jdx/mise-action@v4
       - name: Update npm
         # npm >= 11.5.1 required for OIDC trusted publishing
         run: npm install -g npm@latest


### PR DESCRIPTION
Stacked on #146.

## Summary
- Replace `pnpm/action-setup` + `actions/setup-node` (hardcoded pnpm `10.13.1`, already drifted from the `packageManager: pnpm@10.28.1` pin) with [`jdx/mise-action`](https://github.com/jdx/mise-action) in all 4 workflows: `build-test.yml`, `bump-version.yml`, `publish-gh.yml`, `publish-npm.yml`
- CI now reads node from `.nvmrc` and pnpm/turbo from `.config/mise/config.toml`, the same source as local dev via `mise install` — one place to bump versions instead of four
- `jdx/mise-action` auto-trusts the repo config (`MISE_TRUSTED_CONFIG_PATHS`/`MISE_YES`) and adds mise's shims to `PATH`, so no extra `mise trust` step or logic changes needed downstream
- Verified all 4 workflow files with `actionlint` (no errors)
- Cloudflare Pages deploy (build: `npx turbo docs#build`, deploy: `pnpm wrangler deploy`/`versions upload`) needs no changes — it resolves tools from workspace devDependencies via npx/pnpm and reads Node from `.nvmrc` independently of these workflows

## Test plan
- [ ] `build-test.yml` runs green on this PR (installs deps, builds, tests, coverage)
- [ ] Manually trigger `bump-version.yml` once merged to confirm mise-provisioned pnpm/node work for the release-it flow
- [ ] Watch the next `publish-gh.yml` / `publish-npm.yml` runs on main after merge