### PR TITLE
ci: add dry-run support to release workflows

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -38,6 +38,11 @@ on:
         description: 'GitHub PR branch prefix (default: release/{package}/v)'
         required: false
         type: string
+      dryRun:
+        description: 'Dry run: show the computed version/changelog, skip branch push and PR creation'
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: write
@@ -106,16 +111,20 @@ jobs:
           echo "BUMPED_VERSION=$(pnpm --filter "$PACKAGE" exec release-it --release-version "${INCREMENT_ARGS[@]}")" >> "$GITHUB_ENV"
       - name: Switch branches
         # Create release branch: release/{package}/vX.Y.Z
+        if: ${{ !inputs.dryRun }}
         run: git switch --create "$BRANCH_PREFIX$BUMPED_VERSION"
       - name: Bump version
-        # Actually bump the version in package.json and commit
+        # Actually bump the version in package.json and commit.
+        # --dry-run makes release-it log every git/github/npm write instead of performing it.
         run: |
           pnpm --filter "$PACKAGE" exec \
             release-it \
+              ${{ inputs.dryRun && '--dry-run' || '' }} \
               --increment "$BUMPED_VERSION" \
               --git.commit true \
               --git.push true \
               --git.commitMessage "$(pnpm --silent --filter "$PACKAGE" commit:changelog)"
       - name: Create PR
         # Create PR with auto-generated title and body from commit messages
+        if: ${{ !inputs.dryRun }}
         run: gh pr create --base "$PR_BASE" --head "$BRANCH_PREFIX$BUMPED_VERSION" --fill-verbose

--- a/.github/workflows/publish-gh.yml
+++ b/.github/workflows/publish-gh.yml
@@ -7,6 +7,13 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
+    inputs:
+      dryRun:
+        description: 'Dry run: log the tag/push release-it would perform without creating it'
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: write
@@ -44,6 +51,7 @@ jobs:
         # --no-increment: Don't bump version, tag current version
         # --git.tag true: Create git tag ({package}@X.Y.Z)
         # --git.push true: Push tag to remote, triggering publish-npm workflow
-        run: pnpm --filter ${{ matrix.package }} exec release-it --no-increment --git.tag true --git.push true
+        # inputs.dryRun is only set for manual workflow_dispatch runs; real pushes to main always tag for real.
+        run: pnpm --filter ${{ matrix.package }} exec release-it --no-increment --git.tag true --git.push true ${{ inputs.dryRun && '--dry-run' || '' }}
         # continue-on-error: Tagging is idempotent - if tag exists, we succeed anyway
         continue-on-error: true

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -9,6 +9,20 @@ on:
     tags:
       - 'lit-ui-router@*'
       - 'ui-router-navigation-location-plugin@*'
+  workflow_dispatch:
+    inputs:
+      package:
+        description: 'Package to publish (manual/dry-run testing only; real tag pushes derive this from the tag)'
+        required: true
+        type: choice
+        options:
+          - lit-ui-router
+          - ui-router-navigation-location-plugin
+      dryRun:
+        description: 'Dry run: log the publish/release/attestation release-it would perform without doing it'
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   id-token: write      # Required for OIDC trusted publishing to NPM
@@ -31,8 +45,12 @@ jobs:
           fetch-tags: true
       - name: Extract package info from tag
         run: |
-          TAG="${GITHUB_REF#refs/tags/}"
-          PACKAGE_NAME="${TAG%@*}"
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            PACKAGE_NAME="${{ inputs.package }}"
+          else
+            TAG="${GITHUB_REF#refs/tags/}"
+            PACKAGE_NAME="${TAG%@*}"
+          fi
           echo "$PACKAGE_NAME"
           echo "PACKAGE_NAME=$PACKAGE_NAME" >> "$GITHUB_ENV"
       - name: Setup mise
@@ -57,7 +75,9 @@ jobs:
         # Create tarball for GitHub release attachment
         run: pnpm --filter ${{ env.PACKAGE_NAME }} pack --pack-destination ${{ env.PACKAGE_DIR }}
       - name: Attest build provenance
