### PR TITLE
fix(e2e): migrate Cypress.env to Cypress.expose, disable allowCypressEnv

### DIFF
--- a/apps/sample-app-lit-e2e/cypress.config.ts
+++ b/apps/sample-app-lit-e2e/cypress.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from 'cypress';
 
 export default defineConfig({
+  allowCypressEnv: false,
   fileServerFolder: '.',
   fixturesFolder: './src/fixtures',
   modifyObstructiveCode: false,

--- a/apps/sample-app-lit-e2e/src/support/e2e.ts
+++ b/apps/sample-app-lit-e2e/src/support/e2e.ts
@@ -1,5 +1,5 @@
-// Feature param for location plugin (can be set via Cypress env)
-export const LOCATION_PLUGIN = Cypress.env('LOCATION_PLUGIN') || '';
+// Feature param for location plugin (settable via `cypress run --expose LOCATION_PLUGIN=hash`)
+export const LOCATION_PLUGIN = Cypress.expose('LOCATION_PLUGIN') || '';
 
 export function visitWithFeatures(
   path: string,


### PR DESCRIPTION
## Summary
Silences the Cypress 15 CI warning:

> Warning: The allowCypressEnv configuration option is enabled. This allows any browser code to read values from Cypress.env(). This is insecure and will be removed in a future major version.

- `src/support/e2e.ts`: read `LOCATION_PLUGIN` via `Cypress.expose()` instead of `Cypress.env()` — it's public configuration, not a secret ([migration guide](https://on.cypress.io/cypress-env-migration))
- `cypress.config.ts`: set `allowCypressEnv: false`, opting into the future-major default and making any stray `Cypress.env()` call a hard error

Usage change for the local knob: `cypress run --expose LOCATION_PLUGIN=hash` (was `--env LOCATION_PLUGIN=hash`). Nothing in CI sets this today.

## Testing
- `turbo run build lint --filter=sample-app-lit-e2e` — clean
- `turbo run test --filter=sample-app-lit-e2e` — vanilla + mobx both **All specs passed** (25/25 each), no `allowCypressEnv` warning in the log
- Verified the new plumbing end-to-end: a throwaway spec run with `--expose LOCATION_PLUGIN=hash` confirmed the value reaches the support file and drives hash routing (`#` in URL)