### PR TITLE
chore(deps): override vitepress's vite to ^6.4.3 for dependabot alerts

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,6 +114,7 @@ overrides:
   esbuild: 0.28.1
   undici@6: 6.27.0
   undici@7: 7.28.0
+  vitepress>vite: ^6.4.3
 
 patchedDependencies:
   '@api-viewer/docs': 6cfa0893375a4ba334488a5b9e4a56178c62231d864b5271bf4c7a25a0e4f9ac
@@ -378,7 +379,7 @@ importers:
         version: 3.4.0(vite@7.3.6(@types/node@25.0.9)(jiti@2.7.0)(yaml@2.9.0))
       vitepress:
         specifier: ^1.6.4
-        version: 1.6.4(@algolia/client-search@5.55.1)(@types/node@25.0.9)(axios@1.18.1)(change-case@5.4.4)(postcss@8.5.16)(search-insights@2.17.3)(typescript@6.0.3)
+        version: 1.6.4(@algolia/client-search@5.55.1)(@types/node@25.0.9)(axios@1.18.1)(change-case@5.4.4)(jiti@2.7.0)(postcss@8.5.16)(search-insights@2.17.3)(typescript@6.0.3)(yaml@2.9.0)
       wrangler:
         specifier: 'catalog:'
         version: 4.107.0
@@ -4379,21 +4380,26 @@ packages:
     peerDependencies:
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
 
