### PR TITLE
fix(docs): silence esbuild dep-optimizer errors in vitepress dev

### DIFF
--- a/docs/.vitepress/vite.config.ts
+++ b/docs/.vitepress/vite.config.ts
@@ -5,6 +5,11 @@ import { viteStaticCopy } from 'vite-plugin-static-copy';
 // `examples#build:embeds` (hash routing, so no _redirects entries needed).
 const EMBEDDED_EXAMPLES = ['helloworld', 'hellosolarsystem', 'hellogalaxy'];
 
+// VitePress 1.x / vite 6 default targets list `safari14`, but esbuild >=0.27.7
+// refuses to emit destructuring for Safari <14.1 (JSC array-rest bug,
+// compat-table/compat-table#2008) and has no lowering transform for it.
+const TARGET = ['chrome87', 'edge88', 'es2020', 'firefox78', 'safari14.1'];
+
 /**
  * Vite plugin to handle /app/* and /app-mobx/* deep linking in dev server.
  * Mirrors Cloudflare _redirects: `/app/* /app 200`, `/app-mobx/* /app-mobx 200`
@@ -73,10 +78,15 @@ export default defineConfig({
   ],
 
   build: {
-    // VitePress 1.x defaults this list with `safari14`, but esbuild >=0.27.7
-    // refuses to emit destructuring for Safari <14.1 (JSC array-rest bug,
-    // compat-table/compat-table#2008) and has no lowering transform for it.
-    target: ['chrome87', 'edge88', 'es2020', 'firefox78', 'safari14.1'],
+    target: TARGET,
+  },
+
+  optimizeDeps: {
+    // the dev dep-optimizer ignores build.target and pre-bundles against
+    // vite's internal ESBUILD_MODULES_TARGET, which still lists safari14
+    esbuildOptions: {
+      target: TARGET,
+    },
   },
 
   server: {


### PR DESCRIPTION
## Problem

Every `vitepress dev` run spews ~450 esbuild errors during dependency pre-bundling:

```
✘ [ERROR] Transforming destructuring to the configured target environment
("chrome87", "edge88", "es2020", "firefox78", "safari14" + 2 overrides) is not supported yet
```

Pages still serve (vite falls back to unoptimized deps), so this was noise rather than breakage — but ~450 error lines bury anything real in the dev log. Pre-existing on main before the vite 6 bump in #224; identical output on vite 5.4.21 and 6.4.3.

## Cause

Two facts colliding:

- esbuild >= 0.27.7 (repo pins 0.28.1 via override) **refuses to emit destructuring when `safari14` is a target** — Safari 14.0's JSC has an array-rest bug (compat-table/compat-table#2008) and esbuild has no lowering transform for it.
- `docs/.vitepress/vite.config.ts` already works around this for **build** by setting `build.target` with `safari14.1` — but the **dev dep-optimizer ignores `build.target`** and pre-bundles against vite's internal `ESBUILD_MODULES_TARGET` constant, which still lists `safari14` through vite 6.

## Fix

Hoist the target list to a shared const and pass it to `optimizeDeps.esbuildOptions.target` as well — vite spreads `esbuildOptions` after its own `target:`, so the override takes effect.

Scoped to docs: the sample apps run vite 7, whose defaults moved to baseline (`safari14.1`+), so they never hit this.

## Verification

- Cleared `docs/.vitepress/cache`, ran `vitepress dev`: startup log drops from ~450 ERROR lines to **0** (7-line clean log); `/` and a guide page serve 200
- `turbo run build --filter=docs` re-executed on the changed config and passes
- `lint` + `format:check` for docs pass