### PR TITLE
feat(tooling): migrate eslint to oxlint

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,0 +1,184 @@
+{
+  "$schema": "./node_modules/oxlint/configuration_schema.json",
+  "plugins": ["typescript", "unicorn"],
+  "jsPlugins": ["eslint-plugin-turbo"],
+  "categories": {
+    "correctness": "off"
+  },
+  "env": {
+    "builtin": true
+  },
+  "ignorePatterns": [
+    "**/dist/**",
+    "**/coverage/**",
+    "**/node_modules/**",
+    "**/.vitepress/cache/**",
+    "**/*.config.ts",
+    "**/*.config.js",
+    "!**/vitest.config.ts"
+  ],
+  "rules": {
+    "constructor-super": "error",
+    "for-direction": "error",
+    "getter-return": "error",
+    "no-async-promise-executor": "error",
+    "no-case-declarations": "error",
+    "no-class-assign": "error",
+    "no-compare-neg-zero": "error",
+    "no-cond-assign": "error",
+    "no-const-assign": "error",
+    "no-constant-binary-expression": "error",
+    "no-constant-condition": "error",
+    "no-control-regex": "error",
+    "no-debugger": "error",
+    "no-delete-var": "error",
+    "no-dupe-class-members": "error",
+    "no-dupe-else-if": "error",
+    "no-dupe-keys": "error",
+    "no-duplicate-case": "error",
+    "no-empty": "error",
+    "no-empty-character-class": "error",
+    "no-empty-pattern": "error",
+    "no-empty-static-block": "error",
+    "no-ex-assign": "error",
+    "no-extra-boolean-cast": "error",
+    "no-fallthrough": "error",
+    "no-func-assign": "error",
+    "no-global-assign": "error",
+    "no-import-assign": "error",
+    "no-invalid-regexp": "error",
+    "no-irregular-whitespace": "error",
+    "no-loss-of-precision": "error",
+    "no-misleading-character-class": "error",
+    "no-new-native-nonconstructor": "error",
+    "no-nonoctal-decimal-escape": "error",
+    "no-obj-calls": "error",
+    "no-prototype-builtins": "error",
+    "no-redeclare": "error",
+    "no-regex-spaces": "error",
+    "no-self-assign": "error",
+    "no-setter-return": "error",
+    "no-shadow-restricted-names": "error",
+    "no-sparse-arrays": "error",
+    "no-this-before-super": "error",
+    "no-unassigned-vars": "error",
+    "no-unreachable": "error",
+    "no-unsafe-finally": "error",
+    "no-unsafe-negation": "error",
+    "no-unsafe-optional-chaining": "error",
+    "no-unused-labels": "error",
+    "no-unused-private-class-members": "error",
+    "no-unused-vars": "error",
+    "no-useless-backreference": "error",
+    "no-useless-catch": "error",
+    "no-useless-escape": "error",
+    "no-with": "error",
+    "preserve-caught-error": "error",
+    "require-yield": "error",
+    "use-isnan": "error",
+    "valid-typeof": "error",
+    "no-array-constructor": "error",
+    "no-unused-expressions": "error",
+    "turbo/no-undeclared-env-vars": "warn",
+    "typescript/ban-ts-comment": "error",
+    "typescript/no-duplicate-enum-values": "error",
+    "typescript/no-empty-object-type": "error",
+    "typescript/no-explicit-any": "error",
+    "typescript/no-extra-non-null-assertion": "error",
+    "typescript/no-misused-new": "error",
+    "typescript/no-namespace": "error",
+    "typescript/no-non-null-asserted-optional-chain": "error",
+    "typescript/no-require-imports": "error",
+    "typescript/no-this-alias": "error",
+    "typescript/no-unnecessary-type-constraint": "error",
+    "typescript/no-unsafe-declaration-merging": "error",
+    "typescript/no-unsafe-function-type": "error",
+    "typescript/no-wrapper-object-types": "error",
+    "typescript/prefer-as-const": "error",
+    "typescript/prefer-namespace-keyword": "error",
+    "typescript/triple-slash-reference": "error"
+  },
+  "overrides": [
+    {
+      "files": ["**/*.ts", "**/*.tsx", "**/*.mts", "**/*.cts"],
+      "rules": {
+        "constructor-super": "off",
+        "getter-return": "off",
+        "no-class-assign": "off",
+        "no-const-assign": "off",
+        "no-dupe-class-members": "off",
+        "no-dupe-keys": "off",
+        "no-func-assign": "off",
+        "no-import-assign": "off",
+        "no-new-native-nonconstructor": "off",
+        "no-obj-calls": "off",
+        "no-redeclare": "off",
+        "no-setter-return": "off",
+        "no-this-before-super": "off",
+        "no-unreachable": "off",
+        "no-unsafe-negation": "off",
+        "no-var": "error",
+        "no-with": "off",
+        "prefer-const": "error",
+        "prefer-rest-params": "error",
+        "prefer-spread": "error"
+      }
+    },
+    {
+      "files": ["**/*.vue"],
+      "rules": {
+        "turbo/no-undeclared-env-vars": "off"
+      }
+    },
+    {
+      "files": ["**/*.ts"],
+      "rules": {
+        "typescript/no-explicit-any": "warn",
+        "typescript/no-unsafe-declaration-merging": "off",
+        "typescript/no-non-null-asserted-optional-chain": "warn"
+      }
+    },
+    {
+      "files": ["**/*.js", "**/*.mjs"],
+      "rules": {
+        "no-redeclare": "off",
+        "no-prototype-builtins": "off",
+        "no-unused-vars": "off",
+        "no-unused-expressions": "off",
+        "typescript/no-require-imports": "off"
+      },
+      "env": {
+        "browser": true,
+        "node": true
+      }
+    },
+    {
+      "files": ["**/*.cy.js", "**/cypress/**/*.js"],
+      "globals": {
+        "cy": "readonly",
+        "Cypress": "readonly",
+        "describe": "readonly",
+        "it": "readonly",
+        "beforeEach": "readonly",
+        "afterEach": "readonly",
+        "expect": "readonly"
+      },
+      "env": {
+        "browser": true
+      }
+    },
+    {
+      "files": ["**/*.spec.ts"],
+      "rules": {
+        "no-unused-vars": [
+          "error",
+          {
+            "argsIgnorePattern": "^_",
+            "varsIgnorePattern": "^_"
+          }
+        ],
+        "typescript/no-explicit-any": "off"
+      }
+    }
+  ]
+}

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -127,7 +127,12 @@
     {
       "files": ["**/*.vue"],
       "rules": {
-        "turbo/no-undeclared-env-vars": "off"
+        "turbo/no-undeclared-env-vars": [
+          "warn",
+          {
+            "allowList": ["^SSR$"]
+          }
+        ]
       }
     },
     {
@@ -143,6 +148,7 @@
       "rules": {
         "no-redeclare": "off",
         "no-prototype-builtins": "off",
+        "no-undef": "error",
         "no-unused-vars": "off",
         "no-unused-expressions": "off",
         "typescript/no-require-imports": "off"

--- a/apps/sample-app-lit-e2e/package.json
+++ b/apps/sample-app-lit-e2e/package.json
@@ -9,7 +9,7 @@
     "e2e": "cypress open",
     "format": "prettier --write \"**/*.{ts,js,json,md}\"",
     "format:check": "prettier --check \"**/*.{ts,js,json,md}\"",
-    "lint": "eslint .",
+    "lint": "oxlint .",
     "test": "start-server-and-test docs:start-server 'http://localhost:8787/app/|http://localhost:8787/app-mobx/' test:cypress:all",
     "test:cypress": "cypress run",
     "test:cypress:all": "concurrently --names vanilla,mobx --prefix-colors auto \"pnpm run test:cypress\" \"pnpm run test:cypress:mobx\"",

--- a/apps/sample-app-lit-mobx/package.json
+++ b/apps/sample-app-lit-mobx/package.json
@@ -8,7 +8,7 @@
     "dev": "vite",
     "format": "prettier --write \"**/*.{js,ts,json,md}\"",
     "format:check": "prettier --check \"**/*.{js,ts,json,md}\"",
-    "lint": "eslint ."
+    "lint": "oxlint ."
   },
   "dependencies": {
     "lit": "catalog:",

--- a/apps/sample-app-lit-vanilla/package.json
+++ b/apps/sample-app-lit-vanilla/package.json
@@ -8,7 +8,7 @@
     "dev": "vite",
     "format": "prettier --write \"**/*.{js,ts,json,md}\"",
     "format:check": "prettier --check \"**/*.{js,ts,json,md}\"",
-    "lint": "eslint ."
+    "lint": "oxlint ."
   },
   "dependencies": {
     "lit": "catalog:",

--- a/apps/sample-app-shared/package.json
+++ b/apps/sample-app-shared/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "format": "prettier --write \"**/*.{js,ts,json,md,css}\"",
     "format:check": "prettier --check \"**/*.{js,ts,json,md,css}\"",
-    "lint": "eslint ."
+    "lint": "oxlint ."
   },
   "dependencies": {
     "@api-viewer/docs": "catalog:",

--- a/docs/package.json
+++ b/docs/package.json
@@ -9,7 +9,7 @@
     "docs:preview": "vitepress preview .",
     "format": "prettier --write \"**/*.{md,json,ts}\"",
     "format:check": "prettier --check \"**/*.{md,json,ts}\"",
-    "lint": "eslint .",
+    "lint": "oxlint .",
     "wrangler": "wrangler --config ../wrangler.jsonc",
     "wrangler:dev": "pnpm run wrangler dev"
   },

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,14 +1,15 @@
+// ESLint is retained solely for package.json linting (eslint-plugin-package-json).
+// All JS/TS linting lives in oxlint (.oxlintrc.json).
 import { defineConfig, globalIgnores } from 'eslint/config';
-import eslint from '@eslint/js';
-import tseslint from 'typescript-eslint';
-import globals from 'globals';
-import prettier from 'eslint-config-prettier';
-import turbo from 'eslint-plugin-turbo';
 import packageJson from 'eslint-plugin-package-json';
 
 export default defineConfig(
-  eslint.configs.recommended,
-  tseslint.configs.recommended,
+  globalIgnores([
+    '**/dist/**',
+    '**/coverage/**',
+    '**/node_modules/**',
+    '**/.vitepress/cache/**',
+  ]),
   {
     extends: [packageJson.configs.recommended],
     files: ['**/package.json'],
@@ -18,97 +19,6 @@ export default defineConfig(
         {
           ignorePrivate: true,
         },
-      ],
-    },
-  },
-  prettier,
-  {
-    plugins: { turbo },
-    rules: {
-      'turbo/no-undeclared-env-vars': 'warn',
-    },
-  },
-  globalIgnores([
-    '**/dist/**',
-    '**/coverage/**',
-    '**/node_modules/**',
-    '**/.vitepress/cache/**',
-    '**/*.config.ts',
-    '**/*.config.js',
-    '!**/vitest.config.ts',
-  ]),
-  {
-    files: ['**/*.ts'],
-    languageOptions: {
-      parserOptions: {
-        projectService: true,
-        tsconfigRootDir: import.meta.dirname,
-      },
-    },
-    rules: {
-      '@typescript-eslint/no-explicit-any': 'warn',
-      '@typescript-eslint/no-unsafe-declaration-merging': 'off',
-      '@typescript-eslint/no-non-null-asserted-optional-chain': 'warn',
-    },
-  },
-  {
-    files: ['**/*.js', '**/*.mjs'],
-    languageOptions: {
-      globals: {
-        ...globals.browser,
-        ...globals.node,
-      },
-    },
-    rules: {
-      '@typescript-eslint/no-require-imports': 'off',
-      '@typescript-eslint/no-unused-vars': 'off',
-      '@typescript-eslint/no-unused-expressions': 'off',
-      'no-redeclare': 'off',
-      'no-prototype-builtins': 'off',
-    },
-  },
-  {
-    files: ['**/*.cy.js', '**/cypress/**/*.js'],
-    languageOptions: {
-      globals: {
-        ...globals.browser,
-        cy: 'readonly',
-        Cypress: 'readonly',
-        describe: 'readonly',
-        it: 'readonly',
-        beforeEach: 'readonly',
-        afterEach: 'readonly',
-        expect: 'readonly',
-      },
-    },
-  },
-  {
-    files: ['**/vitest.config.ts', '**/vitest.setup.ts'],
-    languageOptions: {
-      parserOptions: {
-        // These live in the packages' tsconfig.spec.json, which the
-        // project service (tsconfig.json discovery) never consults.
-        projectService: false,
-        project: 'packages/*/tsconfig.spec.json',
-        tsconfigRootDir: import.meta.dirname,
-      },
-    },
-  },
-  {
-    files: ['**/*.spec.ts'],
-    languageOptions: {
-      parserOptions: {
-        // Spec files are excluded from tsconfig.json for build purposes
-        projectService: false,
-      },
-    },
-    rules: {
-      // Tests may use any for mocking
-      '@typescript-eslint/no-explicit-any': 'off',
-      // Allow underscore-prefixed unused vars (common pattern for required but unused params)
-      '@typescript-eslint/no-unused-vars': [
-        'error',
-        { argsIgnorePattern: '^_', varsIgnorePattern: '^_' },
       ],
     },
   },

--- a/examples/package.json
+++ b/examples/package.json
@@ -7,6 +7,6 @@
     "build:embeds": "node build-embeds.mjs",
     "format": "prettier --write \"**/*.{ts,js,mjs,json,md}\"",
     "format:check": "prettier --check \"**/*.{ts,js,mjs,json,md}\"",
-    "lint": "eslint ."
+    "lint": "oxlint ."
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "format:check:root": "prettier --check \"*.{md,ts,js,json,jsonc}\"",
     "format:root": "prettier --write \"*.{md,ts,js,json,jsonc}\"",
     "lint": "turbo run lint",
-    "lint:root": "eslint --format tap --ignore-pattern apps --ignore-pattern tools --ignore-pattern docs --ignore-pattern packages --ignore-pattern examples",
+    "lint:package-json": "eslint --format tap --ignore-pattern examples \"**/package.json\"",
+    "lint:root": "oxlint --ignore-pattern apps --ignore-pattern tools --ignore-pattern docs --ignore-pattern packages --ignore-pattern examples .",
     "test:coverage": "turbo run test:coverage",
     "test:root": "node --test \"scripts/**/*.test.mjs\""
   },
