### PR TITLE
docs: Live Examples page embedding the tutorial apps same-origin

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -17,6 +17,7 @@ function makeSidebar() {
         { text: 'Hello World', link: '/tutorial/helloworld' },
         { text: 'Hello Solar System', link: '/tutorial/hellosolarsystem' },
         { text: 'Hello Galaxy', link: '/tutorial/hellogalaxy' },
+        { text: 'Live Examples', link: '/tutorial/live-examples' },
       ],
     },
     {
@@ -76,7 +77,7 @@ const config = {
   title: 'Lit UI Router',
   description: 'A @uirouter implementation for Lit',
   cleanUrls: true,
-  ignoreDeadLinks: ['/app', '/app-mobx'],
+  ignoreDeadLinks: ['/app', '/app-mobx', /^\/examples\//],
   // ignoreDeadLinks: true,
   vite: {
     configFile: './.vitepress/vite.config.ts',

--- a/docs/.vitepress/theme/components/ExampleEmbed.vue
+++ b/docs/.vitepress/theme/components/ExampleEmbed.vue
@@ -1,0 +1,175 @@
+<script setup lang="ts">
+import { useTemplateRef, ref, onMounted, onUnmounted } from 'vue';
+import screenfull from 'screenfull';
+
+// Same-origin iframe embed for the tutorial examples served at
+// /examples/<name>/ — no StackBlitz boot, just the built app.
+const props = withDefaults(
+  defineProps<{
+    src: string;
+    title: string;
+    height?: string;
+  }>(),
+  { height: '420px' },
+);
+
+const container = useTemplateRef('container');
+const isFullscreenSupported = ref(false);
+const isFullscreen = ref(false);
+const iconsLoaded = ref(false);
+
+const toggleFullscreen = () => {
+  if (screenfull.isEnabled && container.value) {
+    screenfull.toggle(container.value);
+  }
+};
+
+const handleFullscreenChange = () => {
+  isFullscreen.value = screenfull.isFullscreen;
+};
+
+const iframe = useTemplateRef('iframe');
+function restartIframe() {
+  iframe.value.src += '';
+}
+
+async function loadIcons() {
+  await Promise.all([
+    import('@spectrum-web-components/icons-workflow/icons/sp-icon-full-screen.js'),
+    import('@spectrum-web-components/icons-workflow/icons/sp-icon-full-screen-exit.js'),
+    import('@spectrum-web-components/icons-workflow/icons/sp-icon-refresh.js'),
+  ]);
+  iconsLoaded.value = true;
+}
+
+if (!import.meta.env.SSR) {
+  loadIcons();
+}
+
+onMounted(async () => {
+  isFullscreenSupported.value = screenfull.isEnabled;
+  if (screenfull.isEnabled) {
+    screenfull.on('change', handleFullscreenChange);
+  }
+});
+
+onUnmounted(() => {
+  if (screenfull.isEnabled) {
+    screenfull.off('change', handleFullscreenChange);
+  }
+});
+</script>
+
+<template>
+  <div ref="container" class="example-embed" :class="{ fullscreen: isFullscreen }">
+    <iframe
+      :src="src"
+      :title="title"
+      :style="{ height: props.height }"
+      ref="iframe"
+      loading="lazy"
+    />
+    <div class="example-embed-actions">
+      <button
+        v-if="isFullscreenSupported"
+        type="button"
+        class="fullscreen-btn btn"
+        @click="toggleFullscreen"
+      >
+        <sp-icon-full-screen-exit v-if="iconsLoaded && isFullscreen" />
+        <sp-icon-full-screen v-if="iconsLoaded && !isFullscreen" />
+        {{ isFullscreen ? 'Exit Fullscreen' : 'Fullscreen' }}
+      </button>
+      <button @click="restartIframe" class="restart-btn btn" type="button">
+        <sp-icon-refresh v-if="iconsLoaded" label="Restart example" />
+        Restart
+      </button>
+      <slot></slot>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.example-embed {
+  width: 100%;
+  transition: padding 0.3s ease, width 0.3s ease;
+}
+
+.example-embed iframe {
+  width: 100%;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 4px;
+  overflow: hidden;
+  background: #fff;
+  transition: height 0.3s ease, width 0.3s ease, border-radius 0.3s ease;
+  margin: auto;
+}
+
+.example-embed:fullscreen,
+.example-embed:-webkit-full-screen {
+  background: var(--vp-c-bg);
+  padding: 16px;
+}
+
+.example-embed:fullscreen iframe,
+.example-embed:-webkit-full-screen iframe {
+  height: calc(100vh - 80px) !important;
+  border-radius: 8px;
+  width: 88%;
+  transition: height 0.3s ease, width 0s ease, border-radius 0.3s ease;
+}
+
+.example-embed.fullscreen:fullscreen iframe,
+.example-embed.fullscreen:-webkit-full-screen iframe {
+  width: 100%;
+  transition: height 0.3s ease, width 0.3s ease, border-radius 0.3s ease;
+}
+
+.example-embed-actions {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: 8px;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--vp-c-text-1);
+  background: var(--vp-c-bg-soft);
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background-color 0.2s, border-color 0.2s;
+}
+
+.btn:hover {
+  background: var(--vp-c-bg-mute);
+  border-color: var(--vp-c-brand-1);
+}
+
+:deep(a) {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--vp-c-text-1);
+  text-decoration: none;
+  background: var(--vp-c-bg-soft);
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 6px;
+  transition: background-color 0.2s, border-color 0.2s;
+}
+
+:deep(a:hover) {
+  background: var(--vp-c-bg-mute);
+  border-color: var(--vp-c-brand-1);
+}
+</style>

--- a/docs/.vitepress/theme/components/ExampleEmbed.vue
+++ b/docs/.vitepress/theme/components/ExampleEmbed.vue
@@ -38,6 +38,7 @@ async function loadIcons() {
     import('@spectrum-web-components/icons-workflow/icons/sp-icon-full-screen.js'),
     import('@spectrum-web-components/icons-workflow/icons/sp-icon-full-screen-exit.js'),
     import('@spectrum-web-components/icons-workflow/icons/sp-icon-refresh.js'),
+    import('@spectrum-web-components/icons-workflow/icons/sp-icon-link-out.js'),
   ]);
   iconsLoaded.value = true;
 }
