### PR TITLE
feat(ci): optional branch-head CI alongside required merge-head check

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -74,8 +74,6 @@ jobs:
           TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
           TURBO_API: ${{ vars.TURBO_API }}
           TURBO_TEAM: ${{ vars.TURBO_TEAM }}
-          # Set on branch-head runs too: it is a declared turbo env hash input
-          # (sample apps' turbo.json); dropping it would defeat cache sharing.
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
           # Silence per-request [wrangler:info] logging from the e2e dev server.
           WRANGLER_LOG: warn
@@ -90,8 +88,7 @@ jobs:
         with:
           working-directory: packages/navigation-location-plugin
       - name: Upload to Codecov
-        # Skip on branch-head runs: the merge-head/main run uploads for the
-        # same head SHA and a duplicate would churn codecov status checks.
+        # Branch-head runs skip upload; merge-head/main covers the same SHA.
         if: ${{ github.event_name != 'push' || github.ref == 'refs/heads/main' }}
         uses: codecov/codecov-action@v7
         with:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,4 +1,4 @@
-# CI pipeline for pull requests and main branch pushes.
+# CI pipeline for pull requests and branch/main pushes.
 # Runs build, tests (Vitest + Playwright + Cypress), and coverage reporting.
 name: Build and Test
 
@@ -6,7 +6,12 @@ on:
   pull_request:
   push:
     branches:
-      - main
+      # Branch-head runs: CONFLICTING PRs have no merge ref, so pull_request
+      # runs are skipped entirely; push runs still cover the branch head.
+      - '**'
+      # Dependabot push events get dependabot secrets (no TURBO_TOKEN); its
+      # PRs already get merge-head CI.
+      - '!dependabot/**'
   workflow_dispatch:
     inputs:
       force:
@@ -14,13 +19,16 @@ on:
         type: boolean
         default: false
 
-# Cancel superseded PR runs.
+# Cancel superseded runs per event per ref; never cancel main runs.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   build_and_test:
+    # Branch-head (push) runs report under a distinct check name so they can
+    # never satisfy the required "build_and_test" merge gate.
+    name: ${{ github.event_name == 'push' && github.ref != 'refs/heads/main' && 'build_and_test (branch)' || 'build_and_test' }}
     # Security: Only run on first-party PRs (not forks) to protect secrets.
     # Fork PRs don't have access to secrets, so they would fail anyway.
     # Maintainers should review fork PRs and run CI manually.
@@ -66,6 +74,8 @@ jobs:
           TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
           TURBO_API: ${{ vars.TURBO_API }}
           TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+          # Set on branch-head runs too: it is a declared turbo env hash input
+          # (sample apps' turbo.json); dropping it would defeat cache sharing.
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
           # Silence per-request [wrangler:info] logging from the e2e dev server.
           WRANGLER_LOG: warn
@@ -80,6 +90,9 @@ jobs:
         with:
           working-directory: packages/navigation-location-plugin
       - name: Upload to Codecov
+        # Skip on branch-head runs: the merge-head/main run uploads for the
+        # same head SHA and a duplicate would churn codecov status checks.
+        if: ${{ github.event_name != 'push' || github.ref == 'refs/heads/main' }}
         uses: codecov/codecov-action@v7
         with:
           files: packages/lit-ui-router/coverage/lcov.info,packages/lit-ui-router/coverage/coverage-final.json,packages/lit-ui-router-mobx/coverage/lcov.info,packages/lit-ui-router-mobx/coverage/coverage-final.json,packages/navigation-location-plugin/coverage/lcov.info,packages/navigation-location-plugin/coverage/coverage-final.json


### PR DESCRIPTION
## Motivation

