### PR TITLE
feat(packages): add exports maps and sideEffects to published manifests

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -19,9 +19,6 @@ export default defineConfig(
           ignorePrivate: true,
         },
       ],
-      // packaging decisions deferred: exports map + sideEffects audit for published packages
-      'package-json/require-exports': 'off',
-      'package-json/require-sideEffects': 'off',
     },
   },
   prettier,

--- a/packages/lit-ui-router-mobx/package.json
+++ b/packages/lit-ui-router-mobx/package.json
@@ -26,6 +26,14 @@
   "module": "./dist/index.js",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./dist/*": "./dist/*",
+    "./package.json": "./package.json"
+  },
   "sideEffects": false,
   "files": [
     "dist/**"

--- a/packages/lit-ui-router/package.json
+++ b/packages/lit-ui-router/package.json
@@ -17,6 +17,14 @@
   ],
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./dist/*": "./dist/*",
+    "./package.json": "./package.json"
+  },
   "files": [
     "dist/**"
   ],

--- a/packages/navigation-location-plugin/package.json
+++ b/packages/navigation-location-plugin/package.json
@@ -25,6 +25,15 @@
   "module": "./dist/index.js",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./dist/*": "./dist/*",
+    "./package.json": "./package.json"
+  },
+  "sideEffects": false,
   "files": [
     "dist/**"
   ],


### PR DESCRIPTION
Follow-up to #166, which deferred these two packaging decisions behind `package-json/require-exports` / `require-sideEffects` rule-offs. Both rules are re-enabled here.

## exports maps (all three published packages)

```json
"exports": {
  ".": { "types": "./dist/index.d.ts", "default": "./dist/index.js" },
  "./dist/*": "./dist/*",
  "./package.json": "./package.json"
}
```

The `./dist/*` passthrough is deliberate: it keeps every existing deep import working (the sample apps import `lit-ui-router/dist/custom-elements.json?url`, and published consumers may do the same), so introducing the map is **additive rather than a breaking encapsulation change** — consistent with the wide-support strategy from #157, and it keeps the follow-up releases at **minor** bumps. Tightening to root-only exports can be a future major if desired.

## sideEffects

- `ui-router-navigation-location-plugin`: now `false` — its module scope is pure declarations (verified: no top-level execution).
- `lit-ui-router`: unchanged curated array (`ui-router.js`/`ui-view.js` register custom elements).
- `lit-ui-router-mobx`: already `false`.

## Verification

- **dts-backtest**: consumer fixtures compile against the packed tarballs through the new exports maps under both `bundler` and `nodenext` resolution, at the TS 5.0.4 floor and TS 6.0.3 — the exact resolution paths an exports map can break.
- Sample apps build green, including the `?url` deep-import of the custom-elements manifest.
- `turbo run lint format:check build test` green across the workspace with the two rules re-enabled.

## After merge

Trigger `bump-version` release PRs for the three packages (back-to-back merges are safe now that Tag & push runs queue via the `tag-release` concurrency group). Bump size is chosen at dispatch: **minor recommended** — `sideEffects: false` changes consumers' bundle output for the nav plugin, and the exports map is a new formal resolution contract — though patch is defensible for `lit-ui-router` and `lit-ui-router-mobx`, whose resolution outcomes are byte-identical through the passthrough.
