### PR TITLE
fix(sample-app): route unmatched URLs to a 404 state via urlService.rules.otherwise

### DIFF
--- a/apps/README.md
+++ b/apps/README.md
@@ -37,6 +37,21 @@ Everything else — the contacts/mymessages/prefs features, router
 configuration, transition hooks, data sources, dialogs, styles, and the
 simulated REST fixtures in `public/` — is imported from `sample-app-shared`.
 
+## Divergences from the upstream sample apps
+
+The feature set tracks the ui-router sample apps, with one deliberate
+addition: **404 handling**. The
+[angularjs sample](https://github.com/ui-router/sample-app-angularjs) silently
+redirects unmatched URLs to `/welcome`; the
+[angular](https://github.com/ui-router/sample-app-angular) and
+[react](https://github.com/ui-router/sample-app-react) samples don't handle
+them at all. This app routes them to a dedicated `notFound` state that
+preserves the URL, plus a transition hook that keeps the 404 from being
+superseded when a URL matches a lazy-loaded future state's prefix but nothing
+inside the loaded module. See the
+[Unmatched URLs (404) guide](https://lit-ui-router.dev/guide/unmatched-urls)
+for the full pattern.
+
 ## Location plugin selection
 
 Both apps support three location strategies via `locationPluginConfig` in the

--- a/apps/sample-app-lit-e2e/src/integration/not_found.cy.js
+++ b/apps/sample-app-lit-e2e/src/integration/not_found.cy.js
@@ -1,0 +1,39 @@
+import { visitWithFeatures } from '../support/e2e';
+
+describe('404 not found', () => {
+  beforeEach(() => {
+    window.sessionStorage.clear();
+  });
+
+  it('shows the 404 page for an unmatched URL', () => {
+    visitWithFeatures('/no/such/page');
+    cy.contains('404 Page Not Found');
+    cy.get('code').contains('/no/such/page');
+    // The unmatched URL stays in the address bar (the 404 state has no url)
+    cy.url().should('include', '/no/such/page');
+  });
+
+  it('links back to the welcome page', () => {
+    visitWithFeatures('/no/such/page');
+    cy.contains('404 Page Not Found');
+    cy.get('button').contains('Return to Welcome').click();
+    cy.url().should('include', '/welcome');
+    cy.contains('Welcome to the sample app!');
+  });
+
+  it('does not intercept future state URLs (lazy loading still works)', () => {
+    // /mymessages matches the mymessages.** future state's wildcard rule, so
+    // it must lazy load (then redirect to login via requiresAuth), not 404
+    visitWithFeatures('/mymessages');
+    cy.contains('Log In');
+    cy.contains('404 Page Not Found').should('not.exist');
+  });
+
+  it('shows the 404 page for URLs unmatched after a future state lazy loads', () => {
+    // matches the contacts.** wildcard prefix, so the module lazy loads;
+    // after the re-sync no contacts state matches this URL, so otherwise fires
+    visitWithFeatures('/contacts/no/such/contact');
+    cy.contains('404 Page Not Found');
+    cy.get('code').contains('/contacts/no/such/contact');
+  });
+});

--- a/apps/sample-app-shared/src/app/main/NotFound.ts
+++ b/apps/sample-app-shared/src/app/main/NotFound.ts
@@ -1,0 +1,23 @@
+import { html } from 'lit';
+import { uiSref, UIViewInjectedProps } from 'lit-ui-router';
+
+export interface NotFoundResolves {
+  attemptedPath: string;
+}
+
+/**
+ * This is the view for the 'notFound' state. It is activated by the
+ * `urlService.rules.otherwise` rule (see router.config.ts) when no other
+ * URL rule matches. It shows the URL that failed to match and offers a
+ * link back to the welcome state.
+ */
+export default (props: UIViewInjectedProps<NotFoundResolves>) =>
+  html`<div class="container-fluid not-found">
+    <h3>404 Page Not Found</h3>
+    <p>
+      No state matched the URL <code>${props.resolves.attemptedPath}</code>.
+    </p>
+    <button ${uiSref('welcome')} class="btn btn-primary">
+      <i class="fa fa-home"></i><span>Return to Welcome</span>
+    </button>
+  </div>`;

--- a/apps/sample-app-shared/src/app/main/states.ts
+++ b/apps/sample-app-shared/src/app/main/states.ts
@@ -5,6 +5,7 @@ import { App } from '../global/appModules.js';
 import Welcome from '../main/Welcome.js';
 import Login from '../main/Login.js';
 import Home from '../main/Home.js';
+import NotFound from '../main/NotFound.js';
 
 /**
  * This is the parent state for the entire application.
@@ -90,6 +91,30 @@ function returnTo($transition$: Transition) {
   return $state.target('home');
 }
 
+/**
+ * This is the 404 state. The `urlService.rules.otherwise` rule in
+ * router.config.ts targets it when no other URL rule matches — including the
+ * future states' wildcard rules below, so lazy loading still wins when a URL
+ * matches a future state's prefix.
+ *
+ * It intentionally declares no `url`: the unmatched URL stays in the address
+ * bar (like a server 404) and the state can only be activated by the rule.
+ */
+export const notFoundState = {
+  parent: 'app',
+  name: 'notFound',
+  params: { attemptedPath: null },
+  resolve: [
+    {
+      token: 'attemptedPath',
+      deps: ['$transition$'],
+      resolveFn: ($transition$: Transition) =>
+        $transition$.params().attemptedPath,
+    },
+  ],
+  component: NotFound,
+};
+
 // Future State (Placeholder) for the contacts module
 export const contactsFutureState = {
   parent: 'app',
@@ -119,6 +144,7 @@ export default [
   welcomeState,
   homeState,
   loginState,
+  notFoundState,
   contactsFutureState,
   prefsFutureState,
   mymessagesFutureState,

--- a/apps/sample-app-shared/src/router.config.ts
+++ b/apps/sample-app-shared/src/router.config.ts
@@ -109,6 +109,29 @@ export function configureRouter(router = new UIRouterLit()) {
 
   urlService.rules.initial({ state: 'welcome' });
 
+  // 404: otherwise() only fires when no registered rule matches, so the
+  // future states' wildcard rules still win and lazy loading keeps working.
+  // URLs left unmatched after a lazy load re-sync land here too.
+  urlService.rules.otherwise(() => ({
+    state: 'notFound',
+    params: { attemptedPath: urlService.path() },
+  }));
+
+  // When a URL matches a future state's prefix but nothing matches after its
+  // module lazy loads, the core lazyLoad hook re-syncs the URL (triggering
+  // otherwise -> notFound) and returns no redirect, so the original transition
+  // to the now-replaced placeholder keeps running and supersedes the 404.
+  // Abort the stale placeholder transition instead (priority below the core
+  // lazyLoad hook's 0, so this runs after lazy loading resolves).
+  router.transitionService.onBefore(
+    { to: (state) => !!state?.name.endsWith('.**') },
+    (transition) =>
+      transition.router.stateRegistry.get(transition.to().name ?? '') === null
+        ? false
+        : undefined,
+    { priority: -10 },
+  );
+
   // Register the "requires auth" hook with the TransitionsService
   router.transitionService.onBefore(
     reqAuthHook.criteria,

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -16,6 +16,10 @@ function makeSidebar() {
       ],
     },
     {
+      text: 'Guide',
+      items: [{ text: 'Unmatched URLs (404)', link: '/guide/unmatched-urls' }],
+    },
+    {
       text: 'API',
       items: [
         { text: 'Overview', link: '/api/' },
@@ -75,6 +79,7 @@ const config = {
     nav: [
       { text: 'Home', link: '/' },
       { text: 'Tutorial', link: '/tutorial/helloworld' },
+      { text: 'Guide', link: '/guide/unmatched-urls' },
       { text: 'API', link: '/api/' },
       {
         text: 'Sample App',

--- a/docs/guide/unmatched-urls.md
+++ b/docs/guide/unmatched-urls.md
@@ -1,0 +1,98 @@
+---
+title: Unmatched URLs (404)
+description: Route unmatched URLs to a 404 state with urlService.rules.otherwise
+---
+
+# Unmatched URLs (404)
+
+When no registered state matches the browser URL, UI-Router does nothing by
+default: the URL sits in the address bar and no view renders. The
+[`urlService.rules.otherwise`](https://ui-router.github.io/core/docs/latest/classes/_url_urlrules_.urlrules.html#otherwise)
+rule lets you route those URLs somewhere deliberate — a 404 state, or a
+redirect back home.
+
+The [sample app](/app) implements the 404-state approach; this page walks
+through that implementation
+([`router.config.ts`](https://github.com/simshanith/lit-ui-router/blob/main/apps/sample-app-shared/src/router.config.ts),
+[`states.ts`](https://github.com/simshanith/lit-ui-router/blob/main/apps/sample-app-shared/src/app/main/states.ts)).
+
+## The rule
+
+`otherwise()` only fires after every registered URL rule has failed to match,
+so it can never shadow a real state:
+
+```ts
+urlService.rules.otherwise(() => ({
+  state: 'notFound',
+  params: { attemptedPath: urlService.path() },
+}));
+```
+
+Passing the attempted path along as a param lets the 404 view show what
+failed to match. If you'd rather silently return home, target your welcome
+state instead — or use the string shorthand, `otherwise('/welcome')`.
+
+## The 404 state
+
+```ts
+export const notFoundState = {
+  parent: 'app',
+  name: 'notFound',
+  params: { attemptedPath: null },
+  resolve: [
+    {
+      token: 'attemptedPath',
+      deps: ['$transition$'],
+      resolveFn: ($transition$: Transition) => $transition$.params().attemptedPath,
+    },
+  ],
+  component: NotFound,
+};
+```
+
+The state intentionally declares **no `url`**: the unmatched URL stays in the
+address bar (like a server-rendered 404 page), and the state can only be
+activated by the rule. The view is an ordinary component that reads the
+resolved path:
+
+```ts
+export default (props: UIViewInjectedProps<NotFoundResolves>) =>
+  html`<div class="container-fluid not-found">
+    <h3>404 Page Not Found</h3>
+    <p>No state matched the URL <code>${props.resolves.attemptedPath}</code>.</p>
+    <button ${uiSref('welcome')} class="btn btn-primary">Return to Welcome</button>
+  </div>`;
+```
+
+## Caveat: lazy-loaded future states
+
+If your app lazy loads modules through
+[future states](https://ui-router.github.io/guide/lazyloading) (`name:
+'contacts.**'`), there is one gap `otherwise()` cannot cover on its own. A URL
+like `/contacts/no/such/page` _does_ match the `contacts.**` wildcard, so the
+future state's module lazy loads — and if nothing in the loaded module matches
+either, `@uirouter/core` re-syncs the URL (correctly starting the `notFound`
+transition) but then lets the original transition resume, re-activating the
+already-replaced `.**` placeholder and superseding the 404.
+
+Until that's addressed upstream, a low-priority hook that aborts transitions
+to deregistered placeholders closes the gap:
+
+<!-- prettier-ignore -->
+```ts
+// runs after the core lazyLoad hook (priority 0); aborts transitions to
+// placeholders that lazy loading has already replaced in the registry
+router.transitionService.onBefore(
+  { to: (state) => !!state?.name.endsWith('.**') },
+  (transition) =>
+    transition.router.stateRegistry.get(transition.to().name ?? '') === null
+      ? false
+      : undefined,
+  { priority: -10 },
+);
+```
+
+With the rule, the state, and the hook in place, all three cases behave:
+plain garbage URLs render the 404 view, future-state URLs still lazy load,
+and URLs left unmatched _after_ a lazy load land on the 404 view too. The
+sample app's `not_found.cy.js` Cypress spec pins each case.


### PR DESCRIPTION
Closes #102

## What

- **`notFound` state** (`apps/sample-app-shared/src/app/main/states.ts`) with a new `NotFound` view showing the attempted path and a "Return to Welcome" button. The state deliberately declares no `url`, so the unmatched URL stays in the address bar (like a server 404) and the state can only be activated by the rule.
- **`urlService.rules.otherwise`** (`apps/sample-app-shared/src/router.config.ts`) targets `notFound` with the unmatched path as an `attemptedPath` param.
- **Future-state guard hook**: the issue's "take care around the future states / lazy load pattern" turned out to be real. `otherwise()` itself is safe — it only fires when no rule matches, so wildcard future-state rules still win and lazy loading keeps working. But when a URL matches a future state's *prefix* and nothing matches after the module loads (e.g. `/contacts/no/such/contact`), the core `lazyLoad` hook re-syncs the URL (starting the 404 transition) and returns no redirect — so the original transition resumes, supersedes the 404, and activates the now-deregistered `.**` placeholder. Trace of the race before the fix:

  ```
  Transition #1: Started  '' -> 'notFound' {attemptedPath: "/contacts/no/such/contact"}
  Transition #0: Started  '' -> 'contacts.**' {remainder: "/no/such/contact"}
  Transition #1: Rejected (superseded by Transition #0)
  Transition #0: Success, final state: contacts.**   <-- deregistered placeholder wins
  ```

  Fixed with a `priority: -10` `onBefore` hook (runs after the core lazyLoad hook's priority 0) that aborts a transition to a `.**` placeholder that has been replaced in the registry, letting the re-sync (404 or lazily-registered state redirect) win.

- **New e2e spec** `apps/sample-app-lit-e2e/src/integration/not_found.cy.js`:
  1. garbage URL renders the 404 page and keeps the URL in the address bar
  2. "Return to Welcome" navigates to `/welcome`
  3. future state URLs still lazy load (no 404 interception)
  4. URLs left unmatched *after* a future state lazy loads also 404

## Verification

- `turbo run build lint format:check` for the affected packages: 30/30 tasks pass (vite-plugin-checker: 0 TS errors in both apps)
- Full Cypress suite against vite dev servers: **vanilla 25/25, mobx 25/25** (dialog, feature_flags_panel, location_plugins, not_found, sample_app)
- `not_found.cy.js` also passes with `LOCATION_PLUGIN=hash` (4/4)

## Notes

- The placeholder-supersedes-sync race looks like an upstream `@uirouter/core` quirk in `lazyLoad.js`'s `retryTransition` (`sync()` is expected to supersede the original transition, but the original one wins the race); the guard hook works around it app-side and could be worth an upstream issue.

## Docs

- New guide page: [Unmatched URLs (404)](https://lit-ui-router.dev/guide/unmatched-urls) — the rule, the no-`url` 404 state, and the future-state guard hook (flagged as an upstream `@uirouter/core` workaround)
- `apps/README.md`: divergence note vs the upstream sample apps (angularjs silently redirects to `/welcome`; angular/react don't handle unmatched URLs)
