### PR TITLE
fix(ci): restore manifest after devdeps strip

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -82,6 +82,8 @@ jobs:
           (cd "$PACKAGE_DIR" && npm pkg delete devDependencies)
           pnpm --filter ${{ env.PACKAGE_NAME }} pack --pack-destination ${{ env.PACKAGE_DIR }}
           echo "TARBALL=$(realpath "$PACKAGE_DIR"/*.tgz)" >> "$GITHUB_ENV"
+          # restore the stripped manifest: release-it requires a clean working dir
+          git checkout -- "$PACKAGE_DIR/package.json"
       - name: Check packed manifest
         # no devDependencies and no unsubstituted catalog:/workspace: refs may ship
         run: |


### PR DESCRIPTION
Follow-up to #208: `npm pkg delete devDependencies` leaves the working tree dirty, and the later `release-it --release-version` step fails with "Working dir must be clean" (caught by the [main dry-run](https://github.com/simshanith/lit-ui-router/actions/runs/28844360578) — the strip and tarball guard themselves passed). Restore `package.json` immediately after the tarball is created; the packed artifact is unaffected.