### PR TITLE
fix(test): backport upstream isEmbedded tester guard into @vitest/browser patch

### DIFF
--- a/patches/@vitest__browser.patch
+++ b/patches/@vitest__browser.patch
@@ -1,14 +1,35 @@
 diff --git a/dist/client/__vitest_browser__/tester-BJtsJFpD.js b/dist/client/__vitest_browser__/tester-BJtsJFpD.js
-index 0594ada..d8e8328 100644
+index 0594ada9d0e554d9ed42e08dfb51b9744cb01370..74641e14405c4a5f5cade0785e0583350ee17464 100644
 --- a/dist/client/__vitest_browser__/tester-BJtsJFpD.js
 +++ b/dist/client/__vitest_browser__/tester-BJtsJFpD.js
-@@ -2098,6 +2098,9 @@ channel.addEventListener("message", async (e) => {
-   if (!("iframeId" in data) || data.iframeId !== getBrowserState().iframeId) {
-     return;
-   }
-+  if (data.event === "ready" || data.event.startsWith("response:")) {
+@@ -2086,7 +2086,13 @@ const traces = new Traces({
+ });
+ let rootTesterSpan;
+ getBrowserState().traces = traces;
++// a tester opened as a top-level window (e.g. a test clicking <a target="_blank">
++// at the tester URL) would echo `response:` events back recursively
++const isEmbedded = window.self !== window.top;
+ channel.addEventListener("message", async (e) => {
++  if (!isEmbedded) {
 +    return;
 +  }
-   switch (data.event) {
-     case "execute": {
-       const { method, files, context } = data;
+   await client.waitForConnection();
+   const data = e.data;
+   debug == null ? void 0 : debug("event from orchestrator", JSON.stringify(e.data));
+@@ -2151,10 +2157,12 @@ const commands = new CommandsManager();
+ getBrowserState().commands = commands;
+ getBrowserState().activeTraceTaskIds = /* @__PURE__ */ new Set();
+ getBrowserState().iframeId = iframeId;
+-channel.postMessage({
+-  event: "ready",
+-  iframeId
+-});
++if (isEmbedded) {
++  channel.postMessage({
++    event: "ready",
++    iframeId
++  });
++}
+ let contextSwitched = false;
+ async function prepareTestEnvironment(options) {
+   debug == null ? void 0 : debug("trying to resolve the runner");

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,7 +111,7 @@ overrides:
 patchedDependencies:
   '@api-viewer/docs': 6cfa0893375a4ba334488a5b9e4a56178c62231d864b5271bf4c7a25a0e4f9ac
   '@uirouter/dsr': 85054b266dee7294d59dc8e0c386367422777df9777a26acb607455cb8217761
-  '@vitest/browser': a030c08a0684decd647d8128adad2a7567c1eff574e1864280e74c2ec9e23a46
+  '@vitest/browser': 5d79da8178f159b23c7475d749ef63f29e9613181535363eb1697e7359f1e63f
   lit-dialog: d37197dba1504e881c6bcb8fed0d928fbcf4203821b2519be07c5d28cb069d5a
 
 importers:
@@ -5873,7 +5873,7 @@ snapshots:
 
   '@vitest/browser-playwright@4.1.9(playwright@1.61.1)(vite@7.3.6(@types/node@25.0.9)(jiti@2.7.0)(yaml@2.9.0))(vitest@4.1.9)':
     dependencies:
-      '@vitest/browser': 4.1.9(patch_hash=a030c08a0684decd647d8128adad2a7567c1eff574e1864280e74c2ec9e23a46)(vite@7.3.6(@types/node@25.0.9)(jiti@2.7.0)(yaml@2.9.0))(vitest@4.1.9)
+      '@vitest/browser': 4.1.9(patch_hash=5d79da8178f159b23c7475d749ef63f29e9613181535363eb1697e7359f1e63f)(vite@7.3.6(@types/node@25.0.9)(jiti@2.7.0)(yaml@2.9.0))(vitest@4.1.9)
       '@vitest/mocker': 4.1.9(vite@7.3.6(@types/node@25.0.9)(jiti@2.7.0)(yaml@2.9.0))
       playwright: 1.61.1
       tinyrainbow: 3.1.0
@@ -5884,7 +5884,7 @@ snapshots:
       - utf-8-validate
       - vite
 
-  '@vitest/browser@4.1.9(patch_hash=a030c08a0684decd647d8128adad2a7567c1eff574e1864280e74c2ec9e23a46)(vite@7.3.6(@types/node@25.0.9)(jiti@2.7.0)(yaml@2.9.0))(vitest@4.1.9)':
+  '@vitest/browser@4.1.9(patch_hash=5d79da8178f159b23c7475d749ef63f29e9613181535363eb1697e7359f1e63f)(vite@7.3.6(@types/node@25.0.9)(jiti@2.7.0)(yaml@2.9.0))(vitest@4.1.9)':
     dependencies:
       '@blazediff/core': 1.9.1
       '@vitest/mocker': 4.1.9(vite@7.3.6(@types/node@25.0.9)(jiti@2.7.0)(yaml@2.9.0))
@@ -5915,7 +5915,7 @@ snapshots:
       tinyrainbow: 3.1.0
       vitest: 4.1.9(@types/node@25.0.9)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(vite@7.3.6(@types/node@25.0.9)(jiti@2.7.0)(yaml@2.9.0))
     optionalDependencies:
-      '@vitest/browser': 4.1.9(patch_hash=a030c08a0684decd647d8128adad2a7567c1eff574e1864280e74c2ec9e23a46)(vite@7.3.6(@types/node@25.0.9)(jiti@2.7.0)(yaml@2.9.0))(vitest@4.1.9)
+      '@vitest/browser': 4.1.9(patch_hash=5d79da8178f159b23c7475d749ef63f29e9613181535363eb1697e7359f1e63f)(vite@7.3.6(@types/node@25.0.9)(jiti@2.7.0)(yaml@2.9.0))(vitest@4.1.9)
 
   '@vitest/expect@4.1.9':
     dependencies:


### PR DESCRIPTION
Refs #69

Backports the root-cause fix from vitest-dev/vitest#9381 (upstream commit `361c463d5`, `fix(browser): ignore channel events in a tester opened as a top-level window`) into our pnpm patch for `@vitest/browser@4.1.9`, replacing the previous symptom filter — dogfooding the fix ahead of its upstream release.

## What changed

`patches/@vitest__browser.patch` no longer drops `ready` / `response:*` events by name. Instead, adapted from the upstream fix:

- `const isEmbedded = window.self !== window.top` defined once near the channel listener
- `if (!isEmbedded) return` as the first statement of the channel message listener
- the `channel.postMessage({ event: "ready", iframeId })` call wrapped in `if (isEmbedded)`

Root cause: a test clicking `<a href="" target="_blank">` (or modifier-clicking a relative link) opens a popup at the tester URL (the query string carries `sessionId` + `iframeId`). The popup boots a duplicate top-level tester on the same BroadcastChannel that echoes events back recursively, storming the run with `Unknown event: response:response:...` errors. The guard makes the duplicate tester inert instead of filtering the echoes it produces.

## Verification (all from `packages/lit-ui-router`)

| Run | Result | `grep -c 'Unknown event'` |
| --- | --- | --- |
| `pnpm test ui-sref.spec --browser=chromium` (historical storm trigger: "click modifiers" / "target attribute" suites, none skipped) | 25/25 passed | 0 |
| `pnpm test:coverage` (chromium + coverage — previously cascaded with `response:*` echoes) | 155/155 passed, 6 files | 0 |
| `pnpm test` (chromium + firefox + webkit) | 465/465 passed, 18 files | 0 |

## Forward path

- This patch is superseded by the next vitest release containing vitest-dev/vitest#9381; when we bump to it, drop the patch and close #69.
- If we bump vitest before then past the upstream `ack:` handshake release, the guard pattern stays valid but the surrounding bundle code moves (4.1.9 predates `ack:`) — the patch will need regenerating against the new content-hashed bundle, per the existing regen note (`pnpm patch @vitest/browser` → edit → `pnpm patch-commit`).