### PR TITLE
fix(docs): register states individually in Quick Start snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,16 +48,17 @@ Import `UIRouterLit` into your project, register some states and you're good to 
 ```ts
 import { render, html } from 'lit';
 import { hashLocationPlugin } from '@uirouter/core';
-import { UIRouterLit } from 'lit-ui-router';
+import { UIRouterLit, LitStateDeclaration } from 'lit-ui-router';
 
 const router = new UIRouterLit();
 router.plugin(hashLocationPlugin);
 
 // Simple routes using template functions - no LitElement classes needed!
-router.stateRegistry.register([
+const states: LitStateDeclaration[] = [
   { name: 'home', url: '/home', component: () => html`<h1>Home</h1>` },
   { name: 'about', url: '/about', component: () => html`<h1>About</h1>` },
-]);
+];
+states.forEach((state) => router.stateRegistry.register(state));
 
 router.start();
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -15,16 +15,17 @@ built directly on the framework-agnostic
 ```ts
 import { render, html } from 'lit';
 import { hashLocationPlugin } from '@uirouter/core';
-import { UIRouterLit } from 'lit-ui-router';
+import { UIRouterLit, LitStateDeclaration } from 'lit-ui-router';
 
 const router = new UIRouterLit();
 router.plugin(hashLocationPlugin);
 
 // Simple routes using template functions - no LitElement classes needed!
-router.stateRegistry.register([
+const states: LitStateDeclaration[] = [
   { name: 'home', url: '/home', component: () => html`<h1>Home</h1>` },
   { name: 'about', url: '/about', component: () => html`<h1>About</h1>` },
-]);
+];
+states.forEach((state) => router.stateRegistry.register(state));
 
 router.start();
 

--- a/packages/lit-ui-router/README.md
+++ b/packages/lit-ui-router/README.md
@@ -12,17 +12,18 @@ A [UI-Router](https://ui-router.github.io/) implementation for [Lit](https://lit
 ## Quick Start
 
 ```ts
-import { UIRouterLit } from 'lit-ui-router';
+import { UIRouterLit, LitStateDeclaration } from 'lit-ui-router';
 import { hashLocationPlugin } from '@uirouter/core';
 import { html } from 'lit';
 
 const router = new UIRouterLit();
 router.plugin(hashLocationPlugin);
 
-router.stateRegistry.register([
+const states: LitStateDeclaration[] = [
   { name: 'home', url: '/', component: () => html`<h1>Home</h1>` },
   { name: 'about', url: '/about', component: () => html`<h1>About</h1>` },
-]);
+];
+states.forEach((state) => router.stateRegistry.register(state));
 
 router.start();
 ```

--- a/packages/lit-ui-router/src/specs/core.spec.ts
+++ b/packages/lit-ui-router/src/specs/core.spec.ts
@@ -76,23 +76,6 @@ describe('UIRouterLit', () => {
       expect(router.stateRegistry.get('about')).toBeDefined();
     });
 
-    it('should reject an array of states and accept them one at a time', () => {
-      const states: LitStateDeclaration[] = [
-        { name: 'home', url: '/home' },
-        { name: 'about', url: '/about' },
-      ];
-
-      // register() accepts a single state, not an array
-      expect(() =>
-        router.stateRegistry.register(states as unknown as LitStateDeclaration),
-      ).toThrowError('State must have a valid name');
-
-      states.forEach((state) => router.stateRegistry.register(state));
-
-      expect(router.stateRegistry.get('home')).toBeDefined();
-      expect(router.stateRegistry.get('about')).toBeDefined();
-    });
-
     it('should register nested states', () => {
       router.stateRegistry.register({ name: 'parent', url: '/parent' });
       router.stateRegistry.register({

--- a/packages/lit-ui-router/src/specs/core.spec.ts
+++ b/packages/lit-ui-router/src/specs/core.spec.ts
@@ -76,6 +76,23 @@ describe('UIRouterLit', () => {
       expect(router.stateRegistry.get('about')).toBeDefined();
     });
 
+    it('should reject an array of states and accept them one at a time', () => {
+      const states: LitStateDeclaration[] = [
+        { name: 'home', url: '/home' },
+        { name: 'about', url: '/about' },
+      ];
+
+      // register() accepts a single state, not an array
+      expect(() =>
+        router.stateRegistry.register(states as unknown as LitStateDeclaration),
+      ).toThrowError('State must have a valid name');
+
+      states.forEach((state) => router.stateRegistry.register(state));
+
+      expect(router.stateRegistry.get('home')).toBeDefined();
+      expect(router.stateRegistry.get('about')).toBeDefined();
+    });
+
     it('should register nested states', () => {
       router.stateRegistry.register({ name: 'parent', url: '/parent' });
       router.stateRegistry.register({


### PR DESCRIPTION
## Bug

The Quick Start snippets showed:

```ts
router.stateRegistry.register([
  { name: 'home', url: '/', component: () => html`<h1>Home</h1>` },
  { name: 'about', url: '/about', component: () => html`<h1>About</h1>` },
]);
```

but `StateRegistry.register()` from `@uirouter/core` accepts a **single** state:

```ts
// node_modules/@uirouter/core/lib/state/stateRegistry.d.ts
register(stateDefinition: _StateDeclaration): StateObject;
```

Verified repro (node script against the installed package):

```
router.stateRegistry.register([{ name: 'home' }, { name: 'about' }])
// => Error: State must have a valid name
```

## Fix

Docs-only. Every snippet now uses the pattern already established in `docs/api/index.md`, the sample apps (`apps/sample-app-shared/src/router.config.ts`), and the dts-backtest fixture:

```ts
const states: LitStateDeclaration[] = [...];
states.forEach((state) => router.stateRegistry.register(state));
```

Locations fixed (all instances of the array form in the repo):

- `packages/lit-ui-router/README.md` (Quick Start)
- `README.md` (root Get Started)
- `docs/introduction.md`

Audited and already correct: `docs/api/index.md`, `docs/tutorial/*.md`, `examples/*/src/main.ts`, other package READMEs, sample apps.

## API decision: no new public API

Considered adding an array-accepting convenience (e.g. `registerStates()` on `UIRouterLit` or a `states` option on a creation helper). Declined:

- `UIRouterLit` has no bootstrap/creation helper where a `states` option would be idiomatic — the public surface is `new UIRouterLit()` + `start()`, and registration is deliberately the upstream `stateRegistry` API.
- A `registerStates()` method would be a one-line bolt-on over upstream `forEach`, adding API-extractor'd surface (and dts-backtest exposure) for no real ergonomic gain.
- Every real consumer in the repo already uses the `forEach` idiom, so the docs now match reality.

## Tests

None — docs-only. A negative regression test (`should reject an array of states and accept them one at a time` in `core.spec.ts`) was drafted, then dropped during self-review as unnecessary; the merged diff contains no spec changes. *(Body corrected post-merge; it previously described the dropped test as added.)*

## Verification

- `turbo run lint format:check` green
- `turbo run ci --force` green: 49/49 tasks (unit, browser, e2e, pack checks, dts-backtest)

