### PR TITLE
feat(tooling): typescript 7.0 with a typescript6-compat catalog for API consumers

### DIFF
--- a/apps/sample-app-lit-e2e/package.json
+++ b/apps/sample-app-lit-e2e/package.json
@@ -24,7 +24,7 @@
     "cypress": "catalog:",
     "oxfmt": "catalog:",
     "start-server-and-test": "^3.0.11",
-    "typescript": "catalog:ts6",
+    "typescript": "catalog:typescript6-compat",
     "vite": "catalog:"
   }
 }

--- a/apps/sample-app-lit-e2e/package.json
+++ b/apps/sample-app-lit-e2e/package.json
@@ -24,7 +24,7 @@
     "cypress": "catalog:",
     "oxfmt": "catalog:",
     "start-server-and-test": "^3.0.11",
-    "typescript": "catalog:",
+    "typescript": "catalog:ts6",
     "vite": "catalog:"
   }
 }

--- a/apps/sample-app-lit-mobx/package.json
+++ b/apps/sample-app-lit-mobx/package.json
@@ -24,7 +24,7 @@
     "@types/dom-navigation": "catalog:",
     "@types/lodash": "catalog:",
     "oxfmt": "catalog:",
-    "typescript": "catalog:ts6",
+    "typescript": "catalog:typescript6-compat",
     "vite": "catalog:",
     "vite-plugin-checker": "catalog:",
     "vite-plugin-static-copy": "catalog:",

--- a/apps/sample-app-lit-mobx/package.json
+++ b/apps/sample-app-lit-mobx/package.json
@@ -24,7 +24,7 @@
     "@types/dom-navigation": "catalog:",
     "@types/lodash": "catalog:",
     "oxfmt": "catalog:",
-    "typescript": "catalog:",
+    "typescript": "catalog:ts6",
     "vite": "catalog:",
     "vite-plugin-checker": "catalog:",
     "vite-plugin-static-copy": "catalog:",

--- a/apps/sample-app-lit-vanilla/package.json
+++ b/apps/sample-app-lit-vanilla/package.json
@@ -22,7 +22,7 @@
     "@types/dom-navigation": "catalog:",
     "@types/lodash": "catalog:",
     "oxfmt": "catalog:",
-    "typescript": "catalog:ts6",
+    "typescript": "catalog:typescript6-compat",
     "vite": "catalog:",
     "vite-plugin-checker": "catalog:",
     "vite-plugin-static-copy": "catalog:",

--- a/apps/sample-app-lit-vanilla/package.json
+++ b/apps/sample-app-lit-vanilla/package.json
@@ -22,7 +22,7 @@
     "@types/dom-navigation": "catalog:",
     "@types/lodash": "catalog:",
     "oxfmt": "catalog:",
-    "typescript": "catalog:",
+    "typescript": "catalog:ts6",
     "vite": "catalog:",
     "vite-plugin-checker": "catalog:",
     "vite-plugin-static-copy": "catalog:",

--- a/packages/lit-ui-router-mobx/package.json
+++ b/packages/lit-ui-router-mobx/package.json
@@ -65,7 +65,7 @@
     "typedoc-plugin-lit-ui-router": "workspace:*",
     "typedoc-plugin-markdown": "catalog:",
     "typedoc-vitepress-theme": "catalog:",
-    "typescript": "catalog:ts6",
+    "typescript": "catalog:typescript6-compat",
     "vitest": "catalog:"
   },
   "peerDependencies": {

--- a/packages/lit-ui-router-mobx/package.json
+++ b/packages/lit-ui-router-mobx/package.json
@@ -65,7 +65,7 @@
     "typedoc-plugin-lit-ui-router": "workspace:*",
     "typedoc-plugin-markdown": "catalog:",
     "typedoc-vitepress-theme": "catalog:",
-    "typescript": "catalog:",
+    "typescript": "catalog:ts6",
     "vitest": "catalog:"
   },
   "peerDependencies": {

--- a/packages/lit-ui-router/package.json
+++ b/packages/lit-ui-router/package.json
@@ -57,7 +57,7 @@
     "typedoc-plugin-lit-ui-router": "workspace:*",
     "typedoc-plugin-markdown": "catalog:",
     "typedoc-vitepress-theme": "catalog:",
-    "typescript": "catalog:ts6",
+    "typescript": "catalog:typescript6-compat",
     "vitest": "catalog:"
   },
   "customElements": "dist/custom-elements.json"

--- a/packages/lit-ui-router/package.json
+++ b/packages/lit-ui-router/package.json
@@ -57,7 +57,7 @@
     "typedoc-plugin-lit-ui-router": "workspace:*",
     "typedoc-plugin-markdown": "catalog:",
     "typedoc-vitepress-theme": "catalog:",
-    "typescript": "catalog:",
+    "typescript": "catalog:ts6",
     "vitest": "catalog:"
   },
   "customElements": "dist/custom-elements.json"

--- a/packages/navigation-location-plugin/package.json
+++ b/packages/navigation-location-plugin/package.json
@@ -62,7 +62,7 @@
     "typedoc-plugin-lit-ui-router": "workspace:*",
     "typedoc-plugin-markdown": "catalog:",
     "typedoc-vitepress-theme": "catalog:",
-    "typescript": "catalog:ts6",
+    "typescript": "catalog:typescript6-compat",
     "vitest": "catalog:"
   },
   "peerDependencies": {

--- a/packages/navigation-location-plugin/package.json
+++ b/packages/navigation-location-plugin/package.json
@@ -62,7 +62,7 @@
     "typedoc-plugin-lit-ui-router": "workspace:*",
     "typedoc-plugin-markdown": "catalog:",
     "typedoc-vitepress-theme": "catalog:",
-    "typescript": "catalog:",
+    "typescript": "catalog:ts6",
     "vitest": "catalog:"
   },
   "peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -109,7 +109,7 @@ catalogs:
     lit:
       specifier: ^3.0.0
       version: 3.3.3
-  ts6:
+  typescript6-compat:
     typescript:
       specifier: npm:@typescript/typescript6@^6.0.2
       version: 6.0.2
@@ -207,7 +207,7 @@ importers:
         specifier: ^3.0.11
         version: 3.0.11(supports-color@8.1.1)
       typescript:
-        specifier: catalog:ts6
+        specifier: catalog:typescript6-compat
         version: '@typescript/typescript6@6.0.2'
       vite:
         specifier: 'catalog:'
@@ -244,7 +244,7 @@ importers:
         specifier: 'catalog:'
         version: 0.58.0
       typescript:
-        specifier: catalog:ts6
+        specifier: catalog:typescript6-compat
         version: '@typescript/typescript6@6.0.2'
       vite:
         specifier: 'catalog:'
