### PR TITLE
chore(ci): add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,79 @@
+# Dependabot version updates — https://github.com/simshanith/lit-ui-router/issues/23
+# Reference: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference
+version: 2
+updates:
+  # Root pnpm workspace (apps/*, packages/*, tools/*, docs, examples — see pnpm-workspace.yaml).
+  # Dependabot resolves pnpm via the npm ecosystem, including pnpm-workspace.yaml catalogs.
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    open-pull-requests-limit: 10
+    # Mirror pnpm's minimumReleaseAge: 24h (pnpm-workspace config) — wait a day
+    # before proposing freshly published versions.
+    cooldown:
+      default-days: 1
+    commit-message:
+      prefix: 'chore'
+      include: 'scope'
+    groups:
+      # vitest and @vitest/* must move in lockstep: patches/@vitest__browser.patch
+      # targets a content-hashed bundle file inside @vitest/browser and silently
+      # no-ops after any vitest bump — regenerate the patch on every update in
+      # this group before merging.
+      vitest:
+        patterns:
+          - 'vitest'
+          - '@vitest/*'
+      # All other minor + patch updates land as one weekly PR; majors stay
+      # individual so breaking changes get their own review.
+      minor-and-patch:
+        patterns:
+          - '*'
+        exclude-patterns:
+          - 'vitest'
+          - '@vitest/*'
+        update-types:
+          - 'minor'
+          - 'patch'
+
+  # StackBlitz examples are standalone projects with their own npm lockfiles,
+  # deliberately outside the main pnpm workspace (issue #23).
+  - package-ecosystem: 'npm'
+    directories:
+      - '/examples/*'
+    schedule:
+      interval: 'weekly'
+    open-pull-requests-limit: 3
+    cooldown:
+      default-days: 1
+    commit-message:
+      prefix: 'chore'
+      include: 'scope'
+    groups:
+      examples-minor-and-patch:
+        patterns:
+          - '*'
+        update-types:
+          - 'minor'
+          - 'patch'
+
+  # GitHub Actions used by .github/workflows.
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    open-pull-requests-limit: 5
+    # github-actions supports cooldown default-days only (no semver-specific days).
+    cooldown:
+      default-days: 1
+    commit-message:
+      prefix: 'chore'
+      include: 'scope'
+    groups:
+      actions-minor-and-patch:
+        patterns:
+          - '*'
+        update-types:
+          - 'minor'
+          - 'patch'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,31 +2,25 @@
 # Reference: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference
 version: 2
 updates:
-  # Root pnpm workspace (apps/*, packages/*, tools/*, docs, examples — see pnpm-workspace.yaml).
-  # Dependabot resolves pnpm via the npm ecosystem, including pnpm-workspace.yaml catalogs.
+  # root pnpm workspace — npm ecosystem covers pnpm + catalogs
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
       interval: 'weekly'
     open-pull-requests-limit: 10
-    # Mirror pnpm's minimumReleaseAge: 24h (pnpm-workspace config) — wait a day
-    # before proposing freshly published versions.
+    # Mirror pnpm's minimumReleaseAge: 24h (pnpm-workspace config)
     cooldown:
       default-days: 1
     commit-message:
       prefix: 'chore'
       include: 'scope'
     groups:
-      # vitest and @vitest/* must move in lockstep: patches/@vitest__browser.patch
-      # targets a content-hashed bundle file inside @vitest/browser and silently
-      # no-ops after any vitest bump — regenerate the patch on every update in
-      # this group before merging.
+      # regenerate patches/@vitest__browser.patch on every vitest bump (content-hashed target)
       vitest:
         patterns:
           - 'vitest'
           - '@vitest/*'
-      # All other minor + patch updates land as one weekly PR; majors stay
-      # individual so breaking changes get their own review.
+      # majors excluded — breaking changes get individual PRs
       minor-and-patch:
         patterns:
           - '*'