@@ -84,6 +85,10 @@ onUnmounted(() => {
         <sp-icon-refresh v-if="iconsLoaded" label="Restart example" />
         Restart
       </button>
+      <a :href="src" target="_blank" rel="noopener" class="open-btn btn">
+        <sp-icon-link-out v-if="iconsLoaded" />
+        Open in new tab
+      </a>
       <slot></slot>
     </div>
   </div>
@@ -141,6 +146,7 @@ onUnmounted(() => {
   font-size: 14px;
   font-weight: 500;
   color: var(--vp-c-text-1);
+  text-decoration: none;
   background: var(--vp-c-bg-soft);
   border: 1px solid var(--vp-c-divider);
   border-radius: 6px;
@@ -149,26 +155,6 @@ onUnmounted(() => {
 }
 
 .btn:hover {
-  background: var(--vp-c-bg-mute);
-  border-color: var(--vp-c-brand-1);
-}
-
-:deep(a) {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  padding: 6px 12px;
-  font-size: 14px;
-  font-weight: 500;
-  color: var(--vp-c-text-1);
-  text-decoration: none;
-  background: var(--vp-c-bg-soft);
-  border: 1px solid var(--vp-c-divider);
-  border-radius: 6px;
-  transition: background-color 0.2s, border-color 0.2s;
-}
-
-:deep(a:hover) {
   background: var(--vp-c-bg-mute);
   border-color: var(--vp-c-brand-1);
 }

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -1,11 +1,13 @@
 import DefaultTheme from 'vitepress/theme';
 import './custom.css';
 import StackBlitzEmbed from './components/StackBlitzEmbed.vue';
+import ExampleEmbed from './components/ExampleEmbed.vue';
 
 export default {
   extends: DefaultTheme,
   enhanceApp({ app }) {
     app.component('StackBlitzEmbed', StackBlitzEmbed);
+    app.component('ExampleEmbed', ExampleEmbed);
   },
 };
 

--- a/docs/.vitepress/vite.config.ts
+++ b/docs/.vitepress/vite.config.ts
@@ -1,17 +1,26 @@
 import { defineConfig, Plugin } from 'vite';
 import { viteStaticCopy } from 'vite-plugin-static-copy';
 
+// Tutorial examples embedded same-origin at /examples/<name>/; built by
+// `examples#build:embeds` (hash routing, so no _redirects entries needed).
+const EMBEDDED_EXAMPLES = ['helloworld', 'hellosolarsystem', 'hellogalaxy'];
+
 /**
  * Vite plugin to handle /app/* and /app-mobx/* deep linking in dev server.
  * Mirrors Cloudflare _redirects: `/app/* /app 200`, `/app-mobx/* /app-mobx 200`
  * Rewrites requests to serve the matching sample-app SPA html.
+ * Also resolves /examples/<name>/ directory requests to their index.html
+ * (production gets this from Cloudflare's static-asset index resolution).
  */
 function spaFallbackPlugin(): Plugin {
   return {
     name: 'spa-fallback',
     configureServer(server) {
       server.middlewares.use((req, _res, next) => {
-        if (req.url?.startsWith('/app-mobx')) {
+        const exampleDir = req.url?.match(/^\/examples\/([\w-]+)\/?$/);
+        if (exampleDir) {
+          req.url = `/examples/${exampleDir[1]}/index.html`;
+        } else if (req.url?.startsWith('/app-mobx')) {
           req.url = '/app-mobx.html';
         } else if (req.url?.startsWith('/app')) {
           req.url = '/app.html';
@@ -55,6 +64,10 @@ export default defineConfig({
           src: 'node_modules/sample-app-lit-vanilla/dist/static/*',
           dest: 'static',
         },
+        ...EMBEDDED_EXAMPLES.map((name) => ({
+          src: `../examples/${name}/dist/*`,
+          dest: `examples/${name}`,
+        })),
       ],
     }),
   ],

--- a/docs/turbo.json
+++ b/docs/turbo.json
@@ -17,8 +17,13 @@
       "persistent": true
     },
     "build": {
-      "dependsOn": ["^build", "^docs:api"],
+      "dependsOn": ["^build", "^docs:api", "examples#build:embeds"],
       "env": ["VITE_GOOGLE_ANALYTICS_TRACKING_ID"]
+    },
+    "docs": {
+      "dependsOn": ["^build", "^docs:api", "examples#build:embeds"],
+      "cache": false,
+      "persistent": true
     }
   }
 }

--- a/docs/tutorial/live-examples.md
+++ b/docs/tutorial/live-examples.md
@@ -20,7 +20,7 @@ workspace.
 Two sibling states, one `<ui-view>`, and `uiSref` navigation — the smallest
 possible router. Walkthrough: [Hello World tutorial](./helloworld).
 
-<ExampleEmbed src="/examples/helloworld/" title="helloworld example" height="150px" />
+<ExampleEmbed src="/examples/helloworld/" title="helloworld example" height="180px" />
 
 ## Hello Solar System
 
@@ -37,4 +37,4 @@ inheritance, and a lazily loaded 3D astronaut (the `model-viewer` chunk only
 downloads when you visit the astronaut state — watch the network tab).
 Walkthrough: [Hello Galaxy tutorial](./hellogalaxy).
 
-<ExampleEmbed src="/examples/hellogalaxy/" title="hellogalaxy example" height="720px" />
+<ExampleEmbed src="/examples/hellogalaxy/" title="hellogalaxy example" height="800px" />

--- a/docs/tutorial/live-examples.md
+++ b/docs/tutorial/live-examples.md
@@ -1,0 +1,46 @@
+---
+title: Live Examples
+description: The tutorial example apps, running live inside the docs site
+---
+
+# Live Examples
+
+All three tutorial examples run right here — built from
+[`examples/`](https://github.com/simshanith/lit-ui-router/tree/main/examples)
+and served by this site, no StackBlitz boot required. Each frame below is the
+real app, installed from the published npm packages.
+
+The examples route with `hashLocationPlugin`, so navigation stays inside each
+frame. Open one in its own tab to watch the URL change as you click around, or
+head to its tutorial for the full walkthrough with an editable StackBlitz
+workspace.
+
+## Hello World
+
+Two sibling states, one `<ui-view>`, and `uiSref` navigation — the smallest
+possible router. Walkthrough: [Hello World tutorial](./helloworld).
+
+<ExampleEmbed src="/examples/helloworld/" title="helloworld example" height="360px">
+  <a href="/examples/helloworld/" target="_blank" rel="noopener">Open in new tab</a>
+</ExampleEmbed>
+
+## Hello Solar System
+
+A master-detail list of the real solar system: URL parameters, async resolves,
+and transition-driven data loading. Walkthrough:
+[Hello Solar System tutorial](./hellosolarsystem).
+
+<ExampleEmbed src="/examples/hellosolarsystem/" title="hellosolarsystem example" height="480px">
+  <a href="/examples/hellosolarsystem/" target="_blank" rel="noopener">Open in new tab</a>
+</ExampleEmbed>
+
+## Hello Galaxy
+
+Nested states and views: a star catalog in a three-level state tree, resolve
+inheritance, and a lazily loaded 3D astronaut (the `model-viewer` chunk only
+downloads when you visit the astronaut state — watch the network tab).
+Walkthrough: [Hello Galaxy tutorial](./hellogalaxy).
+
+<ExampleEmbed src="/examples/hellogalaxy/" title="hellogalaxy example" height="560px">
+  <a href="/examples/hellogalaxy/" target="_blank" rel="noopener">Open in new tab</a>
+</ExampleEmbed>

--- a/docs/tutorial/live-examples.md
+++ b/docs/tutorial/live-examples.md
@@ -20,7 +20,7 @@ workspace.
 Two sibling states, one `<ui-view>`, and `uiSref` navigation — the smallest
 possible router. Walkthrough: [Hello World tutorial](./helloworld).
 
-<ExampleEmbed src="/examples/helloworld/" title="helloworld example" height="360px" />
+<ExampleEmbed src="/examples/helloworld/" title="helloworld example" height="150px" />
 
 ## Hello Solar System
 
@@ -28,7 +28,7 @@ A master-detail list of the real solar system: URL parameters, async resolves,
 and transition-driven data loading. Walkthrough:
 [Hello Solar System tutorial](./hellosolarsystem).
 
-<ExampleEmbed src="/examples/hellosolarsystem/" title="hellosolarsystem example" height="480px" />
+<ExampleEmbed src="/examples/hellosolarsystem/" title="hellosolarsystem example" height="800px" />
 
 ## Hello Galaxy
 
@@ -37,4 +37,4 @@ inheritance, and a lazily loaded 3D astronaut (the `model-viewer` chunk only
 downloads when you visit the astronaut state — watch the network tab).
 Walkthrough: [Hello Galaxy tutorial](./hellogalaxy).
 
-<ExampleEmbed src="/examples/hellogalaxy/" title="hellogalaxy example" height="560px" />
+<ExampleEmbed src="/examples/hellogalaxy/" title="hellogalaxy example" height="720px" />

--- a/docs/tutorial/live-examples.md
+++ b/docs/tutorial/live-examples.md
@@ -20,9 +20,7 @@ workspace.
 Two sibling states, one `<ui-view>`, and `uiSref` navigation — the smallest
 possible router. Walkthrough: [Hello World tutorial](./helloworld).
 
-<ExampleEmbed src="/examples/helloworld/" title="helloworld example" height="360px">
-  <a href="/examples/helloworld/" target="_blank" rel="noopener">Open in new tab</a>
-</ExampleEmbed>
+<ExampleEmbed src="/examples/helloworld/" title="helloworld example" height="360px" />
 
 ## Hello Solar System
 
@@ -30,9 +28,7 @@ A master-detail list of the real solar system: URL parameters, async resolves,
 and transition-driven data loading. Walkthrough:
 [Hello Solar System tutorial](./hellosolarsystem).
 
-<ExampleEmbed src="/examples/hellosolarsystem/" title="hellosolarsystem example" height="480px">
-  <a href="/examples/hellosolarsystem/" target="_blank" rel="noopener">Open in new tab</a>
-</ExampleEmbed>
+<ExampleEmbed src="/examples/hellosolarsystem/" title="hellosolarsystem example" height="480px" />
 
 ## Hello Galaxy
 
@@ -41,6 +37,4 @@ inheritance, and a lazily loaded 3D astronaut (the `model-viewer` chunk only
 downloads when you visit the astronaut state — watch the network tab).
 Walkthrough: [Hello Galaxy tutorial](./hellogalaxy).
 
-<ExampleEmbed src="/examples/hellogalaxy/" title="hellogalaxy example" height="560px">
-  <a href="/examples/hellogalaxy/" target="_blank" rel="noopener">Open in new tab</a>
-</ExampleEmbed>
+<ExampleEmbed src="/examples/hellogalaxy/" title="hellogalaxy example" height="560px" />

--- a/docs/tutorial/live-examples.md
+++ b/docs/tutorial/live-examples.md
@@ -37,4 +37,4 @@ inheritance, and a lazily loaded 3D astronaut (the `model-viewer` chunk only
 downloads when you visit the astronaut state — watch the network tab).
 Walkthrough: [Hello Galaxy tutorial](./hellogalaxy).
 
-<ExampleEmbed src="/examples/hellogalaxy/" title="hellogalaxy example" height="800px" />
+<ExampleEmbed src="/examples/hellogalaxy/" title="hellogalaxy example" height="920px" />

--- a/examples/build-embeds.mjs
+++ b/examples/build-embeds.mjs
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+// Builds each example for same-origin embedding in the docs site:
+// `npm ci` + `vite build --base=/examples/<name>/` into <name>/dist,
+// which the docs build then static-copies to /examples/<name>/.
+// npm (not pnpm) on purpose — examples are standalone npm projects with
+// their own package-lock.json, matching the StackBlitz consumption path.
+import { execSync } from 'node:child_process';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = dirname(fileURLToPath(import.meta.url));
+const EXAMPLES = ['helloworld', 'hellosolarsystem', 'hellogalaxy'];
+
+for (const name of EXAMPLES) {
+  const cwd = join(root, name);
+  console.log(`\n[build-embeds] ${name}: npm ci`);
+  execSync('npm ci --no-audit --no-fund', { cwd, stdio: 'inherit' });
+  console.log(`[build-embeds] ${name}: vite build --base=/examples/${name}/`);
+  execSync(`npm run build -- --base=/examples/${name}/`, {
+    cwd,
+    stdio: 'inherit',
+  });
+}

--- a/examples/hellogalaxy/index.html
+++ b/examples/hellogalaxy/index.html
@@ -14,9 +14,12 @@
       }
       html {
         min-height: 100%;
+        /* Loading fallback while the photo downloads */
         background: radial-gradient(ellipse at bottom, #1b2735 0%, #090a0f 100%);
       }
-      /* Pure-CSS starfield: tiled radial-gradient dots behind the app */
+      /* Backdrop: the Milky Way's center in infrared, Spitzer Space Telescope.
+         Credit: NASA, JPL-Caltech, Susan Stolovy (SSC/Caltech) et al.
+         https://science.nasa.gov/image-detail/ssc2006-02a-0/ */
       body::before {
         content: '';
         position: fixed;
@@ -24,14 +27,10 @@
         z-index: -1;
         pointer-events: none;
         background-image:
-          radial-gradient(1px 1px at 25px 8px, #fff 50%, transparent 50%),
-          radial-gradient(1px 1px at 60px 120px, rgba(255, 255, 255, 0.7) 50%, transparent 50%),
-          radial-gradient(1.5px 1.5px at 125px 40px, #fff 50%, transparent 50%),
-          radial-gradient(2px 2px at 15px 175px, rgba(255, 255, 255, 0.8) 50%, transparent 50%),
-          radial-gradient(1px 1px at 170px 90px, rgba(255, 255, 255, 0.6) 50%, transparent 50%),
-          radial-gradient(1.5px 1.5px at 95px 155px, rgba(255, 255, 255, 0.9) 50%, transparent 50%),
-          radial-gradient(1px 1px at 200px 200px, rgba(255, 255, 255, 0.5) 50%, transparent 50%);
-        background-size: 220px 220px;
+          linear-gradient(rgba(9, 10, 15, 0.4), rgba(9, 10, 15, 0.7)),
+          url('https://science.nasa.gov/wp-content/uploads/2023/09/ssc2006-02a-0.jpg?w=2048');
+        background-size: cover;
+        background-position: center;
       }
     </style>
   </head>

--- a/examples/hellogalaxy/package.json
+++ b/examples/hellogalaxy/package.json
@@ -21,5 +21,9 @@
   },
   "overrides": {
     "d3-color": "3.1.0"
+  },
+  "allowScripts": {
+    "esbuild@0.27.2": true,
+    "fsevents@2.3.3": true
   }
 }

--- a/examples/hellogalaxy/src/main.ts
+++ b/examples/hellogalaxy/src/main.ts
@@ -147,11 +147,12 @@ class GalaxyShellComponent extends LitElement {
       margin-bottom: 24px;
     }
     nav a {
-      color: #9db2ce;
+      color: #c9d6ea;
       text-decoration: none;
       padding: 6px 14px;
       border-radius: 999px;
-      border: 1px solid #263449;
+      border: 1px solid #3d5a80;
+      background: rgba(9, 12, 20, 0.6);
       cursor: pointer;
     }
     nav a:hover {
@@ -164,13 +165,22 @@ class GalaxyShellComponent extends LitElement {
       border-color: #7aa2ff;
       font-weight: 600;
     }
+    .panel {
+      background: rgba(9, 12, 20, 0.72);
+      border: 1px solid rgba(61, 90, 128, 0.5);
+      border-radius: 12px;
+      padding: 20px;
+      backdrop-filter: blur(6px);
+      -webkit-backdrop-filter: blur(6px);
+    }
     .backdrop-credit {
-      color: #6b7c95;
+      color: #8fa1bb;
       font-size: 0.75rem;
       margin: 32px 0 0;
+      text-shadow: 0 1px 4px rgba(0, 0, 0, 0.9);
     }
     .backdrop-credit a {
-      color: #9db2ce;
+      color: #c9d6ea;
     }
   `;
 
@@ -198,7 +208,9 @@ class GalaxyShellComponent extends LitElement {
         >
       </nav>
       <!-- Child states (galaxy.stars, galaxy.astronaut) render into this nested view -->
-      <ui-view></ui-view>
+      <div class="panel">
+        <ui-view></ui-view>
+      </div>
       <p class="backdrop-credit">
         Backdrop:
         <a
@@ -459,13 +471,15 @@ export class AppRoot extends LitElement {
   static styles = css`
     h1 {
       margin: 0 0 4px;
-      color: #e6edf3;
+      color: #f2f6fc;
       font-size: 1.7rem;
       letter-spacing: 0.02em;
+      text-shadow: 0 1px 6px rgba(0, 0, 0, 0.9);
     }
     .tagline {
-      color: #6b7c95;
+      color: #a7b8d0;
       margin: 0 0 24px;
+      text-shadow: 0 1px 4px rgba(0, 0, 0, 0.9);
     }
   `;
 

--- a/examples/hellogalaxy/src/main.ts
+++ b/examples/hellogalaxy/src/main.ts
@@ -417,8 +417,8 @@ class AstronautViewComponent extends LitElement {
       width: 100%;
       height: 420px;
       /* The glass panel mutes the page backdrop to near-black, so show
-         the galactic-center photo directly inside the viewer instead */
-      background: url('https://science.nasa.gov/wp-content/uploads/2023/09/ssc2006-02a-0.jpg?w=2048')
+         Webb's Cosmic Cliffs directly inside the viewer instead */
+      background: url('https://science.nasa.gov/wp-content/uploads/2023/09/web-first-images-release.png')
         center / cover no-repeat;
       border: 1px solid #263449;
       border-radius: 12px;
@@ -464,6 +464,15 @@ class AstronautViewComponent extends LitElement {
         <a href="https://www.si.edu/Termsofuse" target="_blank" rel="noopener"
           >Usage Conditions Apply</a
         >
+      </p>
+      <p class="attribution">
+        Viewer backdrop:
+        <a
+          href="https://science.nasa.gov/image-detail/web-first-images-release/"
+          target="_blank"
+          rel="noopener"
+          >&ldquo;Cosmic Cliffs&rdquo; in the Carina Nebula</a
+        >, James Webb Space Telescope &mdash; NASA, ESA, CSA, and STScI.
       </p>
     `;
   }

--- a/examples/hellogalaxy/src/main.ts
+++ b/examples/hellogalaxy/src/main.ts
@@ -164,6 +164,14 @@ class GalaxyShellComponent extends LitElement {
       border-color: #7aa2ff;
       font-weight: 600;
     }
+    .backdrop-credit {
+      color: #6b7c95;
+      font-size: 0.75rem;
+      margin: 32px 0 0;
+    }
+    .backdrop-credit a {
+      color: #9db2ce;
+    }
   `;
 
   // Injected by <ui-view>; required by the RoutedLitElement contract
@@ -191,6 +199,16 @@ class GalaxyShellComponent extends LitElement {
       </nav>
       <!-- Child states (galaxy.stars, galaxy.astronaut) render into this nested view -->
       <ui-view></ui-view>
+      <p class="backdrop-credit">
+        Backdrop:
+        <a
+          href="https://science.nasa.gov/image-detail/ssc2006-02a-0/"
+          target="_blank"
+          rel="noopener"
+          >the Milky Way's center in infrared</a
+        >
+        &mdash; NASA, JPL-Caltech, Susan Stolovy (SSC/Caltech) et al.
+      </p>
     `;
   }
 }

--- a/examples/hellogalaxy/src/main.ts
+++ b/examples/hellogalaxy/src/main.ts
@@ -416,7 +416,10 @@ class AstronautViewComponent extends LitElement {
     model-viewer {
       width: 100%;
       height: 420px;
-      background: rgba(13, 20, 33, 0.75);
+      /* The glass panel mutes the page backdrop to near-black, so show
+         the galactic-center photo directly inside the viewer instead */
+      background: url('https://science.nasa.gov/wp-content/uploads/2023/09/ssc2006-02a-0.jpg?w=2048')
+        center / cover no-repeat;
       border: 1px solid #263449;
       border-radius: 12px;
     }

--- a/examples/hellosolarsystem/package.json
+++ b/examples/hellosolarsystem/package.json
@@ -20,5 +20,9 @@
   },
   "overrides": {
     "d3-color": "3.1.0"
+  },
+  "allowScripts": {
+    "fsevents@2.3.3": true,
+    "esbuild@0.27.2": true
   }
 }

--- a/examples/helloworld/package.json
+++ b/examples/helloworld/package.json
@@ -16,5 +16,9 @@
   "devDependencies": {
     "typescript": "^6.0.3",
     "vite": "^7.3.5"
+  },
+  "allowScripts": {
+    "fsevents@2.3.3": true,
+    "esbuild@0.27.2": true
   }
 }

--- a/examples/package.json
+++ b/examples/package.json
@@ -4,8 +4,9 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "format": "prettier --write \"**/*.{ts,js,json,md}\"",
-    "format:check": "prettier --check \"**/*.{ts,js,json,md}\"",
+    "build:embeds": "node build-embeds.mjs",
+    "format": "prettier --write \"**/*.{ts,js,mjs,json,md}\"",
+    "format:check": "prettier --check \"**/*.{ts,js,mjs,json,md}\"",
     "lint": "eslint ."
   }
 }

--- a/examples/turbo.json
+++ b/examples/turbo.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://turborepo.com/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "build:embeds": {
+      "inputs": [
+        "build-embeds.mjs",
+        "*/index.html",
+        "*/package.json",
+        "*/package-lock.json",
+        "*/src/**",
+        "*/tsconfig.json",
+        "*/vite.config.ts"
+      ],
+      "outputs": ["*/dist/**"]
+    }
+  }
+}


