### PR TITLE
fix(ci): publish the pnpm-packed tarball, not an npm re-pack

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -74,8 +74,17 @@ jobs:
           TURBO_API: ${{ vars.TURBO_API }}
           TURBO_TEAM: ${{ vars.TURBO_TEAM }}
       - name: Pack
-        # Create tarball for GitHub release attachment
+        # Create tarball for the GitHub release attachment AND the npm publish
         run: pnpm --filter ${{ env.PACKAGE_NAME }} pack --pack-destination ${{ env.PACKAGE_DIR }}
+      - name: Verify packed manifest
+        # pnpm pack substitutes catalog:/workspace: refs; fail if any leaked
+        run: |
+          TARBALL="$(realpath "$PACKAGE_DIR"/*.tgz)"
+          echo "TARBALL=$TARBALL" >> "$GITHUB_ENV"
+          if tar -xzOf "$TARBALL" package/package.json | grep -nE '"(catalog|workspace):'; then
+            echo "::error::packed manifest contains unsubstituted catalog:/workspace: refs"
+            exit 1
+          fi
       - name: Attest build provenance
         # Generate SLSA provenance attestation for supply chain security.
         # Skipped on manual dry runs: this hits Sigstore/rekor for real and isn't part of release-it's --dry-run.
@@ -92,5 +101,8 @@ jobs:
         # invocation, release id held in memory (no by-tag lookup, which
         # can't see drafts and used to create duplicate releases here).
         # --npm.skipChecks: Skip npm checks since we're using OIDC auth
+        # --npm.publishPath: publish the pnpm-packed (and attested) tarball;
+        # a bare `npm publish` re-packs from source and ships raw
+        # catalog:/workspace: refs npm can't resolve (broke 1.3.0–1.5.0)
         # inputs.dryRun is only set for manual workflow_dispatch runs; real tag pushes always publish for real.
-        run: pnpm --filter ${{ env.PACKAGE_NAME }} exec -- release-it --no-increment --npm.publish true --npm.skipChecks true --github.release true --github.assets "*.tgz" --git.tagExclude "\${npm.name}@$RELEASE_VERSION" ${{ inputs.dryRun && '--dry-run' || '' }}
+        run: pnpm --filter ${{ env.PACKAGE_NAME }} exec -- release-it --no-increment --npm.publish true --npm.skipChecks true --npm.publishPath "$TARBALL" --github.release true --github.assets "*.tgz" --git.tagExclude "\${npm.name}@$RELEASE_VERSION" ${{ inputs.dryRun && '--dry-run' || '' }}

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -75,16 +75,9 @@ jobs:
           TURBO_TEAM: ${{ vars.TURBO_TEAM }}
       - name: Pack
         # Create tarball for the GitHub release attachment AND the npm publish
-        run: pnpm --filter ${{ env.PACKAGE_NAME }} pack --pack-destination ${{ env.PACKAGE_DIR }}
-      - name: Verify packed manifest
-        # pnpm pack substitutes catalog:/workspace: refs; fail if any leaked
         run: |
-          TARBALL="$(realpath "$PACKAGE_DIR"/*.tgz)"
-          echo "TARBALL=$TARBALL" >> "$GITHUB_ENV"
-          if tar -xzOf "$TARBALL" package/package.json | grep -nE '"(catalog|workspace):'; then
-            echo "::error::packed manifest contains unsubstituted catalog:/workspace: refs"
-            exit 1
-          fi
+          pnpm --filter ${{ env.PACKAGE_NAME }} pack --pack-destination ${{ env.PACKAGE_DIR }}
+          echo "TARBALL=$(realpath "$PACKAGE_DIR"/*.tgz)" >> "$GITHUB_ENV"
       - name: Attest build provenance
         # Generate SLSA provenance attestation for supply chain security.
         # Skipped on manual dry runs: this hits Sigstore/rekor for real and isn't part of release-it's --dry-run.

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "build": "turbo run build",
     "check:catalog": "node scripts/check-catalog.mjs",
+    "check:pack": "node scripts/check-pack.mjs",
     "ci": "turbo run ci",
     "dev": "turbo run dev",
     "format": "turbo run format",

--- a/scripts/check-catalog.mjs
+++ b/scripts/check-catalog.mjs
@@ -8,20 +8,11 @@
 // soft default; this check is the hard gate that keeps duplication from drifting
 // back in (e.g. via hand-edited package.json or a `--save-catalog`-less add).
 //
