### PR TITLE
chore(examples): lit ^3.3.3 + typescript ^6.0.3 with regenerated lockfiles

### DIFF
--- a/examples/hellogalaxy/package-lock.json
+++ b/examples/hellogalaxy/package-lock.json
@@ -10,11 +10,11 @@
       "dependencies": {
         "@uirouter/core": "^6.1.2",
         "@uirouter/visualizer": "^7.2.1",
-        "lit": "^3.3.2",
+        "lit": "^3.3.3",
         "lit-ui-router": "^1.5.1"
       },
       "devDependencies": {
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "vite": "^7.3.5"
       }
     },
@@ -1000,9 +1000,9 @@
       }
     },
     "node_modules/lit": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.2.tgz",
-      "integrity": "sha512-NF9zbsP79l4ao2SNrH3NkfmFgN/hBYSQo90saIVI1o5GpjAdCPVstVzO1MrLOakHoEhYkrtRjPK6Ob521aoYWQ==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.3.tgz",
+      "integrity": "sha512-fycuvZg/hkpozL00lm1pEJH5nN/lr9ZXd6mJI2HSN4+Bzc+LDNdEApJ6HFbPkdFNHLvOplIIuJvxkS4XUxqirw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@lit/reactive-element": "^2.1.0",
@@ -1191,9 +1191,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/examples/hellogalaxy/package.json
+++ b/examples/hellogalaxy/package.json
@@ -11,11 +11,11 @@
   "dependencies": {
     "@uirouter/core": "^6.1.2",
     "@uirouter/visualizer": "^7.2.1",
-    "lit": "^3.3.2",
+    "lit": "^3.3.3",
     "lit-ui-router": "^1.5.1"
   },
   "devDependencies": {
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "vite": "^7.3.5"
   },
   "overrides": {

--- a/examples/hellosolarsystem/package-lock.json
+++ b/examples/hellosolarsystem/package-lock.json
@@ -10,11 +10,11 @@
       "dependencies": {
         "@uirouter/core": "^6.1.2",
         "@uirouter/visualizer": "^7.2.1",
-        "lit": "^3.3.2",
+        "lit": "^3.3.3",
         "lit-ui-router": "^1.5.1"
       },
       "devDependencies": {
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "vite": "^7.3.5"
       }
     },
@@ -1000,9 +1000,9 @@
       }
     },
     "node_modules/lit": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.2.tgz",
-      "integrity": "sha512-NF9zbsP79l4ao2SNrH3NkfmFgN/hBYSQo90saIVI1o5GpjAdCPVstVzO1MrLOakHoEhYkrtRjPK6Ob521aoYWQ==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.3.tgz",
+      "integrity": "sha512-fycuvZg/hkpozL00lm1pEJH5nN/lr9ZXd6mJI2HSN4+Bzc+LDNdEApJ6HFbPkdFNHLvOplIIuJvxkS4XUxqirw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@lit/reactive-element": "^2.1.0",
@@ -1191,9 +1191,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/examples/hellosolarsystem/package.json
+++ b/examples/hellosolarsystem/package.json
@@ -11,11 +11,11 @@
   "dependencies": {
     "@uirouter/core": "^6.1.2",
     "@uirouter/visualizer": "^7.2.1",
-    "lit": "^3.3.2",
+    "lit": "^3.3.3",
     "lit-ui-router": "^1.5.1"
   },
   "devDependencies": {
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "vite": "^7.3.5"
   },
   "overrides": {

--- a/examples/helloworld/package-lock.json
+++ b/examples/helloworld/package-lock.json
@@ -9,11 +9,11 @@
       "version": "0.0.0",
       "dependencies": {
         "@uirouter/core": "^6.1.2",
-        "lit": "^3.3.2",
+        "lit": "^3.3.3",
         "lit-ui-router": "^1.5.1"
       },
       "devDependencies": {
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "vite": "^7.3.5"
       }
     },
@@ -961,9 +961,9 @@
       }
     },
     "node_modules/lit": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.2.tgz",
-      "integrity": "sha512-NF9zbsP79l4ao2SNrH3NkfmFgN/hBYSQo90saIVI1o5GpjAdCPVstVzO1MrLOakHoEhYkrtRjPK6Ob521aoYWQ==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.3.tgz",
+      "integrity": "sha512-fycuvZg/hkpozL00lm1pEJH5nN/lr9ZXd6mJI2HSN4+Bzc+LDNdEApJ6HFbPkdFNHLvOplIIuJvxkS4XUxqirw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@lit/reactive-element": "^2.1.0",
@@ -1142,9 +1142,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/examples/helloworld/package.json
+++ b/examples/helloworld/package.json
@@ -10,11 +10,11 @@
   },
   "dependencies": {
     "@uirouter/core": "^6.1.2",
-    "lit": "^3.3.2",
+    "lit": "^3.3.3",
     "lit-ui-router": "^1.5.1"
   },
   "devDependencies": {
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "vite": "^7.3.5"
   }
 }


### PR DESCRIPTION
Supersedes the closed dependabot PRs #195–#198, which bumped `package.json` without regenerating the committed `package-lock.json` (`npm ci` would have failed in every example). Companion to #200, which stops dependabot version-updates for `examples/`.

## Verification (node 24.18.0 / npm 11.16.0 via mise)
- `npm install` regenerated all three lockfiles; each resolves lit **3.3.3** and typescript **6.0.3**
- `npm run build` (vite 7.3.6) passes in all three examples
- `tsc --noEmit` under TS 6: **helloworld clean**; hellogalaxy + hellosolarsystem each have 2 **pre-existing** errors (identical under TS 5.9.3, so not a regression): the examples declare `_uiViewProps?: UIViewInjectedProps` (optional) but `LitViewDeclarationElement` requires it non-optional — likely a library-types ergonomics issue worth its own fix

## Test on StackBlitz from this branch
- [helloworld](https://stackblitz.com/github/simshanith/lit-ui-router/tree/chore/examples-lit-ts-bumps/examples/helloworld)
- [hellosolarsystem](https://stackblitz.com/github/simshanith/lit-ui-router/tree/chore/examples-lit-ts-bumps/examples/hellosolarsystem)
- [hellogalaxy](https://stackblitz.com/github/simshanith/lit-ui-router/tree/chore/examples-lit-ts-bumps/examples/hellogalaxy)