### PR DESCRIPTION
Adds a **Live Examples** tutorial page that embeds the three tutorial apps directly in the docs site — same-origin iframes served by the site itself, no StackBlitz boot. Test target: the Cloudflare preview deployment for this branch → `/tutorial/live-examples`.

## How it works

- **`examples#build:embeds`** (new turbo task): per example, `npm ci` + `vite build --base=/examples/<name>/` into its `dist/` — npm on purpose, matching the standalone/StackBlitz consumption path and installing the published packages from the registry. Inputs/outputs declared, so turbo (incl. remote cache) makes repeat builds free.
- **`docs#build` depends on it** and static-copies each dist to `docs/dist/examples/<name>/` — the same `vite-plugin-static-copy` pattern already used for the sample apps. Cloudflare's `npx turbo docs#build` needs no configuration change.
- The examples use `hashLocationPlugin`, so **no `_redirects` entries** are needed; the vitepress dev-server middleware resolves `/examples/<name>/` to its `index.html` (production gets that from Cloudflare's static-asset index resolution).
- **`ExampleEmbed.vue`**: same-origin sibling of `StackBlitzEmbed` — fullscreen + restart buttons, per-embed height, `loading="lazy"` so the three frames load as you scroll.
- New sidebar entry under Tutorial; existing tutorial pages and their StackBlitz embeds are untouched.

## Verification

- `turbo run build --filter=docs` green from a clean tree; built `index.html`s reference `/examples/<name>/assets/...` correctly.
- Playwright smoke test against the built `docs/dist`: all three iframes boot and render; solar system routes list → Mars detail; galaxy astronaut route lazy-loads the `model-viewer` chunk inside the iframe (`{present: true, loaded: true}`); **0 console errors**.
- `turbo run lint format:check --filter=examples --filter=docs` green (examples' prettier globs now include `.mjs`).

## Notes

- CI cost: `docs#build` now pulls in three `npm ci` runs (~10 s warm, a couple of minutes cold) — cached by turbo keyed on the examples' sources/lockfiles.
- The COOP/COEP headers (`credentialless`) apply to the embedded pages too; the Smithsonian `.glb` loads fine under them (verified in the smoke test, same as on the webcontainer origins).
