### PR TITLE
Release 0.2.1

### DIFF
--- a/packages/navigation-location-plugin/package.json
+++ b/packages/navigation-location-plugin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui-router-navigation-location-plugin",
   "description": "UI Router Location Plugin for Navigation API",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "license": "MIT",
   "author": "Shane Daniel",
   "homepage": "https://github.com/simshanith/lit-ui-router/tree/main/packages/navigation-location-plugin",


### PR DESCRIPTION
* fix(ci): restore manifest after devdeps strip so release-it sees a clean tree (#209) (63f8f8d)
* fix(ci): strip devDependencies from published manifests (#208) (621b664)
* fix(sample-apps): static-copy v4 — resolve visualizer images, bump to ^4.1.1 (#206) (5b65bdf)
* chore(examples): lit ^3.3.3 + typescript ^6.0.3, regenerate lockfiles (#205) (a0b10cf)
* chore(deps): examples get security updates only (#200) (aadb464)
* fix(sample-app): route unmatched URLs to a 404 state via urlService.rules.otherwise (#184) (e97bf23)
* chore(deps): ignore @types/node and vite majors in dependabot (#199) (e619dc2)
* fix(test): backport upstream isEmbedded tester guard into @vitest/browser patch (#186) (18629a8)
* chore(deps): bump actions/attest-build-provenance from 3 to 4 (#188) (a124a83)
* chore(deps): bump actions/checkout from 5 to 7 (#187) (8ae73ca)
* chore(deps): bump the examples-security group across 3 directories with 4 updates (#194) (b0c2bd0)
* chore(deps): bump typedoc in the minor-and-patch group (#189) (69dab52)
* ci(codecov): bundle analysis for sample app builds (#183) (b4ff8f0)
* chore(ci): add dependabot config (#180) (7ba959c)
* chore(tooling): upgrade to pnpm 11 (#177) (972ba45)
* fix(examples): bump to lit-ui-router ^1.5.1 and regenerate lockfiles (#176) (af22b25)
* Release 1.5.1 (#174) (5c878d5)
* Release 0.3.1 (#175) (d8533e7)
* fix(ci): publish the pnpm-packed tarball, not an npm re-pack (#173) (44e98c1)
* chore(tooling): node 24 + @types/node 24 (#172) (31e2a84)
* ci: push only the tag ref from Tag & push (#171) (f9d5087)
