### PR TITLE
fix(examples): bump to lit-ui-router ^1.5.2 and regenerate lockfiles

### DIFF
--- a/examples/hellogalaxy/package-lock.json
+++ b/examples/hellogalaxy/package-lock.json
@@ -11,7 +11,7 @@
         "@uirouter/core": "^6.1.2",
         "@uirouter/visualizer": "^7.2.1",
         "lit": "^3.3.3",
-        "lit-ui-router": "^1.5.1"
+        "lit-ui-router": "^1.5.2"
       },
       "devDependencies": {
         "typescript": "^6.0.3",
@@ -1031,9 +1031,9 @@
       }
     },
     "node_modules/lit-ui-router": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/lit-ui-router/-/lit-ui-router-1.5.1.tgz",
-      "integrity": "sha512-FsK5RNZT+rHlGIora0qfKu95jK/l7u30nf13mf7pzD8pBRNhtEDbSMOPqR6mrHhV385tnsbaTaOoEdREkvsqBA==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/lit-ui-router/-/lit-ui-router-1.5.2.tgz",
+      "integrity": "sha512-qqWJnks4n4qvGIe3YqytuuUaQt/5wEbV8SzAHmArq3Ekkt5xI0TjCkRui9oG3QagnUV9hGhDkrbVeYd8HNEmZw==",
       "license": "MIT",
       "dependencies": {
         "@uirouter/core": "^6.0.8",

--- a/examples/hellogalaxy/package.json
+++ b/examples/hellogalaxy/package.json
@@ -12,7 +12,7 @@
     "@uirouter/core": "^6.1.2",
     "@uirouter/visualizer": "^7.2.1",
     "lit": "^3.3.3",
-    "lit-ui-router": "^1.5.1"
+    "lit-ui-router": "^1.5.2"
   },
   "devDependencies": {
     "typescript": "^6.0.3",

--- a/examples/hellosolarsystem/package-lock.json
+++ b/examples/hellosolarsystem/package-lock.json
@@ -11,7 +11,7 @@
         "@uirouter/core": "^6.1.2",
         "@uirouter/visualizer": "^7.2.1",
         "lit": "^3.3.3",
-        "lit-ui-router": "^1.5.1"
+        "lit-ui-router": "^1.5.2"
       },
       "devDependencies": {
         "typescript": "^6.0.3",
@@ -1031,9 +1031,9 @@
       }
     },
     "node_modules/lit-ui-router": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/lit-ui-router/-/lit-ui-router-1.5.1.tgz",
-      "integrity": "sha512-FsK5RNZT+rHlGIora0qfKu95jK/l7u30nf13mf7pzD8pBRNhtEDbSMOPqR6mrHhV385tnsbaTaOoEdREkvsqBA==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/lit-ui-router/-/lit-ui-router-1.5.2.tgz",
+      "integrity": "sha512-qqWJnks4n4qvGIe3YqytuuUaQt/5wEbV8SzAHmArq3Ekkt5xI0TjCkRui9oG3QagnUV9hGhDkrbVeYd8HNEmZw==",
       "license": "MIT",
       "dependencies": {
         "@uirouter/core": "^6.0.8",

--- a/examples/hellosolarsystem/package.json
+++ b/examples/hellosolarsystem/package.json
@@ -12,7 +12,7 @@
     "@uirouter/core": "^6.1.2",
     "@uirouter/visualizer": "^7.2.1",
     "lit": "^3.3.3",
-    "lit-ui-router": "^1.5.1"
+    "lit-ui-router": "^1.5.2"
   },
   "devDependencies": {
     "typescript": "^6.0.3",

--- a/examples/helloworld/package-lock.json
+++ b/examples/helloworld/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@uirouter/core": "^6.1.2",
         "lit": "^3.3.3",
-        "lit-ui-router": "^1.5.1"
+        "lit-ui-router": "^1.5.2"
       },
       "devDependencies": {
         "typescript": "^6.0.3",
@@ -992,9 +992,9 @@
       }
     },
     "node_modules/lit-ui-router": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/lit-ui-router/-/lit-ui-router-1.5.1.tgz",
-      "integrity": "sha512-FsK5RNZT+rHlGIora0qfKu95jK/l7u30nf13mf7pzD8pBRNhtEDbSMOPqR6mrHhV385tnsbaTaOoEdREkvsqBA==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/lit-ui-router/-/lit-ui-router-1.5.2.tgz",
+      "integrity": "sha512-qqWJnks4n4qvGIe3YqytuuUaQt/5wEbV8SzAHmArq3Ekkt5xI0TjCkRui9oG3QagnUV9hGhDkrbVeYd8HNEmZw==",
       "license": "MIT",
       "dependencies": {
         "@uirouter/core": "^6.0.8",

--- a/examples/helloworld/package.json
+++ b/examples/helloworld/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@uirouter/core": "^6.1.2",
     "lit": "^3.3.3",
-    "lit-ui-router": "^1.5.1"
+    "lit-ui-router": "^1.5.2"
   },
   "devDependencies": {
     "typescript": "^6.0.3",


### PR DESCRIPTION
1.5.2 is the first release with devDependencies stripped from the published manifest (#208/#209). All three examples `npm install` + `vite build` clean against it.