### PR TITLE
Release 1.5.1

### DIFF
--- a/packages/lit-ui-router/package.json
+++ b/packages/lit-ui-router/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lit-ui-router",
   "description": "State-based routing for Lit",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "type": "module",
   "module": "./dist/index.js",
   "homepage": "https://lit-ui-router.dev",


### PR DESCRIPTION
* fix(ci): publish the pnpm-packed tarball, not an npm re-pack (#173) (44e98c1)
* chore(tooling): node 24 + @types/node 24 (#172) (31e2a84)
* ci: push only the tag ref from Tag & push (#171) (f9d5087)
* Release 0.2.0 (#170) (9306d7a)
