### PR TITLE
chore(deps): ignore @types/node and vite majors in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,13 @@ updates:
     # Mirror pnpm's minimumReleaseAge: 24h (pnpm-workspace config)
     cooldown:
       default-days: 1
+    ignore:
+      # node is pinned via mise; keep @types/node on the matching major
+      - dependency-name: '@types/node'
+        update-types: ['version-update:semver-major']
+      # vite majors change lockfile peer-keys, which the updater corrupts (#14794) — bump manually
+      - dependency-name: 'vite'
+        update-types: ['version-update:semver-major']
     commit-message:
       prefix: 'chore'
       include: 'scope'


### PR DESCRIPTION
Follow-up from dependabot triage (closes out the #191/#193 failure class).

- **@types/node majors ignored** — node is pinned via mise (currently 24); #191 bumped to 26 and arrived with a corrupt lockfile.
- **vite majors ignored** — bumps that change pnpm snapshot peer-keys hit dependabot/dependabot-core#14794 and always arrive with `ERR_PNPM_LOCKFILE_MISSING_DEPENDENCY` (#193). Take vite majors manually with `corepack pnpm install` after editing the catalog.

Related triage actions (separate from this PR): merged #187/#188/#189, closed #191/#192/#193 via `@dependabot ignore`, rebased #194 to re-trigger the Workers Builds check. The real vite@5.4.21 advisory lives under vitepress 1.6.4 — remediation is the parked vitepress 2 upgrade (#178) or a targeted override, not #192's downgrade.