### PR TITLE
Release 1.6.0

### DIFF
--- a/packages/lit-ui-router/package.json
+++ b/packages/lit-ui-router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lit-ui-router",
-  "version": "1.5.2",
+  "version": "1.6.0",
   "description": "State-based routing for Lit",
   "homepage": "https://lit-ui-router.dev",
   "license": "MIT",


### PR DESCRIPTION
* feat(core): support argless routed element constructors (#245) (0dae1bb)
* fix(types): accept required-props templates and model Lit views in LitStateDeclaration (#241) (bfb005d)
* fix(dev): deterministic dev server ports, no auto-open (#240) (c05eea6)
* ci(turbo): gate umbrella tsconfigs with a cached typecheck task (#242) (9ad552a)
* refactor(lint): promote no-unsafe-* to error and clear all findings (#243) (9680fe3)
* refactor(tooling): umbrella tsconfigs for first-class spec coverage (#236) (77a2b4c)
* chore(release): strip scripts from published manifests at pack (#237) (7137355)
* feat(ci): optional branch-head CI alongside required merge-head check (#235) (9249904)
* feat(tooling): adopt oxlint-tsgolint type-aware linting (#233) (376be35)
* fix(docs): register states individually in Quick Start snippets (#234) (368157e)
* feat(tooling): migrate prettier to oxfmt (#232) (f9ce7e2)
* feat(tooling): migrate eslint to oxlint (#231) (7bb0c12)
* feat(tooling): vite 8 (stable) (#228) (870cab6)
* chore(ci): reduce build-and-test log noise (#227) (065580e)
* fix(docs): silence esbuild dep-optimizer errors in vitepress dev (#225) (5830cb6)
* fix(e2e): migrate Cypress.env to Cypress.expose, disable allowCypressEnv (#226) (b712b12)
* chore(deps): override vitepress's vite to ^6.4.3 for dependabot alerts (#224) (0a56c62)
* docs: Live Examples page embedding the tutorial apps same-origin (#222) (c99449a)
* chore(deps): bump the vitest group with 3 updates (#221) (5b6e09d)
* feat(examples): hellogalaxy Milky Way explorer + docs for the upgraded examples (#219) (f4dfbb7)
* feat(examples): model the real solar system in hellosolarsystem (#216) (c574f0e)
* docs: introduction, guides expansion, and companion-package coverage (#214) (f59cddb)
* fix(examples): bump to lit-ui-router ^1.5.2 and regenerate lockfiles (#213) (43478a1)
* Release 0.3.2 (#212) (882b301)
