### PR TITLE
fix(sample-apps): static-copy v4 — resolve visualizer images, bump to ^4.1.1

### DIFF
--- a/apps/sample-app-lit-mobx/vite.config.ts
+++ b/apps/sample-app-lit-mobx/vite.config.ts
@@ -34,7 +34,11 @@ export default defineConfig({
     checker({ typescript: true }),
     viteStaticCopy({
       targets: [
-        { src: `${visualizerImages}/**`, dest: 'images', rename: { stripBase } },
+        {
+          src: `${visualizerImages}/**`,
+          dest: 'images',
+          rename: { stripBase },
+        },
       ],
     }),
     // Codecov bundle analysis; no-op unless CODECOV_TOKEN is set (CI).

--- a/apps/sample-app-lit-mobx/vite.config.ts
+++ b/apps/sample-app-lit-mobx/vite.config.ts
@@ -1,7 +1,48 @@
+import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
 import { codecovVitePlugin } from '@codecov/vite-plugin';
 import { defineConfig } from 'vite';
 import checker from 'vite-plugin-checker';
 import { viteStaticCopy } from 'vite-plugin-static-copy';
+
+// @uirouter/visualizer is a dep of sample-app-shared, so resolve it from there;
+// require.resolve yields a realpath, avoiding globs through pnpm symlinks.
+const sharedRequire = createRequire(
+  new URL('../sample-app-shared/package.json', import.meta.url),
+);
+const visualizerImages = path
+  .join(
+    path.dirname(sharedRequire.resolve('@uirouter/visualizer/package.json')),
+    'images',
+  )
+  .replaceAll('\\', '/'); // glob patterns need posix separators
+
+// static-copy v4 matches files only and always preserves source structure;
+// v3 copies matched directories recursively and flattens by default.
+const appRequire = createRequire(import.meta.url);
+// the plugin's exports map blocks ./package.json; its entry lives in dist/
+const staticCopyPkg = path.join(
+  appRequire.resolve('vite-plugin-static-copy'),
+  '../../package.json',
+);
+const staticCopyMajor = Number(
+  (
+    JSON.parse(readFileSync(staticCopyPkg, 'utf8')) as { version: string }
+  ).version.split('.', 1)[0],
+);
+// path segments v4 prepends to dest for sources outside the vite root
+const stripBase = path
+  .relative(path.dirname(fileURLToPath(import.meta.url)), visualizerImages)
+  .replaceAll('\\', '/')
+  .replace(/^(?:\.\.\/)+/, '')
+  .split('/').length;
+const visualizerImagesTarget =
+  staticCopyMajor >= 4
+    ? { src: `${visualizerImages}/**`, dest: 'images', rename: { stripBase } }
+    : { src: `${visualizerImages}/*`, dest: 'images' };
 
 export default defineConfig({
   // Static data (favicon, simulated REST fixtures) lives in the shared
@@ -10,12 +51,7 @@ export default defineConfig({
   plugins: [
     checker({ typescript: true }),
     viteStaticCopy({
-      targets: [
-        {
-          src: '../sample-app-shared/node_modules/@uirouter/visualizer/images/*',
-          dest: 'images',
-        },
-      ],
+      targets: [visualizerImagesTarget],
     }),
     // Codecov bundle analysis; no-op unless CODECOV_TOKEN is set (CI).
     codecovVitePlugin({

--- a/apps/sample-app-lit-mobx/vite.config.ts
+++ b/apps/sample-app-lit-mobx/vite.config.ts
@@ -1,4 +1,3 @@
-import { readFileSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -20,29 +19,12 @@ const visualizerImages = path
   )
   .replaceAll('\\', '/'); // glob patterns need posix separators
 
-// static-copy v4 matches files only and always preserves source structure;
-// v3 copies matched directories recursively and flattens by default.
-const appRequire = createRequire(import.meta.url);
-// the plugin's exports map blocks ./package.json; its entry lives in dist/
-const staticCopyPkg = path.join(
-  appRequire.resolve('vite-plugin-static-copy'),
-  '../../package.json',
-);
-const staticCopyMajor = Number(
-  (
-    JSON.parse(readFileSync(staticCopyPkg, 'utf8')) as { version: string }
-  ).version.split('.', 1)[0],
-);
-// path segments v4 prepends to dest for sources outside the vite root
+// path segments static-copy prepends to dest for sources outside the vite root
 const stripBase = path
   .relative(path.dirname(fileURLToPath(import.meta.url)), visualizerImages)
   .replaceAll('\\', '/')
   .replace(/^(?:\.\.\/)+/, '')
   .split('/').length;
-const visualizerImagesTarget =
-  staticCopyMajor >= 4
-    ? { src: `${visualizerImages}/**`, dest: 'images', rename: { stripBase } }
-    : { src: `${visualizerImages}/*`, dest: 'images' };
 
 export default defineConfig({
   // Static data (favicon, simulated REST fixtures) lives in the shared
@@ -51,7 +33,9 @@ export default defineConfig({
   plugins: [
     checker({ typescript: true }),
     viteStaticCopy({
-      targets: [visualizerImagesTarget],
+      targets: [
+        { src: `${visualizerImages}/**`, dest: 'images', rename: { stripBase } },
+      ],
     }),
     // Codecov bundle analysis; no-op unless CODECOV_TOKEN is set (CI).
     codecovVitePlugin({

--- a/apps/sample-app-lit-vanilla/vite.config.ts
+++ b/apps/sample-app-lit-vanilla/vite.config.ts
@@ -34,7 +34,11 @@ export default defineConfig({
     checker({ typescript: true }),
     viteStaticCopy({
       targets: [
-        { src: `${visualizerImages}/**`, dest: 'images', rename: { stripBase } },
+        {
+          src: `${visualizerImages}/**`,
+          dest: 'images',
+          rename: { stripBase },
+        },
       ],
     }),
     // Codecov bundle analysis; no-op unless CODECOV_TOKEN is set (CI).

--- a/apps/sample-app-lit-vanilla/vite.config.ts
+++ b/apps/sample-app-lit-vanilla/vite.config.ts
@@ -1,7 +1,48 @@
+import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
 import { codecovVitePlugin } from '@codecov/vite-plugin';
 import { defineConfig } from 'vite';
 import checker from 'vite-plugin-checker';
 import { viteStaticCopy } from 'vite-plugin-static-copy';
+
+// @uirouter/visualizer is a dep of sample-app-shared, so resolve it from there;
+// require.resolve yields a realpath, avoiding globs through pnpm symlinks.
+const sharedRequire = createRequire(
+  new URL('../sample-app-shared/package.json', import.meta.url),
+);
+const visualizerImages = path
+  .join(
+    path.dirname(sharedRequire.resolve('@uirouter/visualizer/package.json')),
+    'images',
+  )
+  .replaceAll('\\', '/'); // glob patterns need posix separators
+
+// static-copy v4 matches files only and always preserves source structure;
+// v3 copies matched directories recursively and flattens by default.
+const appRequire = createRequire(import.meta.url);
+// the plugin's exports map blocks ./package.json; its entry lives in dist/
+const staticCopyPkg = path.join(
+  appRequire.resolve('vite-plugin-static-copy'),
+  '../../package.json',
+);
+const staticCopyMajor = Number(
+  (
+    JSON.parse(readFileSync(staticCopyPkg, 'utf8')) as { version: string }
+  ).version.split('.', 1)[0],
+);
+// path segments v4 prepends to dest for sources outside the vite root
+const stripBase = path
+  .relative(path.dirname(fileURLToPath(import.meta.url)), visualizerImages)
+  .replaceAll('\\', '/')
+  .replace(/^(?:\.\.\/)+/, '')
+  .split('/').length;
+const visualizerImagesTarget =
+  staticCopyMajor >= 4
+    ? { src: `${visualizerImages}/**`, dest: 'images', rename: { stripBase } }
+    : { src: `${visualizerImages}/*`, dest: 'images' };
 
 export default defineConfig({
   // Static data (favicon, simulated REST fixtures) lives in the shared
@@ -10,12 +51,7 @@ export default defineConfig({
   plugins: [
     checker({ typescript: true }),
     viteStaticCopy({
-      targets: [
-        {
-          src: '../sample-app-shared/node_modules/@uirouter/visualizer/images/*',
-          dest: 'images',
-        },
-      ],
+      targets: [visualizerImagesTarget],
     }),
     // Codecov bundle analysis; no-op unless CODECOV_TOKEN is set (CI).
     codecovVitePlugin({

--- a/apps/sample-app-lit-vanilla/vite.config.ts
+++ b/apps/sample-app-lit-vanilla/vite.config.ts
@@ -1,4 +1,3 @@
-import { readFileSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -20,29 +19,12 @@ const visualizerImages = path
   )
   .replaceAll('\\', '/'); // glob patterns need posix separators
 
-// static-copy v4 matches files only and always preserves source structure;
-// v3 copies matched directories recursively and flattens by default.
-const appRequire = createRequire(import.meta.url);
-// the plugin's exports map blocks ./package.json; its entry lives in dist/
-const staticCopyPkg = path.join(
-  appRequire.resolve('vite-plugin-static-copy'),
-  '../../package.json',
-);
-const staticCopyMajor = Number(
-  (
-    JSON.parse(readFileSync(staticCopyPkg, 'utf8')) as { version: string }
-  ).version.split('.', 1)[0],
-);
-// path segments v4 prepends to dest for sources outside the vite root
+// path segments static-copy prepends to dest for sources outside the vite root
 const stripBase = path
   .relative(path.dirname(fileURLToPath(import.meta.url)), visualizerImages)
   .replaceAll('\\', '/')
   .replace(/^(?:\.\.\/)+/, '')
   .split('/').length;
-const visualizerImagesTarget =
-  staticCopyMajor >= 4
-    ? { src: `${visualizerImages}/**`, dest: 'images', rename: { stripBase } }
-    : { src: `${visualizerImages}/*`, dest: 'images' };
 
 export default defineConfig({
   // Static data (favicon, simulated REST fixtures) lives in the shared
@@ -51,7 +33,9 @@ export default defineConfig({
   plugins: [
     checker({ typescript: true }),
     viteStaticCopy({
-      targets: [visualizerImagesTarget],
+      targets: [
+        { src: `${visualizerImages}/**`, dest: 'images', rename: { stripBase } },
+      ],
     }),
     // Codecov bundle analysis; no-op unless CODECOV_TOKEN is set (CI).
     codecovVitePlugin({

--- a/docs/package.json
+++ b/docs/package.json
@@ -17,7 +17,7 @@
     "prettier": "catalog:",
     "typescript": "catalog:",
     "vite": "catalog:",
-    "vite-plugin-static-copy": "catalog:",
+    "vite-plugin-static-copy": "catalog:vitepress1",
     "vitepress": "^1.6.4",
     "wrangler": "catalog:"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,8 +88,8 @@ catalogs:
       specifier: ^0.14.4
       version: 0.14.4
     vite-plugin-static-copy:
-      specifier: ^3.4.0
-      version: 3.4.0
+      specifier: ^4.1.1
+      version: 4.1.1
     vitest:
       specifier: ^4.1.9
       version: 4.1.9
@@ -245,7 +245,7 @@ importers:
         version: 0.14.4(eslint@10.6.0(jiti@2.7.0))(optionator@0.9.4)(typescript@6.0.3)(vite@7.3.6(@types/node@25.0.9)(jiti@2.7.0)(yaml@2.9.0))
       vite-plugin-static-copy:
         specifier: 'catalog:'
-        version: 3.4.0(vite@7.3.6(@types/node@25.0.9)(jiti@2.7.0)(yaml@2.9.0))
+        version: 4.1.1(vite@7.3.6(@types/node@25.0.9)(jiti@2.7.0)(yaml@2.9.0))
       wrangler:
         specifier: 'catalog:'
         version: 4.107.0
@@ -288,7 +288,7 @@ importers:
         version: 0.14.4(eslint@10.6.0(jiti@2.7.0))(optionator@0.9.4)(typescript@6.0.3)(vite@7.3.6(@types/node@25.0.9)(jiti@2.7.0)(yaml@2.9.0))
       vite-plugin-static-copy:
         specifier: 'catalog:'
-        version: 3.4.0(vite@7.3.6(@types/node@25.0.9)(jiti@2.7.0)(yaml@2.9.0))
+        version: 4.1.1(vite@7.3.6(@types/node@25.0.9)(jiti@2.7.0)(yaml@2.9.0))
       wrangler:
         specifier: 'catalog:'
         version: 4.107.0
@@ -371,7 +371,7 @@ importers:
         version: 7.3.6(@types/node@25.0.9)(jiti@2.7.0)(yaml@2.9.0)
       vite-plugin-static-copy:
         specifier: 'catalog:'
-        version: 3.4.0(vite@7.3.6(@types/node@25.0.9)(jiti@2.7.0)(yaml@2.9.0))
+        version: 4.1.1(vite@7.3.6(@types/node@25.0.9)(jiti@2.7.0)(yaml@2.9.0))
       vitepress:
         specifier: ^1.6.4
         version: 1.6.4(@algolia/client-search@5.55.1)(@types/node@25.0.9)(axios@1.18.1)(change-case@5.4.4)(postcss@8.5.16)(search-insights@2.17.3)(typescript@6.0.3)
@@ -4363,11 +4363,11 @@ packages:
       vue-tsc:
         optional: true
 
-  vite-plugin-static-copy@3.4.0:
-    resolution: {integrity: sha512-ekryzCw0ouAOE8tw4RvVL/dfqguXzumsV3FBKoKso4MQ1MUUrUXtl5RI4KpJQUNGqFEsg9kxl4EvDl02YtA9VQ==}
-    engines: {node: ^18.0.0 || >=20.0.0}
+  vite-plugin-static-copy@4.1.1:
+    resolution: {integrity: sha512-GrlA8YklrAfSyxJ4M3fdQLOo9oNkp56IM9FYgX/WtEgeIFkPwhu4wzpufBCIuNKCa6Fn77FkRdYxkHqV0FwjAw==}
+    engines: {node: ^22.0.0 || >=24.0.0}
     peerDependencies:
-      vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
 
   vite@5.4.21:
     resolution: {integrity: sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==}
@@ -8471,7 +8471,7 @@ snapshots:
       optionator: 0.9.4
       typescript: 6.0.3
 
-  vite-plugin-static-copy@3.4.0(vite@7.3.6(@types/node@25.0.9)(jiti@2.7.0)(yaml@2.9.0)):
+  vite-plugin-static-copy@4.1.1(vite@7.3.6(@types/node@25.0.9)(jiti@2.7.0)(yaml@2.9.0)):
     dependencies:
       chokidar: 3.6.0
       p-map: 7.0.5

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -103,6 +103,10 @@ catalogs:
     lit:
       specifier: ^3.0.0
       version: 3.3.3
+  vitepress1:
+    vite-plugin-static-copy:
+      specifier: ^3.4.0
+      version: 3.4.0
 
 overrides:
   d3-color: 3.1.0
@@ -370,8 +374,8 @@ importers:
         specifier: 'catalog:'
         version: 7.3.6(@types/node@25.0.9)(jiti@2.7.0)(yaml@2.9.0)
       vite-plugin-static-copy:
-        specifier: 'catalog:'
-        version: 4.1.1(vite@7.3.6(@types/node@25.0.9)(jiti@2.7.0)(yaml@2.9.0))
+        specifier: catalog:vitepress1
+        version: 3.4.0(vite@7.3.6(@types/node@25.0.9)(jiti@2.7.0)(yaml@2.9.0))
       vitepress:
         specifier: ^1.6.4
         version: 1.6.4(@algolia/client-search@5.55.1)(@types/node@25.0.9)(axios@1.18.1)(change-case@5.4.4)(postcss@8.5.16)(search-insights@2.17.3)(typescript@6.0.3)
@@ -4362,6 +4366,12 @@ packages:
         optional: true
       vue-tsc:
         optional: true
+
+  vite-plugin-static-copy@3.4.0:
+    resolution: {integrity: sha512-ekryzCw0ouAOE8tw4RvVL/dfqguXzumsV3FBKoKso4MQ1MUUrUXtl5RI4KpJQUNGqFEsg9kxl4EvDl02YtA9VQ==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    peerDependencies:
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
 
   vite-plugin-static-copy@4.1.1:
     resolution: {integrity: sha512-GrlA8YklrAfSyxJ4M3fdQLOo9oNkp56IM9FYgX/WtEgeIFkPwhu4wzpufBCIuNKCa6Fn77FkRdYxkHqV0FwjAw==}
@@ -8470,6 +8480,14 @@ snapshots:
       eslint: 10.6.0(jiti@2.7.0)
       optionator: 0.9.4
       typescript: 6.0.3
+
+  vite-plugin-static-copy@3.4.0(vite@7.3.6(@types/node@25.0.9)(jiti@2.7.0)(yaml@2.9.0)):
+    dependencies:
+      chokidar: 3.6.0
+      p-map: 7.0.5
+      picocolors: 1.1.1
+      tinyglobby: 0.2.17
+      vite: 7.3.6(@types/node@25.0.9)(jiti@2.7.0)(yaml@2.9.0)
 
   vite-plugin-static-copy@4.1.1(vite@7.3.6(@types/node@25.0.9)(jiti@2.7.0)(yaml@2.9.0)):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -45,6 +45,9 @@ catalogs:
     lit: ^3.0.0
     mobx: ^6.0.0
     typedoc: ^0.28.0
+  # vitepress 1 bundles vite 5; static-copy v4 needs vite >=6 — drop with #178
+  vitepress1:
+    vite-plugin-static-copy: ^3.4.0
 
 allowBuilds:
   cypress: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -33,7 +33,7 @@ catalog:
   typescript: ^6.0.3
   vite: ^7.3.6
   vite-plugin-checker: ^0.14.4
-  vite-plugin-static-copy: ^3.4.0
+  vite-plugin-static-copy: ^4.1.1
   vitest: ^4.1.9
   wrangler: ^4.107.0
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -45,7 +45,6 @@ catalogs:
     lit: ^3.0.0
     mobx: ^6.0.0
     typedoc: ^0.28.0
-  # vitepress 1 bundles vite 5; static-copy v4 needs vite >=6 — drop with #178
   vitepress1:
     vite-plugin-static-copy: ^3.4.0
 


### PR DESCRIPTION
Combines the config fix with dependabot #190's version bump (closed as superseded), per review direction to drop v3 support in the sample apps.

## What changed
- **Sample apps**: resolve the @uirouter/visualizer images dir via `createRequire` anchored at `sample-app-shared` (whose dependency it is under pnpm's strict layout) — `require.resolve` yields the pnpm-store realpath, eliminating globs through symlinks. v4-only target semantics, unconditionally: `images/**` (v4 globs files-only, so `images/*` matched only directories and hard-errored) + `rename: { stripBase }` (v4 preserves source structure; this rebases the store path out of `dist/images/`).
- **Catalog**: `vite-plugin-static-copy ^3.4.0 → ^4.1.1`; lockfile regenerated with `corepack pnpm install`.
- **Docs stay on v3** via a new `vitepress1` named catalog: vitepress 1 bundles vite 5, and static-copy v4 requires vite ≥6 — it crashes in `writeBundle` (`Cannot read properties of undefined (reading 'config')`), which is what broke both the Actions and Cloudflare builds on the first push here. The docs targets also rely on v3 glob/flatten semantics. Retire the pin with the vitepress 2 upgrade (#178).

## Verification (local, mise node 24.18.0)
- `turbo build lint --filter=sample-app-lit-vanilla --filter=sample-app-lit-mobx --force`: 10/10; "Copied 80 items" per app; identical `dist/images/{16,32,64,128,w}/` layout to main
- `turbo build --filter=docs --force`: 11/11; `docs/dist` contains `app.html`, `app-mobx.html`, and the full image set
- `turbo format:check lint` across docs + both apps + root: 8/8
- Only peer warning is pre-existing (@codecov/vite-plugin wants vite ≤6)