### PR TITLE
feat(tooling): dts-backtest consumer-floor guard + TypeScript 6.0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,24 @@ pnpm --filter lit-ui-router test
 pnpm --filter sample-app-lit-e2e test
 ```
 
+## TypeScript authoring
+
+The published packages support consumers on **TypeScript 5.0+**, while the
+repo itself builds with a newer TypeScript (pinned in the pnpm catalog).
+The floor constrains only the **public API surface**: whatever appears in
+the emitted `dist/*.d.ts` (exported types, signatures) must be valid under
+TypeScript 5.0. Implementation code may freely use features of the repo's
+current TypeScript — they only matter if they leak into a declaration
+(e.g. `NoInfer<T>` in an exported signature breaks 5.0 consumers; the same
+type inside a function body emits nothing and is fine).
+
+This is enforced in CI by [`tools/dts-backtest`](./tools/dts-backtest/README.md),
+which typechecks the built declarations with TypeScript 5.0.4 and the
+current version, in `bundler` and `NodeNext` resolution modes. If
+`dts-backtest#test` fails on your change, keep the newer-TS construct out
+of the public surface — or raise the floor, which is a semver-major
+discussion (see the tool README).
+
 ## Pull Requests
 
 - Fork PRs won't run CI automatically (secrets aren't available to forks)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -76,8 +76,8 @@ catalogs:
       specifier: ^1.1.3
       version: 1.1.3
     typescript:
-      specifier: ^5.9.3
-      version: 5.9.3
+      specifier: ^6.0.3
+      version: 6.0.3
     vite:
       specifier: ^7.3.6
       version: 7.3.6
@@ -170,10 +170,10 @@ importers:
         version: 2.10.3
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
       typescript-eslint:
         specifier: ^8.62.1
-        version: 8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+        version: 8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
       wrangler:
         specifier: 'catalog:'
         version: 4.107.0
@@ -201,7 +201,7 @@ importers:
         version: 3.0.11
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
       vite:
         specifier: 'catalog:'
         version: 7.3.6(@types/node@25.0.9)(jiti@2.7.0)(yaml@2.9.0)
@@ -238,13 +238,13 @@ importers:
         version: 3.9.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
       vite:
         specifier: 'catalog:'
         version: 7.3.6(@types/node@25.0.9)(jiti@2.7.0)(yaml@2.9.0)
       vite-plugin-checker:
         specifier: 'catalog:'
-        version: 0.14.4(eslint@9.39.4(jiti@2.7.0))(optionator@0.9.4)(typescript@5.9.3)(vite@7.3.6(@types/node@25.0.9)(jiti@2.7.0)(yaml@2.9.0))
+        version: 0.14.4(eslint@9.39.4(jiti@2.7.0))(optionator@0.9.4)(typescript@6.0.3)(vite@7.3.6(@types/node@25.0.9)(jiti@2.7.0)(yaml@2.9.0))
       vite-plugin-static-copy:
         specifier: 'catalog:'
         version: 3.4.0(vite@7.3.6(@types/node@25.0.9)(jiti@2.7.0)(yaml@2.9.0))
@@ -278,13 +278,13 @@ importers:
         version: 3.9.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
       vite:
         specifier: 'catalog:'
         version: 7.3.6(@types/node@25.0.9)(jiti@2.7.0)(yaml@2.9.0)
       vite-plugin-checker:
         specifier: 'catalog:'
-        version: 0.14.4(eslint@9.39.4(jiti@2.7.0))(optionator@0.9.4)(typescript@5.9.3)(vite@7.3.6(@types/node@25.0.9)(jiti@2.7.0)(yaml@2.9.0))
+        version: 0.14.4(eslint@9.39.4(jiti@2.7.0))(optionator@0.9.4)(typescript@6.0.3)(vite@7.3.6(@types/node@25.0.9)(jiti@2.7.0)(yaml@2.9.0))
       vite-plugin-static-copy:
         specifier: 'catalog:'
         version: 3.4.0(vite@7.3.6(@types/node@25.0.9)(jiti@2.7.0)(yaml@2.9.0))
@@ -336,7 +336,7 @@ importers:
         version: 3.9.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
       vite:
         specifier: 'catalog:'
         version: 7.3.6(@types/node@25.0.9)(jiti@2.7.0)(yaml@2.9.0)
@@ -357,14 +357,14 @@ importers:
         version: 6.0.2
       vue:
         specifier: ^3.5.39
-        version: 3.5.39(typescript@5.9.3)
+        version: 3.5.39(typescript@6.0.3)
     devDependencies:
       prettier:
         specifier: 'catalog:'
         version: 3.9.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
       vite:
         specifier: 'catalog:'
         version: 7.3.6(@types/node@25.0.9)(jiti@2.7.0)(yaml@2.9.0)
@@ -373,7 +373,7 @@ importers:
         version: 3.4.0(vite@7.3.6(@types/node@25.0.9)(jiti@2.7.0)(yaml@2.9.0))
       vitepress:
         specifier: ^1.6.4
-        version: 1.6.4(@algolia/client-search@5.55.1)(@types/node@25.0.9)(axios@1.18.1)(change-case@5.4.4)(postcss@8.5.16)(search-insights@2.17.3)(typescript@5.9.3)
+        version: 1.6.4(@algolia/client-search@5.55.1)(@types/node@25.0.9)(axios@1.18.1)(change-case@5.4.4)(postcss@8.5.16)(search-insights@2.17.3)(typescript@6.0.3)
       wrangler:
         specifier: 'catalog:'
         version: 4.107.0
@@ -412,19 +412,19 @@ importers:
         version: 6.1.3
       typedoc:
         specifier: 'catalog:'
-        version: 0.28.19(typescript@5.9.3)
+        version: 0.28.19(typescript@6.0.3)
       typedoc-plugin-lit-ui-router:
         specifier: workspace:*
         version: link:../../tools/typedoc-plugin-lit-ui-router
       typedoc-plugin-markdown:
         specifier: 'catalog:'
-        version: 4.12.0(typedoc@0.28.19(typescript@5.9.3))
+        version: 4.12.0(typedoc@0.28.19(typescript@6.0.3))
       typedoc-vitepress-theme:
         specifier: 'catalog:'
-        version: 1.1.3(typedoc-plugin-markdown@4.12.0(typedoc@0.28.19(typescript@5.9.3)))
+        version: 1.1.3(typedoc-plugin-markdown@4.12.0(typedoc@0.28.19(typescript@6.0.3)))
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
       vitest:
         specifier: 'catalog:'
         version: 4.1.9(@types/node@25.0.9)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(vite@7.3.6(@types/node@25.0.9)(jiti@2.7.0)(yaml@2.9.0))
@@ -463,19 +463,19 @@ importers:
         version: 6.1.3
       typedoc:
         specifier: 'catalog:'
-        version: 0.28.19(typescript@5.9.3)
+        version: 0.28.19(typescript@6.0.3)
       typedoc-plugin-lit-ui-router:
         specifier: workspace:*
         version: link:../../tools/typedoc-plugin-lit-ui-router
       typedoc-plugin-markdown:
         specifier: 'catalog:'
-        version: 4.12.0(typedoc@0.28.19(typescript@5.9.3))
+        version: 4.12.0(typedoc@0.28.19(typescript@6.0.3))
       typedoc-vitepress-theme:
         specifier: 'catalog:'
-        version: 1.1.3(typedoc-plugin-markdown@4.12.0(typedoc@0.28.19(typescript@5.9.3)))
+        version: 1.1.3(typedoc-plugin-markdown@4.12.0(typedoc@0.28.19(typescript@6.0.3)))
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
       vitest:
         specifier: 'catalog:'
         version: 4.1.9(@types/node@25.0.9)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(vite@7.3.6(@types/node@25.0.9)(jiti@2.7.0)(yaml@2.9.0))
@@ -508,22 +508,52 @@ importers:
         version: 6.1.3
       typedoc:
         specifier: 'catalog:'
-        version: 0.28.19(typescript@5.9.3)
+        version: 0.28.19(typescript@6.0.3)
       typedoc-plugin-lit-ui-router:
         specifier: workspace:*
         version: link:../../tools/typedoc-plugin-lit-ui-router
       typedoc-plugin-markdown:
         specifier: 'catalog:'
-        version: 4.12.0(typedoc@0.28.19(typescript@5.9.3))
+        version: 4.12.0(typedoc@0.28.19(typescript@6.0.3))
       typedoc-vitepress-theme:
         specifier: 'catalog:'
-        version: 1.1.3(typedoc-plugin-markdown@4.12.0(typedoc@0.28.19(typescript@5.9.3)))
+        version: 1.1.3(typedoc-plugin-markdown@4.12.0(typedoc@0.28.19(typescript@6.0.3)))
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
       vitest:
         specifier: 'catalog:'
         version: 4.1.9(@types/node@25.0.9)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(vite@7.3.6(@types/node@25.0.9)(jiti@2.7.0)(yaml@2.9.0))
+
+  tools/dts-backtest:
+    devDependencies:
+      '@types/dom-navigation':
+        specifier: 'catalog:'
+        version: 1.0.7
+      '@uirouter/core':
+        specifier: 'catalog:'
+        version: 6.1.2
+      lit:
+        specifier: 'catalog:'
+        version: 3.3.3
+      lit-ui-router:
+        specifier: workspace:*
+        version: link:../../packages/lit-ui-router
+      lit-ui-router-mobx:
+        specifier: workspace:*
+        version: link:../../packages/lit-ui-router-mobx
+      mobx:
+        specifier: 'catalog:'
+        version: 6.16.1
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      typescript-5.0:
+        specifier: npm:typescript@5.0.4
+        version: typescript@5.0.4
+      ui-router-navigation-location-plugin:
+        specifier: workspace:*
+        version: link:../../packages/navigation-location-plugin
 
   tools/typedoc-plugin-lit-ui-router:
     devDependencies:
@@ -532,10 +562,10 @@ importers:
         version: 22.20.0
       typedoc:
         specifier: 'catalog:'
-        version: 0.28.19(typescript@5.9.3)
+        version: 0.28.19(typescript@6.0.3)
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
 
 packages:
 
@@ -4150,13 +4180,18 @@ packages:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
+  typescript@5.0.4:
+    resolution: {integrity: sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==}
+    engines: {node: '>=12.20'}
+    hasBin: true
+
   typescript@5.4.5:
     resolution: {integrity: sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==}
     engines: {node: '>=14.17'}
     hasBin: true
 
-  typescript@5.9.3:
-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -5711,40 +5746,40 @@ snapshots:
 
   '@types/web-bluetooth@0.0.21': {}
 
-  '@typescript-eslint/eslint-plugin@8.62.1(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@8.62.1(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
       '@typescript-eslint/scope-manager': 8.62.1
-      '@typescript-eslint/type-utils': 8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/type-utils': 8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
       '@typescript-eslint/visitor-keys': 8.62.1
       eslint: 9.39.4(jiti@2.7.0)
       ignore: 7.0.5
       natural-compare: 1.4.0
-      ts-api-utils: 2.5.0(typescript@5.9.3)
-      typescript: 5.9.3
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)':
+  '@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.62.1
       '@typescript-eslint/types': 8.62.1
-      '@typescript-eslint/typescript-estree': 8.62.1(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.62.1(typescript@6.0.3)
       '@typescript-eslint/visitor-keys': 8.62.1
       debug: 4.4.3(supports-color@8.1.1)
       eslint: 9.39.4(jiti@2.7.0)
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.62.1(typescript@5.9.3)':
+  '@typescript-eslint/project-service@8.62.1(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.62.1(typescript@5.9.3)
+      '@typescript-eslint/tsconfig-utils': 8.62.1(typescript@6.0.3)
       '@typescript-eslint/types': 8.62.1
       debug: 4.4.3(supports-color@8.1.1)
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
@@ -5753,47 +5788,47 @@ snapshots:
       '@typescript-eslint/types': 8.62.1
       '@typescript-eslint/visitor-keys': 8.62.1
 
-  '@typescript-eslint/tsconfig-utils@8.62.1(typescript@5.9.3)':
+  '@typescript-eslint/tsconfig-utils@8.62.1(typescript@6.0.3)':
     dependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
 
-  '@typescript-eslint/type-utils@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)':
+  '@typescript-eslint/type-utils@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/types': 8.62.1
-      '@typescript-eslint/typescript-estree': 8.62.1(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.62.1(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
       debug: 4.4.3(supports-color@8.1.1)
       eslint: 9.39.4(jiti@2.7.0)
-      ts-api-utils: 2.5.0(typescript@5.9.3)
-      typescript: 5.9.3
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
   '@typescript-eslint/types@8.62.1': {}
 
-  '@typescript-eslint/typescript-estree@8.62.1(typescript@5.9.3)':
+  '@typescript-eslint/typescript-estree@8.62.1(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.62.1(typescript@5.9.3)
-      '@typescript-eslint/tsconfig-utils': 8.62.1(typescript@5.9.3)
+      '@typescript-eslint/project-service': 8.62.1(typescript@6.0.3)
+      '@typescript-eslint/tsconfig-utils': 8.62.1(typescript@6.0.3)
       '@typescript-eslint/types': 8.62.1
       '@typescript-eslint/visitor-keys': 8.62.1
       debug: 4.4.3(supports-color@8.1.1)
       minimatch: 10.2.5
       semver: 7.8.5
       tinyglobby: 0.2.17
-      ts-api-utils: 2.5.0(typescript@5.9.3)
-      typescript: 5.9.3
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)':
+  '@typescript-eslint/utils@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.7.0))
       '@typescript-eslint/scope-manager': 8.62.1
       '@typescript-eslint/types': 8.62.1
-      '@typescript-eslint/typescript-estree': 8.62.1(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.62.1(typescript@6.0.3)
       eslint: 9.39.4(jiti@2.7.0)
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
@@ -5821,10 +5856,10 @@ snapshots:
 
   '@ungap/structured-clone@1.3.2': {}
 
-  '@vitejs/plugin-vue@5.2.4(vite@5.4.21(@types/node@25.0.9))(vue@3.5.39(typescript@5.9.3))':
+  '@vitejs/plugin-vue@5.2.4(vite@5.4.21(@types/node@25.0.9))(vue@3.5.39(typescript@6.0.3))':
     dependencies:
       vite: 5.4.21(@types/node@25.0.9)
-      vue: 3.5.39(typescript@5.9.3)
+      vue: 3.5.39(typescript@6.0.3)
 
   '@vitest/browser-playwright@4.1.9(playwright@1.61.1)(vite@7.3.6(@types/node@25.0.9)(jiti@2.7.0)(yaml@2.9.0))(vitest@4.1.9)':
     dependencies:
@@ -5977,28 +6012,28 @@ snapshots:
       '@vue/shared': 3.5.39
       csstype: 3.2.3
 
-  '@vue/server-renderer@3.5.39(vue@3.5.39(typescript@5.9.3))':
+  '@vue/server-renderer@3.5.39(vue@3.5.39(typescript@6.0.3))':
     dependencies:
       '@vue/compiler-ssr': 3.5.39
       '@vue/shared': 3.5.39
-      vue: 3.5.39(typescript@5.9.3)
+      vue: 3.5.39(typescript@6.0.3)
 
   '@vue/shared@3.5.39': {}
 
-  '@vueuse/core@12.8.2(typescript@5.9.3)':
+  '@vueuse/core@12.8.2(typescript@6.0.3)':
     dependencies:
       '@types/web-bluetooth': 0.0.21
       '@vueuse/metadata': 12.8.2
-      '@vueuse/shared': 12.8.2(typescript@5.9.3)
-      vue: 3.5.39(typescript@5.9.3)
+      '@vueuse/shared': 12.8.2(typescript@6.0.3)
+      vue: 3.5.39(typescript@6.0.3)
     transitivePeerDependencies:
       - typescript
 
-  '@vueuse/integrations@12.8.2(axios@1.18.1)(change-case@5.4.4)(focus-trap@7.8.0)(typescript@5.9.3)':
+  '@vueuse/integrations@12.8.2(axios@1.18.1)(change-case@5.4.4)(focus-trap@7.8.0)(typescript@6.0.3)':
     dependencies:
-      '@vueuse/core': 12.8.2(typescript@5.9.3)
-      '@vueuse/shared': 12.8.2(typescript@5.9.3)
-      vue: 3.5.39(typescript@5.9.3)
+      '@vueuse/core': 12.8.2(typescript@6.0.3)
+      '@vueuse/shared': 12.8.2(typescript@6.0.3)
+      vue: 3.5.39(typescript@6.0.3)
     optionalDependencies:
       axios: 1.18.1(debug@4.4.3)
       change-case: 5.4.4
@@ -6008,9 +6043,9 @@ snapshots:
 
   '@vueuse/metadata@12.8.2': {}
 
-  '@vueuse/shared@12.8.2(typescript@5.9.3)':
+  '@vueuse/shared@12.8.2(typescript@6.0.3)':
     dependencies:
-      vue: 3.5.39(typescript@5.9.3)
+      vue: 3.5.39(typescript@6.0.3)
     transitivePeerDependencies:
       - typescript
 
@@ -8145,9 +8180,9 @@ snapshots:
 
   trim-lines@3.0.1: {}
 
-  ts-api-utils@2.5.0(typescript@5.9.3):
+  ts-api-utils@2.5.0(typescript@6.0.3):
     dependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
 
   tslib@1.14.1: {}
 
@@ -8176,37 +8211,39 @@ snapshots:
 
   type-fest@2.19.0: {}
 
-  typedoc-plugin-markdown@4.12.0(typedoc@0.28.19(typescript@5.9.3)):
+  typedoc-plugin-markdown@4.12.0(typedoc@0.28.19(typescript@6.0.3)):
     dependencies:
-      typedoc: 0.28.19(typescript@5.9.3)
+      typedoc: 0.28.19(typescript@6.0.3)
 
-  typedoc-vitepress-theme@1.1.3(typedoc-plugin-markdown@4.12.0(typedoc@0.28.19(typescript@5.9.3))):
+  typedoc-vitepress-theme@1.1.3(typedoc-plugin-markdown@4.12.0(typedoc@0.28.19(typescript@6.0.3))):
     dependencies:
-      typedoc-plugin-markdown: 4.12.0(typedoc@0.28.19(typescript@5.9.3))
+      typedoc-plugin-markdown: 4.12.0(typedoc@0.28.19(typescript@6.0.3))
 
-  typedoc@0.28.19(typescript@5.9.3):
+  typedoc@0.28.19(typescript@6.0.3):
     dependencies:
       '@gerrit0/mini-shiki': 3.23.0
       lunr: 2.3.9
       markdown-it: 14.3.0
       minimatch: 10.2.5
-      typescript: 5.9.3
+      typescript: 6.0.3
       yaml: 2.9.0
 
-  typescript-eslint@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3):
+  typescript-eslint@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.62.1(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
-      '@typescript-eslint/parser': 8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
-      '@typescript-eslint/typescript-estree': 8.62.1(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/eslint-plugin': 8.62.1(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
+      '@typescript-eslint/typescript-estree': 8.62.1(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
       eslint: 9.39.4(jiti@2.7.0)
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
+  typescript@5.0.4: {}
+
   typescript@5.4.5: {}
 
-  typescript@5.9.3: {}
+  typescript@6.0.3: {}
 
   typical@4.0.0: {}
 
@@ -8283,7 +8320,7 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite-plugin-checker@0.14.4(eslint@9.39.4(jiti@2.7.0))(optionator@0.9.4)(typescript@5.9.3)(vite@7.3.6(@types/node@25.0.9)(jiti@2.7.0)(yaml@2.9.0)):
+  vite-plugin-checker@0.14.4(eslint@9.39.4(jiti@2.7.0))(optionator@0.9.4)(typescript@6.0.3)(vite@7.3.6(@types/node@25.0.9)(jiti@2.7.0)(yaml@2.9.0)):
     dependencies:
       '@babel/code-frame': 7.29.7
       chokidar: 5.0.0
@@ -8296,7 +8333,7 @@ snapshots:
     optionalDependencies:
       eslint: 9.39.4(jiti@2.7.0)
       optionator: 0.9.4
-      typescript: 5.9.3
+      typescript: 6.0.3
 
   vite-plugin-static-copy@3.4.0(vite@7.3.6(@types/node@25.0.9)(jiti@2.7.0)(yaml@2.9.0)):
     dependencies:
@@ -8329,7 +8366,7 @@ snapshots:
       jiti: 2.7.0
       yaml: 2.9.0
 
-  vitepress@1.6.4(@algolia/client-search@5.55.1)(@types/node@25.0.9)(axios@1.18.1)(change-case@5.4.4)(postcss@8.5.16)(search-insights@2.17.3)(typescript@5.9.3):
+  vitepress@1.6.4(@algolia/client-search@5.55.1)(@types/node@25.0.9)(axios@1.18.1)(change-case@5.4.4)(postcss@8.5.16)(search-insights@2.17.3)(typescript@6.0.3):
     dependencies:
       '@docsearch/css': 3.8.2
       '@docsearch/js': 3.8.2(@algolia/client-search@5.55.1)(search-insights@2.17.3)
@@ -8338,17 +8375,17 @@ snapshots:
       '@shikijs/transformers': 2.5.0
       '@shikijs/types': 2.5.0
       '@types/markdown-it': 14.1.2
-      '@vitejs/plugin-vue': 5.2.4(vite@5.4.21(@types/node@25.0.9))(vue@3.5.39(typescript@5.9.3))
+      '@vitejs/plugin-vue': 5.2.4(vite@5.4.21(@types/node@25.0.9))(vue@3.5.39(typescript@6.0.3))
       '@vue/devtools-api': 7.7.10
       '@vue/shared': 3.5.39
-      '@vueuse/core': 12.8.2(typescript@5.9.3)
-      '@vueuse/integrations': 12.8.2(axios@1.18.1)(change-case@5.4.4)(focus-trap@7.8.0)(typescript@5.9.3)
+      '@vueuse/core': 12.8.2(typescript@6.0.3)
+      '@vueuse/integrations': 12.8.2(axios@1.18.1)(change-case@5.4.4)(focus-trap@7.8.0)(typescript@6.0.3)
       focus-trap: 7.8.0
       mark.js: 8.11.1
       minisearch: 7.2.0
       shiki: 2.5.0
       vite: 5.4.21(@types/node@25.0.9)
-      vue: 3.5.39(typescript@5.9.3)
+      vue: 3.5.39(typescript@6.0.3)
     optionalDependencies:
       postcss: 8.5.16
     transitivePeerDependencies:
@@ -8407,15 +8444,15 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
-  vue@3.5.39(typescript@5.9.3):
+  vue@3.5.39(typescript@6.0.3):
     dependencies:
       '@vue/compiler-dom': 3.5.39
       '@vue/compiler-sfc': 3.5.39
       '@vue/runtime-dom': 3.5.39
-      '@vue/server-renderer': 3.5.39(vue@3.5.39(typescript@5.9.3))
+      '@vue/server-renderer': 3.5.39(vue@3.5.39(typescript@6.0.3))
       '@vue/shared': 3.5.39
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
 
   wait-on@9.0.10(debug@4.4.3):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -29,7 +29,7 @@ catalog:
   typedoc: ^0.28.19
   typedoc-plugin-markdown: ^4.12.0
   typedoc-vitepress-theme: ^1.1.3
-  typescript: ^5.9.3
+  typescript: ^6.0.3
   vite: ^7.3.6
   vite-plugin-checker: ^0.14.4
   vite-plugin-static-copy: ^3.4.0

--- a/tools/dts-backtest/README.md
+++ b/tools/dts-backtest/README.md
@@ -22,14 +22,32 @@ mobx, `@uirouter/core`, `lib.dom`) are counted but tolerated, matching what
 a consumer running `skipLibCheck: true` would experience while still holding
 our own declarations to the strict bar.
 
+Every run starts with a **self-test** proving the harness can fail: it
+injects a `NoInfer<>` probe (TypeScript 5.4+ syntax) into a dist `.d.ts`,
+asserts the floor version rejects it and the current version accepts it,
+then restores the file. A green matrix therefore can't be the result of a
+broken diagnostic filter silently classifying everything as third-party.
+
 ## Running
 
 ```sh
 turbo run test --filter=dts-backtest   # builds the packages first
 ```
 
+## Authoring rule for the published packages
+
+The floor constrains only what surfaces in the emitted `dist/*.d.ts` —
+public API signatures and exported types. Implementation code may use any
+feature of the repo's current TypeScript; a newer-TS construct is only a
+problem when it leaks into a declaration (e.g. `NoInfer<T>` in an exported
+signature). When `dts-backtest#test` fails on your change, either keep the
+construct out of the public surface, or you are proposing a floor raise —
+see below.
+
 ## Raising the floor
 
 Bumping the supported consumer floor is a semver-major signal for the
 published packages: change the `typescript-5.0` devDependency alias (and
-`VERSIONS` in `run.mjs`) and rename accordingly.
+`VERSIONS` in `run.mjs`) and rename accordingly. If the new floor is ≥ 5.4
+the self-test's `NoInfer` probe no longer discriminates — swap it for a
+construct the new floor still rejects.

--- a/tools/dts-backtest/README.md
+++ b/tools/dts-backtest/README.md
@@ -1,0 +1,35 @@
+# dts-backtest
+
+Backtests the published packages' declaration output against the oldest
+TypeScript a consumer might use, so this repo's own TypeScript can be
+upgraded without raising the `.d.ts` floor for consumers.
+
+## What it checks
+
+`run.mjs` typechecks the [consumer fixtures](./fixtures) — real-world usage
+of `lit-ui-router`, `lit-ui-router-mobx`, and
+`ui-router-navigation-location-plugin` — under a matrix of:
+
+- **TypeScript versions**: the pinned floor (`typescript-5.0` → 5.0.4) and
+  the repo's current catalog version
+- **module resolution modes**: `bundler` and `NodeNext`
+
+The fixture compiles with `skipLibCheck: false`, so the packages' built
+`dist/*.d.ts` are themselves fully parsed **and** typechecked under each
+version — new declaration-emit syntax that an older TypeScript cannot handle
+fails the run. Diagnostics originating in third-party declarations (lit,
+mobx, `@uirouter/core`, `lib.dom`) are counted but tolerated, matching what
+a consumer running `skipLibCheck: true` would experience while still holding
+our own declarations to the strict bar.
+
+## Running
+
+```sh
+turbo run test --filter=dts-backtest   # builds the packages first
+```
+
+## Raising the floor
+
+Bumping the supported consumer floor is a semver-major signal for the
+published packages: change the `typescript-5.0` devDependency alias (and
+`VERSIONS` in `run.mjs`) and rename accordingly.

--- a/tools/dts-backtest/fixtures/lit-ui-router-mobx.ts
+++ b/tools/dts-backtest/fixtures/lit-ui-router-mobx.ts
@@ -1,0 +1,34 @@
+import { html, LitElement, type TemplateResult } from 'lit';
+import { comparer } from 'mobx';
+import { UIRouterLit } from 'lit-ui-router';
+import {
+  ReactionController,
+  RouterReactionController,
+  RouterStore,
+  type ReactionControllerOptions,
+  type RouterReactionControllerOptions,
+} from 'lit-ui-router-mobx';
+
+const structural: ReactionControllerOptions<string | undefined> = {
+  equals: comparer.structural,
+  onChange: (value) => void value,
+};
+
+export class NavElement extends LitElement {
+  private store = RouterStore.for(new UIRouterLit());
+
+  private stateName = new RouterReactionController(
+    this,
+    (store: RouterStore) => store.current?.name,
+    structural satisfies RouterReactionControllerOptions<string | undefined>,
+  );
+
+  private params = new ReactionController(this, () => this.store.params, {
+    equals: comparer.structural,
+  });
+
+  render(): TemplateResult {
+    const transition = this.stateName.store?.transition;
+    return html`${this.stateName.value} ${this.params.value.id} ${transition}`;
+  }
+}

--- a/tools/dts-backtest/fixtures/lit-ui-router.ts
+++ b/tools/dts-backtest/fixtures/lit-ui-router.ts
@@ -1,0 +1,107 @@
+import { html, LitElement, type TemplateResult } from 'lit';
+import {
+  pushStateLocationPlugin,
+  type HookResult,
+  type RawParams,
+  type Transition,
+} from '@uirouter/core';
+import {
+  TransitionController,
+  UIRouterLit,
+  UIRouterLitElement,
+  UiView,
+  mergeSrefStatus,
+  uiSref,
+  uiSrefActive,
+  uiSrefTargetEvent,
+  type LitStateDeclaration,
+  type RoutedLitTemplate,
+  type SrefStatus,
+  type TransitionCallback,
+  type UIViewInjectedProps,
+  type UiOnExit,
+  type UiOnParamsChanged,
+  type UiRouterContextEvent,
+} from 'lit-ui-router';
+
+interface UserResolves {
+  user: { name: string };
+}
+
+export const userTemplate = (props?: UIViewInjectedProps<UserResolves>) => html`
+  <h1>${props?.resolves.user.name}</h1>
+  <a ${uiSref('home', { id: 1 })}>home</a>
+  <nav ${uiSrefActive({ activeClasses: ['active'], exactClasses: ['exact'] })}>
+    <a ${uiSref('user.detail')}>detail</a>
+  </nav>
+`;
+
+const onTransition: TransitionCallback = (transition, reason) => {
+  void transition?.params();
+  void reason;
+};
+
+export class UserElement
+  extends LitElement
+  implements UiOnParamsChanged, UiOnExit
+{
+  static sticky = true;
+
+  _uiViewProps: UIViewInjectedProps<UserResolves>;
+
+  private transitions = new TransitionController(this, {
+    events: ['onSuccess', 'onError'],
+    callback: onTransition,
+  });
+
+  constructor(props: UIViewInjectedProps<UserResolves>) {
+    super();
+    this._uiViewProps = props;
+  }
+
+  uiOnParamsChanged(newParams: RawParams, trans?: Transition): void {
+    void newParams;
+    void trans;
+  }
+
+  uiCanExit(): HookResult {
+    return this.transitions !== undefined;
+  }
+
+  render(): TemplateResult {
+    return html`<h1>${this._uiViewProps.resolves.user.name}</h1>`;
+  }
+}
+
+userTemplate satisfies RoutedLitTemplate<UserResolves>;
+
+export const states: LitStateDeclaration<UserResolves>[] = [
+  { name: 'home', url: '/', component: () => html`<h1>Home</h1>` },
+  { name: 'user', url: '/user/:id', component: UserElement },
+  { name: 'user.detail', component: userTemplate },
+];
+
+export function setupRouter(): UIRouterLit {
+  const router = new UIRouterLit();
+  router.plugin(pushStateLocationPlugin);
+  states.forEach((state) => router.stateRegistry.register(state));
+  router.start();
+  return router;
+}
+
+export function elements(root: Element): void {
+  const uiRouter: UIRouterLitElement = new UIRouterLitElement();
+  const uiView: UiView = new UiView();
+  root.append(uiRouter, uiView);
+  root.addEventListener('ui-router-context', (event) => {
+    const contextEvent = event as UiRouterContextEvent;
+    void contextEvent.detail;
+  });
+  root.dispatchEvent(
+    uiSrefTargetEvent(setupRouter().stateService.target('home')),
+  );
+}
+
+export function merge(a: SrefStatus, b: SrefStatus): SrefStatus {
+  return mergeSrefStatus(a, b);
+}

--- a/tools/dts-backtest/fixtures/navigation-location-plugin.ts
+++ b/tools/dts-backtest/fixtures/navigation-location-plugin.ts
@@ -1,0 +1,23 @@
+import { UIRouter } from '@uirouter/core';
+import {
+  isUIRouterNavigateEvent,
+  navigationLocationPlugin,
+  type NavigationLocationService,
+  type UIRouterNavigateEvent,
+  type UIRouterNavigateInfo,
+} from 'ui-router-navigation-location-plugin';
+
+export function setupNavigation(router: UIRouter): NavigationLocationService {
+  router.plugin(navigationLocationPlugin);
+  const { service } = navigationLocationPlugin(router);
+
+  window.navigation.addEventListener('navigate', (event: NavigateEvent) => {
+    if (isUIRouterNavigateEvent(event)) {
+      const navigateEvent: UIRouterNavigateEvent = event;
+      const info: UIRouterNavigateInfo = navigateEvent.info;
+      void info.uiRouter.stateService;
+    }
+  });
+
+  return service as NavigationLocationService;
+}

--- a/tools/dts-backtest/package.json
+++ b/tools/dts-backtest/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "dts-backtest",
+  "description": "Typechecks the published packages' built .d.ts with the oldest supported consumer TypeScript",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "format": "prettier --write \"**/*.{ts,js,mjs,json,md}\"",
+    "format:check": "prettier --check \"**/*.{ts,js,mjs,json,md}\"",
+    "lint": "eslint .",
+    "test": "node run.mjs"
+  },
+  "devDependencies": {
+    "@types/dom-navigation": "catalog:",
+    "@uirouter/core": "catalog:",
+    "lit": "catalog:",
+    "lit-ui-router": "workspace:*",
+    "lit-ui-router-mobx": "workspace:*",
+    "mobx": "catalog:",
+    "typescript": "catalog:",
+    "typescript-5.0": "npm:typescript@5.0.4",
+    "ui-router-navigation-location-plugin": "workspace:*"
+  }
+}

