### PR TITLE
ci: bump checkout to v5, codecov-action to v7 for node24

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: 'Checkout code'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Setup mise
         uses: jdx/mise-action@v4
       - name: Install dependencies
@@ -49,7 +49,7 @@ jobs:
         with:
           working-directory: packages/navigation-location-plugin
       - name: Upload to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           files: packages/lit-ui-router/coverage/lcov.info,packages/navigation-location-plugin/coverage/lcov.info
           fail_ci_if_error: false

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -66,7 +66,7 @@ jobs:
 
     steps:
       - name: 'Checkout code'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           fetch-tags: true

--- a/.github/workflows/publish-gh.yml
+++ b/.github/workflows/publish-gh.yml
@@ -34,7 +34,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
     steps:
       - name: 'Checkout code'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           fetch-tags: true

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -39,7 +39,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: 'Checkout code'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           fetch-tags: true


### PR DESCRIPTION
## Why

GitHub Actions runners are deprecating Node.js 20; runs currently emit:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/checkout@v4, actions/github-script@60a0d83…

## What

- `actions/checkout` v4 → v5 (node24-native) in all four workflows
- `codecov/codecov-action` v5 → v7 in build-test — the pinned `actions/github-script@60a0d83 # v7.0.1` in the warning comes from *inside* codecov-action v5; v6.0.0's only breaking change was the node24/github-script v8 bump, and v7.0.0 just removed an internal CI workflow, so v5 → v7 is config-compatible

## Verified clean (no change needed)

- `jdx/mise-action@v4` — node24
- `davelosert/vitest-coverage-report-action@v2` — node24 at the v2 tag
- `actions/attest-build-provenance@v3` — composite; both sub-actions (predicate@2.0.0, attest@v3.0.0) are node24