### PR TITLE
chore(ci): reduce build-and-test log noise

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -62,8 +62,8 @@ jobs:
         # with a count) only if the server fails to come up.
         run: |
           tmp=$(mktemp)
-          # shellcheck disable=SC2094 # separate r/w fds on the same unlinked file is the point
-          exec {w}>"$tmp" {r}<"$tmp"
+          exec {w}>"$tmp"
+          exec {r}<"$tmp"
           rm "$tmp"
           Xvfb :99 -screen 0 1280x720x24 2>&$w &
           xvfb=$!

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -41,9 +41,17 @@ jobs:
       - name: Add workspace binaries to PATH
         run: echo "${{ github.workspace }}/node_modules/.bin" >> "$GITHUB_PATH"
       - name: Install Playwright Browsers
-        run: playwright install --with-deps
+        # Group collapses the ~1100 lines of apt output from --with-deps.
+        run: |
+          echo "::group::playwright install --with-deps"
+          playwright install --with-deps
+          echo "::endgroup::"
       - name: Install Cypress
-        run: cypress install
+        # Verify up front so the concurrent vanilla/mobx runs skip the
+        # "first time using Cypress" verification banner.
+        run: |
+          cypress install
+          cypress verify
       - name: Start shared Xvfb display
         # The vanilla and MobX Cypress suites run concurrently. Without a
         # DISPLAY, each Cypress process spawns its own Xvfb and the spawns
@@ -59,6 +67,8 @@ jobs:
           TURBO_API: ${{ vars.TURBO_API }}
           TURBO_TEAM: ${{ vars.TURBO_TEAM }}
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+          # Silence per-request [wrangler:info] logging from the e2e dev server.
+          WRANGLER_LOG: warn
       - name: lit-ui-router Vitest Coverage Report
         uses: davelosert/vitest-coverage-report-action@v2
         if: github.event_name == 'pull_request'

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -38,6 +38,10 @@ jobs:
         uses: jdx/mise-action@v4
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+        env:
+          # The Install Cypress step below downloads the binary; skipping it
+          # here keeps download noise out of the pnpm postinstall output.
+          CYPRESS_INSTALL_BINARY: '0'
       - name: Add workspace binaries to PATH
         run: echo "${{ github.workspace }}/node_modules/.bin" >> "$GITHUB_PATH"
       - name: Install Playwright Browsers
@@ -83,5 +87,7 @@ jobs:
         uses: codecov/codecov-action@v7
         with:
           files: packages/lit-ui-router/coverage/lcov.info,packages/navigation-location-plugin/coverage/lcov.info
+          # Files are explicit; skipping the search silences gcov/coverage.py probe warnings.
+          disable_search: true
           fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -79,7 +79,7 @@ jobs:
             pat='^> Warning:[[:space:]]+Could not resolve keysym '
             echo "Xvfb failed to start:"
             grep -Ev "$pat" <<<"$err" || true
-            echo "(filtered $(grep -Ec "$pat" <<<"$err" || true) 'Could not resolve keysym' lines)"
+            echo "(filtered $(grep -Ec "$pat" <<<"$err" || true) 'Could not resolve keysym' warnings)"
             exit 1
           fi
           exec {r}<&-

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -57,33 +57,9 @@ jobs:
         # DISPLAY, each Cypress process spawns its own Xvfb and the spawns
         # race ("Fatal server error"); one shared display serves both.
         # https://docs.cypress.io/app/continuous-integration/overview#Xvfb
-        # Xvfb's stderr is routine xkbcomp keysym noise on the runner image,
-        # so capture it in an unlinked temp file and print it (noise filtered,
-        # with a count) only if the server fails to come up.
-        run: |
-          stderr_file=$(mktemp)
-          exec {stderr_w}>"$stderr_file"
-          exec {stderr_r}<"$stderr_file"
-          rm "$stderr_file"
-          Xvfb :99 -screen 0 1280x720x24 2>&$stderr_w &
-          xvfb_pid=$!
-          exec {stderr_w}>&-
-          display_ready=""
-          for _ in {1..50}; do
-            kill -0 "$xvfb_pid" 2>/dev/null || break
-            if [ -S /tmp/.X11-unix/X99 ]; then display_ready=1; break; fi
-            sleep 0.1
-          done
-          if [ -z "$display_ready" ]; then
-            captured_stderr=$(cat <&"$stderr_r")
-            ignored_warnings_pattern='^> Warning:[[:space:]]+Could not resolve keysym '
-            echo "Xvfb failed to start:"
-            grep -Ev "$ignored_warnings_pattern" <<<"$captured_stderr" || true
-            echo "(filtered $(grep -Ec "$ignored_warnings_pattern" <<<"$captured_stderr" || true) 'Could not resolve keysym' warnings)"
-            exit 1
-          fi
-          exec {stderr_r}<&-
-          echo "DISPLAY=:99" >> "$GITHUB_ENV"
+        # The script captures Xvfb's stderr (routine xkbcomp keysym noise on
+        # the runner image) and prints it, filtered, only on startup failure.
+        run: node scripts/start-xvfb.mjs
       - name: Build and Test
         run: turbo run ci --ui=stream --log-order=stream ${{ inputs.force && '--force' || '' }}
         env:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -61,28 +61,28 @@ jobs:
         # so capture it in an unlinked temp file and print it (noise filtered,
         # with a count) only if the server fails to come up.
         run: |
