### PR TITLE
ci: serialize Tag & push runs to stop rollback tag deletion

### DIFF
--- a/.github/workflows/publish-gh.yml
+++ b/.github/workflows/publish-gh.yml
@@ -15,6 +15,12 @@ on:
         default: false
         type: boolean
 
+# Serialize runs: a run that checks out before a sibling run pushes its tag
+# will re-create that tag, get its push rejected, and release-it's rollback
+# then deletes the tag from the remote.
+concurrency:
+  group: tag-release
+
 permissions:
   contents: write
 


### PR DESCRIPTION
## Incident (2026-07-06, releases 1.4.0 / 0.2.0)

Merging #159 and #160 back-to-back triggered two overlapping **Tag & push** runs (each processes all three packages):

1. `04:01` — run A (from #159) pushes `lit-ui-router@1.4.0` → triggers publish-npm
2. `04:03:03` — run B (from #160), whose checkout predates that push, re-creates the same tag; its push is rejected (`reference already exists`)
3. `04:03:04` — release-it's failure **rollback deletes the tag from the remote** (ref deletion isn't restricted by the ruleset); `continue-on-error` masks the failure
4. `04:03:59` — publish-npm run A: npm publish ✔, draft release + assets ✔, then **publish release 422** — the tag is gone and the ruleset blocks the workflow token from re-creating the ref

Result: `lit-ui-router@1.4.0` live on npm, but its GitHub release stuck in draft and the tag missing. (mobx 0.2.0 was unaffected — its tag never hit the race window.)

## Fix

`concurrency: group: tag-release` (queue, no cancellation): serialized runs check out *after* the prior run's tag push, so release-it takes its graceful `WARNING Tag already exists` path (observed working for the nav-plugin leg) instead of create → reject → rollback-delete.

## Remaining manual cleanup (separate from this PR)

Re-create the annotated tag `lit-ui-router@1.4.0` at c771703 and publish draft release 349317655 — with publish-npm.yml temporarily disabled so the tag push doesn't re-trigger a doomed duplicate npm publish (whose failure rollback would delete the tag again).