### PR TITLE
docs: per-tutorial StackBlitz embed heights

### DIFF
--- a/docs/.vitepress/theme/components/StackBlitzEmbed.vue
+++ b/docs/.vitepress/theme/components/StackBlitzEmbed.vue
@@ -2,10 +2,14 @@
 import { useTemplateRef, ref, onMounted, onUnmounted } from 'vue';
 import screenfull from 'screenfull';
 
-const props = defineProps<{
-  src: string;
-  title: string;
-}>();
+const props = withDefaults(
+  defineProps<{
+    src: string;
+    title: string;
+    height?: string;
+  }>(),
+  { height: '400px' },
+);
 
 const container = useTemplateRef('container');
 const isFullscreenSupported = ref(false);
@@ -59,6 +63,7 @@ onUnmounted(() => {
     <iframe
       :src="src"
       :title="title"
+      :style="{ height: props.height }"
       ref="iframe"
       allow="cross-origin-isolated"
       credentialless
@@ -91,7 +96,6 @@ onUnmounted(() => {
 
 .stackblitz-embed iframe {
   width: 100%;
-  height: 400px;
   border: 0;
   border-radius: 4px;
   overflow: hidden;
@@ -107,7 +111,7 @@ onUnmounted(() => {
 
 .stackblitz-embed:fullscreen iframe,
 .stackblitz-embed:-webkit-full-screen iframe {
-  height: calc(100vh - 80px);
+  height: calc(100vh - 80px) !important;
   border-radius: 8px;
   width: 88%;
   transition: height 0.3s ease, width 0s ease, border-radius 0.3s ease;

--- a/docs/tutorial/hellogalaxy.md
+++ b/docs/tutorial/hellogalaxy.md
@@ -10,6 +10,7 @@ Building on [Hello Solar System](./hellosolarsystem), this tutorial introduces *
 ## Live Demo
 
 <StackBlitzEmbed
+height="920px"
 src="https://stackblitz.com/github/simshanith/lit-ui-router/tree/main/examples/hellogalaxy?embed=1&file=src/main.ts&view=preview"
 title="lit-ui-router-hellogalaxy"><a href="https://stackblitz.com/github/simshanith/lit-ui-router/tree/main/examples/hellogalaxy?file=src/main.ts" target="_blank"><img alt="Open in StackBlitz" src="https://developer.stackblitz.com/img/open_in_stackblitz.svg" /></a></StackBlitzEmbed>
 

--- a/docs/tutorial/hellosolarsystem.md
+++ b/docs/tutorial/hellosolarsystem.md
@@ -10,6 +10,7 @@ Building on [Hello World](./helloworld), this tutorial introduces data fetching 
 ## Live Demo
 
 <StackBlitzEmbed
+height="800px"
 src="https://stackblitz.com/github/simshanith/lit-ui-router/tree/main/examples/hellosolarsystem?embed=1&file=src/main.ts&view=preview"
 title="lit-ui-router-hellosolarsystem"><a href="https://stackblitz.com/github/simshanith/lit-ui-router/tree/main/examples/hellosolarsystem?file=src/main.ts" target="_blank"><img alt="Open in StackBlitz" src="https://developer.stackblitz.com/img/open_in_stackblitz.svg" /></a></StackBlitzEmbed>
 

--- a/docs/tutorial/helloworld.md
+++ b/docs/tutorial/helloworld.md
@@ -10,6 +10,7 @@ This tutorial will guide you through building your first lit-ui-router applicati
 ## Live Demo
 
 <StackBlitzEmbed
+height="480px"
 src="https://stackblitz.com/github/simshanith/lit-ui-router/tree/main/examples/helloworld?embed=1&file=src/main.ts&view=preview"
 title="lit-ui-router-helloworld"><a href="https://stackblitz.com/github/simshanith/lit-ui-router/tree/main/examples/helloworld?file=src/main.ts" target="_blank"><img alt="Open in StackBlitz" src="https://developer.stackblitz.com/img/open_in_stackblitz.svg" /></a></StackBlitzEmbed>
 


### PR DESCRIPTION
Follow-up to #222: `StackBlitzEmbed` gains a `height` prop (default stays 400px) and the tutorial pages size their embeds to match the live-example embeds — helloworld 480px, hellosolarsystem 800px, hellogalaxy 920px. The fullscreen rule now uses `!important` to beat the inline height.

Verified on a local vitepress build: each tutorial's iframe renders at the expected height; docs lint/format green.