### PR TITLE
ci(codecov): bundle analysis for sample app builds

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -58,6 +58,8 @@ jobs:
           TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
           TURBO_API: ${{ vars.TURBO_API }}
           TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+          # Codecov bundle analysis (uploaded by @codecov/vite-plugin during app builds)
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       - name: lit-ui-router Vitest Coverage Report
         uses: davelosert/vitest-coverage-report-action@v2
         if: github.event_name == 'pull_request'

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -58,7 +58,6 @@ jobs:
           TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
           TURBO_API: ${{ vars.TURBO_API }}
           TURBO_TEAM: ${{ vars.TURBO_TEAM }}
-          # Codecov bundle analysis (uploaded by @codecov/vite-plugin during app builds)
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       - name: lit-ui-router Vitest Coverage Report
         uses: davelosert/vitest-coverage-report-action@v2

--- a/apps/sample-app-lit-mobx/package.json
+++ b/apps/sample-app-lit-mobx/package.json
@@ -19,6 +19,7 @@
     "sample-app-shared": "workspace:*"
   },
   "devDependencies": {
+    "@codecov/vite-plugin": "catalog:",
     "@types/dom-navigation": "catalog:",
     "@types/lodash": "catalog:",
     "prettier": "catalog:",

--- a/apps/sample-app-lit-mobx/turbo.json
+++ b/apps/sample-app-lit-mobx/turbo.json
@@ -4,10 +4,12 @@
   "tasks": {
     "build": {
       "env": [
+        "CODECOV_TOKEN",
         "VITE_GOOGLE_ANALYTICS_TRACKING_ID",
         "VITE_SAMPLE_APP_BASE_URL",
         "VITE_SAMPLE_APP_PUSH_STATE"
       ],
+      "passThroughEnv": ["GITHUB_*"],
       "inputs": ["$TURBO_DEFAULT$", "../sample-app-shared/**"]
     }
   }

--- a/apps/sample-app-lit-mobx/vite.config.ts
+++ b/apps/sample-app-lit-mobx/vite.config.ts
@@ -1,3 +1,4 @@
+import { codecovVitePlugin } from '@codecov/vite-plugin';
 import { defineConfig } from 'vite';
 import checker from 'vite-plugin-checker';
 import { viteStaticCopy } from 'vite-plugin-static-copy';
@@ -15,6 +16,14 @@ export default defineConfig({
           dest: 'images',
         },
       ],
+    }),
+    // Codecov bundle analysis; no-op unless CODECOV_TOKEN is set (CI).
+    codecovVitePlugin({
+      enableBundleAnalysis: process.env.CODECOV_TOKEN !== undefined,
+      bundleName: 'sample-app-lit-mobx',
+      uploadToken: process.env.CODECOV_TOKEN,
+      gitService: 'github',
+      telemetry: false,
     }),
   ],
   server: {

--- a/apps/sample-app-lit-vanilla/package.json
+++ b/apps/sample-app-lit-vanilla/package.json
@@ -17,6 +17,7 @@
     "sample-app-shared": "workspace:*"
   },
   "devDependencies": {
+    "@codecov/vite-plugin": "catalog:",
     "@types/dom-navigation": "catalog:",
     "@types/lodash": "catalog:",
     "prettier": "catalog:",

--- a/apps/sample-app-lit-vanilla/turbo.json
+++ b/apps/sample-app-lit-vanilla/turbo.json
@@ -4,10 +4,12 @@
   "tasks": {
     "build": {
       "env": [
+        "CODECOV_TOKEN",
         "VITE_GOOGLE_ANALYTICS_TRACKING_ID",
         "VITE_SAMPLE_APP_BASE_URL",
         "VITE_SAMPLE_APP_PUSH_STATE"
       ],
+      "passThroughEnv": ["GITHUB_*"],
       "inputs": ["$TURBO_DEFAULT$", "../sample-app-shared/**"]
     }
   }

--- a/apps/sample-app-lit-vanilla/vite.config.ts
+++ b/apps/sample-app-lit-vanilla/vite.config.ts
@@ -1,3 +1,4 @@
+import { codecovVitePlugin } from '@codecov/vite-plugin';
 import { defineConfig } from 'vite';
 import checker from 'vite-plugin-checker';
 import { viteStaticCopy } from 'vite-plugin-static-copy';
@@ -15,6 +16,14 @@ export default defineConfig({
           dest: 'images',
         },
       ],
+    }),
+    // Codecov bundle analysis; no-op unless CODECOV_TOKEN is set (CI).
+    codecovVitePlugin({
+      enableBundleAnalysis: process.env.CODECOV_TOKEN !== undefined,
+      bundleName: 'sample-app-lit-vanilla',
+      uploadToken: process.env.CODECOV_TOKEN,
+      gitService: 'github',
+      telemetry: false,
     }),
   ],
   server: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,9 @@ catalogs:
     '@api-viewer/docs':
       specifier: 1.0.0-pre.10
       version: 1.0.0-pre.10
