### PR TITLE
chore(examples): bump lit-ui-router to ^1.4.0

### DIFF
--- a/examples/hellogalaxy/package.json
+++ b/examples/hellogalaxy/package.json
@@ -12,7 +12,7 @@
     "@uirouter/core": "^6.1.2",
     "@uirouter/visualizer": "^7.2.1",
     "lit": "^3.3.2",
-    "lit-ui-router": "^1.3.0"
+    "lit-ui-router": "^1.4.0"
   },
   "devDependencies": {
     "typescript": "^5.9.3",

--- a/examples/hellosolarsystem/package.json
+++ b/examples/hellosolarsystem/package.json
@@ -12,7 +12,7 @@
     "@uirouter/core": "^6.1.2",
     "@uirouter/visualizer": "^7.2.1",
     "lit": "^3.3.2",
-    "lit-ui-router": "^1.3.0"
+    "lit-ui-router": "^1.4.0"
   },
   "devDependencies": {
     "typescript": "^5.9.3",

--- a/examples/helloworld/package.json
+++ b/examples/helloworld/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@uirouter/core": "^6.1.2",
     "lit": "^3.3.2",
-    "lit-ui-router": "^1.3.0"
+    "lit-ui-router": "^1.4.0"
   },
   "devDependencies": {
     "typescript": "^5.9.3",


### PR DESCRIPTION
Points the three tutorial examples (helloworld, hellosolarsystem, hellogalaxy) at the freshly published lit-ui-router 1.4.0 (widened runtime dep floors: lit ^3.0.0, @uirouter/core ^6.0.8 — see #157/#159).