### PR TITLE
fix(test): wire vitest.setup.ts via setupFiles

### DIFF
--- a/packages/lit-ui-router-mobx/vitest.config.ts
+++ b/packages/lit-ui-router-mobx/vitest.config.ts
@@ -15,6 +15,7 @@ export default defineConfig({
   },
   test: {
     globals: true,
+    setupFiles: ['./vitest.setup.ts'],
     include: ['src/specs/**/*.spec.ts'],
     // hanging-process logs the open handles in CI
     reporters: process.env.CI ? ['default', 'hanging-process'] : ['default'],

--- a/packages/lit-ui-router/vitest.config.ts
+++ b/packages/lit-ui-router/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
   cacheDir: `node_modules/.vite-${process.env.VITEST_BROWSER_API_PORT ?? 'default'}`,
   test: {
     globals: true,
+    setupFiles: ['./vitest.setup.ts'],
     include: ['src/specs/**/*.spec.ts'],
     // hanging-process logs the open handles in CI
     reporters: process.env.CI ? ['default', 'hanging-process'] : ['default'],


### PR DESCRIPTION
## Problem

Both `lit-ui-router` and `lit-ui-router-mobx` ship a `vitest.setup.ts` that suppresses Lit's per-worker `Lit is in dev mode` banner, and both `tsconfig.json`s `include` it so it typechecks cleanly. **Nothing ever loaded it** — no `setupFiles` key exists in either vitest config on `main`. The file has been dead code, and the banner prints on every worker of every run.

## Fix

Add `setupFiles: ['./vitest.setup.ts']` to both vitest configs.

## Verification

`lit-ui-router`, chromium, 157 tests:

| | banner lines | vitest `setup` phase | tests |
|---|---|---|---|
| `main` | **12** | `0ms` (never ran) | 157 passed |
| this PR | **0** | `34ms` | 157 passed |

`lit-ui-router-mobx`: 21 passed, 0 banners. `typecheck` green for both packages.

## Provenance

Salvaged from the abandoned `ci-log-noise` branch (tip `445b353`). I audited all 13 of its commits against `main`:

- `scripts/start-xvfb*.mjs`, both `vitest.setup.ts` — **landed** via #227 (byte-identical to `main`)
- `disable_search: true` + `plugins: noop` — **landed** via #238 (already in `main`'s `build-test.yml`)
- `tsconfig.spec.json` ×2 — **superseded** by the umbrella `tsconfig.json` (#236), which already includes the vitest files with `types: ["vitest/globals"]`
- `eslint.config.js`, `turbo.json` — branch copies are **stale** (pre-oxlint #231, pre-typecheck-task #242); rebasing the branch would have reverted both migrations

This `setupFiles` wiring was the only unlanded content, so it is re-applied here as a fresh commit on `main` rather than by rebasing the stale branch.