@@ -24,22 +25,19 @@
   },
   "packageManager": "pnpm@11.10.0",
   "devDependencies": {
-    "@eslint/js": "^10.0.1",
     "@pnpm/fs.find-packages": "catalog:",
     "@pnpm/workspace.read-manifest": "catalog:",
     "cypress": "catalog:",
     "eslint": "^10.6.0",
-    "eslint-config-prettier": "^10.1.8",
     "eslint-formatter-tap": "^9.0.1",
     "eslint-plugin-package-json": "^1.5.0",
     "eslint-plugin-turbo": "^2.10.3",
-    "globals": "^17.7.0",
+    "oxlint": "catalog:",
     "playwright": "catalog:",
     "pnpm": "^11.10.0",
     "prettier": "catalog:",
     "turbo": "^2.10.3",
     "typescript": "catalog:",
-    "typescript-eslint": "^8.62.1",
     "wrangler": "catalog:"
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "format:check:root": "prettier --check \"*.{md,ts,js,json,jsonc}\"",
     "format:root": "prettier --write \"*.{md,ts,js,json,jsonc}\"",
     "lint": "turbo run lint",
-    "lint:package-json": "eslint --format tap --ignore-pattern examples \"**/package.json\"",
+    "lint:package-json": "eslint --format tap \"**/package.json\"",
     "lint:root": "oxlint --ignore-pattern apps --ignore-pattern tools --ignore-pattern docs --ignore-pattern packages --ignore-pattern examples .",
     "test:coverage": "turbo run test:coverage",
     "test:root": "node --test \"scripts/**/*.test.mjs\""

--- a/packages/lit-ui-router-mobx/package.json
+++ b/packages/lit-ui-router-mobx/package.json
@@ -45,7 +45,7 @@
     "docs:api": "rimraf ../../docs/api/lit-ui-router-mobx && typedoc",
     "format": "prettier --write \"**/*.{ts,js,json,md}\"",
     "format:check": "prettier --check \"**/*.{ts,js,json,md}\"",
-    "lint": "eslint .",
+    "lint": "oxlint .",
     "test": "VITEST_BROWSER_API_PORT=63330 vitest run",
     "test:coverage": "VITEST_BROWSER_API_PORT=63335 vitest run --coverage --browser=chromium"
   },

