### PR TITLE
fix(examples): bump to lit-ui-router ^1.5.1 and regenerate lockfiles

### DIFF
--- a/examples/hellogalaxy/package-lock.json
+++ b/examples/hellogalaxy/package-lock.json
@@ -11,7 +11,7 @@
         "@uirouter/core": "^6.1.2",
         "@uirouter/visualizer": "^7.2.1",
         "lit": "^3.3.2",
-        "lit-ui-router": "^1.2.5"
+        "lit-ui-router": "^1.5.1"
       },
       "devDependencies": {
         "typescript": "^5.9.3",
@@ -950,13 +950,13 @@
       }
     },
     "node_modules/lit-ui-router": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/lit-ui-router/-/lit-ui-router-1.2.5.tgz",
-      "integrity": "sha512-WkImROEPf5rH948V167T5NuVVav6LXsR0uoiItFeKo/poxkqmQknY9bu4n9T7s0LtJfHUkfJx7+dd/5hjLHVEQ==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/lit-ui-router/-/lit-ui-router-1.5.1.tgz",
+      "integrity": "sha512-FsK5RNZT+rHlGIora0qfKu95jK/l7u30nf13mf7pzD8pBRNhtEDbSMOPqR6mrHhV385tnsbaTaOoEdREkvsqBA==",
       "license": "MIT",
       "dependencies": {
         "@uirouter/core": "^6.0.8",
-        "lit": "^2.0.0 || ^3.0.0"
+        "lit": "^3.0.0"
       }
     },
     "node_modules/nanoid": {

--- a/examples/hellogalaxy/package.json
+++ b/examples/hellogalaxy/package.json
@@ -12,7 +12,7 @@
     "@uirouter/core": "^6.1.2",
     "@uirouter/visualizer": "^7.2.1",
     "lit": "^3.3.2",
-    "lit-ui-router": "^1.4.0"
+    "lit-ui-router": "^1.5.1"
   },
   "devDependencies": {
     "typescript": "^5.9.3",

--- a/examples/hellosolarsystem/package-lock.json
+++ b/examples/hellosolarsystem/package-lock.json
@@ -11,7 +11,7 @@
         "@uirouter/core": "^6.1.2",
         "@uirouter/visualizer": "^7.2.1",
         "lit": "^3.3.2",
-        "lit-ui-router": "^1.2.5"
+        "lit-ui-router": "^1.5.1"
       },
       "devDependencies": {
         "typescript": "^5.9.3",
@@ -950,13 +950,13 @@
       }
     },
     "node_modules/lit-ui-router": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/lit-ui-router/-/lit-ui-router-1.2.5.tgz",
-      "integrity": "sha512-WkImROEPf5rH948V167T5NuVVav6LXsR0uoiItFeKo/poxkqmQknY9bu4n9T7s0LtJfHUkfJx7+dd/5hjLHVEQ==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/lit-ui-router/-/lit-ui-router-1.5.1.tgz",
+      "integrity": "sha512-FsK5RNZT+rHlGIora0qfKu95jK/l7u30nf13mf7pzD8pBRNhtEDbSMOPqR6mrHhV385tnsbaTaOoEdREkvsqBA==",
       "license": "MIT",
       "dependencies": {
         "@uirouter/core": "^6.0.8",
-        "lit": "^2.0.0 || ^3.0.0"
+        "lit": "^3.0.0"
       }
     },
     "node_modules/nanoid": {

--- a/examples/hellosolarsystem/package.json
+++ b/examples/hellosolarsystem/package.json
@@ -12,7 +12,7 @@
     "@uirouter/core": "^6.1.2",
     "@uirouter/visualizer": "^7.2.1",
     "lit": "^3.3.2",
-    "lit-ui-router": "^1.4.0"
+    "lit-ui-router": "^1.5.1"
   },
   "devDependencies": {
     "typescript": "^5.9.3",

--- a/examples/helloworld/package-lock.json
+++ b/examples/helloworld/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@uirouter/core": "^6.1.2",
         "lit": "^3.3.2",
-        "lit-ui-router": "^1.2.5"
+        "lit-ui-router": "^1.5.1"
       },
       "devDependencies": {
         "typescript": "^5.9.3",
@@ -953,13 +953,13 @@
       }
     },
     "node_modules/lit-ui-router": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/lit-ui-router/-/lit-ui-router-1.2.5.tgz",
-      "integrity": "sha512-WkImROEPf5rH948V167T5NuVVav6LXsR0uoiItFeKo/poxkqmQknY9bu4n9T7s0LtJfHUkfJx7+dd/5hjLHVEQ==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/lit-ui-router/-/lit-ui-router-1.5.1.tgz",
+      "integrity": "sha512-FsK5RNZT+rHlGIora0qfKu95jK/l7u30nf13mf7pzD8pBRNhtEDbSMOPqR6mrHhV385tnsbaTaOoEdREkvsqBA==",
       "license": "MIT",
       "dependencies": {
         "@uirouter/core": "^6.0.8",
-        "lit": "^2.0.0 || ^3.0.0"
+        "lit": "^3.0.0"
       }
     },
     "node_modules/nanoid": {

--- a/examples/helloworld/package.json
+++ b/examples/helloworld/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@uirouter/core": "^6.1.2",
     "lit": "^3.3.2",
-    "lit-ui-router": "^1.4.0"
+    "lit-ui-router": "^1.5.1"
   },
   "devDependencies": {
     "typescript": "^5.9.3",


### PR DESCRIPTION
The standalone examples have been uninstallable since the floor moved past 1.2.5: versions 1.3.0–1.5.0 published with unresolved `catalog:` refs (#173), so npm couldn't regenerate their lockfiles — they stayed locked to 1.2.5 while the manifests asked for `^1.4.0`, and a fresh `npm install` failed with `EUNSUPPORTEDPROTOCOL`.

All three examples bumped to `^1.5.1`, lockfiles regenerated, and `npm install` + `vite build` verified clean against the published 1.5.1 — which also end-to-end validates the #173 publish fix from the consumer side.