### PR TITLE
feat(examples): model the real solar system in hellosolarsystem

### DIFF
--- a/examples/hellosolarsystem/index.html
+++ b/examples/hellosolarsystem/index.html
@@ -5,40 +5,26 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Hello Solar System - lit-ui-router Tutorial</title>
     <style>
+      html {
+        min-height: 100%;
+        background:
+          radial-gradient(1px 1px at 12% 22%, #fff, transparent),
+          radial-gradient(1px 1px at 32% 68%, #cfd8ff, transparent),
+          radial-gradient(2px 2px at 48% 12%, #fff, transparent),
+          radial-gradient(1px 1px at 63% 45%, #ffe9c4, transparent),
+          radial-gradient(1px 1px at 78% 80%, #fff, transparent),
+          radial-gradient(2px 2px at 88% 30%, #cfd8ff, transparent),
+          radial-gradient(1px 1px at 20% 90%, #fff, transparent),
+          radial-gradient(ellipse at bottom, #131c3d 0%, #060a18 70%);
+        background-attachment: fixed;
+      }
       body {
         font-family: system-ui, -apple-system, sans-serif;
         max-width: 800px;
         margin: 40px auto;
         padding: 0 20px;
-      }
-      nav {
-        margin-bottom: 20px;
-      }
-      nav a {
-        margin-right: 16px;
-        color: #333;
-        text-decoration: none;
-      }
-      nav a.active {
-        font-weight: bold;
-      }
-      ul {
-        list-style: none;
-        padding: 0;
-      }
-      li {
-        margin: 8px 0;
-      }
-      a {
-        color: #0066cc;
-        text-decoration: none;
-      }
-      a:hover {
-        text-decoration: underline;
-      }
-      .back-link {
-        margin-top: 16px;
-        display: block;
+        color: #e6e9f0;
+        background: transparent;
       }
     </style>
   </head>

--- a/examples/hellosolarsystem/src/main.ts
+++ b/examples/hellosolarsystem/src/main.ts
@@ -10,86 +10,225 @@ import {
 } from 'lit-ui-router';
 
 // Data Service
-interface Person {
+interface SolarBody {
   id: number;
   name: string;
-  description: string;
+  kind: 'star' | 'rocky planet' | 'gas giant' | 'ice giant' | 'dwarf planet';
+  distanceAu: number;
+  diameterKm: number;
+  moons: number;
+  orbitalPeriod: string;
+  funFact: string;
+  gradient: string;
 }
 
-const people: Person[] = [
+// Ordered by distance from the Sun.
+const solarBodies: SolarBody[] = [
   {
     id: 1,
     name: 'Sun',
-    description: 'The star at the center of our solar system.',
+    kind: 'star',
+    distanceAu: 0,
+    diameterKm: 1392700,
+    moons: 0,
+    orbitalPeriod: '230 million years around the galactic center',
+    funFact: "Contains 99.86% of the solar system's mass.",
+    gradient:
+      'radial-gradient(circle at 35% 35%, #fff7ae, #ffb703 55%, #d00000)',
   },
   {
     id: 2,
     name: 'Mercury',
-    description: 'The smallest planet and closest to the Sun.',
+    kind: 'rocky planet',
+    distanceAu: 0.39,
+    diameterKm: 4879,
+    moons: 0,
+    orbitalPeriod: '88 days',
+    funFact: 'One solar day on Mercury lasts about two Mercury years.',
+    gradient:
+      'radial-gradient(circle at 35% 35%, #d8d8d8, #8d8d8d 60%, #4a4a4a)',
   },
   {
     id: 3,
     name: 'Venus',
-    description: 'The hottest planet with a thick atmosphere.',
+    kind: 'rocky planet',
+    distanceAu: 0.72,
+    diameterKm: 12104,
+    moons: 0,
+    orbitalPeriod: '225 days',
+    funFact: 'Spins backwards, so the Sun rises in the west.',
+    gradient:
+      'radial-gradient(circle at 35% 35%, #f5e3b3, #e0b060 60%, #9c6f2f)',
   },
   {
     id: 4,
     name: 'Earth',
-    description: 'Our home planet, the only known planet with life.',
+    kind: 'rocky planet',
+    distanceAu: 1,
+    diameterKm: 12756,
+    moons: 1,
+    orbitalPeriod: '365.25 days',
+    funFact: 'The only known world with liquid-water oceans at the surface.',
+    gradient:
+      'radial-gradient(circle at 35% 35%, #9bd4f5, #2a7fd4 55%, #123c7a)',
   },
   {
     id: 5,
     name: 'Mars',
-    description: 'The red planet, a target for future exploration.',
+    kind: 'rocky planet',
+    distanceAu: 1.52,
+    diameterKm: 6792,
+    moons: 2,
+    orbitalPeriod: '687 days',
+    funFact: 'Home to Olympus Mons, the tallest volcano in the solar system.',
+    gradient:
+      'radial-gradient(circle at 35% 35%, #f0a075, #c1440e 60%, #6e2408)',
+  },
+  {
+    id: 6,
+    name: 'Jupiter',
+    kind: 'gas giant',
+    distanceAu: 5.2,
+    diameterKm: 142984,
+    moons: 95,
+    orbitalPeriod: '11.9 years',
+    funFact: 'The Great Red Spot is a storm larger than Earth.',
+    gradient:
+      'radial-gradient(circle at 35% 35%, #f3ddc0, #c88b3a 55%, #7a4a1f)',
+  },
+  {
+    id: 7,
+    name: 'Saturn',
+    kind: 'gas giant',
+    distanceAu: 9.5,
+    diameterKm: 120536,
+    moons: 274,
+    orbitalPeriod: '29.4 years',
+    funFact: 'Less dense than water, it would float in a big enough bathtub.',
+    gradient:
+      'radial-gradient(circle at 35% 35%, #f7e7b8, #d9b36c 60%, #8f6f3a)',
+  },
+  {
+    id: 8,
+    name: 'Uranus',
+    kind: 'ice giant',
+    distanceAu: 19.2,
+    diameterKm: 51118,
+    moons: 28,
+    orbitalPeriod: '84 years',
+    funFact: 'Rotates on its side, tilted about 98 degrees.',
+    gradient:
+      'radial-gradient(circle at 35% 35%, #d8f7f7, #7fd4d4 60%, #3a8f9c)',
+  },
+  {
+    id: 9,
+    name: 'Neptune',
+    kind: 'ice giant',
+    distanceAu: 30.1,
+    diameterKm: 49528,
+    moons: 16,
+    orbitalPeriod: '165 years',
+    funFact: 'Winds reach 2,000 km/h, the fastest in the solar system.',
+    gradient:
+      'radial-gradient(circle at 35% 35%, #9fb8f5, #3b5bdb 60%, #1a2f7a)',
+  },
+  {
+    id: 10,
+    name: 'Pluto',
+    kind: 'dwarf planet',
+    distanceAu: 39.5,
+    diameterKm: 2377,
+    moons: 5,
+    orbitalPeriod: '248 years',
+    funFact: 'Reclassified as a dwarf planet in 2006, but still beloved.',
+    gradient:
+      'radial-gradient(circle at 35% 35%, #e8d8c8, #b09880 60%, #6a5a4a)',
   },
 ];
 
-const PeopleService = {
-  getAllPeople: (): Promise<Person[]> => Promise.resolve(people),
-  getPerson: (id: number): Promise<Person | undefined> =>
-    Promise.resolve(people.find((p) => p.id === id)),
+// Simulated network latency so resolves are observably async.
+const delay = <T>(value: T, ms = 300): Promise<T> =>
+  new Promise((resolve) => setTimeout(() => resolve(value), ms));
+
+const SolarSystemService = {
+  getAllBodies: (): Promise<SolarBody[]> => delay(solarBodies),
+  getBody: (id: number): Promise<SolarBody | undefined> =>
+    delay(solarBodies.find((b) => b.id === id)),
 };
 
+// Log scale keeps the Sun and Pluto on the same screen.
+const dotSize = (diameterKm: number): number =>
+  Math.round(Math.log2(diameterKm / 1000) * 6 + 10);
+
 // Components
-@customElement('people-list')
-class PeopleListComponent extends LitElement {
+@customElement('planet-list')
+class PlanetListComponent extends LitElement {
   static styles = css`
     ul {
       list-style: none;
       padding: 0;
     }
     li {
-      margin: 8px 0;
+      margin: 4px 0;
     }
     a {
-      color: #0066cc;
+      display: flex;
+      align-items: center;
+      gap: 14px;
+      padding: 8px 12px;
+      border-radius: 10px;
+      color: #cdd6f4;
       text-decoration: none;
     }
     a:hover {
-      text-decoration: underline;
+      background: rgba(255, 255, 255, 0.07);
+    }
+    .body {
+      flex: none;
+      border-radius: 50%;
+      box-shadow: 0 0 12px rgba(255, 255, 255, 0.25);
+    }
+    .name {
+      min-width: 5.5em;
+      font-weight: 600;
+    }
+    .kind {
+      color: #8892b8;
+      font-size: 0.85em;
     }
   `;
 
+  // The router constructs routed components with injected props.
   @property({ attribute: false })
-  _uiViewProps?: UIViewInjectedProps;
+  _uiViewProps!: UIViewInjectedProps;
 
-  constructor(props?: UIViewInjectedProps) {
+  constructor(props: UIViewInjectedProps) {
     super();
     this._uiViewProps = props;
   }
 
-  get people(): Person[] {
-    return this._uiViewProps!.resolves!.people;
+  // Populated by the `planets` resolve on the list state.
+  get planets(): SolarBody[] {
+    return this._uiViewProps.resolves!.planets;
   }
 
   render() {
     return html`
-      <h3>Solar System</h3>
+      <h3>Bodies by distance from the Sun</h3>
       <ul>
-        ${this.people.map(
-          (person) => html`
+        ${this.planets.map(
+          (planet) => html`
             <li>
-              <a ${uiSref('person', { personId: person.id })}>${person.name}</a>
+              <a ${uiSref('planet', { planetId: planet.id })}>
+                <span
+                  class="body"
+                  style="width:${dotSize(planet.diameterKm)}px;height:${dotSize(
+                    planet.diameterKm,
+                  )}px;background:${planet.gradient}"
+                ></span>
+                <span class="name">${planet.name}</span>
+                <span class="kind">${planet.kind}</span>
+              </a>
             </li>
           `,
         )}
@@ -98,36 +237,84 @@ class PeopleListComponent extends LitElement {
   }
 }
 
-@customElement('person-detail')
-class PersonDetailComponent extends LitElement {
+@customElement('planet-detail')
+class PlanetDetailComponent extends LitElement {
   static styles = css`
+    .body {
+      border-radius: 50%;
+      box-shadow: 0 0 30px rgba(255, 255, 255, 0.3);
+      margin: 8px 0 16px;
+    }
+    dl {
+      display: grid;
+      grid-template-columns: max-content 1fr;
+      gap: 6px 16px;
+      margin: 0 0 16px;
+    }
+    dt {
+      color: #8892b8;
+    }
+    dd {
+      margin: 0;
+    }
+    .fun-fact {
+      font-style: italic;
+      color: #cdd6f4;
+    }
     .back-link {
       margin-top: 16px;
       display: block;
+      color: #8ab4f8;
+      text-decoration: none;
+    }
+    .back-link:hover {
+      text-decoration: underline;
     }
   `;
 
   @property({ attribute: false })
-  _uiViewProps?: UIViewInjectedProps;
+  _uiViewProps!: UIViewInjectedProps;
 
-  constructor(props?: UIViewInjectedProps) {
+  constructor(props: UIViewInjectedProps) {
     super();
     this._uiViewProps = props;
   }
 
-  get person(): Person | undefined {
-    return this._uiViewProps!.resolves!.person;
+  // Populated by the `planet` resolve, keyed off the :planetId route param.
+  get planet(): SolarBody | undefined {
+    return this._uiViewProps.resolves!.planet;
   }
 
   render() {
-    if (!this.person) {
-      return html`<p>Person not found</p>`;
+    if (!this.planet) {
+      return html`<p>
+        Body not found. <a class="back-link" ${uiSref('planets')}>Back</a>
+      </p>`;
     }
+    const size = dotSize(this.planet.diameterKm) * 2;
     return html`
       <div>
-        <h3>${this.person.name}</h3>
-        <p>${this.person.description}</p>
-        <a class="back-link" ${uiSref('people')}>Back to list</a>
+        <h3>${this.planet.name}</h3>
+        <span
+          class="body"
+          style="display:inline-block;width:${size}px;height:${size}px;background:${
+            this.planet.gradient
+          }"
+        ></span>
+        <dl>
+          <dt>Kind</dt>
+          <dd>${this.planet.kind}</dd>
+          <dt>Distance from Sun</dt>
+          <dd>${this.planet.distanceAu} AU</dd>
+          <dt>Diameter</dt>
+          <dd>${this.planet.diameterKm.toLocaleString('en-US')} km</dd>
+          <dt>Known moons</dt>
+          <dd>${this.planet.moons}</dd>
+          <dt>Orbital period</dt>
+          <dd>${this.planet.orbitalPeriod}</dd>
+        </dl>
+        <p class="fun-fact">${this.planet.funFact}</p>
+        <a class="back-link" ${uiSref('planets')}>Back to the solar system</a>
       </div>
     `;
   }
@@ -136,16 +323,23 @@ class PersonDetailComponent extends LitElement {
 @customElement('app-root')
 export class AppRoot extends LitElement {
   static styles = css`
+    :host {
+      color: #e6e9f0;
+    }
+    h2 {
+      letter-spacing: 0.04em;
+    }
     nav {
       margin-bottom: 16px;
     }
     nav a {
       margin-right: 16px;
-      color: #333;
+      color: #8ab4f8;
       text-decoration: none;
     }
     nav a.active {
       font-weight: bold;
+      border-bottom: 2px solid #8ab4f8;
     }
   `;
 
@@ -153,8 +347,8 @@ export class AppRoot extends LitElement {
     return html`
       <h2>Hello Solar System</h2>
       <nav>
-        <a ${uiSrefActive({ activeClasses: ['active'] })} ${uiSref('people')}
-          >People</a
+        <a ${uiSrefActive({ activeClasses: ['active'] })} ${uiSref('planets')}
+          >Planets</a
         >
       </nav>
       <ui-view></ui-view>
@@ -163,29 +357,31 @@ export class AppRoot extends LitElement {
 }
 
 // State definitions
-const peopleState: LitStateDeclaration = {
-  name: 'people',
-  url: '/people',
-  component: PeopleListComponent,
+const planetsState: LitStateDeclaration = {
+  name: 'planets',
+  url: '/planets',
+  component: PlanetListComponent,
+  // Resolve blocks the transition until the async data is ready.
   resolve: [
     {
-      token: 'people',
-      resolveFn: () => PeopleService.getAllPeople(),
+      token: 'planets',
+      resolveFn: () => SolarSystemService.getAllBodies(),
     },
   ],
 };
 
-const personState: LitStateDeclaration = {
-  name: 'person',
-  url: '/people/:personId',
-  component: PersonDetailComponent,
+const planetState: LitStateDeclaration = {
+  name: 'planet',
+  url: '/planets/:planetId',
+  component: PlanetDetailComponent,
+  // deps injects $transition$ so the resolve can read the route parameter.
   resolve: [
     {
-      token: 'person',
+      token: 'planet',
       deps: ['$transition$'],
       resolveFn: ($transition$: Transition) => {
-        const personId = parseInt($transition$.params().personId);
-        return PeopleService.getPerson(personId);
+        const planetId = parseInt($transition$.params().planetId);
+        return SolarSystemService.getBody(planetId);
       },
     },
   ],
@@ -197,9 +393,9 @@ router.plugin(hashLocationPlugin);
 import('@uirouter/visualizer').then(({ Visualizer }) =>
   router.plugin(Visualizer),
 );
-router.stateRegistry.register(peopleState);
-router.stateRegistry.register(personState);
-router.urlService.rules.initial({ state: 'people' });
+router.stateRegistry.register(planetsState);
+router.stateRegistry.register(planetState);
+router.urlService.rules.initial({ state: 'planets' });
 router.start();
 
 // Render


### PR DESCRIPTION
## Summary
- Replaces the copy-paste `Person`/`people` dataset with an honest `SolarBody`/`solarBodies` model: the Sun, all 8 planets in order (Mercury -> Neptune), and a Pluto dwarf-planet easter egg, each with real kind, distance (AU), diameter, known-moon count, orbital period, and a one-line fun fact.
- Keeps the routing lesson front and center: `planets` list state with a resolve that fetches all bodies, and a `planet` detail state at `/planets/:planetId` whose resolve injects `$transition$` via `deps` to read the route param. The service now simulates ~300ms latency so resolve blocking is observable.
- Light space visuals with pure CSS: dark starfield page, planets rendered as radial-gradient circles log-scaled by diameter, list ordered by distance from the Sun. No new dependencies.
- Preserves the taught API surface: `uiSref`/`uiSrefActive`, back link, `hashLocationPlugin`, dynamic `@uirouter/visualizer` import, and `UIViewInjectedProps` constructor injection — now with the canonical non-optional `_uiViewProps!` typing, fixing a pre-existing `tsc --noEmit` failure in this example.

## Verification
- `npm install` (no lockfile changes shipped), `npx tsc --noEmit`, `npm run build` in `examples/hellosolarsystem`
- `corepack pnpm install` + `turbo format lint --filter=examples` at repo root

## Try it on StackBlitz

Open this branch's example directly (WebContainers: npm install + vite dev in-browser):

[examples/hellosolarsystem @ feat/examples-hellosolarsystem-real-data](https://stackblitz.com/github/simshanith/lit-ui-router/tree/feat/examples-hellosolarsystem-real-data/examples/hellosolarsystem)
