### PR TITLE
ci: add lit-ui-router-mobx to release workflow package lists

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -12,6 +12,7 @@ on:
         type: choice
         options:
           - lit-ui-router
+          - lit-ui-router-mobx
           - ui-router-navigation-location-plugin
         default: 'lit-ui-router'
       increment:

--- a/.github/workflows/publish-gh.yml
+++ b/.github/workflows/publish-gh.yml
@@ -27,6 +27,7 @@ jobs:
       matrix:
         package:
           - lit-ui-router
+          - lit-ui-router-mobx
           - ui-router-navigation-location-plugin
     env:
       # PAT required to push tags that trigger downstream workflows.

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -8,6 +8,7 @@ on:
   push:
     tags:
       - 'lit-ui-router@*'
+      - 'lit-ui-router-mobx@*'
       - 'ui-router-navigation-location-plugin@*'
   workflow_dispatch:
     inputs:
@@ -17,6 +18,7 @@ on:
         type: choice
         options:
           - lit-ui-router
+          - lit-ui-router-mobx
           - ui-router-navigation-location-plugin
       dryRun:
         description: 'Dry run: log the publish/release/attestation release-it would perform without doing it'


### PR DESCRIPTION
Adds `lit-ui-router-mobx` to the three hardcoded package lists:

- `bump-version.yml` dispatch choice options
- `publish-gh.yml` tag matrix
- `publish-npm.yml` tag trigger + dispatch choice options

npm side is already prepared: `lit-ui-router-mobx@0.1.0-rc.0` is seeded and the OIDC trusted publisher (`publish-npm.yml`, environment `publish`) is configured.

⚠️ **Merge order matters**: `publish-gh.yml` tags current versions on every push to main, so merging this immediately tags `lit-ui-router-mobx@0.1.0` and triggers the publish. Land after:

1. #148 (the package itself)
2. the `lit-ui-router` release with public `seekRouter` — so the packed `lit-ui-router` peer range floors at that version instead of `^1.2.5`