### PR TITLE
chore(release): strip scripts from published manifests at pack

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -75,21 +75,25 @@ jobs:
           TURBO_TEAM: ${{ vars.TURBO_TEAM }}
       - name: Pack
         # Create tarball for the GitHub release attachment AND the npm publish.
-        # devDependencies are stripped first: they're dev-only metadata and leak
-        # private workspace names (e.g. typedoc-plugin-lit-ui-router) into the
-        # published manifest.
+        # devDependencies and scripts are stripped first: dev-only metadata that
+        # leaks private workspace names (e.g. typedoc-plugin-lit-ui-router) and
+        # monorepo-only commands into the published manifest. None of our
+        # scripts are lifecycle hooks; stripping happens before `pnpm pack`, so
+        # a future prepack/prepare script would be silently skipped — build via
+        # the turbo step above instead.
         run: |
-          (cd "$PACKAGE_DIR" && npm pkg delete devDependencies)
+          (cd "$PACKAGE_DIR" && npm pkg delete devDependencies scripts)
           pnpm --filter ${{ env.PACKAGE_NAME }} pack --pack-destination ${{ env.PACKAGE_DIR }}
           echo "TARBALL=$(realpath "$PACKAGE_DIR"/*.tgz)" >> "$GITHUB_ENV"
           # restore the stripped manifest: release-it requires a clean working dir
           git checkout -- "$PACKAGE_DIR/package.json"
       - name: Check packed manifest
-        # no devDependencies and no unsubstituted catalog:/workspace: refs may ship
+        # no devDependencies, no scripts, and no unsubstituted catalog:/workspace: refs may ship
         run: |
           tar -xOzf "$TARBALL" package/package.json | node -e '
             const m = JSON.parse(require("fs").readFileSync(0));
             if (m.devDependencies) throw new Error("devDependencies leaked into packed manifest");
+            if (m.scripts) throw new Error("scripts leaked into packed manifest");
             const runtime = JSON.stringify([m.dependencies, m.peerDependencies, m.optionalDependencies]);
             if (/catalog:|workspace:/.test(runtime)) throw new Error("unsubstituted refs in packed manifest");
             console.log("packed manifest clean");


### PR DESCRIPTION
## What

Extends the existing devDependencies strip in the publish workflow to also drop `scripts` from published manifests, and extends the packed-manifest guard to fail if scripts ever leak.

## Why

`scripts` are the same category as devDependencies — dev-only metadata (the rationale already written into the Pack step comment) — and they go stale the moment tooling changes. Exhibit A, live on the registry today:

```console
$ npm view lit-ui-router@1.5.2 scripts
{
  format: 'prettier --write "**/*.{ts,js,json,md}"',
  lint: 'eslint .',
  ...
}
```

Both tools have since been removed from the repo (#231/#232). None of the published scripts work outside the monorepo anyway (`release-it`, `typedoc`, relative `../../docs` paths), and none are install lifecycle hooks — consumers see zero behavioral change.

## Caveat (encoded in the workflow comment)

Stripping happens **before** `pnpm pack`, so a future `prepack`/`prepare` script would be silently skipped. We have none today — builds belong in the turbo Build step above — and the comment says so.

## Verification

Replicated the exact Pack + Check steps locally against `packages/lit-ui-router`:

```console
$ (cd packages/lit-ui-router && npm pkg delete devDependencies scripts)
$ pnpm --filter lit-ui-router pack
$ tar -xOzf lit-ui-router-*.tgz package/package.json | node <guard>
packed manifest clean: {"deps":{"@uirouter/core":"^6.0.8","lit":"^3.0.0"}}
```

— no scripts, no devDeps, catalog refs still substituted (i.e. `pnpm pack` has no dependency on the deleted scripts).

A branch-ref `dryRun` dispatch was attempted ([run 28916806600](https://github.com/simshanith/lit-ui-router/actions/runs/28916806600)) and was rejected by the `publish` environment's deployment branch policy before any step ran — working as intended. Full proof therefore comes from a `dryRun: true` dispatch from `main` **after merge** (same verification pattern as the pnpm 11 migration, #177).

_No version bumps needed: scripts are inert registry metadata; the cleaned manifest ships with each package's next regular release._