@@ -284,7 +284,7 @@ importers:
         specifier: 'catalog:'
         version: 0.58.0
       typescript:
-        specifier: catalog:ts6
+        specifier: catalog:typescript6-compat
         version: '@typescript/typescript6@6.0.2'
       vite:
         specifier: 'catalog:'
@@ -430,7 +430,7 @@ importers:
         specifier: 'catalog:'
         version: 1.1.3(typedoc-plugin-markdown@4.12.0(typedoc@0.28.20(@typescript/typescript6@6.0.2)))
       typescript:
-        specifier: catalog:ts6
+        specifier: catalog:typescript6-compat
         version: '@typescript/typescript6@6.0.2'
       vitest:
         specifier: 'catalog:'
@@ -481,7 +481,7 @@ importers:
         specifier: 'catalog:'
         version: 1.1.3(typedoc-plugin-markdown@4.12.0(typedoc@0.28.20(@typescript/typescript6@6.0.2)))
       typescript:
-        specifier: catalog:ts6
+        specifier: catalog:typescript6-compat
         version: '@typescript/typescript6@6.0.2'
       vitest:
         specifier: 'catalog:'
@@ -526,7 +526,7 @@ importers:
         specifier: 'catalog:'
         version: 1.1.3(typedoc-plugin-markdown@4.12.0(typedoc@0.28.20(@typescript/typescript6@6.0.2)))
       typescript:
-        specifier: catalog:ts6
+        specifier: catalog:typescript6-compat
         version: '@typescript/typescript6@6.0.2'
       vitest:
         specifier: 'catalog:'
@@ -577,7 +577,7 @@ importers:
         specifier: 'catalog:'
         version: 0.28.20(@typescript/typescript6@6.0.2)
       typescript:
-        specifier: catalog:ts6
+        specifier: catalog:typescript6-compat
         version: '@typescript/typescript6@6.0.2'
 
 packages:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -207,8 +207,8 @@ importers:
         specifier: ^3.0.11
         version: 3.0.11(supports-color@8.1.1)
       typescript:
-        specifier: 'catalog:'
-        version: 7.0.2
+        specifier: catalog:ts6
+        version: '@typescript/typescript6@6.0.2'
       vite:
         specifier: 'catalog:'
         version: 8.1.3(@types/node@25.0.9)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,8 +85,8 @@ catalogs:
       specifier: ^1.1.3
       version: 1.1.3
     typescript:
-      specifier: ^6.0.3
-      version: 6.0.3
+      specifier: ^7.0.2
+      version: 7.0.2
     vite:
       specifier: ^8.1.3
       version: 8.1.3
@@ -109,6 +109,10 @@ catalogs:
     lit:
       specifier: ^3.0.0
       version: 3.3.3
+  ts6:
+    typescript:
+      specifier: npm:@typescript/typescript6@^6.0.2
+      version: 6.0.2
   vitepress1:
     vite-plugin-static-copy:
       specifier: ^3.4.0
@@ -176,7 +180,7 @@ importers:
         version: 2.10.3
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
       wrangler:
         specifier: 'catalog:'
         version: 4.107.0
@@ -204,7 +208,7 @@ importers:
         version: 3.0.11(supports-color@8.1.1)
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
       vite:
         specifier: 'catalog:'
         version: 8.1.3(@types/node@25.0.9)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)
@@ -240,14 +244,14 @@ importers:
         specifier: 'catalog:'
         version: 0.58.0
       typescript:
-        specifier: 'catalog:'
-        version: 6.0.3
+        specifier: catalog:ts6
+        version: '@typescript/typescript6@6.0.2'
       vite:
         specifier: 'catalog:'
         version: 8.1.3(@types/node@25.0.9)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)
       vite-plugin-checker:
         specifier: 'catalog:'