--- a/packages/lit-ui-router/package.json
+++ b/packages/lit-ui-router/package.json
@@ -36,7 +36,7 @@
     "docs:api": "rimraf ../../docs/api/reference && typedoc --defaultCategory other",
     "format": "prettier --write \"**/*.{ts,js,json,md}\"",
     "format:check": "prettier --check \"**/*.{ts,js,json,md}\"",
-    "lint": "eslint .",
+    "lint": "oxlint .",
     "test": "VITEST_BROWSER_API_PORT=63320 vitest run",
     "test:coverage": "VITEST_BROWSER_API_PORT=63325 vitest run --coverage --browser=chromium"
   },

--- a/packages/navigation-location-plugin/package.json
+++ b/packages/navigation-location-plugin/package.json
@@ -44,7 +44,7 @@
     "docs:api": "rimraf ../../docs/api/navigation-location-plugin && typedoc",
     "format": "prettier --write \"**/*.{ts,js,json,md}\"",
     "format:check": "prettier --check \"**/*.{ts,js,json,md}\"",
-    "lint": "eslint .",
+    "lint": "oxlint .",
     "test": "VITEST_BROWSER_API_PORT=63340 vitest run",
     "test:coverage": "VITEST_BROWSER_API_PORT=63345 vitest run --coverage --browser=chromium"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,6 +57,9 @@ catalogs:
     mobx:
       specifier: ^6.16.1
       version: 6.16.1
+    oxlint:
+      specifier: 1.73.0
+      version: 1.73.0
     playwright:
       specifier: ^1.61.1
       version: 1.61.1
@@ -126,9 +129,6 @@ importers:
 
   .:
     devDependencies:
-      '@eslint/js':
-        specifier: ^10.0.1
-        version: 10.0.1(eslint@10.6.0(jiti@2.7.0)(supports-color@8.1.1))
       '@pnpm/fs.find-packages':
         specifier: 'catalog:'
         version: 1000.0.24(@pnpm/logger@1001.0.1)
@@ -141,9 +141,6 @@ importers:
       eslint:
         specifier: ^10.6.0
         version: 10.6.0(jiti@2.7.0)(supports-color@8.1.1)
-      eslint-config-prettier:
-        specifier: ^10.1.8
-        version: 10.1.8(eslint@10.6.0(jiti@2.7.0)(supports-color@8.1.1))
       eslint-formatter-tap:
         specifier: ^9.0.1
         version: 9.0.1
@@ -153,9 +150,9 @@ importers:
       eslint-plugin-turbo:
         specifier: ^2.10.3
         version: 2.10.3(eslint@10.6.0(jiti@2.7.0)(supports-color@8.1.1))(turbo@2.10.3)
-      globals:
-        specifier: ^17.7.0
-        version: 17.7.0
+      oxlint:
+        specifier: 'catalog:'
+        version: 1.73.0
       playwright:
         specifier: 'catalog:'
         version: 1.61.1
@@ -171,9 +168,6 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
-      typescript-eslint:
-        specifier: ^8.62.1
-        version: 8.62.1(eslint@10.6.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)
       wrangler:
         specifier: 'catalog:'
         version: 4.107.0
@@ -247,7 +241,7 @@ importers:
         version: 7.3.6(@types/node@25.0.9)(jiti@2.7.0)(yaml@2.9.0)
       vite-plugin-checker:
         specifier: 'catalog:'
-        version: 0.14.4(eslint@10.6.0(jiti@2.7.0))(optionator@0.9.4)(typescript@6.0.3)(vite@7.3.6(@types/node@25.0.9)(jiti@2.7.0)(yaml@2.9.0))
+        version: 0.14.4(eslint@10.6.0(jiti@2.7.0))(optionator@0.9.4)(oxlint@1.73.0)(typescript@6.0.3)(vite@7.3.6(@types/node@25.0.9)(jiti@2.7.0)(yaml@2.9.0))
       vite-plugin-static-copy:
         specifier: 'catalog:'
         version: 4.1.1(vite@7.3.6(@types/node@25.0.9)(jiti@2.7.0)(yaml@2.9.0))
@@ -290,7 +284,7 @@ importers:
         version: 7.3.6(@types/node@25.0.9)(jiti@2.7.0)(yaml@2.9.0)
       vite-plugin-checker:
         specifier: 'catalog:'