--- a/tools/dts-backtest/run.mjs
+++ b/tools/dts-backtest/run.mjs
@@ -1,0 +1,115 @@
+#!/usr/bin/env node
+// Backtests the published packages' declaration output: typechecks the
+// consumer fixtures (and, via skipLibCheck:false, the packages' dist/*.d.ts)
+// under each TypeScript version a consumer might use — most importantly the
+// oldest supported one — so the repo's own TypeScript can move ahead without
+// raising the floor for consumers.
+//
+// A diagnostic fails the run only if it originates in a fixture file or in a
+// dist/*.d.ts of one of the packages under test; diagnostics from third-party
+// declarations (lit, mobx, @uirouter/core, lib.dom, …) are counted and
+// reported but tolerated, matching what a consumer with skipLibCheck:true
+// would experience while still fully checking OUR declarations.
+
+import { createRequire } from 'node:module';
+import { dirname, join, resolve, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const require = createRequire(import.meta.url);
+
+// devDependency aliases; "typescript" is the repo's current catalog version.
+const VERSIONS = ['typescript-5.0', 'typescript'];
+
+const CONFIGS = ['tsconfig.fixture.json', 'tsconfig.fixture.nodenext.json'];
+
+// dist dirs whose .d.ts must check clean (pnpm symlinks resolve to these)
+const PACKAGE_DIRS = [
+  'lit-ui-router',
+  'lit-ui-router-mobx',
+  'navigation-location-plugin',
+].map((dir) => resolve(here, '..', '..', 'packages', dir, 'dist') + sep);
+
+function loadConfig(ts, configFile) {
+  let fatal;
+  const host = {
+    ...ts.sys,
+    onUnRecoverableConfigFileDiagnostic: (diagnostic) => {
+      fatal = ts.flattenDiagnosticMessageText(diagnostic.messageText, '\n');
+    },
+  };
+  const parsed = ts.getParsedCommandLineOfConfigFile(
+    join(here, configFile),
+    undefined,
+    host,
+  );
+  if (!parsed || fatal) {
+    throw new Error(`failed to parse ${configFile}: ${fatal ?? 'unknown'}`);
+  }
+  return parsed;
+}
+
+function ownedBy(ts, fileName) {
+  const real = ts.sys.realpath ? ts.sys.realpath(fileName) : fileName;
+  const normalized = resolve(real);
+  if (normalized.startsWith(here + sep)) return true;
+  return PACKAGE_DIRS.some((dir) => normalized.startsWith(dir));
+}
+
+function run(specifier, configFile) {
+  const ts = require(specifier);
+  const parsed = loadConfig(ts, configFile);
+  const program = ts.createProgram({
+    rootNames: parsed.fileNames,
+    options: parsed.options,
+  });
+
+  // guard: the packages under test must actually be in the program (built)
+  const files = program.getSourceFiles().map((file) => file.fileName);
+  const missing = PACKAGE_DIRS.filter(
+    (dir) =>
+      !files.some((file) =>
+        resolve(ts.sys.realpath ? ts.sys.realpath(file) : file).startsWith(dir),
+      ),
+  );
+  if (missing.length > 0) {
+    throw new Error(
+      `dist .d.ts missing from program (run \`turbo run build\` first):\n  ${missing.join('\n  ')}`,
+    );
+  }
+
+  const diagnostics = ts.getPreEmitDiagnostics(program);
+  const owned = [];
+  let foreign = 0;
+  for (const diagnostic of diagnostics) {
+    if (!diagnostic.file || ownedBy(ts, diagnostic.file.fileName)) {
+      owned.push(diagnostic);
+    } else {
+      foreign += 1;
+    }
+  }
+
+  const label = `TS ${ts.version} · ${configFile}`;
+  if (owned.length > 0) {
+    const formatHost = {
+      getCurrentDirectory: () => here,
+      getCanonicalFileName: (fileName) => fileName,
+      getNewLine: () => '\n',
+    };
+    console.error(`✖ ${label}`);
+    console.error(ts.formatDiagnosticsWithColorAndContext(owned, formatHost));
+    return false;
+  }
+  const foreignNote =
+    foreign > 0 ? ` (${foreign} third-party diagnostics ignored)` : '';
+  console.log(`✔ ${label} — ${files.length} files checked${foreignNote}`);
+  return true;
+}
+
+let ok = true;
+for (const specifier of VERSIONS) {
+  for (const configFile of CONFIGS) {
+    ok = run(specifier, configFile) && ok;
+  }
+}
+process.exit(ok ? 0 : 1);

--- a/tools/dts-backtest/run.mjs
+++ b/tools/dts-backtest/run.mjs
@@ -11,6 +11,7 @@
 // reported but tolerated, matching what a consumer with skipLibCheck:true
 // would experience while still fully checking OUR declarations.
 
+import { readFileSync, writeFileSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import { dirname, join, resolve, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -56,7 +57,7 @@ function ownedBy(ts, fileName) {
   return PACKAGE_DIRS.some((dir) => normalized.startsWith(dir));
 }
 
-function run(specifier, configFile) {
+function check(specifier, configFile) {
   const ts = require(specifier);
   const parsed = loadConfig(ts, configFile);
   const program = ts.createProgram({
@@ -89,6 +90,12 @@ function run(specifier, configFile) {
     }
   }
 
+  return { ts, owned, foreign, fileCount: files.length };
+}
+
+function run(specifier, configFile) {
+  const { ts, owned, foreign, fileCount } = check(specifier, configFile);
+
   const label = `TS ${ts.version} · ${configFile}`;
   if (owned.length > 0) {
     const formatHost = {
@@ -102,11 +109,50 @@ function run(specifier, configFile) {
   }
   const foreignNote =
     foreign > 0 ? ` (${foreign} third-party diagnostics ignored)` : '';
-  console.log(`✔ ${label} — ${files.length} files checked${foreignNote}`);
+  console.log(`✔ ${label} — ${fileCount} files checked${foreignNote}`);
   return true;
 }
 
-let ok = true;
+// Self-test: prove the harness can fail. Injects a NoInfer<> probe (TS 5.4+
+// syntax) into a dist .d.ts, then asserts the floor leg rejects it and the
+// current leg accepts it. Guards against a filter/ownership bug that would
+// classify everything as third-party and stay green forever. If the floor is
+// ever raised past 5.4, this fails loudly — pick a newer-syntax probe.
+const PROBE = '\nexport type __dtsBacktestProbe = NoInfer<string>;\n';
+
+function selftest() {
+  const [floor, current] = VERSIONS;
+  const target = join(PACKAGE_DIRS[0], 'index.d.ts');
+  const original = readFileSync(target, 'utf8');
+  writeFileSync(target, original + PROBE);
+  try {
+    const floorRun = check(floor, CONFIGS[0]);
+    const probeCaught = floorRun.owned.some((diagnostic) =>
+      diagnostic.file?.fileName.endsWith('index.d.ts'),
+    );
+    if (!probeCaught) {
+      console.error(
+        `✖ selftest — TS ${floorRun.ts.version} did not reject the NoInfer probe in ${target}`,
+      );
+      return false;
+    }
+    const currentRun = check(current, CONFIGS[0]);
+    if (currentRun.owned.length > 0) {
+      console.error(
+        `✖ selftest — TS ${currentRun.ts.version} unexpectedly rejected the NoInfer probe`,
+      );
+      return false;
+    }
+    console.log(
+      `✔ selftest — floor TS ${floorRun.ts.version} rejects the probe, current TS ${currentRun.ts.version} accepts it`,
+    );
+    return true;
+  } finally {
+    writeFileSync(target, original);
+  }
+}
+
+let ok = selftest();
 for (const specifier of VERSIONS) {
   for (const configFile of CONFIGS) {
     ok = run(specifier, configFile) && ok;

--- a/tools/dts-backtest/tsconfig.fixture.json
+++ b/tools/dts-backtest/tsconfig.fixture.json
@@ -1,0 +1,17 @@
+{
+  // Simulates a consumer project: fixtures import the built dist of the
+  // published packages. skipLibCheck is OFF so the packages' .d.ts are fully
+  // checked under each TypeScript version; run.mjs filters out diagnostics
+  // from third-party declarations.
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "types": ["dom-navigation"],
+    "strict": true,
+    "skipLibCheck": false,
+    "noEmit": true
+  },
+  "include": ["fixtures/**/*.ts"]
+}

--- a/tools/dts-backtest/tsconfig.fixture.nodenext.json
+++ b/tools/dts-backtest/tsconfig.fixture.nodenext.json
@@ -1,0 +1,8 @@
+{
+  // Same consumer fixture under node16/nodenext resolution (no bundler).
+  "extends": "./tsconfig.fixture.json",
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext"
+  }
+}

--- a/tools/dts-backtest/tsconfig.json
+++ b/tools/dts-backtest/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  // For eslint/IDE tooling only; run.mjs drives the tsconfig.fixture*.json matrix.
+  "extends": "./tsconfig.fixture.json"
+}

--- a/tools/typedoc-plugin-lit-ui-router/tsconfig.json
+++ b/tools/typedoc-plugin-lit-ui-router/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "types": ["node"],
     "outDir": "./dist",
     "declaration": true,
     "declarationMap": true,

--- a/turbo.json
+++ b/turbo.json
@@ -14,6 +14,10 @@
       "dependsOn": ["^test"],
       "inputs": ["src/**/*.ts", "vitest.config.ts", "cypress.config.ts"]
     },
+    "dts-backtest#test": {
+      "dependsOn": ["^build"],
+      "inputs": ["fixtures/**", "run.mjs", "tsconfig.fixture*.json"]
+    },
     "test:coverage": {
       "dependsOn": ["^build", "^test:coverage"],
       "inputs": ["src/**/*.ts", "vitest.config.ts"],


### PR DESCRIPTION
Picks up the TypeScript upgrade deferred in #157. The deferral concern was that TS 6 could raise the `.d.ts` floor for consumers, counter to the wide-support goal for the shipped libraries. This PR resolves it in both directions: a permanent CI guard that *proves* the floor, and the bump itself.

## `tools/dts-backtest` — consumer-floor guard

A private workspace tool that typechecks consumer fixtures (realistic usage of `lit-ui-router`, `lit-ui-router-mobx`, and `ui-router-navigation-location-plugin`, cribbed from the sample apps) under a matrix of:

- **TypeScript versions**: pinned floor **5.0.4** (npm alias devDependency `typescript-5.0`) + the repo's current catalog version
- **module resolution**: `bundler` and `NodeNext`

The fixtures compile with `skipLibCheck: false`, so the packages' built `dist/*.d.ts` are themselves fully parsed **and** typechecked under each version — new declaration-emit syntax an older TypeScript can't handle fails the run. Diagnostics originating in third-party declarations are counted but tolerated (all 17 currently ignored under TS 5.0 are mobx's own d.ts using ES2024 lib names — mobx's floor, not ours), matching what a `skipLibCheck: true` consumer experiences while holding our declarations to the strict bar.

Wiring: runs as `dts-backtest#test` in `turbo run ci`, with `dependsOn: ["^build"]`. Negative-tested: injecting a `NoInfer` (TS 5.4+) reference into a dist d.ts fails the 5.0 legs while current passes. Raising the floor is a semver-major signal for the published packages (see the tool README).

## TypeScript ^6.0.3

- **d.ts output is byte-identical to 5.9.3** across all three packages; backtest green on all four matrix legs — consumers on TS 5.0 are unaffected by the bump.
- **One breakage**: TS 6.0 changed the default of `compilerOptions.types` from "everything in `node_modules/@types`" to `[]`. That broke the typedoc plugin build (`TS2591 Cannot find name 'fs'`); fixed with an explicit `"types": ["node"]`. Every other tsconfig in the repo already listed its `types` explicitly.
- typedoc 0.28.19 accepts TS 6 as a peer (`docs:api` builds clean); typescript-eslint 8.62 is fine.
- `examples/*` keep their standalone `typescript ^5.9.3` pins — they now double as real down-level consumers.

## TS 7 outlook

`typescript@7.0.1-rc` (Go compiler) already typechecks all three packages with zero errors, and its declaration emit differs from TS 6's by a single union-member ordering. When 7.0 ships stable the bump should be trivial, and the backtest's "current" leg will verify its output automatically.

## Verification

Full `turbo run ci`: **46/46 tasks green** (41 pre-existing + the new dts-backtest test/lint/format tasks), plus `docs:api` (typedoc under TS 6) clean.