-        version: 0.14.4(eslint@10.6.0(jiti@2.7.0))(optionator@0.9.4)(oxlint@1.73.0(oxlint-tsgolint@0.24.0))(typescript@6.0.3)(vite@8.1.3(@types/node@25.0.9)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 0.14.4(@typescript/typescript6@6.0.2)(eslint@10.6.0(jiti@2.7.0))(optionator@0.9.4)(oxlint@1.73.0(oxlint-tsgolint@0.24.0))(vite@8.1.3(@types/node@25.0.9)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
       vite-plugin-static-copy:
         specifier: 'catalog:'
         version: 4.1.1(vite@8.1.3(@types/node@25.0.9)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
@@ -280,14 +284,14 @@ importers:
         specifier: 'catalog:'
         version: 0.58.0
       typescript:
-        specifier: 'catalog:'
-        version: 6.0.3
+        specifier: catalog:ts6
+        version: '@typescript/typescript6@6.0.2'
       vite:
         specifier: 'catalog:'
         version: 8.1.3(@types/node@25.0.9)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)
       vite-plugin-checker:
         specifier: 'catalog:'
-        version: 0.14.4(eslint@10.6.0(jiti@2.7.0))(optionator@0.9.4)(oxlint@1.73.0(oxlint-tsgolint@0.24.0))(typescript@6.0.3)(vite@8.1.3(@types/node@25.0.9)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 0.14.4(@typescript/typescript6@6.0.2)(eslint@10.6.0(jiti@2.7.0))(optionator@0.9.4)(oxlint@1.73.0(oxlint-tsgolint@0.24.0))(vite@8.1.3(@types/node@25.0.9)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
       vite-plugin-static-copy:
         specifier: 'catalog:'
         version: 4.1.1(vite@8.1.3(@types/node@25.0.9)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
@@ -339,7 +343,7 @@ importers:
         version: 0.58.0
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
       vite:
         specifier: 'catalog:'
         version: 8.1.3(@types/node@25.0.9)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)
@@ -360,14 +364,14 @@ importers:
         version: 6.0.2
       vue:
         specifier: ^3.5.39
-        version: 3.5.39(typescript@6.0.3)
+        version: 3.5.39(typescript@7.0.2)
     devDependencies:
       oxfmt:
         specifier: 'catalog:'
         version: 0.58.0
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
       vite:
         specifier: 'catalog:'
         version: 8.1.3(@types/node@25.0.9)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)
@@ -376,7 +380,7 @@ importers:
         version: 3.4.0(vite@8.1.3(@types/node@25.0.9)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
       vitepress:
         specifier: ^1.6.4
-        version: 1.6.4(@algolia/client-search@5.55.1)(@types/node@25.0.9)(axios@1.18.1)(change-case@5.4.4)(jiti@2.7.0)(lightningcss@1.32.0)(postcss@8.5.16)(search-insights@2.17.3)(typescript@6.0.3)(yaml@2.9.0)
+        version: 1.6.4(@algolia/client-search@5.55.1)(@types/node@25.0.9)(axios@1.18.1)(change-case@5.4.4)(jiti@2.7.0)(lightningcss@1.32.0)(postcss@8.5.16)(search-insights@2.17.3)(typescript@7.0.2)(yaml@2.9.0)
       wrangler:
         specifier: 'catalog:'
         version: 4.107.0
@@ -415,19 +419,19 @@ importers:
         version: 6.1.3
       typedoc:
         specifier: 'catalog:'
-        version: 0.28.20(typescript@6.0.3)
+        version: 0.28.20(@typescript/typescript6@6.0.2)
       typedoc-plugin-lit-ui-router:
         specifier: workspace:*
         version: link:../../tools/typedoc-plugin-lit-ui-router
       typedoc-plugin-markdown:
         specifier: 'catalog:'
-        version: 4.12.0(typedoc@0.28.20(typescript@6.0.3))
+        version: 4.12.0(typedoc@0.28.20(@typescript/typescript6@6.0.2))
       typedoc-vitepress-theme:
         specifier: 'catalog:'
-        version: 1.1.3(typedoc-plugin-markdown@4.12.0(typedoc@0.28.20(typescript@6.0.3)))
+        version: 1.1.3(typedoc-plugin-markdown@4.12.0(typedoc@0.28.20(@typescript/typescript6@6.0.2)))
       typescript:
-        specifier: 'catalog:'
-        version: 6.0.3
+        specifier: catalog:ts6
+        version: '@typescript/typescript6@6.0.2'
       vitest:
         specifier: 'catalog:'
         version: 4.1.10(@types/node@25.0.9)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(vite@8.1.3(@types/node@25.0.9)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
@@ -466,19 +470,19 @@ importers:
         version: 6.1.3
       typedoc:
         specifier: 'catalog:'
-        version: 0.28.20(typescript@6.0.3)
+        version: 0.28.20(@typescript/typescript6@6.0.2)
       typedoc-plugin-lit-ui-router:
         specifier: workspace:*
         version: link:../../tools/typedoc-plugin-lit-ui-router
       typedoc-plugin-markdown:
         specifier: 'catalog:'
-        version: 4.12.0(typedoc@0.28.20(typescript@6.0.3))
+        version: 4.12.0(typedoc@0.28.20(@typescript/typescript6@6.0.2))
       typedoc-vitepress-theme:
         specifier: 'catalog:'
-        version: 1.1.3(typedoc-plugin-markdown@4.12.0(typedoc@0.28.20(typescript@6.0.3)))
+        version: 1.1.3(typedoc-plugin-markdown@4.12.0(typedoc@0.28.20(@typescript/typescript6@6.0.2)))
       typescript:
-        specifier: 'catalog:'
-        version: 6.0.3
+        specifier: catalog:ts6
+        version: '@typescript/typescript6@6.0.2'
       vitest:
         specifier: 'catalog:'
         version: 4.1.10(@types/node@25.0.9)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(vite@8.1.3(@types/node@25.0.9)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
@@ -511,19 +515,19 @@ importers:
         version: 6.1.3
       typedoc:
         specifier: 'catalog:'
-        version: 0.28.20(typescript@6.0.3)
+        version: 0.28.20(@typescript/typescript6@6.0.2)
       typedoc-plugin-lit-ui-router:
         specifier: workspace:*
         version: link:../../tools/typedoc-plugin-lit-ui-router
       typedoc-plugin-markdown:
         specifier: 'catalog:'
-        version: 4.12.0(typedoc@0.28.20(typescript@6.0.3))
+        version: 4.12.0(typedoc@0.28.20(@typescript/typescript6@6.0.2))
       typedoc-vitepress-theme:
         specifier: 'catalog:'
-        version: 1.1.3(typedoc-plugin-markdown@4.12.0(typedoc@0.28.20(typescript@6.0.3)))
+        version: 1.1.3(typedoc-plugin-markdown@4.12.0(typedoc@0.28.20(@typescript/typescript6@6.0.2)))
       typescript:
-        specifier: 'catalog:'
-        version: 6.0.3
+        specifier: catalog:ts6
+        version: '@typescript/typescript6@6.0.2'
       vitest:
         specifier: 'catalog:'
         version: 4.1.10(@types/node@25.0.9)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(vite@8.1.3(@types/node@25.0.9)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
@@ -548,12 +552,18 @@ importers:
       mobx:
         specifier: 'catalog:'
         version: 6.16.1
-      typescript:
-        specifier: 'catalog:'
-        version: 6.0.3
       typescript-5.0:
         specifier: npm:typescript@5.0.4
         version: typescript@5.0.4
+      typescript-5.9:
+        specifier: npm:typescript@^5.9.3
+        version: typescript@5.9.3
+      typescript-6:
+        specifier: npm:typescript@^6.0.3
+        version: typescript@6.0.3
+      typescript-7:
+        specifier: npm:typescript@^7.0.2
+        version: typescript@7.0.2
       ui-router-navigation-location-plugin:
         specifier: workspace:*
         version: link:../../packages/navigation-location-plugin
@@ -565,10 +575,10 @@ importers:
         version: 24.13.2
       typedoc:
         specifier: 'catalog:'
-        version: 0.28.20(typescript@6.0.3)
+        version: 0.28.20(@typescript/typescript6@6.0.2)
       typescript:
-        specifier: 'catalog:'
-        version: 6.0.3
+        specifier: catalog:ts6
+        version: '@typescript/typescript6@6.0.2'
 
 packages:
 
@@ -2299,6 +2309,130 @@ packages:
 
   '@types/web-bluetooth@0.0.21':
     resolution: {integrity: sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==}
+
+  '@typescript/typescript-aix-ppc64@7.0.2':
+    resolution: {integrity: sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@typescript/typescript-darwin-arm64@7.0.2':
+    resolution: {integrity: sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@typescript/typescript-darwin-x64@7.0.2':
+    resolution: {integrity: sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@typescript/typescript-freebsd-arm64@7.0.2':
+    resolution: {integrity: sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@typescript/typescript-freebsd-x64@7.0.2':
+    resolution: {integrity: sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@typescript/typescript-linux-arm64@7.0.2':
+    resolution: {integrity: sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@typescript/typescript-linux-arm@7.0.2':
+    resolution: {integrity: sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm]
+    os: [linux]
+
+  '@typescript/typescript-linux-loong64@7.0.2':
+    resolution: {integrity: sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@typescript/typescript-linux-mips64el@7.0.2':
+    resolution: {integrity: sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@typescript/typescript-linux-ppc64@7.0.2':
+    resolution: {integrity: sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@typescript/typescript-linux-riscv64@7.0.2':
+    resolution: {integrity: sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@typescript/typescript-linux-s390x@7.0.2':
+    resolution: {integrity: sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@typescript/typescript-linux-x64@7.0.2':
+    resolution: {integrity: sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@typescript/typescript-netbsd-arm64@7.0.2':
+    resolution: {integrity: sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@typescript/typescript-netbsd-x64@7.0.2':
+    resolution: {integrity: sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@typescript/typescript-openbsd-arm64@7.0.2':
+    resolution: {integrity: sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@typescript/typescript-openbsd-x64@7.0.2':
+    resolution: {integrity: sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@typescript/typescript-sunos-x64@7.0.2':
+    resolution: {integrity: sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@typescript/typescript-win32-arm64@7.0.2':
+    resolution: {integrity: sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@typescript/typescript-win32-x64@7.0.2':
+    resolution: {integrity: sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [win32]
+
+  '@typescript/typescript6@6.0.2':
+    resolution: {integrity: sha512-mbCddXd+jm7hfx7w2YU64/Av4/NqqeG3GoRZgxPcgoTxYjhrcfJRw9ULch71SS4G+Q3bOXFhRvPqjguN0Hyp5w==}
+    hasBin: true
 
   '@uirouter/core@6.1.2':
     resolution: {integrity: sha512-pYcg+cxVd9E9poC7AJf7ZrlQQrwAV6KVkiPvlbLJX5km+pBWrUOGQhdd87oIGc7/5iVQ7qSiAdl9QD+l55yegg==}
@@ -4643,9 +4777,19 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
   typescript@6.0.3:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
+    hasBin: true
+
+  typescript@7.0.2:
+    resolution: {integrity: sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==}
+    engines: {node: '>=16.20.0'}
     hasBin: true
 
   typical@4.0.0:
@@ -6466,6 +6610,70 @@ snapshots:
 
   '@types/web-bluetooth@0.0.21': {}
 
+  '@typescript/typescript-aix-ppc64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-darwin-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-darwin-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-freebsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-freebsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-arm@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-loong64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-mips64el@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-ppc64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-riscv64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-s390x@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-netbsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-netbsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-openbsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-openbsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-sunos-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-win32-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-win32-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript6@6.0.2':
+    dependencies:
+      '@typescript/old': typescript@6.0.3
+
   '@uirouter/core@6.1.2': {}
 
   '@uirouter/dsr@1.2.0(patch_hash=85054b266dee7294d59dc8e0c386367422777df9777a26acb607455cb8217761)(@uirouter/core@6.1.2)':
@@ -6485,10 +6693,10 @@ snapshots:
 
   '@ungap/structured-clone@1.3.2': {}
 
-  '@vitejs/plugin-vue@5.2.4(vite@6.4.3(@types/node@25.0.9)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))(vue@3.5.39(typescript@6.0.3))':
+  '@vitejs/plugin-vue@5.2.4(vite@6.4.3(@types/node@25.0.9)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))(vue@3.5.39(typescript@7.0.2))':
     dependencies:
       vite: 6.4.3(@types/node@25.0.9)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0)
-      vue: 3.5.39(typescript@6.0.3)
+      vue: 3.5.39(typescript@7.0.2)
 
   '@vitest/browser-playwright@4.1.10(playwright@1.61.1)(vite@8.1.3(@types/node@25.0.9)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(vitest@4.1.10)':
     dependencies:
@@ -6641,28 +6849,28 @@ snapshots:
       '@vue/shared': 3.5.39
       csstype: 3.2.3
 
-  '@vue/server-renderer@3.5.39(vue@3.5.39(typescript@6.0.3))':
+  '@vue/server-renderer@3.5.39(vue@3.5.39(typescript@7.0.2))':
     dependencies:
       '@vue/compiler-ssr': 3.5.39
       '@vue/shared': 3.5.39
-      vue: 3.5.39(typescript@6.0.3)
+      vue: 3.5.39(typescript@7.0.2)
 
   '@vue/shared@3.5.39': {}
 
-  '@vueuse/core@12.8.2(typescript@6.0.3)':
+  '@vueuse/core@12.8.2(typescript@7.0.2)':
     dependencies:
       '@types/web-bluetooth': 0.0.21
       '@vueuse/metadata': 12.8.2
-      '@vueuse/shared': 12.8.2(typescript@6.0.3)
-      vue: 3.5.39(typescript@6.0.3)
+      '@vueuse/shared': 12.8.2(typescript@7.0.2)
+      vue: 3.5.39(typescript@7.0.2)
     transitivePeerDependencies:
       - typescript
 
-  '@vueuse/integrations@12.8.2(axios@1.18.1)(change-case@5.4.4)(focus-trap@7.8.0)(typescript@6.0.3)':
+  '@vueuse/integrations@12.8.2(axios@1.18.1)(change-case@5.4.4)(focus-trap@7.8.0)(typescript@7.0.2)':
     dependencies:
-      '@vueuse/core': 12.8.2(typescript@6.0.3)
-      '@vueuse/shared': 12.8.2(typescript@6.0.3)
-      vue: 3.5.39(typescript@6.0.3)
+      '@vueuse/core': 12.8.2(typescript@7.0.2)
+      '@vueuse/shared': 12.8.2(typescript@7.0.2)
+      vue: 3.5.39(typescript@7.0.2)
     optionalDependencies:
       axios: 1.18.1(debug@4.4.3(supports-color@8.1.1))
       change-case: 5.4.4
@@ -6672,9 +6880,9 @@ snapshots:
 
   '@vueuse/metadata@12.8.2': {}
 
-  '@vueuse/shared@12.8.2(typescript@6.0.3)':
+  '@vueuse/shared@12.8.2(typescript@7.0.2)':
     dependencies:
-      vue: 3.5.39(typescript@6.0.3)
+      vue: 3.5.39(typescript@7.0.2)
     transitivePeerDependencies:
       - typescript
 
@@ -8980,28 +9188,53 @@ snapshots:
 
   type-fest@2.19.0: {}
 
-  typedoc-plugin-markdown@4.12.0(typedoc@0.28.20(typescript@6.0.3)):
+  typedoc-plugin-markdown@4.12.0(typedoc@0.28.20(@typescript/typescript6@6.0.2)):
     dependencies:
-      typedoc: 0.28.20(typescript@6.0.3)
+      typedoc: 0.28.20(@typescript/typescript6@6.0.2)
 
-  typedoc-vitepress-theme@1.1.3(typedoc-plugin-markdown@4.12.0(typedoc@0.28.20(typescript@6.0.3))):
+  typedoc-vitepress-theme@1.1.3(typedoc-plugin-markdown@4.12.0(typedoc@0.28.20(@typescript/typescript6@6.0.2))):
     dependencies:
-      typedoc-plugin-markdown: 4.12.0(typedoc@0.28.20(typescript@6.0.3))
+      typedoc-plugin-markdown: 4.12.0(typedoc@0.28.20(@typescript/typescript6@6.0.2))
 
-  typedoc@0.28.20(typescript@6.0.3):
+  typedoc@0.28.20(@typescript/typescript6@6.0.2):
     dependencies:
       '@gerrit0/mini-shiki': 3.23.0
       lunr: 2.3.9
       markdown-it: 14.3.0
       minimatch: 10.2.5
-      typescript: 6.0.3
+      typescript: '@typescript/typescript6@6.0.2'
       yaml: 2.9.0
 
   typescript@5.0.4: {}
 
   typescript@5.4.5: {}
 
+  typescript@5.9.3: {}
+
   typescript@6.0.3: {}
+
+  typescript@7.0.2:
+    optionalDependencies:
+      '@typescript/typescript-aix-ppc64': 7.0.2
+      '@typescript/typescript-darwin-arm64': 7.0.2
+      '@typescript/typescript-darwin-x64': 7.0.2
+      '@typescript/typescript-freebsd-arm64': 7.0.2
+      '@typescript/typescript-freebsd-x64': 7.0.2
+      '@typescript/typescript-linux-arm': 7.0.2
+      '@typescript/typescript-linux-arm64': 7.0.2
+      '@typescript/typescript-linux-loong64': 7.0.2
+      '@typescript/typescript-linux-mips64el': 7.0.2
+      '@typescript/typescript-linux-ppc64': 7.0.2
+      '@typescript/typescript-linux-riscv64': 7.0.2
+      '@typescript/typescript-linux-s390x': 7.0.2
+      '@typescript/typescript-linux-x64': 7.0.2
+      '@typescript/typescript-netbsd-arm64': 7.0.2
+      '@typescript/typescript-netbsd-x64': 7.0.2
+      '@typescript/typescript-openbsd-arm64': 7.0.2
+      '@typescript/typescript-openbsd-x64': 7.0.2
+      '@typescript/typescript-sunos-x64': 7.0.2
+      '@typescript/typescript-win32-arm64': 7.0.2
+      '@typescript/typescript-win32-x64': 7.0.2
 
   typical@4.0.0: {}
 
@@ -9085,7 +9318,7 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite-plugin-checker@0.14.4(eslint@10.6.0(jiti@2.7.0))(optionator@0.9.4)(oxlint@1.73.0(oxlint-tsgolint@0.24.0))(typescript@6.0.3)(vite@8.1.3(@types/node@25.0.9)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)):
+  vite-plugin-checker@0.14.4(@typescript/typescript6@6.0.2)(eslint@10.6.0(jiti@2.7.0))(optionator@0.9.4)(oxlint@1.73.0(oxlint-tsgolint@0.24.0))(vite@8.1.3(@types/node@25.0.9)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)):
     dependencies:
       '@babel/code-frame': 7.29.7
       chokidar: 5.0.0
@@ -9099,7 +9332,7 @@ snapshots:
       eslint: 10.6.0(jiti@2.7.0)
       optionator: 0.9.4
       oxlint: 1.73.0(oxlint-tsgolint@0.24.0)
-      typescript: 6.0.3
+      typescript: '@typescript/typescript6@6.0.2'
 
   vite-plugin-static-copy@3.4.0(vite@8.1.3(@types/node@25.0.9)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)):
     dependencies:
@@ -9146,7 +9379,7 @@ snapshots:
       jiti: 2.7.0
       yaml: 2.9.0
 
-  vitepress@1.6.4(@algolia/client-search@5.55.1)(@types/node@25.0.9)(axios@1.18.1)(change-case@5.4.4)(jiti@2.7.0)(lightningcss@1.32.0)(postcss@8.5.16)(search-insights@2.17.3)(typescript@6.0.3)(yaml@2.9.0):
+  vitepress@1.6.4(@algolia/client-search@5.55.1)(@types/node@25.0.9)(axios@1.18.1)(change-case@5.4.4)(jiti@2.7.0)(lightningcss@1.32.0)(postcss@8.5.16)(search-insights@2.17.3)(typescript@7.0.2)(yaml@2.9.0):
     dependencies:
       '@docsearch/css': 3.8.2
       '@docsearch/js': 3.8.2(@algolia/client-search@5.55.1)(search-insights@2.17.3)
@@ -9155,17 +9388,17 @@ snapshots:
       '@shikijs/transformers': 2.5.0
       '@shikijs/types': 2.5.0
       '@types/markdown-it': 14.1.2
-      '@vitejs/plugin-vue': 5.2.4(vite@6.4.3(@types/node@25.0.9)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))(vue@3.5.39(typescript@6.0.3))
+      '@vitejs/plugin-vue': 5.2.4(vite@6.4.3(@types/node@25.0.9)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))(vue@3.5.39(typescript@7.0.2))
       '@vue/devtools-api': 7.7.10
       '@vue/shared': 3.5.39
-      '@vueuse/core': 12.8.2(typescript@6.0.3)
-      '@vueuse/integrations': 12.8.2(axios@1.18.1)(change-case@5.4.4)(focus-trap@7.8.0)(typescript@6.0.3)
+      '@vueuse/core': 12.8.2(typescript@7.0.2)
+      '@vueuse/integrations': 12.8.2(axios@1.18.1)(change-case@5.4.4)(focus-trap@7.8.0)(typescript@7.0.2)
       focus-trap: 7.8.0
       mark.js: 8.11.1
       minisearch: 7.2.0
       shiki: 2.5.0
       vite: 6.4.3(@types/node@25.0.9)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0)
-      vue: 3.5.39(typescript@6.0.3)
+      vue: 3.5.39(typescript@7.0.2)
     optionalDependencies:
       postcss: 8.5.16
     transitivePeerDependencies:
@@ -9227,15 +9460,15 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
-  vue@3.5.39(typescript@6.0.3):
+  vue@3.5.39(typescript@7.0.2):
     dependencies:
       '@vue/compiler-dom': 3.5.39
       '@vue/compiler-sfc': 3.5.39
       '@vue/runtime-dom': 3.5.39
-      '@vue/server-renderer': 3.5.39(vue@3.5.39(typescript@6.0.3))
+      '@vue/server-renderer': 3.5.39(vue@3.5.39(typescript@7.0.2))
       '@vue/shared': 3.5.39
     optionalDependencies:
-      typescript: 6.0.3
+      typescript: 7.0.2
 
   wait-on@9.0.10(debug@4.4.3(supports-color@8.1.1)):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -47,7 +47,7 @@ catalogs:
     lit: ^3.0.0
     mobx: ^6.0.0
     typedoc: ^0.28.0
-  ts6:
+  typescript6-compat:
     typescript: npm:@typescript/typescript6@^6.0.2
   vitepress1:
     vite-plugin-static-copy: ^3.4.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -32,7 +32,7 @@ catalog:
   typedoc: ^0.28.20
   typedoc-plugin-markdown: ^4.12.0
   typedoc-vitepress-theme: ^1.1.3
-  typescript: ^6.0.3
+  typescript: ^7.0.2
   vite: ^8.1.3
   vite-plugin-checker: ^0.14.4
   vite-plugin-static-copy: ^4.1.1
@@ -47,6 +47,8 @@ catalogs:
     lit: ^3.0.0
     mobx: ^6.0.0
     typedoc: ^0.28.0
+  ts6:
+    typescript: npm:@typescript/typescript6@^6.0.2
   vitepress1:
     vite-plugin-static-copy: ^3.4.0
 
@@ -73,3 +75,26 @@ patchedDependencies:
   '@vitest/browser': patches/@vitest__browser.patch
   '@uirouter/dsr': patches/@uirouter__dsr.patch
   lit-dialog: patches/lit-dialog.patch
+
+minimumReleaseAgeExclude:
+  - '@typescript/typescript-aix-ppc64@7.0.2'
+  - '@typescript/typescript-darwin-arm64@7.0.2'
+  - '@typescript/typescript-darwin-x64@7.0.2'
+  - '@typescript/typescript-freebsd-arm64@7.0.2'
+  - '@typescript/typescript-freebsd-x64@7.0.2'
+  - '@typescript/typescript-linux-arm64@7.0.2'
+  - '@typescript/typescript-linux-arm@7.0.2'
+  - '@typescript/typescript-linux-loong64@7.0.2'
+  - '@typescript/typescript-linux-mips64el@7.0.2'
+  - '@typescript/typescript-linux-ppc64@7.0.2'
+  - '@typescript/typescript-linux-riscv64@7.0.2'
+  - '@typescript/typescript-linux-s390x@7.0.2'
+  - '@typescript/typescript-linux-x64@7.0.2'
+  - '@typescript/typescript-netbsd-arm64@7.0.2'
+  - '@typescript/typescript-netbsd-x64@7.0.2'
+  - '@typescript/typescript-openbsd-arm64@7.0.2'
+  - '@typescript/typescript-openbsd-x64@7.0.2'
+  - '@typescript/typescript-sunos-x64@7.0.2'
+  - '@typescript/typescript-win32-arm64@7.0.2'
+  - '@typescript/typescript-win32-x64@7.0.2'
+  - typescript@7.0.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -76,6 +76,8 @@ patchedDependencies:
   '@uirouter/dsr': patches/@uirouter__dsr.patch
   lit-dialog: patches/lit-dialog.patch
 
+minimumReleaseAgeStrict: true
+
 minimumReleaseAgeExclude:
   - '@typescript/typescript-aix-ppc64@7.0.2'
   - '@typescript/typescript-darwin-arm64@7.0.2'

--- a/tools/dts-backtest/package.json
+++ b/tools/dts-backtest/package.json
@@ -17,8 +17,10 @@
     "lit-ui-router": "workspace:*",
     "lit-ui-router-mobx": "workspace:*",
     "mobx": "catalog:",
-    "typescript": "catalog:",
     "typescript-5.0": "npm:typescript@5.0.4",
+    "typescript-5.9": "npm:typescript@^5.9.3",
+    "typescript-6": "npm:typescript@^6.0.3",
+    "typescript-7": "npm:typescript@^7.0.2",
     "ui-router-navigation-location-plugin": "workspace:*"
   }
 }

--- a/tools/dts-backtest/run.mjs
+++ b/tools/dts-backtest/run.mjs
@@ -10,8 +10,13 @@
 // declarations (lit, mobx, @uirouter/core, lib.dom, …) are counted and
 // reported but tolerated, matching what a consumer with skipLibCheck:true
 // would experience while still fully checking OUR declarations.
+//
+// Legs through 6.x drive the classic `ts.createProgram` API. TypeScript 7
+// dropped that API, so its leg drives the native compiler through
+// `typescript/unstable/sync` — a different, still-unstable surface that 7.1 is
+// expected to replace.
 
-import { readFileSync, writeFileSync } from 'node:fs';
+import { readFileSync, realpathSync, writeFileSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import { dirname, join, resolve, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -19,8 +24,11 @@ import { fileURLToPath } from 'node:url';
 const here = dirname(fileURLToPath(import.meta.url));
 const require = createRequire(import.meta.url);
 
-// devDependency aliases; "typescript" is the repo's current catalog version.
-const VERSIONS = ['typescript-5.0', 'typescript'];
+// devDependency aliases, oldest first; every leg is pinned so none tracks the
+// repo's own catalog. 6.x is the newest TypeScript with the classic API.
+const API_VERSIONS = ['typescript-5.0', 'typescript-5.9', 'typescript-6'];
+
+const NATIVE_VERSION = 'typescript-7';
 
 const CONFIGS = ['tsconfig.fixture.json', 'tsconfig.fixture.nodenext.json'];
 
@@ -30,6 +38,19 @@ const PACKAGE_DIRS = [
   'lit-ui-router-mobx',
   'navigation-location-plugin',
 ].map((dir) => resolve(here, '..', '..', 'packages', dir, 'dist') + sep);
+
+// A file we cannot resolve is treated as ours: it means the compiler reported
+// against something we planted or mangled, which must never be tolerated.
+function ownsPath(fileName) {
+  let normalized;
+  try {
+    normalized = resolve(realpathSync(fileName));
+  } catch {
+    return true;
+  }
+  if (normalized.startsWith(here + sep)) return true;
+  return PACKAGE_DIRS.some((dir) => normalized.startsWith(dir));
+}
 
 function loadConfig(ts, configFile) {
   let fatal;
@@ -48,13 +69,6 @@ function loadConfig(ts, configFile) {
     throw new Error(`failed to parse ${configFile}: ${fatal ?? 'unknown'}`);
   }
   return parsed;
-}
-
-function ownedBy(ts, fileName) {
-  const real = ts.sys.realpath ? ts.sys.realpath(fileName) : fileName;
-  const normalized = resolve(real);
-  if (normalized.startsWith(here + sep)) return true;
-  return PACKAGE_DIRS.some((dir) => normalized.startsWith(dir));
 }
 
 function check(specifier, configFile) {
@@ -83,7 +97,7 @@ function check(specifier, configFile) {
   const owned = [];
   let foreign = 0;
   for (const diagnostic of diagnostics) {
-    if (!diagnostic.file || ownedBy(ts, diagnostic.file.fileName)) {
+    if (!diagnostic.file || ownsPath(diagnostic.file.fileName)) {
       owned.push(diagnostic);
     } else {
       foreign += 1;
@@ -91,6 +105,84 @@ function check(specifier, configFile) {
   }
 
   return { ts, owned, foreign, fileCount: files.length };
+}
+
+// TypeScript 7 equivalent of check(). Diagnostics come back as plain objects
+// ({ fileName, pos, end, code, category, text }) rather than ts.Diagnostic.
+async function checkNative(specifier, configFile) {
+  const { API, DiagnosticCategory } = await import(
+    `${specifier}/unstable/sync`
+  );
+  const { version } = require(
+    join(
+      dirname(require.resolve(`${specifier}/package.json`)),
+      'lib',
+      'version.cjs',
+    ),
+  );
+
+  const api = new API({ cwd: here });
+  const configPath = join(here, configFile);
+  const snapshot = api.updateSnapshot({ openProjects: [configPath] });
+  try {
+    const project = snapshot.getProject(configPath);
+    if (!project) throw new Error(`no project for ${configFile}`);
+    const { program } = project;
+
+    const files = program.getSourceFileNames();
+    const missing = PACKAGE_DIRS.filter(
+      (dir) => !files.some((file) => resolve(file).startsWith(dir)),
+    );
+    if (missing.length > 0) {
+      throw new Error(
+        `dist .d.ts missing from program (run \`turbo run build\` first):\n  ${missing.join('\n  ')}`,
+      );
+    }
+
+    const owned = [];
+    let foreign = 0;
+    const diagnostics = [
+      ...program.getConfigFileParsingDiagnostics(),
+      ...program.getGlobalDiagnostics(),
+      ...program.getSyntacticDiagnostics(),
+      ...program.getSemanticDiagnostics(),
+    ];
+    for (const diagnostic of diagnostics) {
+      if (diagnostic.category !== DiagnosticCategory.Error) continue;
+      if (!diagnostic.fileName || ownsPath(diagnostic.fileName)) {
+        owned.push(diagnostic);
+      } else {
+        foreign += 1;
+      }
+    }
+    return { version, owned, foreign, fileCount: files.length };
+  } finally {
+    snapshot.dispose();
+    api.close();
+  }
+}
+
+function formatNative(diagnostics) {
+  return diagnostics
+    .map((d) => `  ${d.fileName ?? '<unknown>'}: TS${d.code}: ${d.text}`)
+    .join('\n');
+}
+
+async function runNative(specifier, configFile) {
+  const { version, owned, foreign, fileCount } = await checkNative(
+    specifier,
+    configFile,
+  );
+  const label = `TS ${version} · ${configFile}`;
+  if (owned.length > 0) {
+    console.error(`✖ ${label}`);
+    console.error(formatNative(owned));
+    return false;
+  }
+  const foreignNote =
+    foreign > 0 ? ` (${foreign} third-party diagnostics ignored)` : '';
+  console.log(`✔ ${label} — ${fileCount} files checked${foreignNote}`);
+  return true;
 }
 
 function run(specifier, configFile) {
@@ -120,12 +212,28 @@ function run(specifier, configFile) {
 // ever raised past 5.4, this fails loudly — pick a newer-syntax probe.
 const PROBE = '\nexport type __dtsBacktestProbe = NoInfer<string>;\n';
 
-function selftest() {
-  const [floor, current] = VERSIONS;
+// The native leg has its own ownership filter, so it needs its own proof. An
+// unresolvable name must surface as an owned diagnostic, not a tolerated one.
+const NATIVE_PROBE =
+  '\nexport type __dtsBacktestNativeProbe = __NoSuchTypeExists__;\n';
+
+// async: the native leg reads the probe after an await, so the restore must not
+// run until the body has fully resolved.
+async function withProbe(probe, body) {
   const target = join(PACKAGE_DIRS[0], 'index.d.ts');
   const original = readFileSync(target, 'utf8');
-  writeFileSync(target, original + PROBE);
+  writeFileSync(target, original + probe);
   try {
+    return await body(target);
+  } finally {
+    writeFileSync(target, original);
+  }
+}
+
+function selftest() {
+  const floor = API_VERSIONS[0];
+  const current = API_VERSIONS[API_VERSIONS.length - 1];
+  return withProbe(PROBE, (target) => {
     const floorRun = check(floor, CONFIGS[0]);
     const probeCaught = floorRun.owned.some((diagnostic) =>
       diagnostic.file?.fileName.endsWith('index.d.ts'),
@@ -147,15 +255,32 @@ function selftest() {
       `✔ selftest — floor TS ${floorRun.ts.version} rejects the probe, current TS ${currentRun.ts.version} accepts it`,
     );
     return true;
-  } finally {
-    writeFileSync(target, original);
-  }
+  });
 }
 
-let ok = selftest();
-for (const specifier of VERSIONS) {
+async function selftestNative() {
+  const { version, owned } = await withProbe(NATIVE_PROBE, () =>
+    checkNative(NATIVE_VERSION, CONFIGS[0]),
+  );
+  const caught = owned.some((diagnostic) =>
+    diagnostic.fileName?.endsWith('index.d.ts'),
+  );
+  if (!caught) {
+    console.error(`✖ selftest native — TS ${version} did not reject the probe`);
+    return false;
+  }
+  console.log(`✔ selftest native — TS ${version} rejects the probe`);
+  return true;
+}
+
+let ok = await selftest();
+ok = (await selftestNative()) && ok;
+for (const specifier of API_VERSIONS) {
   for (const configFile of CONFIGS) {
     ok = run(specifier, configFile) && ok;
   }
+}
+for (const configFile of CONFIGS) {
+  ok = (await runNative(NATIVE_VERSION, configFile)) && ok;
 }
 process.exit(ok ? 0 : 1);

--- a/tools/typedoc-plugin-lit-ui-router/package.json
+++ b/tools/typedoc-plugin-lit-ui-router/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "@types/node": "^24.13.2",
     "typedoc": "catalog:",
-    "typescript": "catalog:ts6"
+    "typescript": "catalog:typescript6-compat"
   },
   "peerDependencies": {
     "typedoc": "catalog:publishedPeer"

--- a/tools/typedoc-plugin-lit-ui-router/package.json
+++ b/tools/typedoc-plugin-lit-ui-router/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "@types/node": "^24.13.2",
     "typedoc": "catalog:",
-    "typescript": "catalog:"
+    "typescript": "catalog:ts6"
   },
   "peerDependencies": {
     "typedoc": "catalog:publishedPeer"


### PR DESCRIPTION
Evaluation of TypeScript 7.0 (`latest` as of 2026-07-08). Draft — see open questions.

## What TS 7.0 actually is

`tsc` is now the native Go port, and **the package ships no JS API**: `main` and `types` are `null`, `"."` exports only `lib/version.cjs`, and 20 platform binaries arrive as optionalDependencies. Anything that `import`s the compiler as a library breaks — not with a peer warning, but at runtime:

```
TypeError: Cannot read properties of undefined (reading 'PropertyDeclaration')
    at typedoc/dist/index.js:537   // ts4.SyntaxKind.PropertyDeclaration
```

## Approach

Bare `catalog: typescript` → `^7.0.2`, so `tsc` is native by default. A new named `typescript6-compat` catalog aliases `typescript` to `@typescript/typescript6` (Microsoft's compat package: reexports the 6.x API, adds a `tsc6` bin) for the seven members that need a real API.

Why not the obvious alternatives — each was tried and rejected with evidence:

| attempt | result |
|---|---|
| `overrides: 'typedoc>typescript'` | inert — typedoc declares `typescript` only as a **peer**, resolved from the importing package |
| `packageExtensions` adding a `dependencies.typescript` | inert — peer still wins; typedoc got 7.0.2 and crashed |
| `peerDependencyRules.allowedVersions` | silences the warning, keeps the runtime crash — strictly worse than failing loudly |

A third consumer only surfaced in CI: **Cypress**. Its bundled `ts-loader` resolves `typescript` from the project, so under TS 7 it got a `{ version }`-only module and died on `ts.sys.fileExists` — all 5 specs × 2 apps failed at 0ms with `Webpack Compilation Error`. `apps/sample-app-lit-e2e` builds fine with native `tsc`, so `pnpm run build` never caught it; only `pnpm run test` does. It takes `catalog:typescript6-compat` as well.

The alias is not a downgrade in disguise: `@typescript/typescript6` ships only a `tsc6` bin, so `tsc` still resolves to **7.0.2** from the workspace root's `.bin`. Packages compile and emit with native TS 7 while typedoc reads their sources with the TS 6 API.

## dts-backtest

It was itself a TS API consumer (`createProgram`, `getPreEmitDiagnostics`), and its "current" leg tracked the catalog — which under TS 7 would mean `require('typescript')` returning `{ version }` and nothing else. Left alone, **consumers on TS 7 would have had their `.d.ts` unchecked.**

It's now an explicit matrix, no leg tracking the catalog:

| leg | driver |
|---|---|
| 5.0.4 (consumer floor) | classic `ts.createProgram` |
| 5.9.3 | classic |
| 6.0.3 (last with a JS API) | classic |
| 7.0.2 | `typescript/unstable/sync` |

The 7.0 leg uses TS 7's own unstable API rather than the compat package — the compat package *is* TS 6 (its README: "provides a `tsc6` command that runs TypeScript 6's `tsc`"), so pointing a "TS 7 leg" at it would re-run TS 6 under a 7-shaped label and stay green forever. `unstable/sync` returns structured diagnostics (`{ fileName, pos, end, code, category, text }`) with absolute paths, which beats parsing `tsc --pretty false` text. It is explicitly unstable and 7.1 is expected to replace it.

The native leg has its own ownership filter, so it gets its own probe self-test. Both self-tests were mutation-tested: forcing `ownsPath()` to return `false` turns the run red (exit 1), so neither can pass vacuously.

## Verification

- `turbo run build` — 13/13 ✅
- typecheck + `.d.ts` emit under native `tsc` 7.0.2, all 3 packages ✅
- `docs:api` (typedoc), all 3 packages ✅ — crashed before this change
- `vite build` for both `vite-plugin-checker` sample apps ✅
- `sample-app-lit-e2e` Cypress suites, run locally: 25 + 25 specs passing ✅
- `dts-backtest` — 8 legs + 2 self-tests, exit 0, TS 7 checks the same 214 files as TS 6 ✅

Source needed **zero** changes: no `baseUrl`, no `target: es5`, `rootDir` already explicit everywhere.

## Release-age note

`minimumReleaseAgeExclude` in this diff was written by **pnpm**, not by hand. pnpm 11 defaults `minimumReleaseAge` to 1440 minutes, but when that default is *inherited* rather than set explicitly, it records an exception and installs anyway:

```
Added 21 entries to minimumReleaseAgeExclude in pnpm-workspace.yaml
 (set minimumReleaseAgeStrict to true to gate these updates with a prompt)
```

**This PR now sets `minimumReleaseAgeStrict: true`**, which turns that into `ERR_PNPM_NO_MATURE_MATCHING_VERSION`: accepting an hours-old release becomes a deliberate, reviewable edit rather than a silent one.

The gate applies to `--frozen-lockfile` as well, which is how CI installs — verified by removing a single exclude entry and watching `pnpm install --frozen-lockfile` fail. So the 21 exclude entries are what keep CI green until 7.0.2 ages past the 24h window; after that they are inert no-ops. Dependabot's `cooldown: default-days: 1` already keeps its PRs on the safe side of the same window.

`.github/dependabot.yml` says it mirrors "pnpm's minimumReleaseAge: 24h (pnpm-workspace config)" — the 24h is real, but it's pnpm's built-in default, not a setting in this repo.

## Editors

Worth stating plainly, because it looks like a side effect of the `typescript6-compat` alias and is not: **TypeScript 7 ships no `tsserver.js`.** Its `lib/` holds only `tsc.js`, `getExePath.js` and `version.cjs`. `@typescript/typescript6` doesn't have one either — it's a 45-byte re-export (`module.exports = require("@typescript/old")`, where `@typescript/old` is `npm:typescript@^6`) whose only job is to rename the bin to `tsc6`.

The per-package `catalog:typescript6-compat` has no bearing on this: VS Code resolves `tsserver` from the workspace folder root or `typescript.tsdk`, never from each package's `node_modules`. With root `typescript` on 7, the editor simply falls back to its own bundled TypeScript.

The replacement is the native language server, and it's already in the box — the shipped binary answers `--lsp`:

```
$ .../@typescript/typescript-darwin-arm64/tsc --lsp --help
Usage of lsp:
  -pipe string
        use named pipe for communication
```

So no `.vscode` settings and no editor-only TypeScript alias here. Editor integration moves to the native LSP client, sequenced with the 7.1 work below.

## Resolved questions

1. **`unstable/sync` will change in 7.1** — accepted as expected churn, to be absorbed by the 7.1 feature bump rather than pre-emptively traded for a brittle `tsc` subprocess.
2. **Editors** — see above. Not caused by the alias; fixed by the native LSP, not by pinning a tsdk.
3. **`minimumReleaseAgeStrict: true`** — adopted (commit 2).
4. Examples landed separately in #248.

