### PR TITLE
Release 0.3.1

### DIFF
--- a/packages/lit-ui-router-mobx/package.json
+++ b/packages/lit-ui-router-mobx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lit-ui-router-mobx",
   "description": "MobX bindings for lit-ui-router: an observable router store and reaction-based Lit ReactiveControllers",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "license": "MIT",
   "author": "Shane Daniel",
   "homepage": "https://github.com/simshanith/lit-ui-router/tree/main/packages/lit-ui-router-mobx",


### PR DESCRIPTION
* fix(ci): publish the pnpm-packed tarball, not an npm re-pack (#173) (44e98c1)
* chore(tooling): node 24 + @types/node 24 (#172) (31e2a84)
* ci: push only the tag ref from Tag & push (#171) (f9d5087)
* Release 0.2.0 (#170) (9306d7a)
* Release 1.5.0 (#168) (eed692c)
