### PR TITLE
chore(deps): dependabot examples get security updates only

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -43,25 +43,22 @@ updates:
         patterns:
           - '*'
 
-  # standalone StackBlitz examples
+  # standalone StackBlitz examples — security updates only:
+  # version-updates bump package.json without regenerating package-lock.json,
+  # and no CI covers examples/, so broken PRs sail through green
   - package-ecosystem: 'npm'
     directories:
       - '/examples/*'
     schedule:
       interval: 'weekly'
-    open-pull-requests-limit: 3
+    # 0 disables version updates; security updates (and their grouping) still apply
+    open-pull-requests-limit: 0
     cooldown:
       default-days: 1
     commit-message:
       prefix: 'chore'
       include: 'scope'
     groups:
-      examples-minor-and-patch:
-        patterns:
-          - '*'
-        update-types:
-          - 'minor'
-          - 'patch'
       # batch security PRs across the three example lockfiles
       examples-security:
         applies-to: security-updates


### PR DESCRIPTION
Follow-up to #199 (cherry-picked onto post-merge main after #199's branch was deleted).

Dependabot's npm version-update path for the standalone examples bumps `package.json` without regenerating the committed `package-lock.json` (#195–#198 all shipped this way — `npm ci` would fail), and no CI job covers `examples/`, so those PRs pass green. Setting `open-pull-requests-limit: 0` disables version updates while keeping grouped security updates, which demonstrably work (#194 regenerated lockfiles correctly).

The lit + typescript bumps from the closed PRs land manually with regenerated lockfiles in a companion PR.