### PR TITLE
fix(ci): strip devDependencies from published manifests

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -27,9 +27,9 @@ on:
         type: boolean
 
 permissions:
-  id-token: write      # Required for OIDC trusted publishing to NPM
-  contents: write      # Required for creating GitHub releases
-  attestations: write  # Required for build provenance attestation
+  id-token: write # Required for OIDC trusted publishing to NPM
+  contents: write # Required for creating GitHub releases
+  attestations: write # Required for build provenance attestation
   artifact-metadata: write
 
 jobs:
@@ -74,10 +74,24 @@ jobs:
           TURBO_API: ${{ vars.TURBO_API }}
           TURBO_TEAM: ${{ vars.TURBO_TEAM }}
       - name: Pack
-        # Create tarball for the GitHub release attachment AND the npm publish
+        # Create tarball for the GitHub release attachment AND the npm publish.
+        # devDependencies are stripped first: they're dev-only metadata and leak
+        # private workspace names (e.g. typedoc-plugin-lit-ui-router) into the
+        # published manifest.
         run: |
+          (cd "$PACKAGE_DIR" && npm pkg delete devDependencies)
           pnpm --filter ${{ env.PACKAGE_NAME }} pack --pack-destination ${{ env.PACKAGE_DIR }}
           echo "TARBALL=$(realpath "$PACKAGE_DIR"/*.tgz)" >> "$GITHUB_ENV"
+      - name: Check packed manifest
+        # no devDependencies and no unsubstituted catalog:/workspace: refs may ship
+        run: |
+          tar -xOzf "$TARBALL" package/package.json | node -e '
+            const m = JSON.parse(require("fs").readFileSync(0));
+            if (m.devDependencies) throw new Error("devDependencies leaked into packed manifest");
+            const runtime = JSON.stringify([m.dependencies, m.peerDependencies, m.optionalDependencies]);
+            if (/catalog:|workspace:/.test(runtime)) throw new Error("unsubstituted refs in packed manifest");
+            console.log("packed manifest clean");
+          '
       - name: Attest build provenance
         # Generate SLSA provenance attestation for supply chain security.
         # Skipped on manual dry runs: this hits Sigstore/rekor for real and isn't part of release-it's --dry-run.


### PR DESCRIPTION
Published manifests currently ship the full devDependencies block, including the **private, unpublished** workspace package `typedoc-plugin-lit-ui-router@0.0.1` (404 on npm — a squattable name) in all three packages, plus an exact-pinned `lit-ui-router: 1.5.0` inside `lit-ui-router-mobx`. devDependencies are dev-only metadata consumers never install, so the publish pipeline now deletes them before `pnpm pack`, and a new post-pack guard fails the run if devDependencies (or any unsubstituted `catalog:`/`workspace:` ref in runtime deps) appear in the tarball manifest.

Verified locally by simulating the CI recipe: strip → `pnpm pack` → tarball manifest has no devDependencies and correctly substituted `dependencies` (`@uirouter/core: ^6.0.8`, `lit: ^3.0.0`). Workflow dry-run linked in comments.

⚠️ Found while investigating: **`ui-router-navigation-location-plugin@0.2.0` (latest published) predates #173 and ships a raw `"@uirouter/core": "catalog:publishedPeer"` peerDependency** — the same class of broken manifest as lit-ui-router 1.3.0–1.5.0. It needs a 0.2.1 release from main (and 0.2.0 deprecated) independent of this PR.