-        # Generate SLSA provenance attestation for supply chain security
+        # Generate SLSA provenance attestation for supply chain security.
+        # Skipped on manual dry runs: this hits Sigstore/rekor for real and isn't part of release-it's --dry-run.
+        if: ${{ !inputs.dryRun }}
         uses: actions/attest-build-provenance@v3
         with:
           subject-path: '${{ env.PACKAGE_DIR }}/*.tgz'
@@ -67,7 +87,8 @@ jobs:
       - name: Publish
         # Create draft release first - allows uploading assets after create
         # --npm.skipChecks: Skip npm checks since we're using OIDC auth
-        run: pnpm --filter ${{ env.PACKAGE_NAME }} exec -- release-it --no-increment --npm.publish true --npm.skipChecks true --github.release true --github.assets "*.tgz" --github.draft true --git.tagExclude "\${npm.name}@$RELEASE_VERSION"
+        # inputs.dryRun is only set for manual workflow_dispatch runs; real tag pushes always publish for real.
+        run: pnpm --filter ${{ env.PACKAGE_NAME }} exec -- release-it --no-increment --npm.publish true --npm.skipChecks true --github.release true --github.assets "*.tgz" --github.draft true --git.tagExclude "\${npm.name}@$RELEASE_VERSION" ${{ inputs.dryRun && '--dry-run' || '' }}
         # Finalize the GitHub release
       - name: Mark Release as final
-        run: pnpm --filter ${{ env.PACKAGE_NAME }} exec -- release-it --no-increment --github.release true --github.update true --no-github.draft
+        run: pnpm --filter ${{ env.PACKAGE_NAME }} exec -- release-it --no-increment --github.release true --github.update true --no-github.draft ${{ inputs.dryRun && '--dry-run' || '' }}


### PR DESCRIPTION
Stacked on #149 (which is stacked on #146).

## Summary
release-it (used by `bump-version.yml`, `publish-gh.yml`, `publish-npm.yml`) already has a full `--dry-run` mode — verified against the installed source (`node_modules/release-it`):
- `lib/shell.js` skips any "write" command (git commit/tag/push) under `isDryRun`, only logs it
- `lib/plugin/github/GitHub.js` checks `isDryRun` before calling the GitHub API for release create/update
- `lib/plugin/npm/npm.js` passes `--dry-run` through to the underlying `npm publish` call

The workflows just never exposed it. This PR wires it up so you can test the release pipeline end-to-end (including from a feature branch, e.g. to validate the mise-action CI change) without any real git tag, GitHub release, or npm publish:

- **`bump-version.yml`**: new `dryRun` input (default `false`). When true, skips creating/pushing the release branch and opening the PR, and passes `--dry-run` to release-it so you only get the computed version + changelog preview.
- **`publish-gh.yml`**: adds a `workflow_dispatch` trigger (previously push-to-main only) with a `dryRun` input (default `false`), so the tag/push step can be exercised manually without pushing to main. Real pushes to main are unaffected — `inputs.dryRun` is only non-null on `workflow_dispatch`.
- **`publish-npm.yml`**: adds a `workflow_dispatch` trigger (previously tag-push only) with a `package` picker and `dryRun` input (default `false`). Real tag pushes still derive the package name from the tag as before. The build-provenance attestation step (`actions/attest-build-provenance`) is skipped under dry run since it hits Sigstore/rekor for real and isn't covered by release-it's `--dry-run`.

All three keep their existing push/tag-triggered behavior byte-for-byte identical when not manually dispatched with `dryRun: true`.

## Test plan
- [ ] `actionlint` passes on all 3 files (done locally, no errors)
- [ ] Manually dispatch `bump-version.yml` with `dryRun: true` from a branch and confirm it prints the computed version/changelog with no branch/PR created
- [ ] Manually dispatch `publish-gh.yml` with `dryRun: true` and confirm no tag is created/pushed
- [ ] Manually dispatch `publish-npm.yml` with `dryRun: true` and confirm no npm publish, GitHub release, or attestation occurs
- [ ] Confirm a real push to `main` / real tag push still behaves exactly as before (no `--dry-run` leaks in)