### PR TITLE
fix(lint): ignore .claude worktrees in eslint config

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -9,8 +9,6 @@ export default defineConfig(
     '**/coverage/**',
     '**/node_modules/**',
     '**/.vitepress/cache/**',
-    // Git worktrees live here; each ships its own eslint.config.js that ESLint
-    // would otherwise load (flat config resolves per-file, and ignores .gitignore).
     '**/.claude/**',
   ]),
   {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -9,6 +9,9 @@ export default defineConfig(
     '**/coverage/**',
     '**/node_modules/**',
     '**/.vitepress/cache/**',
+    // Git worktrees live here; each ships its own eslint.config.js that ESLint
+    // would otherwise load (flat config resolves per-file, and ignores .gitignore).
+    '**/.claude/**',
   ]),
   {
     extends: [packageJson.configs.recommended],


### PR DESCRIPTION
## Problem

`pnpm lint:package-json` fails locally with:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@eslint/js' imported from
  .claude/worktrees/agent-ae0f5517c3aa916e9/eslint.config.js
```

The script globs `**/package.json` from the repo root. ESLint flat config resolves a config file **per linted file** and does **not** read `.gitignore` — so the glob descends into `.claude/worktrees/*/` and loads each worktree's own `eslint.config.js`. Worktrees sitting on branches that predate the oxlint migration (#231) still `import '@eslint/js'`, which is no longer a root dependency. ESLint dies before linting a single file.

11 of 22 local worktrees carry such a config. `lint:root` (oxlint) was never affected — oxlint honors `.gitignore`.

## Fix

Add `**/.claude/**` to `globalIgnores`. `.claude` is already gitignored; nothing under it should ever be linted.

## Verification

Planted a decoy stale config at `.claude/worktrees/decoy/eslint.config.js` importing `@eslint/js`:

| | exit | result |
|---|---|---|
| without fix | 2 | `ERR_MODULE_NOT_FOUND` — same error as reported |
| with fix | 0 | 15 real `package.json` files linted, decoy skipped |

Also green: `lint:root`, `format:check:root`, `lint:package-json`.