-          tmp=$(mktemp)
-          exec {w}>"$tmp"
-          exec {r}<"$tmp"
-          rm "$tmp"
-          Xvfb :99 -screen 0 1280x720x24 2>&$w &
-          xvfb=$!
-          exec {w}>&-
-          up=""
+          stderr_file=$(mktemp)
+          exec {stderr_w}>"$stderr_file"
+          exec {stderr_r}<"$stderr_file"
+          rm "$stderr_file"
+          Xvfb :99 -screen 0 1280x720x24 2>&$stderr_w &
+          xvfb_pid=$!
+          exec {stderr_w}>&-
+          display_ready=""
           for _ in {1..50}; do
-            kill -0 "$xvfb" 2>/dev/null || break
-            if [ -S /tmp/.X11-unix/X99 ]; then up=1; break; fi
+            kill -0 "$xvfb_pid" 2>/dev/null || break
+            if [ -S /tmp/.X11-unix/X99 ]; then display_ready=1; break; fi
             sleep 0.1
           done
-          if [ -z "$up" ]; then
-            err=$(cat <&"$r")
-            pat='^> Warning:[[:space:]]+Could not resolve keysym '
+          if [ -z "$display_ready" ]; then
+            captured_stderr=$(cat <&"$stderr_r")
+            ignored_warnings_pattern='^> Warning:[[:space:]]+Could not resolve keysym '
             echo "Xvfb failed to start:"
-            grep -Ev "$pat" <<<"$err" || true
-            echo "(filtered $(grep -Ec "$pat" <<<"$err" || true) 'Could not resolve keysym' warnings)"
+            grep -Ev "$ignored_warnings_pattern" <<<"$captured_stderr" || true
+            echo "(filtered $(grep -Ec "$ignored_warnings_pattern" <<<"$captured_stderr" || true) 'Could not resolve keysym' warnings)"
             exit 1
           fi
-          exec {r}<&-
+          exec {stderr_r}<&-
           echo "DISPLAY=:99" >> "$GITHUB_ENV"
       - name: Build and Test
         run: turbo run ci --ui=stream --log-order=stream ${{ inputs.force && '--force' || '' }}

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -45,11 +45,7 @@ jobs:
       - name: Add workspace binaries to PATH
         run: echo "${{ github.workspace }}/node_modules/.bin" >> "$GITHUB_PATH"
       - name: Install Playwright Browsers
-        # Group collapses the ~1100 lines of apt output from --with-deps.
-        run: |
-          echo "::group::playwright install --with-deps"
-          playwright install --with-deps
-          echo "::endgroup::"
+        run: playwright install --with-deps
       - name: Install Cypress
         # Verify up front so the concurrent vanilla/mobx runs skip the
         # "first time using Cypress" verification banner.
@@ -61,8 +57,32 @@ jobs:
         # DISPLAY, each Cypress process spawns its own Xvfb and the spawns
         # race ("Fatal server error"); one shared display serves both.
         # https://docs.cypress.io/app/continuous-integration/overview#Xvfb
+        # Xvfb's stderr is routine xkbcomp keysym noise on the runner image,
+        # so capture it in an unlinked temp file and print it (noise filtered,
+        # with a count) only if the server fails to come up.
         run: |
-          Xvfb :99 -screen 0 1280x720x24 &
+          tmp=$(mktemp)
+          # shellcheck disable=SC2094 # separate r/w fds on the same unlinked file is the point
+          exec {w}>"$tmp" {r}<"$tmp"
+          rm "$tmp"
+          Xvfb :99 -screen 0 1280x720x24 2>&$w &
+          xvfb=$!
+          exec {w}>&-
+          up=""
+          for _ in {1..50}; do
+            kill -0 "$xvfb" 2>/dev/null || break
+            if [ -S /tmp/.X11-unix/X99 ]; then up=1; break; fi
+            sleep 0.1
+          done
+          if [ -z "$up" ]; then
+            err=$(cat <&"$r")
+            pat='^> Warning:[[:space:]]+Could not resolve keysym '
+            echo "Xvfb failed to start:"
+            grep -Ev "$pat" <<<"$err" || true
+            echo "(filtered $(grep -Ec "$pat" <<<"$err" || true) 'Could not resolve keysym' lines)"
+            exit 1
+          fi
+          exec {r}<&-
           echo "DISPLAY=:99" >> "$GITHUB_ENV"
       - name: Build and Test
         run: turbo run ci --ui=stream --log-order=stream ${{ inputs.force && '--force' || '' }}

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -106,8 +106,7 @@ jobs:
       - name: Upload to Codecov
         uses: codecov/codecov-action@v7
         with:
