### PR TITLE
docs: core-concept guides (location plugins, guards, lifecycle, reactivity)

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -17,7 +17,16 @@ function makeSidebar() {
     },
     {
       text: 'Guide',
-      items: [{ text: 'Unmatched URLs (404)', link: '/guide/unmatched-urls' }],
+      items: [
+        { text: 'Location Plugins', link: '/guide/location-plugins' },
+        { text: 'Route Guards', link: '/guide/route-guards' },
+        {
+          text: 'Component Lifecycle Hooks',
+          link: '/guide/component-lifecycle',
+        },
+        { text: 'Reactive Components', link: '/guide/reactive-components' },
+        { text: 'Unmatched URLs (404)', link: '/guide/unmatched-urls' },
+      ],
     },
     {
       text: 'API',
@@ -79,7 +88,7 @@ const config = {
     nav: [
       { text: 'Home', link: '/' },
       { text: 'Tutorial', link: '/tutorial/helloworld' },
-      { text: 'Guide', link: '/guide/unmatched-urls' },
+      { text: 'Guide', link: '/guide/location-plugins' },
       { text: 'API', link: '/api/' },
       {
         text: 'Sample App',

--- a/docs/guide/component-lifecycle.md
+++ b/docs/guide/component-lifecycle.md
@@ -1,0 +1,101 @@
+---
+title: Component Lifecycle Hooks
+description: React to routing events from inside routed components with uiCanExit and uiOnParamsChanged
+---
+
+# Component Lifecycle Hooks
+
+Routed components can participate in the routing lifecycle by implementing
+two optional interfaces. Unlike
+[transition hooks](./route-guards) registered on the `TransitionService`,
+these are declared on the component itself and only fire while that
+component is active inside a `<ui-view>`.
+
+| Interface                                                     | Method                                 | Called when…                                                     |
+| ------------------------------------------------------------- | -------------------------------------- | ---------------------------------------------------------------- |
+| [`UiOnExit`](/api/reference/hooks/UiOnExit)                   | `uiCanExit(trans?)`                    | a transition is about to exit the component's state              |
+| [`UiOnParamsChanged`](/api/reference/hooks/UiOnParamsChanged) | `uiOnParamsChanged(newParams, trans?)` | dynamic parameter values change without recreating the component |
+
+## uiCanExit: confirm or block navigation
+
+`uiCanExit` is called before a transition that would exit the component's
+state. Return `true`/`undefined` to allow it, `false` to cancel it, or a
+Promise to make the transition wait — the classic "unsaved changes" prompt:
+
+```ts
+import { LitElement, html } from 'lit';
+import { Transition, HookResult } from '@uirouter/core';
+import { UiOnExit } from 'lit-ui-router';
+
+class EditContact extends LitElement implements UiOnExit {
+  private dirty = false;
+
+  uiCanExit(trans?: Transition): HookResult {
+    if (this.dirty) {
+      return window.confirm('Discard unsaved changes?');
+    }
+    return true;
+  }
+}
+```
+
+The pending transition is passed in, so the component can inspect where the
+user is heading — or return a
+[`TargetState`](https://ui-router.github.io/core/docs/latest/classes/state.targetstate.html)
+to redirect instead of cancel.
+
+::: tip Async confirmation
+Returning a `Promise<boolean>` works too — for example, awaiting a custom
+dialog element instead of `window.confirm`. The transition pauses until the
+promise settles. The sample app's
+[EditContact](https://github.com/simshanith/lit-ui-router/blob/main/apps/sample-app-shared/src/app/contacts/EditContact.ts)
+does exactly this with a dialog service.
+:::
+
+## uiOnParamsChanged: react to dynamic parameters
+
+Normally, when a parameter in the URL changes, UI-Router exits and re-enters
+the state — destroying and recreating the component. Declaring a parameter
+**dynamic** changes that: the transition still runs, but the component
+instance is kept, and `uiOnParamsChanged` is called with the changed values:
+
+```ts
+const messagesState: LitStateDeclaration = {
+  name: 'messages',
+  url: '/messages?folder',
+  params: {
+    folder: { dynamic: true, value: 'inbox' },
+  },
+  component: MessageList,
+};
+```
+
+```ts
+import { RawParams, Transition } from '@uirouter/core';
+import { UiOnParamsChanged } from 'lit-ui-router';
+
+class MessageList extends LitElement implements UiOnParamsChanged {
+  uiOnParamsChanged(newParams: RawParams, trans?: Transition) {
+    // Only *changed* values are present on newParams
+    if (newParams.folder) {
+      this.loadFolder(newParams.folder);
+    }
+  }
+}
+```
+
+This is the right tool for parameters that tweak a view rather than replace
+it — sort order, filters, pagination, a selected tab — where a full
+destroy/recreate cycle would throw away scroll position, focus, and fetched
+data.
+
+## Where these fit among the other hooks
+
+- **Global concerns** (auth, analytics, error handling) belong in
+  [`TransitionService` hooks](./route-guards) — they run regardless of which
+  components are on screen.
+- **Per-component concerns** (unsaved changes, reacting to a dynamic param)
+  belong in these component lifecycle hooks.
+- **Re-rendering on navigation** doesn't need hooks at all — see the
+  [`TransitionController`](/api/reference/controllers/TransitionController)
+  reactive controller.

--- a/docs/guide/location-plugins.md
+++ b/docs/guide/location-plugins.md
@@ -1,0 +1,93 @@
+---
+title: Location Plugins
+description: Choosing a URL strategy - hash, pushState, or the Navigation API
+---
+
+# Location Plugins
+
+UI-Router delegates all URL reading and writing to a pluggable **location
+service**. Exactly one location plugin must be registered before
+`router.start()`; which one you choose determines what your URLs look like
+and what your server must do.
+
+| Plugin       | URL format | Browser support                              | Server requirements          |
+| ------------ | ---------- | -------------------------------------------- | ---------------------------- |
+| `hash`       | `/#/path`  | All browsers                                 | None                         |
+| `pushState`  | `/path`    | Modern browsers                              | Rewrite URLs to `index.html` |
+| `navigation` | `/path`    | Chrome/Edge 102+, Firefox 147+, Safari 26.2+ | Rewrite URLs to `index.html` |
+
+## Hash URLs
+
+The fragment (`#`) portion of a URL never reaches the server, so hash routing
+works on any static file host with zero configuration — the right default for
+demos, StackBlitz examples, and file-based deployments:
+
+```ts
+import { hashLocationPlugin } from '@uirouter/core';
+
+router.plugin(hashLocationPlugin);
+// URLs look like https://example.com/#/people/3
+```
+
+The trade-offs: URLs are less clean, and the fragment is invisible to servers
+and most crawlers, so hash URLs are a poor fit when SEO matters.
+
+## HTML5 pushState
+
+`pushStateLocationPlugin` uses the History API for real paths:
+
+```ts
+import { pushStateLocationPlugin } from '@uirouter/core';
+
+router.plugin(pushStateLocationPlugin);
+// URLs look like https://example.com/people/3
+```
+
+Two things to configure:
+
+**Server rewrites.** A user can bookmark or refresh `/people/3`, and the
+browser will request that path from your server. The server must respond with
+your `index.html` for every application route (an "SPA fallback" — most
+hosts have a one-line setting for this).
+
+**Base tag.** When the app is served from a subdirectory rather than the
+origin root, declare it with a `<base>` tag so the router resolves paths
+correctly:
+
+```html
+<base href="/my-app/" />
+```
+
+## Navigation API
+
+[`ui-router-navigation-location-plugin`](https://www.npmjs.com/package/ui-router-navigation-location-plugin)
+is an experimental companion package that produces the same clean URLs as
+`pushState`, but drives them with the modern
+[Navigation API](https://developer.mozilla.org/en-US/docs/Web/API/Navigation_API)
+and exposes the router inside `navigate` events for interception. Since the
+API is only recently cross-engine, pair it with a fallback:
+
+```ts
+import { pushStateLocationPlugin } from '@uirouter/core';
+import { navigationLocationPlugin } from 'ui-router-navigation-location-plugin';
+
+router.plugin('navigation' in window ? navigationLocationPlugin : pushStateLocationPlugin);
+```
+
+The <a href="/app" target="_self">sample app</a> ships all three strategies —
+its Preferences → Feature Flags panel switches between them and shows browser
+compatibility for each.
+
+## The initial rule
+
+Whatever plugin you choose, tell the router where to go when the app loads at
+its root URL (empty path) — otherwise nothing renders until the user clicks a
+link:
+
+```ts
+router.urlService.rules.initial({ state: 'home' });
+```
+
+`initial` only matches the empty initial URL. For URLs that match no state at
+all, add an `otherwise` rule — see
+[Unmatched URLs (404)](./unmatched-urls).

--- a/docs/guide/reactive-components.md
+++ b/docs/guide/reactive-components.md
@@ -1,0 +1,105 @@
+---
+title: Reactive Components
+description: Keep any component in sync with the router using TransitionController
+---
+
+# Reactive Components
+
+`<ui-view>` re-renders **routed** components automatically. But most apps
+also have components _outside_ the viewport that depend on router state — a
+nav header highlighting the active section, a breadcrumb trail, a user menu
+that appears after login. Lit doesn't know these components care about the
+router, so by default they render once and go stale.
+
+[`TransitionController`](/api/reference/controllers/TransitionController) is
+the core package's answer: a zero-dependency Lit
+[ReactiveController](https://lit.dev/docs/composition/controllers/) that
+calls `host.requestUpdate()` whenever a matching transition event fires.
+
+## Basic usage
+
+```ts
+import { html, LitElement } from 'lit';
+import { TransitionController } from 'lit-ui-router';
+
+class NavHeader extends LitElement {
+  private transitions = new TransitionController(this);
+
+  render() {
+    // Re-evaluated after every successful transition
+    return html`
+      <span>Current state: ${this.transitions.current?.name}</span>
+      ${this.transitions.includes('admin.**') ? html`<admin-toolbar></admin-toolbar>` : null}
+    `;
+  }
+}
+```
+
+No wiring is needed: on `hostConnected` the controller discovers the router
+from the nearest `<ui-router>` (or `<ui-view>`) ancestor via the
+`ui-router-context` event, registers its transition hooks, and deregisters
+them all on `hostDisconnected` — nothing leaks when elements come and go
+from the DOM.
+
+## Reading router state
+
+The controller exposes the essentials directly:
+
+| Member                | What it returns                                                    |
+| --------------------- | ------------------------------------------------------------------ |
+| `current`             | The current `StateDeclaration` (`globals.current`)                 |
+| `params`              | The current parameter values (`globals.params`)                    |
+| `transition`          | The most recent observed `Transition`                              |
+| `includes(state, p?)` | `StateService.includes` — supports glob patterns like `'admin.**'` |
+| `router` / `globals`  | The discovered `UIRouter` instance and its globals                 |
+
+## Scoping with criteria and callbacks
+
+By default the controller observes every successful transition. Options
+narrow that down and let you run logic before the re-render:
+
+```ts
+class UserDetail extends LitElement {
+  private transitions = new TransitionController(this, {
+    criteria: { to: 'users.detail' },
+    callback: () => this.loadUser(this.transitions.params.userId),
+  });
+}
+```
+
+- `criteria` — a
+  [HookMatchCriteria](https://ui-router.github.io/core/docs/latest/interfaces/transition.hookmatchcriteria.html)
+  limiting which transitions notify the host (`to`, `from`, glob patterns,
+  predicate functions)
+- `callback` — invoked before `requestUpdate()` with the transition and the
+  reason (`'onSuccess'`, `'hostConnected'`, …)
+- `events` — which lifecycle events to observe; defaults to `['onSuccess']`,
+  and accepts any of `'onBefore' | 'onStart' | 'onSuccess' | 'onError'`
+- `router` — an explicit router instance, skipping context discovery
+
+For `'onBefore'` and `'onStart'` events, the callback's return value is
+passed back to UI-Router as a
+[HookResult](https://ui-router.github.io/core/docs/latest/modules/transition.html#hookresult)
+— so a controller can even cancel or redirect pending transitions.
+
+## Reconnect safety
+
+On every (re)connect the controller synchronizes once with the router's
+current state before any new transition fires. Components that enter the DOM
+_after_ navigation completed — or that are detached and re-attached, as with
+[sticky states](https://github.com/ui-router/sticky-states) — render fresh
+values immediately instead of waiting for the next transition.
+
+## See it in a real app
+
+The <a href="/app" target="_self">vanilla sample app</a> is built on this
+pattern — its
+[`App`](https://github.com/simshanith/lit-ui-router/blob/main/apps/sample-app-lit-vanilla/src/app/main/App.ts),
+nav header, and message compose view each use a `TransitionController`. The
+behaviorally identical <a href="/app-mobx" target="_self">MobX sample app</a>
+solves the same problems with the observable store and reaction controllers
+from
+[`lit-ui-router-mobx`](https://www.npmjs.com/package/lit-ui-router-mobx) —
+if your app already uses MobX, prefer those bindings; the
+[two codebases](https://github.com/simshanith/lit-ui-router/tree/main/apps)
+compare the idioms file-by-file.

--- a/docs/guide/route-guards.md
+++ b/docs/guide/route-guards.md
@@ -1,0 +1,138 @@
+---
+title: Route Guards
+description: Protect states with transition hooks - the requiresAuth pattern
+---
+
+# Route Guards (Transition Hooks)
+
+Every navigation in UI-Router is a
+[Transition](https://ui-router.github.io/core/docs/latest/classes/transition.transition-1.html),
+and transitions can be observed and altered with **transition hooks**. A hook
+that redirects or cancels a transition is a route guard. Because guards run
+in the router — not in components — a single hook can protect any number of
+states.
+
+This page walks through the authentication guard the
+<a href="/app" target="_self">sample app</a> uses
+([`requiresAuth.hook.ts`](https://github.com/simshanith/lit-ui-router/blob/main/apps/sample-app-shared/src/app/global/requiresAuth.hook.ts)).
+
+## Mark states that need protection
+
+State declarations accept an arbitrary `data` object. Child states inherit
+(and may override) their parent's `data`, so marking one parent protects a
+whole subtree:
+
+```ts
+const contactsState: LitStateDeclaration = {
+  name: 'contacts',
+  url: '/contacts',
+  component: Contacts,
+  data: { requiresAuth: true },
+};
+
+// contacts.detail, contacts.edit, … inherit requiresAuth automatically
+```
+
+## Write the guard
+
+A hook has two parts: **criteria** choosing which transitions it applies to,
+and a **callback** that decides what happens. Returning a `TargetState`
+redirects the transition; returning `false` cancels it; returning nothing
+lets it proceed.
+
+```ts
+import { StateObject, Transition } from '@uirouter/core';
+
+const requiresAuthHook = {
+  // Matches transitions to any state whose data has a truthy `requiresAuth`
+  criteria: {
+    to: (state: StateObject | undefined) => state?.data && state.data.requiresAuth,
+  },
+  // Redirect to login if the user is not authenticated
+  callback: (transition: Transition) => {
+    const $state = transition.router.stateService;
+    if (!AuthService.isAuthenticated()) {
+      return $state.target('login', undefined, { location: false });
+    }
+  },
+};
+```
+
+`{ location: false }` keeps the attempted URL in the address bar during the
+redirect, so logging in can return the user to where they were headed.
+
+## Register it
+
+```ts
+router.transitionService.onBefore(requiresAuthHook.criteria, requiresAuthHook.callback, { priority: 10 });
+```
+
+`onBefore` runs before the transition starts any work (before resolves
+fetch). Higher `priority` hooks run first. The
+[TransitionService](https://ui-router.github.io/core/docs/latest/classes/transition.transitionservice.html)
+offers the full lifecycle — `onBefore`, `onStart`, `onEnter`, `onRetain`,
+`onExit`, `onFinish`, `onSuccess`, `onError` — and all of them accept the
+same criteria/callback shape.
+
+## Return the user after login
+
+The redirect above targets a `login` state. To send the user back where they
+were going, the login state resolves its return target from the transition
+that redirected to it:
+
+```ts
+const loginState: LitStateDeclaration = {
+  name: 'login',
+  url: '/login',
+  component: Login,
+  resolve: [{ token: 'returnTo', deps: ['$transition$'], resolveFn: returnTo }],
+};
+
+/** The state to return to after a successful login. */
+function returnTo($transition$: Transition) {
+  // Redirected here by the guard? Return to the original target.
+  if ($transition$.redirectedFrom()) {
+    return $transition$.redirectedFrom().targetState();
+  }
+
+  const $state = $transition$.router.stateService;
+
+  // Navigated here directly? Go back to the previous state.
+  if ($transition$.from().name !== '') {
+    return $state.target($transition$.from(), $transition$.params('from'));
+  }
+
+  // Otherwise (deep-linked straight to /login), fall back to home.
+  return $state.target('home');
+}
+```
+
+After authenticating, the login component navigates to the resolved target:
+
+```ts
+const { returnTo } = this._uiViewProps.resolves;
+router.stateService.go(returnTo.state(), returnTo.params(), {
+  reload: true,
+});
+```
+
+## Async guards
+
+Hook callbacks may return a Promise; the transition waits for it. That makes
+guards a natural place for "check the session with the server" logic:
+
+```ts
+router.transitionService.onBefore(criteria, async (transition) => {
+  const ok = await AuthService.checkSession();
+  if (!ok) {
+    return transition.router.stateService.target('login');
+  }
+});
+```
+
+## Guards in components
+
+For per-component concerns — like an edit form warning about unsaved changes
+before the user navigates away — implement the `uiCanExit` lifecycle hook on
+the routed component instead of a global guard. See the
+[UiOnExit](/api/reference/hooks/UiOnExit) interface.


### PR DESCRIPTION
## What

The docs site's Guide section had a single page (Unmatched URLs). The tutorials teach states, resolves, and nesting well, but stop short of the concepts every real app hits next — and `TransitionController`, arguably the package's most-used non-routing export, was documented only in the generated API reference. Following the shape of the ui-router core guides (and the guide sections of TanStack Router / React Router / Vite), this adds four task-oriented pages, each grounded in the sample app's actual implementation:

- **`/guide/location-plugins`** — choosing a URL strategy: hash vs pushState vs the experimental Navigation API plugin (with the feature-detect fallback the sample app uses), server rewrite requirements, `<base>` tag, and the `initial` rule.
- **`/guide/route-guards`** — the `requiresAuth` transition-hook pattern: `data` inheritance to protect subtrees, criteria/callback hooks, `{ location: false }` redirects, the `returnTo` resolve for post-login return, async guards.
- **`/guide/component-lifecycle`** — `uiCanExit` (unsaved-changes prompts, async confirmation) and `uiOnParamsChanged` (dynamic params that update a retained component instead of recreating it).
- **`/guide/reactive-components`** — `TransitionController`: why components outside `<ui-view>` go stale, context discovery, criteria/events/callback scoping, reconnect safety under sticky states, and when to prefer the MobX bindings instead.

Sidebar lists all five guides; the nav Guide entry now points at the first one.

## Verification

- `turbo run build --filter=docs` passes — VitePress's dead-link check validates all internal links, including those into the generated typedoc pages (`/api/reference/controllers/TransitionController`, `/api/reference/hooks/UiOnExit`, …)
- `prettier` formatted, `eslint` clean
- Guard/lifecycle code cross-checked against `apps/sample-app-shared` (`requiresAuth.hook.ts`, `main/states.ts` returnTo, `EditContact.ts` uiCanExit)

## Related

Sibling PR #214 adds an introduction page and companion-package guides; both touch the same sidebar block in `docs/.vitepress/config.ts`, so whichever merges second needs a trivial conflict resolution there.