+    '@codecov/vite-plugin':
+      specifier: ^2.0.1
+      version: 2.0.1
     '@pnpm/fs.find-packages':
       specifier: ^1000.0.24
       version: 1000.0.24
@@ -219,6 +222,9 @@ importers:
         specifier: workspace:*
         version: link:../sample-app-shared
     devDependencies:
+      '@codecov/vite-plugin':
+        specifier: 'catalog:'
+        version: 2.0.1(vite@7.3.6(@types/node@25.0.9)(jiti@2.7.0)(yaml@2.9.0))
       '@types/dom-navigation':
         specifier: 'catalog:'
         version: 1.0.7
@@ -259,6 +265,9 @@ importers:
         specifier: workspace:*
         version: link:../sample-app-shared
     devDependencies:
+      '@codecov/vite-plugin':
+        specifier: 'catalog:'
+        version: 2.0.1(vite@7.3.6(@types/node@25.0.9)(jiti@2.7.0)(yaml@2.9.0))
       '@types/dom-navigation':
         specifier: 'catalog:'
         version: 1.0.7
@@ -561,6 +570,24 @@ importers:
 
 packages:
 
+  '@actions/core@3.0.1':
+    resolution: {integrity: sha512-a6d/Nwahm9fliVGRhdhofo40HjHQasUPusmc7vBfyky+7Z+P2A1J68zyFVaNcEclc/Se+eO595oAr5nwEIoIUA==}
+
+  '@actions/exec@3.0.0':
+    resolution: {integrity: sha512-6xH/puSoNBXb72VPlZVm7vQ+svQpFyA96qdDBvhB8eNZOE8LtPf9L4oAsfzK/crCL8YZ+19fKYVnM63Sl+Xzlw==}
+
+  '@actions/github@9.1.1':
+    resolution: {integrity: sha512-tL5JbYOBZHc0ngEnCsaDcryUizIUIlQyIMwy1Wkx93H5HzbBJ7TbiPx2PnFjBwZW0Vh05JmfFZhecE6gglYegA==}
+
+  '@actions/http-client@3.0.2':
+    resolution: {integrity: sha512-JP38FYYpyqvUsz+Igqlc/JG6YO9PaKuvqjM3iGvaLqFnJ7TFmcLyy2IDrY0bI0qCQug8E9K+elv5ZNfw62ZJzA==}
+
+  '@actions/http-client@4.0.1':
+    resolution: {integrity: sha512-+Nvd1ImaOZBSoPbsUtEhv+1z99H12xzncCkz0a3RuehINE81FZSe2QTj3uvAPTcJX/SCzUQHQ0D1GrPMbrPitg==}
+
+  '@actions/io@3.0.2':
+    resolution: {integrity: sha512-nRBchcMM+QK1pdjO7/idu86rbJI5YHUKCvKs0KxnSYbVe3F51UfGxuZX4Qy/fWlp6l7gWFwIkrOzN+oUK03kfw==}
+
   '@algolia/abtesting@1.21.1':
     resolution: {integrity: sha512-Wia5/mNTfiU0PIUN25UMfAGGdASkkwuCS9nBAdmhqrNPY/ff7U/6MgBVdwFDPsa3sA1msutPtO50gvOzx6MOXA==}
     engines: {node: '>= 14.0.0'}