-          files: packages/lit-ui-router/coverage/lcov.info,packages/navigation-location-plugin/coverage/lcov.info
-          # Files are explicit; skipping the search silences gcov/coverage.py probe warnings.
+          files: packages/lit-ui-router/coverage/lcov.info,packages/lit-ui-router/coverage/coverage-final.json,packages/lit-ui-router-mobx/coverage/lcov.info,packages/lit-ui-router-mobx/coverage/coverage-final.json,packages/navigation-location-plugin/coverage/lcov.info,packages/navigation-location-plugin/coverage/coverage-final.json
           disable_search: true
           fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -84,5 +84,6 @@ jobs:
         with:
           files: packages/lit-ui-router/coverage/lcov.info,packages/lit-ui-router/coverage/coverage-final.json,packages/lit-ui-router-mobx/coverage/lcov.info,packages/lit-ui-router-mobx/coverage/coverage-final.json,packages/navigation-location-plugin/coverage/lcov.info,packages/navigation-location-plugin/coverage/coverage-final.json
           disable_search: true
+          plugins: noop
           fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -82,10 +82,10 @@ export default defineConfig(
     },
   },
   {
-    files: ['**/*.spec.ts'],
+    files: ['**/*.spec.ts', '**/vitest.setup.ts'],
     languageOptions: {
       parserOptions: {
-        // Spec files are excluded from tsconfig.json for build purposes
+        // Spec and setup files are excluded from tsconfig.json for build purposes
         projectService: false,
       },
     },

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -35,6 +35,7 @@ export default defineConfig(
     '**/.vitepress/cache/**',
     '**/*.config.ts',
     '**/*.config.js',
+    '!**/vitest.config.ts',
   ]),
   {
     files: ['**/*.ts'],
@@ -82,10 +83,22 @@ export default defineConfig(
     },
   },
   {
-    files: ['**/*.spec.ts', '**/vitest.setup.ts'],
+    files: ['**/vitest.config.ts', '**/vitest.setup.ts'],
     languageOptions: {
       parserOptions: {
-        // Spec and setup files are excluded from tsconfig.json for build purposes
+        // These live in the packages' tsconfig.spec.json, which the
+        // project service (tsconfig.json discovery) never consults.
+        projectService: false,
+        project: 'packages/*/tsconfig.spec.json',
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+  {
+    files: ['**/*.spec.ts'],
+    languageOptions: {
+      parserOptions: {
+        // Spec files are excluded from tsconfig.json for build purposes
         projectService: false,
       },
     },

--- a/examples/hellogalaxy/vite.config.ts
+++ b/examples/hellogalaxy/vite.config.ts
@@ -3,5 +3,7 @@ import { defineConfig } from 'vite';
 export default defineConfig({
   build: {
     target: 'esnext',
+    // model-viewer is a single ~1 MB chunk; fine for a demo embed.
+    chunkSizeWarningLimit: 1100,
   },
 });

--- a/packages/lit-ui-router-mobx/tsconfig.spec.json
+++ b/packages/lit-ui-router-mobx/tsconfig.spec.json
@@ -10,6 +10,6 @@
     "sourceMap": true,
     "types": ["vitest/globals"]
   },
-  "include": ["vitest.config.ts", "src/**/*.spec.ts"],
+  "include": ["vitest.config.ts", "vitest.setup.ts", "src/**/*.spec.ts"],
   "exclude": ["node_modules", "dist"]
 }

--- a/packages/lit-ui-router-mobx/vitest.config.ts
+++ b/packages/lit-ui-router-mobx/vitest.config.ts
@@ -15,6 +15,7 @@ export default defineConfig({
   },
   test: {
     globals: true,
+    setupFiles: ['./vitest.setup.ts'],
     include: ['src/specs/**/*.spec.ts'],
     // hanging-process logs the open handles in CI
     reporters: process.env.CI ? ['default', 'hanging-process'] : ['default'],

--- a/packages/lit-ui-router-mobx/vitest.setup.ts
+++ b/packages/lit-ui-router-mobx/vitest.setup.ts
@@ -1,0 +1,5 @@
+// Suppress the per-worker "Lit is in dev mode" banner: https://github.com/lit/lit/issues/4877
+const g = globalThis as typeof globalThis & {
+  litIssuedWarnings?: Set<unknown>;
+};
+(g.litIssuedWarnings ??= new Set()).add('dev-mode');

--- a/packages/lit-ui-router/tsconfig.spec.json
+++ b/packages/lit-ui-router/tsconfig.spec.json
@@ -10,6 +10,6 @@
     "sourceMap": true,
     "types": ["vitest/globals"]
   },
-  "include": ["vitest.config.ts", "src/**/*.spec.ts"],
+  "include": ["vitest.config.ts", "vitest.setup.ts", "src/**/*.spec.ts"],
   "exclude": ["node_modules", "dist"]
 }

--- a/packages/lit-ui-router/vitest.config.ts
+++ b/packages/lit-ui-router/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
   cacheDir: `node_modules/.vite-${process.env.VITEST_BROWSER_API_PORT ?? 'default'}`,
   test: {
     globals: true,
+    setupFiles: ['./vitest.setup.ts'],
     include: ['src/specs/**/*.spec.ts'],
     // hanging-process logs the open handles in CI
     reporters: process.env.CI ? ['default', 'hanging-process'] : ['default'],

--- a/packages/lit-ui-router/vitest.setup.ts
+++ b/packages/lit-ui-router/vitest.setup.ts
@@ -1,3 +1,5 @@
 // Suppress the per-worker "Lit is in dev mode" banner: https://github.com/lit/lit/issues/4877
-const g = globalThis as typeof globalThis & { litIssuedWarnings?: Set<unknown> };
+const g = globalThis as typeof globalThis & {
+  litIssuedWarnings?: Set<unknown>;
+};
 (g.litIssuedWarnings ??= new Set()).add('dev-mode');

--- a/packages/lit-ui-router/vitest.setup.ts
+++ b/packages/lit-ui-router/vitest.setup.ts
@@ -1,0 +1,3 @@
+// Suppress the per-worker "Lit is in dev mode" banner: https://github.com/lit/lit/issues/4877
+const g = globalThis as typeof globalThis & { litIssuedWarnings?: Set<unknown> };
+(g.litIssuedWarnings ??= new Set()).add('dev-mode');

--- a/scripts/start-xvfb.core.mjs
+++ b/scripts/start-xvfb.core.mjs
@@ -3,23 +3,20 @@
 export const IGNORED_WARNINGS_PATTERN =
   /^> Warning:\s+Could not resolve keysym /;
 
-export async function filterStderr(lines) {
-  const kept = [];
+// Yields the lines worth showing as they arrive; returns (as the generator's
+// return value) the number of filtered keysym warnings.
+export async function* filterStderr(lines) {
   let filtered = 0;
   for await (const line of lines) {
     if (IGNORED_WARNINGS_PATTERN.test(line)) {
       filtered += 1;
     } else if (line !== '') {
-      kept.push(line);
+      yield line;
     }
   }
-  return { kept, filtered };
+  return filtered;
 }
 
-export function formatFailure({ kept, filtered }) {
-  return [
-    'Xvfb failed to start:',
-    ...kept,
-    `(filtered ${filtered} 'Could not resolve keysym' warnings)`,
-  ].join('\n');
+export function formatFilteredCount(filtered) {
+  return `(filtered ${filtered} 'Could not resolve keysym' warnings)`;
 }

--- a/scripts/start-xvfb.core.mjs
+++ b/scripts/start-xvfb.core.mjs
@@ -1,0 +1,26 @@
+// Filtering for the CI Xvfb stderr capture: routine xkbcomp keysym warnings
+// from the runner image are dropped; every other line is kept.
+export const IGNORED_WARNINGS_PATTERN =
+  /^> Warning:\s+Could not resolve keysym /;
+
+export function filterStderr(text) {
+  const kept = [];
+  let filtered = 0;
+  for (const line of text.split('\n')) {
+    if (IGNORED_WARNINGS_PATTERN.test(line)) {
+      filtered += 1;
+    } else if (line !== '') {
+      kept.push(line);
+    }
+  }
+  return { kept, filtered };
+}
+
+export function formatFailure(text) {
+  const { kept, filtered } = filterStderr(text);
+  return [
+    'Xvfb failed to start:',
+    ...kept,
+    `(filtered ${filtered} 'Could not resolve keysym' warnings)`,
+  ].join('\n');
+}

--- a/scripts/start-xvfb.core.mjs
+++ b/scripts/start-xvfb.core.mjs
@@ -3,10 +3,10 @@
 export const IGNORED_WARNINGS_PATTERN =
   /^> Warning:\s+Could not resolve keysym /;
 
-export function filterStderr(text) {
+export async function filterStderr(lines) {
   const kept = [];
   let filtered = 0;
-  for (const line of text.split('\n')) {
+  for await (const line of lines) {
     if (IGNORED_WARNINGS_PATTERN.test(line)) {
       filtered += 1;
     } else if (line !== '') {
@@ -16,8 +16,7 @@ export function filterStderr(text) {
   return { kept, filtered };
 }
 
-export function formatFailure(text) {
-  const { kept, filtered } = filterStderr(text);
+export function formatFailure({ kept, filtered }) {
   return [
     'Xvfb failed to start:',
     ...kept,

--- a/scripts/start-xvfb.mjs
+++ b/scripts/start-xvfb.mjs
@@ -13,7 +13,7 @@ import path from 'node:path';
 import readline from 'node:readline';
 import { setTimeout as delay } from 'node:timers/promises';
 
-import { filterStderr, formatFailure } from './start-xvfb.core.mjs';
+import { filterStderr, formatFilteredCount } from './start-xvfb.core.mjs';
 
 const display = ':99';
 const xvfbBin = process.env.XVFB_BIN ?? 'Xvfb';
@@ -56,7 +56,11 @@ if (!ready) {
   const captured = readline.createInterface({
     input: fs.createReadStream(null, { fd: stderrFd, start: 0 }),
   });
-  console.error(formatFailure(await filterStderr(captured)));
+  console.error('Xvfb failed to start:');
+  const kept = filterStderr(captured);
+  let next;
+  while (!(next = await kept.next()).done) console.error(next.value);
+  console.error(formatFilteredCount(next.value));
   process.exit(1);
 }
 

--- a/scripts/start-xvfb.mjs
+++ b/scripts/start-xvfb.mjs
@@ -10,9 +10,10 @@ import { spawn } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import readline from 'node:readline';
 import { setTimeout as delay } from 'node:timers/promises';
 
-import { formatFailure } from './start-xvfb.core.mjs';
+import { filterStderr, formatFailure } from './start-xvfb.core.mjs';
 
 const display = ':99';
 const xvfbBin = process.env.XVFB_BIN ?? 'Xvfb';
@@ -52,10 +53,10 @@ while (Date.now() < deadline) {
 
 if (!ready) {
   if (spawnError) console.error(String(spawnError));
-  const size = fs.fstatSync(stderrFd).size;
-  const captured = Buffer.alloc(size);
-  if (size > 0) fs.readSync(stderrFd, captured, 0, size, 0);
-  console.error(formatFailure(captured.toString('utf8')));
+  const captured = readline.createInterface({
+    input: fs.createReadStream(null, { fd: stderrFd, start: 0 }),
+  });
+  console.error(formatFailure(await filterStderr(captured)));
   process.exit(1);
 }
 

--- a/scripts/start-xvfb.mjs
+++ b/scripts/start-xvfb.mjs
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+// Starts the shared CI Xvfb display and exports DISPLAY via GITHUB_ENV.
+//
+// Xvfb's stderr is routine xkbcomp keysym noise on the runner image, so it
+// goes to an unlinked temp file — a durable sink Xvfb can keep writing to
+// after this process exits (a pipe would go EPIPE on later writes). The
+// capture is read back, noise filtered with a count, only if the server
+// fails to come up.
+import { spawn } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { setTimeout as delay } from 'node:timers/promises';
+
+import { formatFailure } from './start-xvfb.core.mjs';
+
+const display = ':99';
+const xvfbBin = process.env.XVFB_BIN ?? 'Xvfb';
+const socketPath =
+  process.env.XVFB_SOCKET ?? `/tmp/.X11-unix/X${display.slice(1)}`;
+const timeoutMs = Number(process.env.XVFB_TIMEOUT_MS ?? 5000);
+
+const stderrPath = path.join(os.tmpdir(), `xvfb-stderr-${process.pid}`);
+const stderrFd = fs.openSync(stderrPath, 'w+');
+fs.unlinkSync(stderrPath);
+
+const xvfb = spawn(xvfbBin, [display, '-screen', '0', '1280x720x24'], {
+  detached: true,
+  stdio: ['ignore', 'ignore', stderrFd],
+});
+xvfb.unref();
+
+let spawnError;
+let exited = false;
+xvfb.on('error', (error) => {
+  spawnError = error;
+});
+xvfb.on('exit', () => {
+  exited = true;
+});
+
+let ready = false;
+const deadline = Date.now() + timeoutMs;
+while (Date.now() < deadline) {
+  if (spawnError || exited) break;
+  if (fs.existsSync(socketPath)) {
+    ready = true;
+    break;
+  }
+  await delay(100);
+}
+
+if (!ready) {
+  if (spawnError) console.error(String(spawnError));
+  const size = fs.fstatSync(stderrFd).size;
+  const captured = Buffer.alloc(size);
+  if (size > 0) fs.readSync(stderrFd, captured, 0, size, 0);
+  console.error(formatFailure(captured.toString('utf8')));
+  process.exit(1);
+}
+
+fs.closeSync(stderrFd);
+if (process.env.GITHUB_ENV) {
+  fs.appendFileSync(process.env.GITHUB_ENV, `DISPLAY=${display}\n`);
+}
+console.log(`Xvfb ready on ${display}`);

--- a/scripts/start-xvfb.test.mjs
+++ b/scripts/start-xvfb.test.mjs
@@ -1,0 +1,127 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { filterStderr, formatFailure } from './start-xvfb.core.mjs';
+
+const KEYSYM_NOISE = [
+  '> Warning:          Could not resolve keysym XF86CameraAccessEnable',
+  '> Warning:          Could not resolve keysym XF86CameraAccessDisable',
+  '> Warning:          Could not resolve keysym XF86CameraAccessToggle',
+];
+const REAL_LINES = [
+  'The XKEYBOARD keymap compiler (xkbcomp) reports:',
+  'Errors from xkbcomp are not fatal to the X server',
+  '(EE) Fatal server error: Cannot establish any listening sockets',
+];
+const SAMPLE = [
+  REAL_LINES[0],
+  ...KEYSYM_NOISE,
+  REAL_LINES[1],
+  REAL_LINES[2],
+  '',
+].join('\n');
+
+describe('filterStderr', () => {
+  it('drops only exact keysym warnings and counts them', () => {
+    const { kept, filtered } = filterStderr(SAMPLE);
+    assert.deepEqual(kept, REAL_LINES);
+    assert.equal(filtered, 3);
+  });
+
+  it('keeps other xkbcomp warnings', () => {
+    const { kept, filtered } = filterStderr(
+      '> Warning:          Type "ONE_LEVEL" has 1 levels\n',
+    );
+    assert.deepEqual(kept, [
+      '> Warning:          Type "ONE_LEVEL" has 1 levels',
+    ]);
+    assert.equal(filtered, 0);
+  });
+});
+
+describe('formatFailure', () => {
+  it('reports real lines and the filtered count', () => {
+    const report = formatFailure(SAMPLE);
+    assert.equal(
+      report,
+      [
+        'Xvfb failed to start:',
+        ...REAL_LINES,
+        "(filtered 3 'Could not resolve keysym' warnings)",
+      ].join('\n'),
+    );
+  });
+});
+
+const scriptPath = fileURLToPath(new URL('./start-xvfb.mjs', import.meta.url));
+
+function writeFakeXvfb(dir, body) {
+  const bin = path.join(dir, 'fake-xvfb.mjs');
+  fs.writeFileSync(bin, `#!/usr/bin/env node\n${body}`, { mode: 0o755 });
+  return bin;
+}
+
+function runStartXvfb(env) {
+  return spawnSync(process.execPath, [scriptPath], {
+    encoding: 'utf8',
+    env: { ...process.env, XVFB_TIMEOUT_MS: '3000', ...env },
+  });
+}
+
+describe('start-xvfb.mjs', () => {
+  it('fails with filtered stderr when Xvfb dies', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'xvfb-test-'));
+    const bin = writeFakeXvfb(
+      dir,
+      [...KEYSYM_NOISE, ...REAL_LINES]
+        .map((line) => `console.error(${JSON.stringify(line)});`)
+        .join('\n') + '\nprocess.exit(1);\n',
+    );
+    const run = runStartXvfb({
+      XVFB_BIN: bin,
+      XVFB_SOCKET: path.join(dir, 'no-such-socket'),
+    });
+    assert.equal(run.status, 1);
+    assert.match(run.stderr, /Xvfb failed to start:/);
+    assert.match(run.stderr, /Fatal server error/);
+    assert.match(
+      run.stderr,
+      /\(filtered 3 'Could not resolve keysym' warnings\)/,
+    );
+    assert.doesNotMatch(run.stderr, /XF86CameraAccess/);
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('exports DISPLAY and stays quiet when the display comes up', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'xvfb-test-'));
+    const socket = path.join(dir, 'socket');
+    const githubEnv = path.join(dir, 'github.env');
+    fs.writeFileSync(githubEnv, '');
+    const bin = writeFakeXvfb(
+      dir,
+      [
+        "import fs from 'node:fs';",
+        ...KEYSYM_NOISE.map(
+          (line) => `console.error(${JSON.stringify(line)});`,
+        ),
+        `fs.writeFileSync(${JSON.stringify(socket)}, '');`,
+        'setTimeout(() => {}, 3000);',
+      ].join('\n') + '\n',
+    );
+    const run = runStartXvfb({
+      XVFB_BIN: bin,
+      XVFB_SOCKET: socket,
+      GITHUB_ENV: githubEnv,
+    });
+    assert.equal(run.status, 0);
+    assert.match(run.stdout, /Xvfb ready on :99/);
+    assert.doesNotMatch(run.stderr, /keysym/);
+    assert.equal(fs.readFileSync(githubEnv, 'utf8'), 'DISPLAY=:99\n');
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+});

--- a/scripts/start-xvfb.test.mjs
+++ b/scripts/start-xvfb.test.mjs
@@ -6,7 +6,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { filterStderr, formatFailure } from './start-xvfb.core.mjs';
+import { filterStderr, formatFilteredCount } from './start-xvfb.core.mjs';
 
 const KEYSYM_NOISE = [
   '> Warning:          Could not resolve keysym XF86CameraAccessEnable',
@@ -30,23 +30,34 @@ async function* asAsyncLines(lines) {
   yield* lines;
 }
 
+// Collects a filterStderr generator's yields and its trailing return value
+// (which for-await would discard).
+async function drain(generator) {
+  const kept = [];
+  let next;
+  while (!(next = await generator.next()).done) kept.push(next.value);
+  return { kept, filtered: next.value };
+}
+
 describe('filterStderr', () => {
   it('drops only exact keysym warnings and counts them', async () => {
-    const { kept, filtered } = await filterStderr(SAMPLE_LINES);
+    const { kept, filtered } = await drain(filterStderr(SAMPLE_LINES));
     assert.deepEqual(kept, REAL_LINES);
     assert.equal(filtered, 3);
   });
 
   it('accepts async iterables of lines', async () => {
-    const { kept, filtered } = await filterStderr(asAsyncLines(SAMPLE_LINES));
+    const { kept, filtered } = await drain(
+      filterStderr(asAsyncLines(SAMPLE_LINES)),
+    );
     assert.deepEqual(kept, REAL_LINES);
     assert.equal(filtered, 3);
   });
 
   it('keeps other xkbcomp warnings', async () => {
-    const { kept, filtered } = await filterStderr([
-      '> Warning:          Type "ONE_LEVEL" has 1 levels',
-    ]);
+    const { kept, filtered } = await drain(
+      filterStderr(['> Warning:          Type "ONE_LEVEL" has 1 levels']),
+    );
     assert.deepEqual(kept, [
       '> Warning:          Type "ONE_LEVEL" has 1 levels',
     ]);
@@ -54,16 +65,11 @@ describe('filterStderr', () => {
   });
 });
 
-describe('formatFailure', () => {
-  it('reports real lines and the filtered count', async () => {
-    const report = formatFailure(await filterStderr(SAMPLE_LINES));
+describe('formatFilteredCount', () => {
+  it('reports the filtered count', () => {
     assert.equal(
-      report,
-      [
-        'Xvfb failed to start:',
-        ...REAL_LINES,
-        "(filtered 3 'Could not resolve keysym' warnings)",
-      ].join('\n'),
+      formatFilteredCount(3),
+      "(filtered 3 'Could not resolve keysym' warnings)",
     );
   });
 });

--- a/scripts/start-xvfb.test.mjs
+++ b/scripts/start-xvfb.test.mjs
@@ -18,25 +18,35 @@ const REAL_LINES = [
   'Errors from xkbcomp are not fatal to the X server',
   '(EE) Fatal server error: Cannot establish any listening sockets',
 ];
-const SAMPLE = [
+const SAMPLE_LINES = [
   REAL_LINES[0],
   ...KEYSYM_NOISE,
   REAL_LINES[1],
   REAL_LINES[2],
   '',
-].join('\n');
+];
+
+async function* asAsyncLines(lines) {
+  yield* lines;
+}
 
 describe('filterStderr', () => {
-  it('drops only exact keysym warnings and counts them', () => {
-    const { kept, filtered } = filterStderr(SAMPLE);
+  it('drops only exact keysym warnings and counts them', async () => {
+    const { kept, filtered } = await filterStderr(SAMPLE_LINES);
     assert.deepEqual(kept, REAL_LINES);
     assert.equal(filtered, 3);
   });
 
-  it('keeps other xkbcomp warnings', () => {
-    const { kept, filtered } = filterStderr(
-      '> Warning:          Type "ONE_LEVEL" has 1 levels\n',
-    );
+  it('accepts async iterables of lines', async () => {
+    const { kept, filtered } = await filterStderr(asAsyncLines(SAMPLE_LINES));
+    assert.deepEqual(kept, REAL_LINES);
+    assert.equal(filtered, 3);
+  });
+
+  it('keeps other xkbcomp warnings', async () => {
+    const { kept, filtered } = await filterStderr([
+      '> Warning:          Type "ONE_LEVEL" has 1 levels',
+    ]);
     assert.deepEqual(kept, [
       '> Warning:          Type "ONE_LEVEL" has 1 levels',
     ]);
@@ -45,8 +55,8 @@ describe('filterStderr', () => {
 });
 
 describe('formatFailure', () => {
-  it('reports real lines and the filtered count', () => {
-    const report = formatFailure(SAMPLE);
+  it('reports real lines and the filtered count', async () => {
+    const report = formatFailure(await filterStderr(SAMPLE_LINES));
     assert.equal(
       report,
       [

--- a/turbo.json
+++ b/turbo.json
@@ -13,7 +13,8 @@
       "with": ["//#test:root"],
       "dependsOn": ["^test"],
       "inputs": ["src/**/*.ts", "vitest.config.ts", "cypress.config.ts"],
-      "env": ["VITEST_BROWSER_API_PORT", "CI"]
+      "env": ["VITEST_BROWSER_API_PORT", "CI"],
+      "passThroughEnv": ["WRANGLER_LOG"]
     },
     "dts-backtest#test": {
       "dependsOn": ["^build"],

--- a/turbo.json
+++ b/turbo.json
@@ -12,7 +12,8 @@
     "test": {
       "with": ["//#test:root"],
       "dependsOn": ["^test"],
-      "inputs": ["src/**/*.ts", "vitest.config.ts", "cypress.config.ts"]
+      "inputs": ["src/**/*.ts", "vitest.config.ts", "cypress.config.ts"],
+      "env": ["VITEST_BROWSER_API_PORT", "CI"]
     },
     "dts-backtest#test": {
       "dependsOn": ["^build"],
@@ -21,6 +22,7 @@
     "test:coverage": {
       "dependsOn": ["^build", "^test:coverage"],
       "inputs": ["src/**/*.ts", "vitest.config.ts"],
+      "env": ["VITEST_BROWSER_API_PORT", "CI"],
       "outputs": ["coverage/**"]
     },
     "lint": {


### PR DESCRIPTION
Follow-up to the CI-log audit of [run 28891367836](https://github.com/simshanith/lit-ui-router/actions/runs/28891367836/job/85704648154). Companion to #226 (allowCypressEnv, merged). Changes:

1. **wrangler request logging (666 lines)** — `WRANGLER_LOG: warn` on the Build and Test step silences per-request `[wrangler:info]` lines from the e2e dev server.
2. **"Lit is in dev mode" banner (36×, once per Vitest worker)** — seed `globalThis.litIssuedWarnings` with `'dev-mode'` in a new `vitest.setup.ts` for `packages/lit-ui-router`. This is lit's sanctioned per-warning switch (lit/lit#4877); other warnings still surface.
3. **Duplicate "first time using Cypress" verification banner** — run `cypress verify` in the Install Cypress step so the concurrent vanilla/mobx runs find existing verification state and skip it.
4. **Cypress binary download during `pnpm install`** — `CYPRESS_INSTALL_BINARY: '0'` on the dependency install step; the dedicated Install Cypress step owns the download.
5. **Xvfb xkbcomp keysym warnings (18 lines)** — startup extracted to `scripts/start-xvfb.mjs` (scripts/ convention: `.core.mjs` logic + `node:test` coverage, unit and e2e against fake Xvfb binaries). Stderr goes to an unlinked temp file — a durable sink Xvfb can keep writing to after the step ends, where a pipe would EPIPE on later client connects. The script polls for the display socket; on startup failure it prints the capture with only the exact `> Warning: Could not resolve keysym` lines filtered — noting how many warnings were filtered — and exits nonzero. Real errors (fatal server errors, other xkbcomp output) always surface.
6. **Vite 500 kB chunk warning in `examples:build:embeds`** — bump `chunkSizeWarningLimit` to 1100 in `examples/hellogalaxy/vite.config.ts`; the ~1 MB `model-viewer` chunk is fine for a demo embed.
7. **Codecov gcov/coverage.py probe warnings** — `disable_search: true`, with the `files:` list expanded to the six reports auto-search actually uploaded (lcov + istanbul json × 3 packages). The earlier two-file list dropped mobx coverage entirely (project 97.71% → 93.08%) and lcov-alone reported more partial branches.
8. **Typed linting for vitest files** — `vitest.config.ts` was globally lint-ignored and `vitest.setup.ts` initially linted untyped; both now parse against `packages/*/tsconfig.spec.json` (which already includes them), so they get full type-aware linting. Linting the configs surfaced `turbo/no-undeclared-env-vars` for `VITEST_BROWSER_API_PORT` and `CI`, now declared in turbo.json's `test`/`test:coverage` env.

Deliberately skipped: `::group::` around `playwright install --with-deps` (steps are already collapsed in the Actions UI) and the Turbo telemetry banner (harmless).

## Testing
- `turbo run test --filter=lit-ui-router --force` — 18/18 test files pass, zero "dev mode" lines (was 18 per run)
- `turbo run lint format:check --force` — clean repo-wide, zero env-var warnings; typed parse verified by running a type-aware rule against the vitest files
- Local wrangler with `WRANGLER_LOG=warn` serves both apps with zero `wrangler:info` lines
- `turbo run build:embeds --filter=examples --force` — same model-viewer chunk, zero chunk-size warnings
- Xvfb failure path simulated with a fake Xvfb emitting keysym noise + a fatal error: real lines print, `(filtered 3 'Could not resolve keysym' warnings)`, exit 1
- `cypress verify` smoke-tested locally; `actionlint` clean on the workflow

⚠️ Touches `.github/workflows/` — needs merge via web UI (local gh token lacks workflow scope).