-// This file is the IO shell: it enumerates workspace members and reads the
-// workspace manifest via the pnpm SDK, then delegates all decisions to the pure,
-// unit-tested functions in ./check-catalog.core.mjs.
-//
-// Why the SDK (not the lockfile, not hand-parsed YAML): pnpm-lock.yaml has
-// already resolved `catalog:` refs to concrete versions, so it can't distinguish
-// a catalogued dep from an inline one — that lives only in package.json.
-// `findPackages` is pnpm's own workspace resolver, so we inherit its glob
-// handling, including that the standalone tutorials under examples/* are NOT
-// members (the glob is `examples`, not `examples/*`).
+// This file is the IO shell: it enumerates workspace members via
+// ./workspace.mjs, then delegates all decisions to the pure, unit-tested
+// functions in ./check-catalog.core.mjs.
 
-import { findPackages } from '@pnpm/fs.find-packages';
-import { readWorkspaceManifest } from '@pnpm/workspace.read-manifest';
-import { dirname, join, relative } from 'node:path';
+import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import {
@@ -30,26 +21,9 @@ import {
   findViolations,
   formatReport,
 } from './check-catalog.core.mjs';
+import { loadWorkspace } from './workspace.mjs';
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
-
-/** Enumerate workspace members (incl. root) and the parsed workspace manifest. */
-export async function loadWorkspace(root) {
-  const workspaceManifest = await readWorkspaceManifest(root);
-  const projects = await findPackages(root, {
-    patterns: workspaceManifest?.packages,
-    includeRoot: true,
-  });
-  const members = projects.map((project) => {
-    const dir = relative(root, project.rootDir) || '<root>';
-    return {
-      name: project.manifest?.name ?? dir,
-      dir,
-      manifest: project.manifest,
-    };
-  });
-  return { members, workspaceManifest };
-}
 
 async function main() {
   const { members, workspaceManifest } = await loadWorkspace(ROOT);
@@ -62,10 +36,7 @@ async function main() {
   if (!ok) process.exitCode = 1;
 }
 
-// Guarded so check-pack.mjs can import loadWorkspace without running this check.
-if (process.argv[1] === fileURLToPath(import.meta.url)) {
-  main().catch((error) => {
-    console.error(error);
-    process.exitCode = 1;
-  });
-}
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/scripts/check-catalog.mjs
+++ b/scripts/check-catalog.mjs
@@ -62,7 +62,10 @@ async function main() {
   if (!ok) process.exitCode = 1;
 }
 
-main().catch((error) => {
-  console.error(error);
-  process.exitCode = 1;
-});
+// Guarded so check-pack.mjs can import loadWorkspace without running this check.
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/check-pack.core.mjs
+++ b/scripts/check-pack.core.mjs
@@ -1,0 +1,68 @@
+// Pure logic for the packed-manifest check — no filesystem or pnpm here, so
+// every unit is directly testable with plain fixtures (see check-pack.test.mjs).
+// The IO (enumerating publishable packages, running `pnpm pack`, extracting
+// the packed package.json) lives in check-pack.mjs.
+
+import { DEP_FIELDS } from './check-catalog.core.mjs';
+
+// Specifier protocols pnpm must substitute at pack time. The npm registry
+// accepts a manifest that still contains them, but consumers then fail with
+// EUNSUPPORTEDPROTOCOL — so a leak here means every publish is broken.
+const UNSUBSTITUTED_PREFIXES = ['catalog:', 'workspace:'];
+
+/**
+ * Declaration sites in a packed manifest whose specifier was not substituted.
+ * @param {object} manifest parsed package.json from inside the packed tarball
+ * @returns {Array<{ field: string, dep: string, spec: string }>}
+ */
+export function findUnsubstitutedRefs(manifest) {
+  const refs = [];
+  for (const field of DEP_FIELDS) {
+    for (const [dep, spec] of Object.entries(manifest?.[field] ?? {})) {
+      if (typeof spec !== 'string') continue;
+      if (!UNSUBSTITUTED_PREFIXES.some((p) => spec.trim().startsWith(p))) {
+        continue;
+      }
+      refs.push({ field, dep, spec });
+    }
+  }
+  return refs;
+}
+
+/**
+ * Render the human-readable report.
+ * @param {Array<{ name: string, dir: string, refs: Array<{ field: string, dep: string, spec: string }> }>} results
+ * @returns {{ ok: boolean, text: string }}
+ */
+export function formatReport(results) {
+  if (results.length === 0) {
+    return {
+      ok: false,
+      text: '✗ pack check failed — no publishable workspace packages found (broken workspace globs?).',
+    };
+  }
+
+  const bad = results.filter((result) => result.refs.length > 0);
+  if (bad.length === 0) {
+    return {
+      ok: true,
+      text:
+        `✓ pack check passed — ${results.length} publishable packages, ` +
+        `all packed manifests fully substituted.`,
+    };
+  }
+
+  const lines = [
+    `✗ pack check failed — packed manifests contain catalog:/workspace: ` +
+      `refs npm cannot resolve (publishing would break consumers):`,
+    '',
+  ];
+  for (const { name, dir, refs } of bad) {
+    lines.push(`  ${name} (${dir})`);
+    for (const { field, dep, spec } of refs) {
+      lines.push(`      • ${field.padEnd(20)} ${dep.padEnd(30)} ${spec}`);
+    }
+    lines.push('');
+  }
+  return { ok: false, text: lines.join('\n') };
+}

--- a/scripts/check-pack.mjs
+++ b/scripts/check-pack.mjs
@@ -17,8 +17,8 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { promisify } from 'node:util';
 
-import { loadWorkspace } from './check-catalog.mjs';
 import { findUnsubstitutedRefs, formatReport } from './check-pack.core.mjs';
+import { loadWorkspace } from './workspace.mjs';
 
 const run = promisify(execFile);
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');

--- a/scripts/check-pack.mjs
+++ b/scripts/check-pack.mjs
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+// Guard publishable packages against shipping unsubstituted catalog:/workspace:
+// refs. `pnpm pack` rewrites those protocols into concrete ranges; npm's own
+// pack does not, which is how lit-ui-router 1.3.0–1.5.0 published manifests
+// consumers cannot install. Packing here — in the ci pipeline, with the same
+// pnpm the publish workflow uses — keeps main releasable instead of
+// discovering a leak at publish time.
+//
+// This file is the IO shell: it packs each non-private workspace package into
+// a temp dir, extracts the packed package.json, and delegates all decisions to
+// the pure, unit-tested functions in ./check-pack.core.mjs.
+
+import { execFile } from 'node:child_process';
+import { mkdtemp, readdir, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
+
+import { loadWorkspace } from './check-catalog.mjs';
+import { findUnsubstitutedRefs, formatReport } from './check-pack.core.mjs';
+
+const run = promisify(execFile);
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+/** `pnpm pack` in `cwd`; falls back to corepack when pnpm is not on PATH. */
+async function pnpmPack(cwd, destination) {
+  const args = ['pack', '--pack-destination', destination];
+  try {
+    await run('pnpm', args, { cwd });
+  } catch (error) {
+    if (error.code !== 'ENOENT') throw error;
+    await run('corepack', ['pnpm', ...args], { cwd });
+  }
+}
+
+/** Pack one package and return the manifest from inside the tarball. */
+async function packedManifest(packageDir) {
+  const destination = await mkdtemp(join(tmpdir(), 'check-pack-'));
+  try {
+    await pnpmPack(packageDir, destination);
+    const tarball = (await readdir(destination)).find((f) =>
+      f.endsWith('.tgz'),
+    );
+    const { stdout } = await run(
+      'tar',
+      ['-xzOf', join(destination, tarball), 'package/package.json'],
+      { maxBuffer: 16 * 1024 * 1024 },
+    );
+    return JSON.parse(stdout);
+  } finally {
+    await rm(destination, { recursive: true, force: true });
+  }
+}
+
+async function main() {
+  const { members } = await loadWorkspace(ROOT);
+  const publishable = members.filter(
+    (member) =>
+      member.dir !== '<root>' &&
+      member.manifest &&
+      member.manifest.private !== true,
+  );
+  const results = [];
+  for (const { name, dir } of publishable) {
+    const manifest = await packedManifest(join(ROOT, dir));
+    results.push({ name, dir, refs: findUnsubstitutedRefs(manifest) });
+  }
+  const { ok, text } = formatReport(results);
+  (ok ? console.log : console.error)(text);
+  if (!ok) process.exitCode = 1;
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/scripts/check-pack.test.mjs
+++ b/scripts/check-pack.test.mjs
@@ -1,0 +1,89 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { findUnsubstitutedRefs, formatReport } from './check-pack.core.mjs';
+
+describe('findUnsubstitutedRefs', () => {
+  it('passes a fully substituted manifest', () => {
+    const manifest = {
+      dependencies: { '@uirouter/core': '^6.0.8', lit: '^3.0.0' },
+      peerDependencies: { mobx: '^6.0.0', 'lit-ui-router': '^1.5.1' },
+      devDependencies: { vitest: '^4.1.9' },
+    };
+    assert.deepEqual(findUnsubstitutedRefs(manifest), []);
+  });
+
+  it('flags catalog: refs in any dependency field', () => {
+    const manifest = {
+      dependencies: { lit: 'catalog:publishedPeer' },
+      devDependencies: { vitest: 'catalog:' },
+    };
+    assert.deepEqual(findUnsubstitutedRefs(manifest), [
+      { field: 'dependencies', dep: 'lit', spec: 'catalog:publishedPeer' },
+      { field: 'devDependencies', dep: 'vitest', spec: 'catalog:' },
+    ]);
+  });
+
+  it('flags workspace: refs', () => {
+    const manifest = {
+      peerDependencies: { 'lit-ui-router': 'workspace:^' },
+    };
+    assert.deepEqual(findUnsubstitutedRefs(manifest), [
+      { field: 'peerDependencies', dep: 'lit-ui-router', spec: 'workspace:^' },
+    ]);
+  });
+
+  it('ignores missing fields and non-string specifiers', () => {
+    assert.deepEqual(findUnsubstitutedRefs({}), []);
+    assert.deepEqual(findUnsubstitutedRefs(undefined), []);
+    assert.deepEqual(
+      findUnsubstitutedRefs({ dependencies: { odd: 42 } }),
+      [],
+    );
+  });
+});
+
+describe('formatReport', () => {
+  it('passes when every packed manifest is clean', () => {
+    const { ok, text } = formatReport([
+      { name: 'lit-ui-router', dir: 'packages/lit-ui-router', refs: [] },
+      { name: 'lit-ui-router-mobx', dir: 'packages/lit-ui-router-mobx', refs: [] },
+    ]);
+    assert.equal(ok, true);
+    assert.match(text, /✓ pack check passed — 2 publishable packages/);
+  });
+
+  it('fails and lists every leaked ref', () => {
+    const { ok, text } = formatReport([
+      { name: 'lit-ui-router', dir: 'packages/lit-ui-router', refs: [] },
+      {
+        name: 'lit-ui-router-mobx',
+        dir: 'packages/lit-ui-router-mobx',
+        refs: [
+          {
+            field: 'peerDependencies',
+            dep: 'lit-ui-router',
+            spec: 'workspace:^',
+          },
+          {
+            field: 'peerDependencies',
+            dep: 'lit',
+            spec: 'catalog:publishedPeer',
+          },
+        ],
+      },
+    ]);
+    assert.equal(ok, false);
+    assert.match(text, /✗ pack check failed/);
+    assert.match(text, /lit-ui-router-mobx \(packages\/lit-ui-router-mobx\)/);
+    assert.match(text, /workspace:\^/);
+    assert.match(text, /catalog:publishedPeer/);
+    assert.doesNotMatch(text, /lit-ui-router \(packages\/lit-ui-router\)/);
+  });
+
+  it('fails when no publishable packages were found', () => {
+    const { ok, text } = formatReport([]);
+    assert.equal(ok, false);
+    assert.match(text, /no publishable workspace packages/);
+  });
+});

--- a/scripts/workspace.mjs
+++ b/scripts/workspace.mjs
@@ -1,0 +1,30 @@
+// Shared workspace enumeration for the check:* scripts, via the pnpm SDK.
+//
+// Why the SDK (not the lockfile, not hand-parsed YAML): pnpm-lock.yaml has
+// already resolved `catalog:` refs to concrete versions, so it can't distinguish
+// a catalogued dep from an inline one — that lives only in package.json.
+// `findPackages` is pnpm's own workspace resolver, so we inherit its glob
+// handling, including that the standalone tutorials under examples/* are NOT
+// members (the glob is `examples`, not `examples/*`).
+
+import { findPackages } from '@pnpm/fs.find-packages';
+import { readWorkspaceManifest } from '@pnpm/workspace.read-manifest';
+import { relative } from 'node:path';
+
+/** Enumerate workspace members (incl. root) and the parsed workspace manifest. */
+export async function loadWorkspace(root) {
+  const workspaceManifest = await readWorkspaceManifest(root);
+  const projects = await findPackages(root, {
+    patterns: workspaceManifest?.packages,
+    includeRoot: true,
+  });
+  const members = projects.map((project) => {
+    const dir = relative(root, project.rootDir) || '<root>';
+    return {
+      name: project.manifest?.name ?? dir,
+      dir,
+      manifest: project.manifest,
+    };
+  });
+  return { members, workspaceManifest };
+}

--- a/turbo.json
+++ b/turbo.json
@@ -45,6 +45,7 @@
       "inputs": [
         "scripts/check-catalog.mjs",
         "scripts/check-catalog.core.mjs",
+        "scripts/workspace.mjs",
         "pnpm-workspace.yaml",
         "**/package.json"
       ]
@@ -53,8 +54,8 @@
       "inputs": [
         "scripts/check-pack.mjs",
         "scripts/check-pack.core.mjs",
-        "scripts/check-catalog.mjs",
         "scripts/check-catalog.core.mjs",
+        "scripts/workspace.mjs",
         "pnpm-workspace.yaml",
         "**/package.json"
       ]

--- a/turbo.json
+++ b/turbo.json
@@ -37,11 +37,22 @@
         "test:coverage",
         "lint",
         "format:check",
-        "//#check:catalog"
+        "//#check:catalog",
+        "//#check:pack"
       ]
     },
     "//#check:catalog": {
       "inputs": [
+        "scripts/check-catalog.mjs",
+        "scripts/check-catalog.core.mjs",
+        "pnpm-workspace.yaml",
+        "**/package.json"
+      ]
+    },
+    "//#check:pack": {
+      "inputs": [
+        "scripts/check-pack.mjs",
+        "scripts/check-pack.core.mjs",
         "scripts/check-catalog.mjs",
         "scripts/check-catalog.core.mjs",
         "pnpm-workspace.yaml",


### PR DESCRIPTION
## The bug (production impact — npm consumers broken since 1.3.0)

`npm view lit-ui-router@1.5.0 dependencies` returns:

```
{ '@uirouter/core': 'catalog:publishedPeer', lit: 'catalog:publishedPeer' }
```

**`lit-ui-router@1.3.0/1.4.0/1.5.0` and `lit-ui-router-mobx@0.3.0` were published with unreplaced `catalog:publishedPeer` refs** (mobx also has a raw `workspace:^` on lit-ui-router). Plain-npm installs fail with `EUNSUPPORTEDPROTOCOL`; last good version is 1.2.5. This is also why `examples/*/package-lock.json` can no longer be regenerated.

## Root cause

The workflow's Pack step builds a **correct** tarball with `pnpm pack` (which substitutes `catalog:`/`workspace:` refs) — but that tarball is only attested and attached to the GitHub release. The actual npm publish is release-it → `npm publish`, which **re-packs from the source directory**, and the npm CLI doesn't understand pnpm's protocols. It broke at 1.3.0, the first release after #157 moved the published deps onto the `publishedPeer` catalog (before that, the manifests held literal ranges, so npm's re-pack was harmless).

## The fix

1. **Publish the pnpm-packed tarball.** The Publish step passes `--npm.publishPath "$TARBALL"`, so release-it runs `npm publish <tarball>` on the **same artifact** that gets attested and attached to the GitHub release — one canonical artifact everywhere.
2. **Guard at CI time, not publish time** — a leak should fail PR CI and keep main releasable, not surface mid-release. New root task `check:pack` (same shape as `check:catalog`: IO shell + pure core + `node:test` units, wired into the `ci` turbo task) packs each publishable package with `pnpm pack` and fails if the packed manifest still contains `catalog:`/`workspace:` refs. `loadWorkspace` is extracted into a shared `scripts/workspace.mjs` used by both `check:*` shells.

## Verification

- pnpm-packed tarball manifests confirmed fully substituted for both packages (`@uirouter/core: ^6.0.8`, `lit: ^3.0.0`, `mobx: ^6.0.0`, `lit-ui-router: ^<version>`)
- release-it 20.2.1 source confirmed `publishPath` is passed straight through: dry-run emits `npm publish /…/lit-ui-router-1.5.0.tgz --tag latest --workspaces=false`; `npm publish <tarball> --dry-run` accepted
- `check:pack` passes on all 3 publishable packages; appears in the `turbo run ci` graph; 7 new unit tests green (20 total in `test:root`)
- **Mutation-tested**: feeding the scanner an *npm*-packed lit-ui-router manifest (the exact 1.3.0 failure mode) fails with 14 flagged refs

## After merge — recovery runbook

1. (Optional) `gh workflow run publish-npm.yml -f package=lit-ui-router -f dryRun=true` to validate on CI infra.
2. `gh workflow run bump-version.yml -f package=lit-ui-router -f increment=patch` → merge the release PR → approve publish → **1.5.1**.
3. Then the same for `lit-ui-router-mobx` → **0.3.1** (sequenced after, so its `workspace:^` packs as `^1.5.1`).
4. Deprecate the broken versions (needs npm owner auth):
   ```
   npm deprecate lit-ui-router@"1.3.0 - 1.5.0" "Published with unresolved catalog: refs (npm cannot install); use 1.5.1+"
   npm deprecate lit-ui-router-mobx@0.3.0 "Published with unresolved catalog:/workspace: refs (npm cannot install); use 0.3.1+"
   ```