GitHub only runs `pull_request` workflows against the PR **merge ref**. When a PR is CONFLICTING, no merge ref exists, so CI is skipped entirely — merge conflicts hamstring CI completely. This bit us twice today (#229, #233): a conflicted PR shows *zero* signal about whether the branch itself is healthy.

This PR adds an **optional branch-head check** that runs on every push regardless of mergeability, while the existing **merge-head check remains the required gate** for merging.

## Design

### One job, event-dependent check name

The `push` trigger is widened from `main` to all branches, and the single `build_and_test` job gets a dynamic `name`:

```yaml
name: ${{ github.event_name == 'push' && github.ref != 'refs/heads/main' && 'build_and_test (branch)' || 'build_and_test' }}
```

- `pull_request` (merge ref), `push` to `main`, and `workflow_dispatch` all evaluate to the literal **`build_and_test`** — the exact context required by the `main` ruleset (id 6938828), so the merge gate is untouched.
- `push` to any other branch reports as **`build_and_test (branch)`** — a *different* status-check context. Required-check matching is an exact string match (parenthesized suffixes are not prefix-matched; this mirrors how matrix jobs must be required by their full name), so the branch-head run can never satisfy the required check by name collision.

Why not two jobs or a reusable workflow? Two jobs would duplicate ~55 lines of steps that will drift; a reusable workflow reports checks as `caller / callee`, which would *change* the required-check context. A single job with a dynamic name keeps the merge-head name byte-for-byte identical with zero duplication.

### Triggers

```yaml
push:
  branches:
    - '**'
    - '!dependabot/**'
```

- `branches:` filters exclude tag pushes, so release tags don't double-run CI.
- `dependabot/**` is excluded: dependabot-actor push events receive *dependabot* secrets (no `TURBO_TOKEN` → no remote cache), and its PRs already get merge-head CI. Recent human branch names here (`feat/*`, `fix/*`, `chore/*`, `docs/*`, `ci/*`, `experiment/*`) are all intentional work — no ephemeral bot patterns to ignore beyond dependabot.
- Secrets are available on push events for same-repo branches (all PRs here are same-repo), so `TURBO_TOKEN`/`CODECOV_TOKEN` work identically. The existing fork guard is kept.

### Cost

On a mergeable PR, push + pull_request fire on the same commit. The two trees are near-identical (merge ref = branch + main), so `turbo run ci` in the second run is largely remote-cache replays; on re-pushes, unchanged packages replay from prior runs. The runs launch concurrently, so the very first pair shares only tasks that finish early — subsequent pushes get full absorption.

Concurrency now cancels superseded runs **per event per ref** (previously PR-only):

```yaml
group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
```

Push and PR runs never cancel each other (different event in group), stale branch pushes cancel their predecessors, and `main` runs are never cancelled.

### Codecov

- The `codecov-action` coverage upload is **skipped on branch-head runs** — both runs see the same head SHA, and a duplicate upload for the same commit would churn codecov's status re-evaluation and notifications for no information gain. Merge-head (PR) and `main` runs upload exactly as before. The Vitest PR-comment steps were already `pull_request`-only.
- `CODECOV_TOKEN` **stays in the turbo step env on all runs**: it is a declared turbo `env` hash input in the sample apps' `turbo.json` (codecov bundle-analysis vite plugin). Dropping it on branch-head runs would change the task hashes and defeat the cache sharing the cost model relies on. On cache replays the vite plugin doesn't re-execute, so no duplicate bundle-analysis upload either.

## Server-side configuration

**Nothing required.** The `main` ruleset already requires exactly `build_and_test` (plus `Workers Builds: lit-ui-router`); this PR keeps that context unchanged and introduces only a new, differently-named optional context. Do **not** add `build_and_test (branch)` to the required checks — it intentionally stays optional so a conflicted PR isn't double-blocked.

## Self-demonstration

This PR is its own test: the push of this branch fires the **branch-head** run (using this branch's workflow version — push events execute the workflow file on the pushed ref) reporting as `build_and_test (branch)`, and the PR fires the **merge-head** run reporting as `build_and_test`. Evidence in comments/checks below.
