### PR TITLE
ci: push only the tag ref from Tag & push

### DIFF
--- a/.github/workflows/publish-gh.yml
+++ b/.github/workflows/publish-gh.yml
@@ -18,6 +18,10 @@ on:
 # Serialize runs: a run that checks out before a sibling run pushes its tag
 # will re-create that tag, get its push rejected, and release-it's rollback
 # then deletes the tag from the remote.
+# The queue alone is not enough: release-it's own push sends main + tag
+# together, so a main push that lands mid-run rejects the whole push and the
+# rollback deletes the tag. Hence tagging and pushing are separate steps below,
+# and only the tag ref is ever pushed.
 concurrency:
   group: tag-release
 
@@ -54,11 +58,25 @@ jobs:
         uses: jdx/mise-action@v4
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-      - name: Tag & push
+      - name: Tag
         # --no-increment: Don't bump version, tag current version
-        # --git.tag true: Create git tag ({package}@X.Y.Z)
-        # --git.push true: Push tag to remote, triggering publish-npm workflow
+        # --git.tag true: Create git tag ({package}@X.Y.Z), locally only
+        # --git.push false: pushing main + tag together is release-it's rollback trap
         # inputs.dryRun is only set for manual workflow_dispatch runs; real pushes to main always tag for real.
-        run: pnpm --filter ${{ matrix.package }} exec release-it --no-increment --git.tag true --git.push true ${{ inputs.dryRun && '--dry-run' || '' }}
+        run: pnpm --filter ${{ matrix.package }} exec release-it --no-increment --git.tag true --git.push false ${{ inputs.dryRun && '--dry-run' || '' }}
         # continue-on-error: Tagging is idempotent - if tag exists, we succeed anyway
+        continue-on-error: true
+      - name: Push tag
+        # Push only the tag ref: a stale local main can't reject the push, and an
+        # already-pushed tag is "Everything up-to-date". Triggers publish-npm.
+        run: |
+          version=$(pnpm --filter ${{ matrix.package }} exec node -p "require('./package.json').version")
+          tag="${{ matrix.package }}@${version}"
+          if [ "${{ inputs.dryRun }}" = "true" ]; then
+            echo "dry-run: would push refs/tags/${tag}"
+          else
+            git push origin "refs/tags/${tag}"
+          fi
+        # continue-on-error: a tag existing on the remote at a different commit is
+        # rejected here, matching the previous tag-exists behavior
         continue-on-error: true


### PR DESCRIPTION
Hardens `publish-gh.yml` against the within-run variant of the rollback trap observed during today's `lit-ui-router-mobx@0.3.0` release.

## What happened

The `tag-release` concurrency queue (#162) serializes runs, but release-it's `git push` sends **main + tag together**. #168 merged in the seconds between run [28828969790](https://github.com/simshanith/lit-ui-router/actions/runs/28828969790)'s checkout and its push, so:

1. tag push succeeded → triggered publish-npm
2. `main -> main` rejected (non-fast-forward) → release-it treated the push as failed
3. rollback **deleted the just-pushed tag** from the remote
4. the tag was restored seconds later — accidentally, by the triggered publish-npm run's own release-it git push — firing a *second* publish-npm run
5. the two runs raced `npm publish`; the loser failed with E403 "cannot publish over previously published versions: 0.3.0" ([28828989010](https://github.com/simshanith/lit-ui-router/actions/runs/28828989010))

Outcome was fine (tag, GitHub release, and npm all correct), but only because step 4 happened at all.

## The fix

Split tagging from pushing:

- **Tag**: `release-it --no-increment --git.tag true --git.push false` — creates the tag locally only; nothing remote to roll back
- **Push tag**: `git push origin refs/tags/<pkg>@<version>` — pushes *only* the tag ref, so a stale local `main` can't reject the push

Behavior preserved:
- ordinary main pushes (version already tagged): release-it fails tag creation (`continue-on-error`), and pushing the fetched, already-remote tag is `Everything up-to-date`
- a remote tag at a *different* commit is still rejected, as before
- `dryRun` dispatch logs the exact ref it would push

Verified: `actionlint` clean; the version-extraction command reproduces all three current tag names exactly (`lit-ui-router@1.5.0`, `lit-ui-router-mobx@0.3.0`, `ui-router-navigation-location-plugin@0.2.0`). After merge, a `workflow_dispatch` with `dryRun: true` exercises the new steps harmlessly.