-  vite@5.4.21:
-    resolution: {integrity: sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==}
-    engines: {node: ^18.0.0 || >=20.0.0}
+  vite@6.4.3:
+    resolution: {integrity: sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
     peerDependencies:
-      '@types/node': ^18.0.0 || >=20.0.0
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      jiti: '>=1.21.0'
       less: '*'
       lightningcss: ^1.21.0
       sass: '*'
       sass-embedded: '*'
       stylus: '*'
       sugarss: '*'
-      terser: ^5.4.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
     peerDependenciesMeta:
       '@types/node':
+        optional: true
+      jiti:
         optional: true
       less:
         optional: true
@@ -4408,6 +4414,10 @@ packages:
       sugarss:
         optional: true
       terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
         optional: true
 
   vite@7.3.6:
@@ -5977,9 +5987,9 @@ snapshots:
 
   '@ungap/structured-clone@1.3.2': {}
 
-  '@vitejs/plugin-vue@5.2.4(vite@5.4.21(@types/node@25.0.9))(vue@3.5.39(typescript@6.0.3))':
+  '@vitejs/plugin-vue@5.2.4(vite@6.4.3(@types/node@25.0.9)(jiti@2.7.0)(yaml@2.9.0))(vue@3.5.39(typescript@6.0.3))':
     dependencies:
-      vite: 5.4.21(@types/node@25.0.9)
+      vite: 6.4.3(@types/node@25.0.9)(jiti@2.7.0)(yaml@2.9.0)
       vue: 3.5.39(typescript@6.0.3)
 
   '@vitest/browser-playwright@4.1.10(playwright@1.61.1)(vite@7.3.6(@types/node@25.0.9)(jiti@2.7.0)(yaml@2.9.0))(vitest@4.1.10)':
@@ -8497,14 +8507,19 @@ snapshots:
       tinyglobby: 0.2.17
       vite: 7.3.6(@types/node@25.0.9)(jiti@2.7.0)(yaml@2.9.0)
 
-  vite@5.4.21(@types/node@25.0.9):
+  vite@6.4.3(@types/node@25.0.9)(jiti@2.7.0)(yaml@2.9.0):
     dependencies:
       esbuild: 0.28.1
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
       postcss: 8.5.16
       rollup: 4.62.2
+      tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 25.0.9
       fsevents: 2.3.3
+      jiti: 2.7.0
+      yaml: 2.9.0
 
   vite@7.3.6(@types/node@25.0.9)(jiti@2.7.0)(yaml@2.9.0):
     dependencies:
@@ -8520,7 +8535,7 @@ snapshots:
       jiti: 2.7.0
       yaml: 2.9.0
 
-  vitepress@1.6.4(@algolia/client-search@5.55.1)(@types/node@25.0.9)(axios@1.18.1)(change-case@5.4.4)(postcss@8.5.16)(search-insights@2.17.3)(typescript@6.0.3):
+  vitepress@1.6.4(@algolia/client-search@5.55.1)(@types/node@25.0.9)(axios@1.18.1)(change-case@5.4.4)(jiti@2.7.0)(postcss@8.5.16)(search-insights@2.17.3)(typescript@6.0.3)(yaml@2.9.0):
     dependencies:
       '@docsearch/css': 3.8.2
       '@docsearch/js': 3.8.2(@algolia/client-search@5.55.1)(search-insights@2.17.3)
@@ -8529,7 +8544,7 @@ snapshots:
       '@shikijs/transformers': 2.5.0
       '@shikijs/types': 2.5.0
       '@types/markdown-it': 14.1.2
-      '@vitejs/plugin-vue': 5.2.4(vite@5.4.21(@types/node@25.0.9))(vue@3.5.39(typescript@6.0.3))
+      '@vitejs/plugin-vue': 5.2.4(vite@6.4.3(@types/node@25.0.9)(jiti@2.7.0)(yaml@2.9.0))(vue@3.5.39(typescript@6.0.3))
       '@vue/devtools-api': 7.7.10
       '@vue/shared': 3.5.39
       '@vueuse/core': 12.8.2(typescript@6.0.3)
@@ -8538,7 +8553,7 @@ snapshots:
       mark.js: 8.11.1
       minisearch: 7.2.0
       shiki: 2.5.0
-      vite: 5.4.21(@types/node@25.0.9)
+      vite: 6.4.3(@types/node@25.0.9)(jiti@2.7.0)(yaml@2.9.0)
       vue: 3.5.39(typescript@6.0.3)
     optionalDependencies:
       postcss: 8.5.16
@@ -8552,6 +8567,7 @@ snapshots:
       - drauu
       - fuse.js
       - idb-keyval
+      - jiti
       - jwt-decode
       - less
       - lightningcss
@@ -8566,8 +8582,10 @@ snapshots:
       - stylus
       - sugarss
       - terser
+      - tsx
       - typescript
       - universal-cookie
+      - yaml
 
   vitest@4.1.10(@types/node@25.0.9)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(vite@7.3.6(@types/node@25.0.9)(jiti@2.7.0)(yaml@2.9.0)):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -62,10 +62,8 @@ overrides:
   esbuild: 0.28.1
   'undici@6': 6.27.0
   'undici@7': 7.28.0
-  # vitepress 1 pins vite ^5; GHSA fixes land in 6.4.3 (dependabot alerts 28-30)
   'vitepress>vite': ^6.4.3
 
-# upstream hasn't added vite 7 to its peer range (codecov-javascript-bundler-plugins#264)
 peerDependencyRules:
   allowedVersions:
     '@codecov/vite-plugin>vite': '7'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -62,6 +62,8 @@ overrides:
   esbuild: 0.28.1
   'undici@6': 6.27.0
   'undici@7': 7.28.0
+  # vitepress 1 pins vite ^5; GHSA fixes land in 6.4.3 (dependabot alerts 28-30)
+  'vitepress>vite': ^6.4.3
 
 verifyDepsBeforeRun: false
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -65,6 +65,11 @@ overrides:
   # vitepress 1 pins vite ^5; GHSA fixes land in 6.4.3 (dependabot alerts 28-30)
   'vitepress>vite': ^6.4.3
 
+# upstream hasn't added vite 7 to its peer range (codecov-javascript-bundler-plugins#264)
+peerDependencyRules:
+  allowedVersions:
+    '@codecov/vite-plugin>vite': '7'
+
 verifyDepsBeforeRun: false
 
 patchedDependencies:


### PR DESCRIPTION
## Summary

Resolves the three open Dependabot alerts (#28, #29, #30) — all against `vite <= 6.4.2`, patched in **6.4.3**:

- **high** — `server.fs.deny` bypass on Windows alternate paths
- **medium** — path traversal in optimized-deps `.map` handling
- **medium** — launch-editor NTLMv2 hash disclosure via UNC paths

The only vulnerable resolution in the lockfile was `vite@5.4.21`, pulled in by **vitepress 1.6.4** (which hard-pins `vite: ^5`). The root catalog is already on vite 7.3.6, which is unaffected.

## Approach

A parent-scoped pnpm override in `pnpm-workspace.yaml`:

```yaml
'vitepress>vite': ^6.4.3
```

This rewrites only vitepress's direct dependency, so the root vite 7.3.6 and every package's vite *peer* range are untouched. (A bare range selector like `vite@<6.4.3` was tried first and rejected — pnpm also rewrites intersecting peer-dependency ranges, spraying bogus `unmet peer` warnings across vitest and the vite plugins.)

`@vitejs/plugin-vue@5.2.4` (vite ^5||^6) and `vite-plugin-static-copy@3.4.0` (vite ^5–^8) are both compatible with the 6.4.3 resolution.

## Verification

- `pnpm install` clean; lockfile shows `vite@5.4.21` → `vite@6.4.3`, `vite@7.3.6` unchanged
- `turbo run build --filter=docs` — vitepress 1.6.4 builds successfully on vite 6.4.3
- `turbo run test:coverage` — all three browser-mode suites re-executed (cache miss) and pass (155/21/+ tests), no `response:*` echo errors
- `@vitest/browser` stays at 4.1.10, so `patches/@vitest__browser.patch` still applies — patched `isEmbedded` guard confirmed present in the installed bundle
- `check:catalog` passes; `pnpm peers check` is fully clean — the one pre-existing warning (`@codecov/vite-plugin` peers vite ≤6, upstream vite 7 support pending since 2025 in [codecov/codecov-javascript-bundler-plugins#264](https://github.com/codecov/codecov-javascript-bundler-plugins/issues/264) — drop the rule once that ships) is silenced via `peerDependencyRules.allowedVersions` (`packageExtensions` can't widen an existing peer range)
