### PR TITLE
chore(examples): bump lit-ui-router to ^1.6.0

### DIFF
--- a/examples/hellogalaxy/package-lock.json
+++ b/examples/hellogalaxy/package-lock.json
@@ -12,7 +12,7 @@
         "@uirouter/core": "^6.1.2",
         "@uirouter/visualizer": "^7.2.1",
         "lit": "^3.3.3",
-        "lit-ui-router": "^1.5.2"
+        "lit-ui-router": "^1.6.0"
       },
       "devDependencies": {
         "typescript": "^6.0.3",
@@ -840,9 +840,9 @@
       }
     },
     "node_modules/lit-ui-router": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/lit-ui-router/-/lit-ui-router-1.5.2.tgz",
-      "integrity": "sha512-qqWJnks4n4qvGIe3YqytuuUaQt/5wEbV8SzAHmArq3Ekkt5xI0TjCkRui9oG3QagnUV9hGhDkrbVeYd8HNEmZw==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/lit-ui-router/-/lit-ui-router-1.6.0.tgz",
+      "integrity": "sha512-XA1i6AhncmvvFKpj+lCzh9Vb2WhMvRLZkkZ+CO4oTCHhxvx2J7XMGyLiO4ftcMPEl/zWjKqaF9QDggMAnMacKg==",
       "license": "MIT",
       "dependencies": {
         "@uirouter/core": "^6.0.8",

--- a/examples/hellogalaxy/package.json
+++ b/examples/hellogalaxy/package.json
@@ -13,7 +13,7 @@
     "@uirouter/core": "^6.1.2",
     "@uirouter/visualizer": "^7.2.1",
     "lit": "^3.3.3",
-    "lit-ui-router": "^1.5.2"
+    "lit-ui-router": "^1.6.0"
   },
   "devDependencies": {
     "typescript": "^6.0.3",

--- a/examples/hellosolarsystem/package-lock.json
+++ b/examples/hellosolarsystem/package-lock.json
@@ -11,7 +11,7 @@
         "@uirouter/core": "^6.1.2",
         "@uirouter/visualizer": "^7.2.1",
         "lit": "^3.3.3",
-        "lit-ui-router": "^1.5.2"
+        "lit-ui-router": "^1.6.0"
       },
       "devDependencies": {
         "typescript": "^6.0.3",
@@ -790,9 +790,9 @@
       }
     },
     "node_modules/lit-ui-router": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/lit-ui-router/-/lit-ui-router-1.5.2.tgz",
-      "integrity": "sha512-qqWJnks4n4qvGIe3YqytuuUaQt/5wEbV8SzAHmArq3Ekkt5xI0TjCkRui9oG3QagnUV9hGhDkrbVeYd8HNEmZw==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/lit-ui-router/-/lit-ui-router-1.6.0.tgz",
+      "integrity": "sha512-XA1i6AhncmvvFKpj+lCzh9Vb2WhMvRLZkkZ+CO4oTCHhxvx2J7XMGyLiO4ftcMPEl/zWjKqaF9QDggMAnMacKg==",
       "license": "MIT",
       "dependencies": {
         "@uirouter/core": "^6.0.8",

--- a/examples/hellosolarsystem/package.json
+++ b/examples/hellosolarsystem/package.json
@@ -12,7 +12,7 @@
     "@uirouter/core": "^6.1.2",
     "@uirouter/visualizer": "^7.2.1",
     "lit": "^3.3.3",
-    "lit-ui-router": "^1.5.2"
+    "lit-ui-router": "^1.6.0"
   },
   "devDependencies": {
     "typescript": "^6.0.3",

--- a/examples/helloworld/package-lock.json
+++ b/examples/helloworld/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@uirouter/core": "^6.1.2",
         "lit": "^3.3.3",
-        "lit-ui-router": "^1.5.2"
+        "lit-ui-router": "^1.6.0"
       },
       "devDependencies": {
         "typescript": "^6.0.3",
@@ -751,9 +751,9 @@
       }
     },
     "node_modules/lit-ui-router": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/lit-ui-router/-/lit-ui-router-1.5.2.tgz",
-      "integrity": "sha512-qqWJnks4n4qvGIe3YqytuuUaQt/5wEbV8SzAHmArq3Ekkt5xI0TjCkRui9oG3QagnUV9hGhDkrbVeYd8HNEmZw==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/lit-ui-router/-/lit-ui-router-1.6.0.tgz",
+      "integrity": "sha512-XA1i6AhncmvvFKpj+lCzh9Vb2WhMvRLZkkZ+CO4oTCHhxvx2J7XMGyLiO4ftcMPEl/zWjKqaF9QDggMAnMacKg==",
       "license": "MIT",
       "dependencies": {
         "@uirouter/core": "^6.0.8",

--- a/examples/helloworld/package.json
+++ b/examples/helloworld/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@uirouter/core": "^6.1.2",
     "lit": "^3.3.3",
-    "lit-ui-router": "^1.5.2"
+    "lit-ui-router": "^1.6.0"
   },
   "devDependencies": {
     "typescript": "^6.0.3",


### PR DESCRIPTION
## Summary
1.6.0 was released last night (#246). This bumps the pinned `lit-ui-router` dependency in all three tutorial examples from `^1.5.2` to `^1.6.0` and regenerates each `package-lock.json`.

## Changes
- `examples/helloworld`, `examples/hellosolarsystem`, `examples/hellogalaxy`: `lit-ui-router` `^1.5.2` → `^1.6.0`
- Regenerated `package-lock.json` for each (now resolves `lit-ui-router@1.6.0` from the npm registry)

## Verification
- `npm install` in each example succeeded (0 vulnerabilities)
- `npm run build` (vite 8.1.3) passed for all three examples against 1.6.0

Diff is scoped to the six `package.json` / `package-lock.json` files — only the version spec, resolved tarball URL, and integrity hash changed in the lockfiles.