-        version: 0.14.4(eslint@10.6.0(jiti@2.7.0))(optionator@0.9.4)(typescript@6.0.3)(vite@7.3.6(@types/node@25.0.9)(jiti@2.7.0)(yaml@2.9.0))
+        version: 0.14.4(eslint@10.6.0(jiti@2.7.0))(optionator@0.9.4)(oxlint@1.73.0)(typescript@6.0.3)(vite@7.3.6(@types/node@25.0.9)(jiti@2.7.0)(yaml@2.9.0))
       vite-plugin-static-copy:
         specifier: 'catalog:'
         version: 4.1.1(vite@7.3.6(@types/node@25.0.9)(jiti@2.7.0)(yaml@2.9.0))
@@ -993,15 +987,6 @@ packages:
     resolution: {integrity: sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
-  '@eslint/js@10.0.1':
-    resolution: {integrity: sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
-    peerDependencies:
-      eslint: ^10.0.0
-    peerDependenciesMeta:
-      eslint:
-        optional: true
-
   '@eslint/object-schema@3.0.5':
     resolution: {integrity: sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
@@ -1551,6 +1536,128 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@oxlint/binding-android-arm-eabi@1.73.0':
+    resolution: {integrity: sha512-HZQRN/UMBu+Ut+/9MiAChkbP4qZqrNOWBcNI45vOT40GVhbGR0JgHB87L48D4iAqFQIdVmeQYtV9RF89AjTKkg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
+  '@oxlint/binding-android-arm64@1.73.0':
+    resolution: {integrity: sha512-Gp+KJRylv2aW7thRpG5p1KTxZq4ZJFbWowrKzufNq9d3ssl3r3JviYV45/+p+7CN1Nv0zDd1e8Ex0b/HUDq4TQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxlint/binding-darwin-arm64@1.73.0':
+    resolution: {integrity: sha512-3de96NdtXhxERMjIz7wsp2HYMY6pMQycGxFWac2mFecAx6VeARF/IqFb1QIaqiCRIdfzBwzTed+pCTCoiS+CYA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxlint/binding-darwin-x64@1.73.0':
+    resolution: {integrity: sha512-5zx/uPW32TiaOeVY1dQ/H5iOf0K1HOdFKOJhLqGl4o63+i1fpzoqqu/mKtd7OFgFjNCdhlyTGgjVkQTZm1ELcg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxlint/binding-freebsd-x64@1.73.0':
+    resolution: {integrity: sha512-qNe4gKHaGnLuZJ8toUg90JAa0S2vTVvDw+0bRi3q1avXZXDT4u5mMeECf3nD4HYrbdn1O7dXqWut4onY/yx/Xg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxlint/binding-linux-arm-gnueabihf@1.73.0':
+    resolution: {integrity: sha512-cCehYh5hTbfShm/fxTD6wwrGUWIpvX+N5OxmAMhFhDeTGXvw+BeNj889tpxsFQ9ZLatQ6wImuY8tsKLZ+FMz7w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxlint/binding-linux-arm-musleabihf@1.73.0':
+    resolution: {integrity: sha512-d5j5GDU/2dMgjVhw7TQT9ITrsIr1Y02KEXKyVGIXUkD+KiaxE9TP65FS2ZdgTBemQvoRL+gSBdbrIm3cQIeacg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxlint/binding-linux-arm64-gnu@1.73.0':
+    resolution: {integrity: sha512-Eyf1SrP3+yR1DI3OJgOY2Pvrr9dWP9TK37xPaDYycwTtlGlI45erJAVIfH5/m/xosDt6BupJYEFi47bvbTuuyw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-arm64-musl@1.73.0':
+    resolution: {integrity: sha512-IlT/OJApEDKaMmCooHuncgJZbbCe7T5QIWmTZBEtYscWvzPQuuEinVcid6kwQRVQOUdb7PUCz4jQHnaYXdfJXw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxlint/binding-linux-ppc64-gnu@1.73.0':
+    resolution: {integrity: sha512-L+JYcb/vdg5fmcH08V6o0YYLU28cTH1SPNulwJdvK9NK49aXSkYy6oNpKBmddArVOXYqNepriDGiZ04G54kh1Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-riscv64-gnu@1.73.0':
+    resolution: {integrity: sha512-Qtk0g3bKV6OwWjIm7R8kQN1uOZRKQt/MODK2a8QfkwhTpXBD53ozx5XLVWLGDQAVyp2otLW4D2wB98XfAfMPGA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-riscv64-musl@1.73.0':
+    resolution: {integrity: sha512-wX0NQKZVxltkAOVmzFcpOaMpdaUvsq1Eqpx9tkAfl71UdkTlSo1R4AdAnGccR1Fm2+TzFgZ22CyyGuZ41RDr/A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxlint/binding-linux-s390x-gnu@1.73.0':
+    resolution: {integrity: sha512-vPe7UGBMWyiLTtnqS4xxgMQFSFGmtQwhwCxuiw6lXygaO6bVt0D8dFVg8Xv05eaiN3ybC0HXXHUAohFMFvqoCQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-x64-gnu@1.73.0':
+    resolution: {integrity: sha512-2CwIWr9cemFC/CbRBWZvuk5mffz6ObmfFkfcC/9rTQ7f+icNhYr2kOjf9Rt8lLvugvkdGDOmkoVoFFHh6ClCTw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-x64-musl@1.73.0':
+    resolution: {integrity: sha512-nDadfJgg7NBBxG0N560wOe7LLX5QiYp6qBaI7viuk5EUORFBktU/NfV0MbTqU3gTqQDCh4VyxKdo5VADxk9w8Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxlint/binding-openharmony-arm64@1.73.0':
+    resolution: {integrity: sha512-wGjJC+NLH9xP+IKGn9RDW94ojJR/wPbg5WCnQjj/oReaOtCQthr8ws1zICe77JFmo4ouUdeTHHZL/ESGiF6Pmw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxlint/binding-win32-arm64-msvc@1.73.0':
+    resolution: {integrity: sha512-I7X47GPGljw225YUQ5SbC/rb1Kkdrd0yQf0x+hYxeKS6DpfjMbo9ccQPQ6LNY6BoJQ1sHhgDUGuMn5Vg5gHT6w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxlint/binding-win32-ia32-msvc@1.73.0':
+    resolution: {integrity: sha512-5lWj+3h+74Fm1jYOO9qkJA4xkAlZA099DkXppuXsk7UpnpZLttsefrZU469vChGaG6hcSqrkKXQOvMTZtbjeNg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@oxlint/binding-win32-x64-msvc@1.73.0':
+    resolution: {integrity: sha512-WaNRvh4f6zY9CvUQk2YoA1O90ieWrIklI84+HXFr9Isjz9CSESrdqo/RtIYt4Dll/cAchqGDMehfaZd0vqEFZw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
   '@phun-ky/typeof@2.0.3':
     resolution: {integrity: sha512-oeQJs1aa8Ghke8JIK9yuq/+KjMiaYeDZ38jx7MhkXncXlUKjqQ3wEm2X3qCKyjo+ZZofZj+WsEEiqkTtRuE2xQ==}
     engines: {node: ^20.9.0 || >=22.0.0, npm: '>=10.8.2'}
@@ -1936,65 +2043,6 @@ packages:
 
   '@types/web-bluetooth@0.0.21':
     resolution: {integrity: sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==}
-
-  '@typescript-eslint/eslint-plugin@8.62.1':
-    resolution: {integrity: sha512-4EQM77WgVNxj7OkL/5b/D/xZsw00G577+UriYTC7JF5opcF3T2AuoeY7ueLaZgSVjSgCS6yOAJB5bRGLPSJUzA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      '@typescript-eslint/parser': ^8.62.1
-      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: '>=4.8.4 <6.1.0'
-
-  '@typescript-eslint/parser@8.62.1':
-    resolution: {integrity: sha512-sPhE4iHuJDSvoAiec+Ro8JyXw8f0ql13HFR82P99nCm9GwTEKG0KYLvDe6REk8BCXuit6vJAv/Yxg5ABaNS2rA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: '>=4.8.4 <6.1.0'
-
-  '@typescript-eslint/project-service@8.62.1':
-    resolution: {integrity: sha512-yQ3RgY5RkSBpsNS1Bx/JQEcA24FOSdfGktoyprAr5u18390UQdtVcfnEv4nIrIshNnavlVyZBKxQwT1fIAE6cg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <6.1.0'
-
-  '@typescript-eslint/scope-manager@8.62.1':
-    resolution: {integrity: sha512-r4d249KbQ1SFdpeStvob8Ih6aPPIzfqllPVOtvhve6ZcpuVcYo5/7zUWckKpHE7StASX4kTKZTLf0WQm/wPkcg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/tsconfig-utils@8.62.1':
-    resolution: {integrity: sha512-xadytJqX9vJVQ2fdQjkcIVigwaOJNWkpjdLt6cEQ+xPnrI1fkp+/jZE/I97k9KUjqtpd25i0HeyZf3T6dutv2g==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <6.1.0'
-
-  '@typescript-eslint/type-utils@8.62.1':
-    resolution: {integrity: sha512-aXM5xlqXiTxPibXB93cLAURfT3rlizf7uMXISCXy66Isr/9hISJx3yDsKl0L7lKa51b8JpFuNKby0/O0pEm9jg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: '>=4.8.4 <6.1.0'
-
-  '@typescript-eslint/types@8.62.1':
-    resolution: {integrity: sha512-ooCzJFaf+Hg+uG6fA3NRFGuFjlfNlDhBthbv4ZPU/0elCAFUfnyXUvf/WOpHz/jYwSmvU2GkR2LtyUfy1AxZ1Q==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/typescript-estree@8.62.1':
-    resolution: {integrity: sha512-xMcW9oP9u7fAMXYs9A65CVmtLQe2r//oXINHfi8HV+oiqhih17sbLdhXr4540YWlgpDKQdY854OL5ZrdCiQsAA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <6.1.0'
-
-  '@typescript-eslint/utils@8.62.1':
-    resolution: {integrity: sha512-sHtbPfuKNZCG+ih8SyjjucqRntSVmp8XgL5u6o9mAhiSn8ds5o/M/XdM0abweme2Tln3szOstOrZ9OXitvPh0g==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: '>=4.8.4 <6.1.0'
-
-  '@typescript-eslint/visitor-keys@8.62.1':
-    resolution: {integrity: sha512-4g3BLxfdTMy8iZG0MaBkadnlRrCJ74cQiFbyEVMrkwIoqdyaXXQM22cotDvrl4x28wgIZ9rEJRoM+mmhSJpJ1g==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@uirouter/core@6.1.2':
     resolution: {integrity: sha512-pYcg+cxVd9E9poC7AJf7ZrlQQrwAV6KVkiPvlbLJX5km+pBWrUOGQhdd87oIGc7/5iVQ7qSiAdl9QD+l55yegg==}
@@ -2748,12 +2796,6 @@ packages:
     engines: {node: '>=6.0'}
     hasBin: true
 
-  eslint-config-prettier@10.1.8:
-    resolution: {integrity: sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==}
-    hasBin: true
-    peerDependencies:
-      eslint: '>=7.0.0'
-
   eslint-fix-utils@0.4.2:
     resolution: {integrity: sha512-n7ZTcwwkP5scedlhvWMcqxED+O1NzXcj5Rxn/0kJQMP88k02vRcBfQ1qsk/JHb6Aw8bajFoetFCCBiNIcNCsvA==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
@@ -3043,10 +3085,6 @@ packages:
     resolution: {integrity: sha512-NBcGGFbBA9s1VzD41QXDG+3++t9Mn5t1FpLdhESY6oKY4gYTFpX4wO3sqGUa0Srjtbfj3szX0RnemmrVRUdULA==}
     engines: {node: '>=10'}
 
-  globals@17.7.0:
-    resolution: {integrity: sha512-Czmyns5dUsq4seFBR/Kdydhmo8y9kC79hiSkPn0YcGtNnYWnrgt0vjrSjx9tspoDGWm2CMarffRuLjM4xUz8xg==}
-    engines: {node: '>=18'}
-
   globby@11.0.4:
     resolution: {integrity: sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==}
     engines: {node: '>=10'}
@@ -3130,10 +3168,6 @@ packages:
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
-    engines: {node: '>= 4'}
-
-  ignore@7.0.5:
-    resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
 
   imurmurhash@0.1.4:
@@ -3626,6 +3660,19 @@ packages:
 
   oxc-resolver@11.23.0:
     resolution: {integrity: sha512-f0+l598CJMOLnYPXsXxttJALH0ljtivdRMKtvHhxRuWa5FYmw5+qODARl8oYjMC/brpzKcrpdORsOBrTqhBZ9A==}
+
+  oxlint@1.73.0:
+    resolution: {integrity: sha512-u91G9TJzU6yqKWNZUYprQB07W7YvntZXaRxQ6CkoytepYhLWUXWsr1M8zUJ34VatNPuUAr3Z8GH+O2A331CluQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      oxlint-tsgolint: '>=0.24.0'
+      vite-plus: '*'
+    peerDependenciesMeta:
+      oxlint-tsgolint:
+        optional: true
+      vite-plus:
+        optional: true
 
   p-filter@2.1.0:
     resolution: {integrity: sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw==}
@@ -4177,12 +4224,6 @@ packages:
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
 
-  ts-api-utils@2.5.0:
-    resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
-    engines: {node: '>=18.12'}
-    peerDependencies:
-      typescript: '>=4.8.4'
-
   tslib@1.14.1:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
 
@@ -4232,13 +4273,6 @@ packages:
     hasBin: true
     peerDependencies:
       typescript: 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x || 5.9.x || 6.0.x
-
-  typescript-eslint@8.62.1:
-    resolution: {integrity: sha512-vymnnM5g0AKQDSAyfP12nMIBvgwgA42syg74kkuZ4x1VuTzwQKwc5h9rGxeShCjny5o+zWAb6OEoz7XLgrIkIw==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: '>=4.8.4 <6.1.0'
 
   typescript@5.0.4:
     resolution: {integrity: sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==}
@@ -5067,10 +5101,6 @@ snapshots:
     dependencies:
       '@types/json-schema': 7.0.15
 
-  '@eslint/js@10.0.1(eslint@10.6.0(jiti@2.7.0)(supports-color@8.1.1))':
-    optionalDependencies:
-      eslint: 10.6.0(jiti@2.7.0)(supports-color@8.1.1)
-
   '@eslint/object-schema@3.0.5': {}
 
   '@eslint/plugin-kit@0.7.2':
@@ -5514,6 +5544,63 @@ snapshots:
   '@oxc-resolver/binding-win32-x64-msvc@11.23.0':
     optional: true
 
+  '@oxlint/binding-android-arm-eabi@1.73.0':
+    optional: true
+
+  '@oxlint/binding-android-arm64@1.73.0':
+    optional: true
+
+  '@oxlint/binding-darwin-arm64@1.73.0':
+    optional: true
+
+  '@oxlint/binding-darwin-x64@1.73.0':
+    optional: true
+
+  '@oxlint/binding-freebsd-x64@1.73.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm-gnueabihf@1.73.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm-musleabihf@1.73.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm64-gnu@1.73.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm64-musl@1.73.0':
+    optional: true
+
+  '@oxlint/binding-linux-ppc64-gnu@1.73.0':
+    optional: true
+
+  '@oxlint/binding-linux-riscv64-gnu@1.73.0':
+    optional: true
+
+  '@oxlint/binding-linux-riscv64-musl@1.73.0':
+    optional: true
+
+  '@oxlint/binding-linux-s390x-gnu@1.73.0':
+    optional: true
+
+  '@oxlint/binding-linux-x64-gnu@1.73.0':
+    optional: true
+
+  '@oxlint/binding-linux-x64-musl@1.73.0':
+    optional: true
+
+  '@oxlint/binding-openharmony-arm64@1.73.0':
+    optional: true
+
+  '@oxlint/binding-win32-arm64-msvc@1.73.0':
+    optional: true
+
+  '@oxlint/binding-win32-ia32-msvc@1.73.0':
+    optional: true
+
+  '@oxlint/binding-win32-x64-msvc@1.73.0':
+    optional: true
+
   '@phun-ky/typeof@2.0.3': {}
 
   '@pnpm/constants@1001.3.1': {}
@@ -5876,97 +5963,6 @@ snapshots:
   '@types/unist@3.0.3': {}
 
   '@types/web-bluetooth@0.0.21': {}
-
-  '@typescript-eslint/eslint-plugin@8.62.1(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint@10.6.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)':
-    dependencies:
-      '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.62.1(eslint@10.6.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)
-      '@typescript-eslint/scope-manager': 8.62.1
-      '@typescript-eslint/type-utils': 8.62.1(eslint@10.6.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.62.1(eslint@10.6.0(jiti@2.7.0)(supports-color@8.1.1))(typescript@6.0.3)
-      '@typescript-eslint/visitor-keys': 8.62.1
-      eslint: 10.6.0(jiti@2.7.0)(supports-color@8.1.1)
-      ignore: 7.0.5
-      natural-compare: 1.4.0
-      ts-api-utils: 2.5.0(typescript@6.0.3)
-      typescript: 6.0.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)':
-    dependencies:
-      '@typescript-eslint/scope-manager': 8.62.1
-      '@typescript-eslint/types': 8.62.1
-      '@typescript-eslint/typescript-estree': 8.62.1(typescript@6.0.3)
-      '@typescript-eslint/visitor-keys': 8.62.1
-      debug: 4.4.3(supports-color@8.1.1)
-      eslint: 10.6.0(jiti@2.7.0)(supports-color@8.1.1)
-      typescript: 6.0.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/project-service@8.62.1(typescript@6.0.3)':
-    dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.62.1(typescript@6.0.3)
-      '@typescript-eslint/types': 8.62.1
-      debug: 4.4.3(supports-color@8.1.1)
-      typescript: 6.0.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/scope-manager@8.62.1':
-    dependencies:
-      '@typescript-eslint/types': 8.62.1
-      '@typescript-eslint/visitor-keys': 8.62.1
-
-  '@typescript-eslint/tsconfig-utils@8.62.1(typescript@6.0.3)':
-    dependencies:
-      typescript: 6.0.3
-
-  '@typescript-eslint/type-utils@8.62.1(eslint@10.6.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)':
-    dependencies:
-      '@typescript-eslint/types': 8.62.1
-      '@typescript-eslint/typescript-estree': 8.62.1(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.62.1(eslint@10.6.0(jiti@2.7.0)(supports-color@8.1.1))(typescript@6.0.3)
-      debug: 4.4.3(supports-color@8.1.1)
-      eslint: 10.6.0(jiti@2.7.0)(supports-color@8.1.1)
-      ts-api-utils: 2.5.0(typescript@6.0.3)
-      typescript: 6.0.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/types@8.62.1': {}
-
-  '@typescript-eslint/typescript-estree@8.62.1(typescript@6.0.3)':
-    dependencies:
-      '@typescript-eslint/project-service': 8.62.1(typescript@6.0.3)
-      '@typescript-eslint/tsconfig-utils': 8.62.1(typescript@6.0.3)
-      '@typescript-eslint/types': 8.62.1
-      '@typescript-eslint/visitor-keys': 8.62.1
-      debug: 4.4.3(supports-color@8.1.1)
-      minimatch: 10.2.5
-      semver: 7.8.5
-      tinyglobby: 0.2.17
-      ts-api-utils: 2.5.0(typescript@6.0.3)
-      typescript: 6.0.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/utils@8.62.1(eslint@10.6.0(jiti@2.7.0)(supports-color@8.1.1))(typescript@6.0.3)':
-    dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.6.0(jiti@2.7.0)(supports-color@8.1.1))
-      '@typescript-eslint/scope-manager': 8.62.1
-      '@typescript-eslint/types': 8.62.1
-      '@typescript-eslint/typescript-estree': 8.62.1(typescript@6.0.3)
-      eslint: 10.6.0(jiti@2.7.0)(supports-color@8.1.1)
-      typescript: 6.0.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/visitor-keys@8.62.1':
-    dependencies:
-      '@typescript-eslint/types': 8.62.1
-      eslint-visitor-keys: 5.0.1
 
   '@uirouter/core@6.1.2': {}
 
@@ -6757,10 +6753,6 @@ snapshots:
     optionalDependencies:
       source-map: 0.6.1
 
-  eslint-config-prettier@10.1.8(eslint@10.6.0(jiti@2.7.0)(supports-color@8.1.1)):
-    dependencies:
-      eslint: 10.6.0(jiti@2.7.0)(supports-color@8.1.1)
-
   eslint-fix-utils@0.4.2(@types/estree@1.0.9)(eslint@10.6.0(jiti@2.7.0)(supports-color@8.1.1)):
     dependencies:
       eslint: 10.6.0(jiti@2.7.0)(supports-color@8.1.1)
@@ -7125,8 +7117,6 @@ snapshots:
     dependencies:
       ini: 2.0.0
 
-  globals@17.7.0: {}
-
   globby@11.0.4:
     dependencies:
       array-union: 2.1.0
@@ -7223,8 +7213,6 @@ snapshots:
   ieee754@1.2.1: {}
 
   ignore@5.3.2: {}
-
-  ignore@7.0.5: {}
 
   imurmurhash@0.1.4: {}
 
@@ -7721,6 +7709,28 @@ snapshots:
       '@oxc-resolver/binding-wasm32-wasi': 11.23.0
       '@oxc-resolver/binding-win32-arm64-msvc': 11.23.0
       '@oxc-resolver/binding-win32-x64-msvc': 11.23.0
+
+  oxlint@1.73.0:
+    optionalDependencies:
+      '@oxlint/binding-android-arm-eabi': 1.73.0
+      '@oxlint/binding-android-arm64': 1.73.0
+      '@oxlint/binding-darwin-arm64': 1.73.0
+      '@oxlint/binding-darwin-x64': 1.73.0
+      '@oxlint/binding-freebsd-x64': 1.73.0
+      '@oxlint/binding-linux-arm-gnueabihf': 1.73.0
+      '@oxlint/binding-linux-arm-musleabihf': 1.73.0
+      '@oxlint/binding-linux-arm64-gnu': 1.73.0
+      '@oxlint/binding-linux-arm64-musl': 1.73.0
+      '@oxlint/binding-linux-ppc64-gnu': 1.73.0
+      '@oxlint/binding-linux-riscv64-gnu': 1.73.0
+      '@oxlint/binding-linux-riscv64-musl': 1.73.0
+      '@oxlint/binding-linux-s390x-gnu': 1.73.0
+      '@oxlint/binding-linux-x64-gnu': 1.73.0
+      '@oxlint/binding-linux-x64-musl': 1.73.0
+      '@oxlint/binding-openharmony-arm64': 1.73.0
+      '@oxlint/binding-win32-arm64-msvc': 1.73.0
+      '@oxlint/binding-win32-ia32-msvc': 1.73.0
+      '@oxlint/binding-win32-x64-msvc': 1.73.0
 
   p-filter@2.1.0:
     dependencies:
@@ -8327,10 +8337,6 @@ snapshots:
 
   trim-lines@3.0.1: {}
 
-  ts-api-utils@2.5.0(typescript@6.0.3):
-    dependencies:
-      typescript: 6.0.3
-
   tslib@1.14.1: {}
 
   tslib@2.8.1: {}
@@ -8376,17 +8382,6 @@ snapshots:
       minimatch: 10.2.5
       typescript: 6.0.3
       yaml: 2.9.0
-
-  typescript-eslint@8.62.1(eslint@10.6.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3):
-    dependencies:
-      '@typescript-eslint/eslint-plugin': 8.62.1(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint@10.6.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)
-      '@typescript-eslint/parser': 8.62.1(eslint@10.6.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)
-      '@typescript-eslint/typescript-estree': 8.62.1(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.62.1(eslint@10.6.0(jiti@2.7.0)(supports-color@8.1.1))(typescript@6.0.3)
-      eslint: 10.6.0(jiti@2.7.0)(supports-color@8.1.1)
-      typescript: 6.0.3
-    transitivePeerDependencies:
-      - supports-color
 
   typescript@5.0.4: {}
 
@@ -8476,7 +8471,7 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite-plugin-checker@0.14.4(eslint@10.6.0(jiti@2.7.0))(optionator@0.9.4)(typescript@6.0.3)(vite@7.3.6(@types/node@25.0.9)(jiti@2.7.0)(yaml@2.9.0)):
+  vite-plugin-checker@0.14.4(eslint@10.6.0(jiti@2.7.0))(optionator@0.9.4)(oxlint@1.73.0)(typescript@6.0.3)(vite@7.3.6(@types/node@25.0.9)(jiti@2.7.0)(yaml@2.9.0)):
     dependencies:
       '@babel/code-frame': 7.29.7
       chokidar: 5.0.0
@@ -8489,6 +8484,7 @@ snapshots:
     optionalDependencies:
       eslint: 10.6.0(jiti@2.7.0)
       optionator: 0.9.4
+      oxlint: 1.73.0
       typescript: 6.0.3
 
   vite-plugin-static-copy@3.4.0(vite@7.3.6(@types/node@25.0.9)(jiti@2.7.0)(yaml@2.9.0)):

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -23,6 +23,7 @@ catalog:
   lit-dialog: ^2.0.1
   lodash: ^4.18.1
   mobx: ^6.16.1
+  oxlint: 1.73.0
   playwright: ^1.61.1
   prettier: ^3.9.4
   release-it: ^20.2.1

--- a/tools/dts-backtest/package.json
+++ b/tools/dts-backtest/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "format": "prettier --write \"**/*.{ts,js,mjs,json,md}\"",
     "format:check": "prettier --check \"**/*.{ts,js,mjs,json,md}\"",
-    "lint": "eslint .",
+    "lint": "oxlint .",
     "test": "node run.mjs"
   },
   "devDependencies": {

--- a/tools/typedoc-plugin-lit-ui-router/package.json
+++ b/tools/typedoc-plugin-lit-ui-router/package.json
@@ -19,7 +19,7 @@
     "build": "tsc",
     "format": "prettier --write \"**/*.{ts,js,json,md}\"",
     "format:check": "prettier --check \"**/*.{ts,js,json,md}\"",
-    "lint": "eslint ."
+    "lint": "oxlint ."
   },
   "peerDependencies": {
     "typedoc": "catalog:publishedPeer"

--- a/turbo.json
+++ b/turbo.json
@@ -27,11 +27,14 @@
       "outputs": ["coverage/**"]
     },
     "lint": {
-      "with": ["//#lint:root"],
-      "inputs": ["**/*.ts", "**/*.js", "eslint.config.js", "$TURBO_DEFAULT$"]
+      "with": ["//#lint:root", "//#lint:package-json"],
+      "inputs": ["**/*.ts", "**/*.js", ".oxlintrc.json", "$TURBO_DEFAULT$"]
     },
     "//#lint:root": {
-      "inputs": ["examples/**/*.{ts,js}", "eslint.config.js", "$TURBO_DEFAULT$"]
+      "inputs": ["examples/**/*.{ts,js}", ".oxlintrc.json", "$TURBO_DEFAULT$"]
+    },
+    "//#lint:package-json": {
+      "inputs": ["**/package.json", "eslint.config.js"]
     },
     "ci": {
       "dependsOn": [


### PR DESCRIPTION
## Summary

Migrates JS/TS linting from eslint 10 (flat config, typescript-eslint) to **oxlint 1.73.0**, keeping a slimmed eslint config **only** for `package.json` linting. `.oxlintrc.json` was seeded with `npx @oxlint/migrate eslint.config.js` (141 rules mapped) and then curated.

## What is covered

- All of `eslint.configs.recommended` + `tseslint.configs.recommended` rule coverage that previously fired (both are syntactic rule sets; see "type-aware" below), including the per-glob overrides for cypress specs, `*.spec.ts`, and plain JS files.
- **`turbo/no-undeclared-env-vars` genuinely works under oxlint's `jsPlugins`** — verified: the same 5 warnings on `scripts/start-xvfb.mjs` (XVFB_BIN, XVFB_SOCKET, XVFB_TIMEOUT_MS, GITHUB_ENV x2) appear on this branch as on `main`. `eslint-plugin-turbo` stays a devDependency because oxlint loads it at runtime.
- **`no-undef` is retained** for plain JS via oxlint's nursery implementation, opted in per-rule and scoped to `**/*.{js,mjs}` — the exact surface eslint recommended covered on main (tseslint disables it for TS files). Evidence for adopting the nursery rule: zero false positives across the full repo; seeded typo'd globals (`consol`, `procss`) fire in `scripts/*.mjs`; a seeded undefined identifier fires in a cypress spec while `cy`/`Cypress` globals and browser/node envs resolve correctly. Nursery-rule instability is gated by the exact `1.73.0` catalog pin — a bump is a deliberate act.
- Bonus coverage gained: oxlint lints `<script>` blocks in `.vue` files (`docs/.vitepress/theme/components/*`), which the old eslint config never parsed.

## Vite's `import.meta.env.SSR` in .vue files

The turbo rule flags `import.meta.env.SSR`, a Vite **compile-time constant**, not an environment variable. Handled with the rule's `allowList` option, scoped to `**/*.vue` where the constant is actually used:

```json
"turbo/no-undeclared-env-vars": ["warn", { "allowList": ["^SSR$"] }]
```

Verified both directions under the oxlint jsPlugin runtime: `SSR` is no longer flagged, and a seeded genuinely-undeclared `process.env.*` reference in a `.vue` script block **is** still flagged. The alternative — declaring `SSR` in `turbo.json` `globalPassThroughEnv`/`passThroughEnv` — was rejected: it would assert a non-existent env var to turbo, is semantically wrong (nothing reads an `SSR` env var at runtime), and perturbs turbo's env handling for every task rather than one lint scope.

## What is NOT covered (hybrid residue)

- **`eslint-plugin-package-json` does not work under oxlint**, even as a jsPlugin: oxlint's file walker never visits `.json` files (`oxlint packages/lit-ui-router/package.json` → "No files found to lint"). `@oxlint/migrate` optimistically wires it into `jsPlugins`; that config block is dead weight and was removed.
- Residue kept: a slim `eslint.config.js` containing **only** `packageJson.configs.recommended` + `package-json/require-description` (ignorePrivate), run by a new root turbo task `//#lint:package-json` (`eslint --format tap "**/package.json"`, 15 manifests including `examples/**` — the example manifests were linted on main via `examples:lint`, so the root task absorbs them now that `examples:lint` runs oxlint). Verified it still errors on a seeded missing-description violation. The residue covers nothing else — plain-JS `no-undef` stayed on the oxlint side (above), so the `globals`/`@eslint/js`/`typescript-eslint` deps remain gone.

## Type-aware rules

None were lost, because none were enabled: `main` configures `projectService: true` but only extends `tseslint.configs.recommended`, which contains **no type-aware rules** (those live in `recommendedTypeChecked`). The type-aware parsing setup was effectively unused. If the repo later wants type-aware linting, `oxlint-tsgolint` (experimental) is the oxc-native option — not adopted here since there is nothing to replace.

## Rules dropped or changed

| Rule | Status | Why / mitigation |
| --- | --- | --- |
| `no-undef` | **covered (nursery opt-in)** | oxlint nursery implementation, enabled per-rule for `**/*.{js,mjs}` only. 0 false positives repo-wide; catches seeded typos in scripts and cypress specs. Exact version pin gates nursery churn. |
| `no-useless-assignment` | dropped (evaluated, rejected) | oxlint's nursery implementation produces false positives on this repo — see open questions for the evidence. Revisit when it leaves the nursery. |
| `no-dupe-args`, `no-octal` | dropped | oxlint will not implement; both are impossible in strict-mode/ESM code. |
| `turbo/no-undeclared-env-vars` in `.vue` | narrowed | `allowList: ["^SSR$"]` for Vite's compile-time constant; everything else still flagged (verified with seeded violation). |
| `eslint-config-prettier` | removed | the slim package.json-only eslint config has no stylistic rules to disable. Also dropped: `@eslint/js`, `typescript-eslint`, `globals`. |

## Timing (warm run, 2nd of 2, same machine)

| | main (eslint) | this branch (oxlint) |
| --- | --- | --- |
| full-repo single lint invocation | **7.90s** (9.58s user) | **0.61s** (0.62s user) — ~13x |
| `turbo run lint --force` | 9.9s | sub-second lint tasks; bottleneck is now turbo/task overhead |

## Verification

- `oxlint .` full repo: clean except the 5 pre-existing `turbo/no-undeclared-env-vars` warnings that `main` also emits (warn-level, non-failing, same as before).
- `turbo run ci`: **49/49 tasks green** end to end; `turbo run lint format:check` re-verified green after the allowList/no-undef refinements.
- Seeded-violation checks: `package-json/require-description` fails on a stripped description; turbo env-var rule fires on an undeclared var in both `.mjs` and `.vue`; `no-undef` fires on typo'd globals in `.mjs` and cypress specs.

## Versioning / maturity

oxlint is post-1.0 and stable, but minor releases add rules to existing categories and may change nursery-rule behavior. The pnpm catalog pins **`oxlint: 1.73.0` exactly**; bump deliberately and re-run the seeded checks (especially `no-undef`, which is nursery).

## Open questions

- Adopt `oxlint-tsgolint` later for `recommendedTypeChecked`-class rules (would be net-new coverage, not parity)?
- `no-useless-assignment`: **evaluated and rejected** with the same methodology as `no-undef`. A genuine seeded dead store (`let x = compute(); x = other();`) fires correctly, and closure-reassignment and loop-accumulator patterns are clean — but the full-repo run produced 2 false positives, both the class-field counter-initializer pattern that eslint 10's own implementation passes cleanly on the very same files: `packages/lit-ui-router/src/core.ts:42` (`$id: number = viewConfigIdCounter++`) and `packages/lit-ui-router/src/ui-view.ts:95` (`private viewId = viewIdCounter++`) — the incremented module-level counter *is* read by every subsequent instantiation. A try/catch probe (`let result = 'fallback'; try { result = parse(); } catch { result = 'error'; }`) is also flagged, diverging from eslint's deliberately conservative try/catch handling. The rule has no options to configure these away, and the hits are errors in shipped source. Re-evaluate on the next deliberate oxlint bump / when the rule leaves the nursery.
- ~~`examples/**` remain unlinted~~ — this was wrong: the `examples` workspace package has always had its own `lint` script, which the initial sweep missed (it kept running eslint). Fixed: `examples:lint` now runs `oxlint .` (clean) and `//#lint:package-json` covers the example manifests.