@@ -37,8 +31,7 @@ updates:
           - 'minor'
           - 'patch'
 
-  # StackBlitz examples are standalone projects with their own npm lockfiles,
-  # deliberately outside the main pnpm workspace (issue #23).
+  # standalone StackBlitz examples
   - package-ecosystem: 'npm'
     directories:
       - '/examples/*'
@@ -58,13 +51,12 @@ updates:
           - 'minor'
           - 'patch'
 
-  # GitHub Actions used by .github/workflows.
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
       interval: 'weekly'
     open-pull-requests-limit: 5
-    # github-actions supports cooldown default-days only (no semver-specific days).
+    # github-actions cooldown supports default-days only
     cooldown:
       default-days: 1
     commit-message:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,8 @@
 version: 2
 updates:
   # root pnpm workspace — npm ecosystem covers pnpm + catalogs
+  # updater lacks pnpm 11 (workspace updates blocked; alerts unaffected):
+  # https://github.com/dependabot/dependabot-core/issues/14794
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
@@ -29,6 +31,10 @@ updates:
         update-types:
           - 'minor'
           - 'patch'
+      security:
+        applies-to: security-updates
+        patterns:
+          - '*'
 
   # standalone StackBlitz examples
   - package-ecosystem: 'npm'
@@ -49,6 +55,11 @@ updates:
         update-types:
           - 'minor'
           - 'patch'
+      # batch security PRs across the three example lockfiles
+      examples-security:
+        applies-to: security-updates
+        patterns:
+          - '*'
 
   - package-ecosystem: 'github-actions'
     directory: '/'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,4 @@
-# Dependabot version updates — https://github.com/simshanith/lit-ui-router/issues/23
-# Reference: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference
+# Dependabot version updates https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference
 version: 2
 updates:
   # root pnpm workspace — npm ecosystem covers pnpm + catalogs


### PR DESCRIPTION
Refs #23.

Adds `.github/dependabot.yml` with weekly version updates and modest PR limits.

## Checklist items addressed (issue #23)

- **create `.github/dependabot.yml`** — this PR
- **configure version updates** — this PR (weekly schedule, per-ecosystem limits)
- **stackblitz examples/\* handled separate from main pnpm-workspace** — dedicated `npm` update config with `directories: ['/examples/*']`; these are standalone projects with their own `package-lock.json` files
- **determine appropriate package groups** — see below

## Settings-level items (alerts / security updates) — for review

Two repo settings were toggled via `gh api` during this work and are flagged here for explicit review (revert by swapping `PUT` for `DELETE` if not wanted):

- Dependabot alerts: `PUT /repos/simshanith/lit-ui-router/vulnerability-alerts` (was disabled, now enabled). Alerts already report findings on the default branch: https://github.com/simshanith/lit-ui-router/security/dependabot
- Dependabot security updates: `PUT /repos/simshanith/lit-ui-router/automated-security-fixes` (was disabled, now enabled)

UI equivalent for both: Settings → Advanced Security → Dependabot.

## Config rationale

- **Root pnpm workspace** (`npm` ecosystem at `/`): Dependabot resolves pnpm — including `pnpm-workspace.yaml` catalogs — through the npm ecosystem.
- **Grouping**: minor+patch updates land as one weekly PR; majors stay individual for isolated review. `vitest` + `@vitest/*` are grouped across all update types because `patches/@vitest__browser.patch` targets a content-hashed bundle file and silently no-ops on every vitest bump — the patch must be regenerated before merging any PR from that group (noted in a YAML comment).
- **Cooldown**: `cooldown.default-days: 1` on all ecosystems mirrors the workspace's pnpm `minimumReleaseAge: 24h`. (`github-actions` supports `default-days` only.)
- **GitHub Actions** (`github-actions` at `/`): covers `.github/workflows`, minor+patch grouped.
- Commit messages use `prefix: chore` + `include: scope` to match the repo's conventional-commit style.