### PR TITLE
fix(dev): deterministic dev server ports, no auto-open

### DIFF
--- a/apps/README.md
+++ b/apps/README.md
@@ -79,6 +79,18 @@ selects the best available plugin:
 The Feature Flags panel shows browser compatibility indicators for each plugin
 option.
 
+## Local development
+
+`turbo dev` starts both apps' Vite dev servers on pinned ports —
+`sample-app-lit-vanilla` on `:5173`, `sample-app-lit-mobx` on `:5174` — with
+`strictPort` set, so a taken port fails loudly instead of silently drifting
+to the next free one. Neither server auto-opens a browser. To run one app on
+a different port, override it on the CLI:
+
+```bash
+pnpm --filter sample-app-lit-vanilla dev --port 5273
+```
+
 ## End-to-end tests
 
 `sample-app-lit-e2e` runs the same Cypress specs against both apps:

--- a/apps/sample-app-lit-mobx/vite.config.ts
+++ b/apps/sample-app-lit-mobx/vite.config.ts
@@ -50,7 +50,15 @@ export default defineConfig({
       telemetry: false,
     }),
   ],
+  // Pinned ports (vanilla 5173/4173, mobx 5174/4174): strictPort fails loudly
+  // instead of drifting, and open stays off so `turbo dev` spawns no browsers.
   server: {
-    open: true,
+    port: 5174,
+    strictPort: true,
+    open: false,
+  },
+  preview: {
+    port: 4174,
+    strictPort: true,
   },
 });

--- a/apps/sample-app-lit-vanilla/vite.config.ts
+++ b/apps/sample-app-lit-vanilla/vite.config.ts
@@ -50,7 +50,15 @@ export default defineConfig({
       telemetry: false,
     }),
   ],
+  // Pinned ports (vanilla 5173/4173, mobx 5174/4174): strictPort fails loudly
+  // instead of drifting, and open stays off so `turbo dev` spawns no browsers.
   server: {
-    open: true,
+    port: 5173,
+    strictPort: true,
+    open: false,
+  },
+  preview: {
+    port: 4173,
+    strictPort: true,
   },
 });


### PR DESCRIPTION
## The race

`turbo dev` spawns both sample-app Vite dev servers (`sample-app-lit-vanilla` and `sample-app-lit-mobx`) simultaneously, and both asked for Vite's default port. Whichever won the race got `:5173`; the loser silently drifted to `:5174` (or wherever Vite's auto-increment landed), nondeterministically. Both configs also had `server.open: true`, so every `turbo dev` popped two browser windows.

## Port assignments

| App | dev | preview |
| --- | --- | --- |
| `sample-app-lit-vanilla` | `5173` | `4173` |
| `sample-app-lit-mobx` | `5174` | `4174` |

All four are pinned with `strictPort: true`, so a taken port now fails loudly (`Error: Port 5173 is already in use`, exit 1) instead of drifting. `server.open` is now explicitly `false`. Neither app has a `preview` script today, but anyone running `vite preview` in both apps would have hit the identical race on `:4173`, so preview gets the same treatment. The e2e suite is untouched — it runs against wrangler on `:8787`, not the dev servers.

`apps/README.md` documents the assignments and the CLI escape hatch (`pnpm --filter sample-app-lit-vanilla dev --port 5273`), which was verified to override the pinned config.

## Shared-server evaluation: rejected

Considered serving both apps from a single Vite dev server (MPA with two HTML entries, a wrapper config, or the environments API). Rejected — it is not a simplification:

- **Per-app env is load-bearing.** Each app has its own `.env` with `VITE_SAMPLE_APP_BASE_URL` (`/app/` vs `/app-mobx/`) baked into `import.meta.env` at config load. A single server has a single env; giving two HTML entries different base URLs would need a custom per-entry define/rewrite plugin — more machinery than the two-line port pin it replaces.
- **Distinct dependency graphs are the point.** The mobx app depends on `lit-ui-router-mobx` + `mobx`; the vanilla app deliberately does not. A shared server would prebundle the union, blurring the isolation that makes each sample a faithful standalone consumer of the published packages.
- **Build must stay per-app anyway.** Each app builds separately (own Codecov bundle name, own dist embedded by the docs site at `/app/` and `/app-mobx/`). A shared dev server would make dev topology diverge from build/deploy topology.
- **Vite's environments API** targets client/SSR splits within one app, not two sibling apps with separate roots and env files — experimental complexity for zero user-facing gain.

Pinned ports cost ~8 lines per config; a shared server would cost a new wrapper plus env plumbing while weakening the samples' independence.

## Verification

- `turbo dev` (foreground, logged): both servers came up; `curl :5173` returned `<title>UI-Router Lit sample app</title>`, `curl :5174` returned `<title>UI-Router Lit sample app (MobX)</title>` — each app deterministically on its pinned port, confirmed via `lsof`.
- **strictPort failure mode**: occupied `:5173` with a dummy listener, ran the vanilla `dev` script — Vite exited 1 with `Error: Port 5173 is already in use` instead of drifting.
- **No auto-open**: zero `open`/`is in use, trying another` lines in the dev log; no browser windows spawned.
- **CLI override**: `pnpm run dev --port 5273` served the app on `:5273` (strictPort still applies to the overridden port).
- `turbo run lint format:check`: 37/37 tasks pass.

Note: the docs package (`vitepress dev`) also defaults to `:5173` but runs under the separate `turbo docs` task, so it does not participate in this race; left as-is.