@@ -719,6 +746,16 @@ packages:
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
+
+  '@codecov/bundler-plugin-core@2.0.1':
+    resolution: {integrity: sha512-TkdKn/rEwZQ723M7DDUmHe5r0IJa23rUT4TAx5jXmg12wGZGAHGWWU7LKeQsYCsKdLMxK7bLaGk9M++4wSRD5w==}
+    engines: {node: '>=20.0.0'}
+
+  '@codecov/vite-plugin@2.0.1':
+    resolution: {integrity: sha512-w7nGA9SSc0WECzn05yRrw3uN8293I620Kd9x97I0kyyxUjtWxCMmlgmAbS364gJZYvljd0A6iQyAigVV2dOX9A==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      vite: 4.x || 5.x || 6.x
 
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
@@ -4150,6 +4187,10 @@ packages:
   tunnel-agent@0.6.0:
     resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
 
+  tunnel@0.0.6:
+    resolution: {integrity: sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==}
+    engines: {node: '>=0.6.11 <=0.7.0 || >=0.7.3'}
+
   turbo@2.10.3:
     resolution: {integrity: sha512-uZIqzfgtWbyqu1Tqwdd0giRnPGgL0ejbcdF8eZLJhtTTVSrOgArZGzYeXTD6XNcc7ANgdhqex11Y9bHBeyiQLQ==}
     hasBin: true
@@ -4222,6 +4263,10 @@ packages:
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
+  undici@6.27.0:
+    resolution: {integrity: sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==}
+    engines: {node: '>=18.17'}
+
   undici@7.28.0:
     resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
@@ -4254,6 +4299,10 @@ packages:
   universalify@2.0.1:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
+
+  unplugin@1.16.1:
+    resolution: {integrity: sha512-4/u/j4FrCKdi17jaxuJA0jClGxB1AvU2hw/IuayPc4ay1XGaJs/rbb4v5WKwAjNifjmXK9PIFyuPiaK8azyR9w==}
+    engines: {node: '>=14.0.0'}
 
   untildify@4.0.0:
     resolution: {integrity: sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==}
@@ -4457,6 +4506,9 @@ packages:
     engines: {node: '>=20.0.0'}
     hasBin: true
 
+  webpack-virtual-modules@0.6.2:
+    resolution: {integrity: sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==}
+
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
@@ -4559,10 +4611,44 @@ packages:
   youch@4.1.0-beta.10:
     resolution: {integrity: sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==}
 
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
+
+  '@actions/core@3.0.1':
+    dependencies:
+      '@actions/exec': 3.0.0
+      '@actions/http-client': 4.0.1
+
+  '@actions/exec@3.0.0':
+    dependencies:
+      '@actions/io': 3.0.2
+
+  '@actions/github@9.1.1':
+    dependencies:
+      '@actions/http-client': 3.0.2
+      '@octokit/core': 7.0.6
+      '@octokit/plugin-paginate-rest': 14.0.0(@octokit/core@7.0.6)
+      '@octokit/plugin-rest-endpoint-methods': 17.0.0(@octokit/core@7.0.6)
+      '@octokit/request': 10.0.11
+      '@octokit/request-error': 7.1.0
+      undici: 6.27.0
+
+  '@actions/http-client@3.0.2':
+    dependencies:
+      tunnel: 0.0.6
+      undici: 6.27.0
+
+  '@actions/http-client@4.0.1':
+    dependencies:
+      tunnel: 0.0.6
+      undici: 6.27.0
+
+  '@actions/io@3.0.2': {}
 
   '@algolia/abtesting@1.21.1':
     dependencies:
@@ -4744,6 +4830,21 @@ snapshots:
 
   '@cloudflare/workerd-windows-64@1.20260701.1':
     optional: true
+
+  '@codecov/bundler-plugin-core@2.0.1':
+    dependencies:
+      '@actions/core': 3.0.1
+      '@actions/github': 9.1.1
+      chalk: 4.1.2
+      semver: 7.8.5
+      unplugin: 1.16.1
+      zod: 3.25.76
+
+  '@codecov/vite-plugin@2.0.1(vite@7.3.6(@types/node@25.0.9)(jiti@2.7.0)(yaml@2.9.0))':
+    dependencies:
+      '@codecov/bundler-plugin-core': 2.0.1
+      unplugin: 1.16.1
+      vite: 7.3.6(@types/node@25.0.9)(jiti@2.7.0)(yaml@2.9.0)
 
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
@@ -8218,6 +8319,8 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
+  tunnel@0.0.6: {}
+
   turbo@2.10.3:
     optionalDependencies:
       '@turbo/darwin-64': 2.10.3
@@ -8280,6 +8383,8 @@ snapshots:
 
   undici-types@7.18.2: {}
 
+  undici@6.27.0: {}
+
   undici@7.28.0: {}
 
   unenv@2.0.0-rc.24:
@@ -8314,6 +8419,11 @@ snapshots:
   universal-user-agent@7.0.3: {}
 
   universalify@2.0.1: {}
+
+  unplugin@1.16.1:
+    dependencies:
+      acorn: 8.17.0
+      webpack-virtual-modules: 0.6.2
 
   untildify@4.0.0: {}
 
@@ -8491,6 +8601,8 @@ snapshots:
       - debug
       - supports-color
 
+  webpack-virtual-modules@0.6.2: {}
+
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
@@ -8592,5 +8704,7 @@ snapshots:
       '@speed-highlight/core': 1.2.17
       cookie: 1.1.1
       youch-core: 0.3.3
+
+  zod@3.25.76: {}
 
   zwitch@2.0.4: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,6 +7,7 @@ packages:
 
 catalog:
   '@api-viewer/docs': 1.0.0-pre.10
+  '@codecov/vite-plugin': ^2.0.1
   '@pnpm/fs.find-packages': ^1000.0.24
   '@pnpm/workspace.read-manifest': ^1000.3.1
   '@types/dom-navigation': ^1.0.7


### PR DESCRIPTION
Part of #11

The "easy win" slice of perf/regression testing: Codecov bundle analysis, wired via [`@codecov/vite-plugin`](https://docs.codecov.com/docs/javascript-bundle-analysis) (v2.0.1, added to the workspace catalog).

## What's tracked

The publishable packages build with plain `tsc` (unbundled ESM), so there is no library bundle to instrument directly. The two vite-built sample apps are the real bundles, and together they cover all three libraries:

| Bundle | Libraries exercised |
| --- | --- |
| `sample-app-lit-vanilla` | `lit-ui-router`, `ui-router-navigation-location-plugin` (via `sample-app-shared`) |
| `sample-app-lit-mobx` | the above + `lit-ui-router-mobx` |

Library `src/` changes propagate through turbo (`dependsOn: ^build`) into fresh app builds, so library size regressions show up as bundle deltas on every PR.

## How it behaves

- **Local / no token:** `enableBundleAnalysis` is gated on `CODECOV_TOKEN`, so the plugin is a complete no-op — builds don't fail and nothing is uploaded. Verified with a tokenless `turbo run build`.
- **CI:** the existing `CODECOV_TOKEN` secret (already used by `codecov/codecov-action`) is passed to the `turbo run ci` step; the plugin uploads bundle stats during `vite build`.
- **Turbo env plumbing:** `CODECOV_TOKEN` is declared in the apps' `build.env` (hash-affecting, so tokenless local cache artifacts can't satisfy CI builds); `GITHUB_*` is in `passThroughEnv` (available for the plugin's CI/commit detection under strict env mode, without busting the cache every commit). Note: on a full turbo cache hit the build (and upload) is skipped — acceptable, since a cache hit means the bundle inputs didn't change.
- `telemetry: false` keeps the plugin from sending Sentry telemetry; `gitService: 'github'` matches the documented public-repo GitHub Actions setup.

## Follow-up (dashboard side)

- Bundle analysis appears under the repo's **Bundles** tab on Codecov after the first upload from `main`; no extra Codecov configuration is required, but the tab stays empty until a tokened build runs.
- Optionally add `bundle_analysis` status/comment settings to `codecov.yml` later if PR comments on bundle deltas are wanted.