### PR TITLE
fix(sample-app): route the app root to welcome on every url sync

### DIFF
--- a/apps/sample-app-lit-e2e/src/integration/not_found.cy.js
+++ b/apps/sample-app-lit-e2e/src/integration/not_found.cy.js
@@ -1,8 +1,36 @@
-import { visitWithFeatures } from '../support/e2e';
+import {
+  LOCATION_PLUGIN,
+  visitRootWithFeatures,
+  visitWithFeatures,
+} from '../support/e2e';
 
 describe('404 not found', () => {
   beforeEach(() => {
     window.sessionStorage.clear();
+  });
+
+  it('routes the app root to welcome, not the 404 page', () => {
+    visitRootWithFeatures();
+    cy.contains('Welcome to the sample app!');
+    cy.contains('404 Page Not Found').should('not.exist');
+    cy.url().should('include', '/welcome');
+  });
+
+  // HashLocationService._set ignores the replace flag, so the root keeps its
+  // history entry and Back re-resolves it to welcome in place, never reaching
+  // the login entry. The 404 regression this pins is pushState/navigation only.
+  const itPushesState = LOCATION_PLUGIN === 'hash' ? it.skip : it;
+
+  itPushesState('does not 404 when navigating back to the app root', () => {
+    visitWithFeatures('/login');
+    visitRootWithFeatures();
+    cy.contains('Welcome to the sample app!');
+
+    // The root replaced its history entry, so Back skips it for the login page.
+    // Without that, Back re-syncs the root, where otherwise() renders the 404.
+    cy.go('back');
+    cy.contains('Log In');
+    cy.contains('404 Page Not Found').should('not.exist');
   });
 
   it('shows the 404 page for an unmatched URL', () => {

--- a/apps/sample-app-lit-e2e/src/integration/not_found.cy.js
+++ b/apps/sample-app-lit-e2e/src/integration/not_found.cy.js
@@ -1,8 +1,4 @@
-import {
-  LOCATION_PLUGIN,
-  visitRootWithFeatures,
-  visitWithFeatures,
-} from '../support/e2e';
+import { visitRootWithFeatures, visitWithFeatures } from '../support/e2e';
 
 describe('404 not found', () => {
   beforeEach(() => {
@@ -16,12 +12,7 @@ describe('404 not found', () => {
     cy.url().should('include', '/welcome');
   });
 
-  // HashLocationService._set ignores the replace flag, so the root keeps its
-  // history entry and Back re-resolves it to welcome in place, never reaching
-  // the login entry. The 404 regression this pins is pushState/navigation only.
-  const itPushesState = LOCATION_PLUGIN === 'hash' ? it.skip : it;
-
-  itPushesState('does not 404 when navigating back to the app root', () => {
+  it('does not 404 when navigating back to the app root', () => {
     visitWithFeatures('/login');
     visitRootWithFeatures();
     cy.contains('Welcome to the sample app!');

--- a/apps/sample-app-lit-e2e/src/support/e2e.ts
+++ b/apps/sample-app-lit-e2e/src/support/e2e.ts
@@ -3,10 +3,7 @@ export const LOCATION_PLUGIN =
   // Cypress.expose(key) is typed `any`.
   (Cypress.expose('LOCATION_PLUGIN') as string | undefined) || '';
 
-export function visitWithFeatures(
-  path: string,
-  features: Record<string, string> = {},
-) {
+function featureQuery(features: Record<string, string>) {
   const params = new URLSearchParams();
   for (const [key, value] of Object.entries(features)) {
     params.set(`feature-${key}`, value);
@@ -17,8 +14,15 @@ export function visitWithFeatures(
   if (locationPlugin) {
     params.set('feature-location-plugin', locationPlugin);
   }
-  const isHashMode = locationPlugin === 'hash';
-  const query = params.toString();
+
+  return { query: params.toString(), isHashMode: locationPlugin === 'hash' };
+}
+
+export function visitWithFeatures(
+  path: string,
+  features: Record<string, string> = {},
+) {
+  const { query, isHashMode } = featureQuery(features);
   const url = query
     ? isHashMode
       ? `?${query}#${path}`
@@ -27,4 +31,15 @@ export function visitWithFeatures(
       ? `#${path}`
       : path;
   return cy.visit(url);
+}
+
+/**
+ * Visits the app root with no trailing slash (`/app`, not `/app/`) — the entry
+ * the docs site links to. `baseUrl` carries the trailing slash, so the root
+ * can't be reached with a relative `cy.visit`.
+ */
+export function visitRootWithFeatures(features: Record<string, string> = {}) {
+  const { query } = featureQuery(features);
+  const root = (Cypress.config('baseUrl') ?? '').replace(/\/+$/, '');
+  return cy.visit(query ? `${root}?${query}` : root);
 }

--- a/apps/sample-app-shared/src/app/util/ga.js
+++ b/apps/sample-app-shared/src/app/util/ga.js
@@ -51,7 +51,10 @@ function trackException(event) {
 
 export default function googleAnalyticsHook(transitionService) {
   const path = (trans) => {
-    const formattedRoute = trans.$to().url.format(trans.params());
+    // States declared without a url (the 404 state) have no UrlMatcher to
+    // format; their attempted path is already in location.pathname.
+    const urlMatcher = trans.$to().url;
+    const formattedRoute = urlMatcher ? urlMatcher.format(trans.params()) : '';
     const withSitePrefix = location.pathname + formattedRoute;
     return `/${withSitePrefix
       .split('/')

--- a/apps/sample-app-shared/src/app/util/replaceAwareHashLocation.ts
+++ b/apps/sample-app-shared/src/app/util/replaceAwareHashLocation.ts
@@ -1,6 +1,7 @@
 import {
   BrowserLocationConfig,
   HashLocationService,
+  LocationPlugin,
   locationPluginFactory,
   UIRouter,
 } from '@uirouter/core';
@@ -44,4 +45,4 @@ export const replaceAwareHashLocationPlugin = locationPluginFactory(
   false,
   ReplaceAwareHashLocationService,
   BrowserLocationConfig,
-);
+) satisfies (router: UIRouter) => LocationPlugin;

--- a/apps/sample-app-shared/src/app/util/replaceAwareHashLocation.ts
+++ b/apps/sample-app-shared/src/app/util/replaceAwareHashLocation.ts
@@ -6,16 +6,19 @@ import {
 } from '@uirouter/core';
 
 /**
- * A `hashLocationPlugin` whose location service honors the `replace` flag.
+ * A `hashLocationPlugin` whose location service can replace the current history
+ * entry instead of always pushing a new one.
  *
- * `HashLocationService._set` assigns `location.hash`, which always pushes a
- * history entry — it ignores `replace` entirely. A url rule that redirects the
- * app root (`''`) to a state therefore leaves the root behind in history, and
- * pressing Back re-enters it, re-runs the redirect, and pushes again: the root
- * becomes a Back-trap you can never move past.
+ * `HashLocationService` predates the widespread History API: assigning
+ * `location.hash` was the only way to change the url without a page load, and
+ * it always pushes. Honoring `replace` therefore isn't something core left out
+ * — the hash strategy exists precisely for browsers that lack `replaceState`.
  *
- * `replaceState` writes the same hash without adding an entry, so the root is
- * consumed by the redirect and Back reaches whatever preceded it.
+ * The sample app targets browsers that have it, so it opts in: a url rule that
+ * redirects the app root (`''`) to a state would otherwise leave the root in
+ * history, where Back re-enters it, re-runs the redirect, and pushes again,
+ * making the root a Back-trap. Where `replaceState` is missing, fall back to
+ * the base behavior — a spare history entry beats a broken url.
  */
 class ReplaceAwareHashLocationService extends HashLocationService {
   // locationPluginFactory types the router as optional; the base class requires it.
@@ -27,7 +30,7 @@ class ReplaceAwareHashLocationService extends HashLocationService {
   }
 
   _set(state: unknown, title: string, url: string, replace: boolean) {
-    if (!replace) {
+    if (!replace || typeof this._history.replaceState !== 'function') {
       super._set(state, title, url, replace);
       return;
     }

--- a/apps/sample-app-shared/src/app/util/replaceAwareHashLocation.ts
+++ b/apps/sample-app-shared/src/app/util/replaceAwareHashLocation.ts
@@ -1,0 +1,44 @@
+import {
+  BrowserLocationConfig,
+  HashLocationService,
+  locationPluginFactory,
+  UIRouter,
+} from '@uirouter/core';
+
+/**
+ * A `hashLocationPlugin` whose location service honors the `replace` flag.
+ *
+ * `HashLocationService._set` assigns `location.hash`, which always pushes a
+ * history entry — it ignores `replace` entirely. A url rule that redirects the
+ * app root (`''`) to a state therefore leaves the root behind in history, and
+ * pressing Back re-enters it, re-runs the redirect, and pushes again: the root
+ * becomes a Back-trap you can never move past.
+ *
+ * `replaceState` writes the same hash without adding an entry, so the root is
+ * consumed by the redirect and Back reaches whatever preceded it.
+ */
+class ReplaceAwareHashLocationService extends HashLocationService {
+  // locationPluginFactory types the router as optional; the base class requires it.
+  constructor(router?: UIRouter) {
+    if (!router) {
+      throw new Error('ReplaceAwareHashLocationService requires a UIRouter');
+    }
+    super(router);
+  }
+
+  _set(state: unknown, title: string, url: string, replace: boolean) {
+    if (!replace) {
+      super._set(state, title, url, replace);
+      return;
+    }
+    const { pathname, search } = this._location;
+    this._history.replaceState(state, title, `${pathname}${search}#${url}`);
+  }
+}
+
+export const replaceAwareHashLocationPlugin = locationPluginFactory(
+  'sampleApp.replaceAwareHashLocation',
+  false,
+  ReplaceAwareHashLocationService,
+  BrowserLocationConfig,
+);

--- a/apps/sample-app-shared/src/router.config.ts
+++ b/apps/sample-app-shared/src/router.config.ts
@@ -1,5 +1,4 @@
 import {
-  hashLocationPlugin,
   pushStateLocationPlugin,
   trace,
   Category,
@@ -23,6 +22,7 @@ import {
   resolveLocationPlugin,
   LocationPluginFeatureSymbol,
 } from './app/util/featureDetection.js';
+import { replaceAwareHashLocationPlugin } from './app/util/replaceAwareHashLocation.js';
 
 export const HOME = 'home';
 export const NESTED_HOME = 'home.nested';
@@ -38,12 +38,12 @@ const locationPluginConfig = {
     message: 'pushStateLocationPlugin enabled',
   },
   hash: {
-    plugin: hashLocationPlugin,
+    plugin: replaceAwareHashLocationPlugin,
     message: 'hashLocationPlugin enabled',
   },
 } satisfies Record<
   LocationPluginFeatureSymbol,
-  { plugin: typeof hashLocationPlugin; message: string }
+  { plugin: typeof pushStateLocationPlugin; message: string }
 >;
 
 export function configureRouter(router = new UIRouterLit()) {
@@ -111,8 +111,6 @@ export function configureRouter(router = new UIRouterLit()) {
   // once a transition has run, so Back to the base href would fall through to
   // otherwise() and 404; match it on every sync instead. `location: 'replace'`
   // keeps the root out of history, so Back from /welcome leaves the app.
-  // HashLocationService._set ignores the replace flag, so under the hash plugin
-  // the root keeps its entry and Back re-resolves it to welcome in place.
   urlService.rules.when(/^\/?$/, () => ({
     state: 'welcome',
     options: { location: 'replace' },

--- a/apps/sample-app-shared/src/router.config.ts
+++ b/apps/sample-app-shared/src/router.config.ts
@@ -2,7 +2,9 @@ import {
   pushStateLocationPlugin,
   trace,
   Category,
+  LocationPlugin,
   Rejection,
+  UIRouter,
 } from '@uirouter/core';
 import { StickyStatesPlugin } from '@uirouter/sticky-states';
 // @ts-expect-error - @uirouter/dsr lacks proper ESM exports field for nodenext resolution
@@ -43,7 +45,7 @@ const locationPluginConfig = {
   },
 } satisfies Record<
   LocationPluginFeatureSymbol,
-  { plugin: typeof pushStateLocationPlugin; message: string }
+  { plugin: (router: UIRouter) => LocationPlugin; message: string }
 >;
 
 export function configureRouter(router = new UIRouterLit()) {

--- a/apps/sample-app-shared/src/router.config.ts
+++ b/apps/sample-app-shared/src/router.config.ts
@@ -107,7 +107,16 @@ export function configureRouter(router = new UIRouterLit()) {
     stateRegistry.register(state as LitStateDeclaration),
   );
 
-  urlService.rules.initial({ state: 'welcome' });
+  // The app root ('' or '/') has no state url. rules.initial() stops matching
+  // once a transition has run, so Back to the base href would fall through to
+  // otherwise() and 404; match it on every sync instead. `location: 'replace'`
+  // keeps the root out of history, so Back from /welcome leaves the app.
+  // HashLocationService._set ignores the replace flag, so under the hash plugin
+  // the root keeps its entry and Back re-resolves it to welcome in place.
+  urlService.rules.when(/^\/?$/, () => ({
+    state: 'welcome',
+    options: { location: 'replace' },
+  }));
 
   // 404: otherwise() only fires when no registered rule matches, so the
   // future states' wildcard rules still win and lazy loading keeps working.

--- a/docs/guides/unmatched-urls.md
+++ b/docs/guides/unmatched-urls.md
@@ -64,11 +64,46 @@ urlService.rules.when(/^\/?$/, () => ({
 with and without a trailing slash on the base href. `location: 'replace'` makes
 Back from `/welcome` leave the app, rather than bouncing off the root.
 
-With the [hash location plugin](https://ui-router.github.io/docs/latest/modules/vanilla.html)
-the `replace` half doesn't apply: `HashLocationService` sets `location.hash`
-directly and ignores the flag, so the root keeps its history entry. Landing on
-it again just re-resolves to welcome. That is the trade — under `hashLocation`
-the root is a redirect you cannot press Back through, but it never 404s.
+### Making `replace` work under the hash plugin
+
+`location: 'replace'` is a no-op with the stock `hashLocationPlugin`.
+`HashLocationService._set` assigns `location.hash`, which _always_ pushes an
+entry — the flag is ignored:
+
+```ts
+// @uirouter/core
+HashLocationService.prototype._set = function (state, title, url, replace) {
+  this._location.hash = url; // `replace` never read
+};
+```
+
+So the root keeps its entry, Back re-enters it, the rule redirects and pushes
+again: the root becomes a Back-trap. `replaceState` writes the same hash
+without adding an entry, and the class is exported, so a three-line subclass
+fixes it:
+
+```ts
+class ReplaceAwareHashLocationService extends HashLocationService {
+  _set(state: unknown, title: string, url: string, replace: boolean) {
+    if (!replace) return super._set(state, title, url, replace);
+    const { pathname, search } = this._location;
+    this._history.replaceState(state, title, `${pathname}${search}#${url}`);
+  }
+}
+
+export const replaceAwareHashLocationPlugin = locationPluginFactory(
+  'sampleApp.replaceAwareHashLocation',
+  false,
+  ReplaceAwareHashLocationService,
+  BrowserLocationConfig,
+);
+```
+
+Reaching for `history.go(-2)` to hop over the entry instead is a trap of its
+own: neither `popstate` nor `hashchange` tells you which direction you arrived
+from, so it cannot tell Back from Forward or from a fresh load — and if the
+root is the session's first entry, it walks the user off the site. Not creating
+the entry is the fix.
 
 ## The 404 state
 

--- a/docs/guides/unmatched-urls.md
+++ b/docs/guides/unmatched-urls.md
@@ -32,6 +32,44 @@ Passing the attempted path along as a param lets the 404 view show what
 failed to match. If you'd rather silently return home, target your welcome
 state instead — or use the string shorthand, `otherwise('/welcome')`.
 
+## Caveat: the app root
+
+`otherwise()` catches the app root too, and the root is rarely a state url of
+its own. It is tempting to reach for
+[`rules.initial`](https://ui-router.github.io/core/docs/latest/classes/_url_urlrules_.urlrules.html#initial),
+but that rule matches **only while no transition has run yet**:
+
+```ts
+// only fires on the first sync — a later sync of '' or '/' falls through
+urlService.rules.initial({ state: 'welcome' });
+```
+
+So the root works on load, then 404s the moment it is synced again. The common
+way to hit that: the root pushes a _new_ history entry when it redirects, so
+`/app` → `/app/welcome` leaves `/app` sitting in history. Pressing **Back**
+returns to `/app`, `initial` no longer matches, and `otherwise()` renders the
+404 — with an empty attempted path, since the root is the empty path.
+
+Match the empty path on every sync instead, and replace the history entry so
+the root never lingers there at all:
+
+```ts
+urlService.rules.when(/^\/?$/, () => ({
+  state: 'welcome',
+  options: { location: 'replace' },
+}));
+```
+
+`/^\/?$/` covers both `''` and `'/'`, which is what the empty path looks like
+with and without a trailing slash on the base href. `location: 'replace'` makes
+Back from `/welcome` leave the app, rather than bouncing off the root.
+
+With the [hash location plugin](https://ui-router.github.io/docs/latest/modules/vanilla.html)
+the `replace` half doesn't apply: `HashLocationService` sets `location.hash`
+directly and ignores the flag, so the root keeps its history entry. Landing on
+it again just re-resolves to welcome. That is the trade — under `hashLocation`
+the root is a redirect you cannot press Back through, but it never 404s.
+
 ## The 404 state
 
 ```ts
@@ -53,8 +91,9 @@ export const notFoundState = {
 
 The state intentionally declares **no `url`**: the unmatched URL stays in the
 address bar (like a server-rendered 404 page), and the state can only be
-activated by the rule. The view is an ordinary component that reads the
-resolved path:
+activated by the rule. Anything that reads `transition.$to().url` — an
+analytics hook, say — has to tolerate that `null`. The view is an ordinary
+component that reads the resolved path:
 
 ```ts
 export default (props: UIViewInjectedProps<NotFoundResolves>) =>
@@ -97,7 +136,7 @@ router.transitionService.onBefore(
 );
 ```
 
-With the rule, the state, and the hook in place, all three cases behave:
-plain garbage URLs render the 404 view, future-state URLs still lazy load,
-and URLs left unmatched _after_ a lazy load land on the 404 view too. The
-sample app's `not_found.cy.js` Cypress spec pins each case.
+With the rules, the state, and the hook in place, every case behaves: plain
+garbage URLs render the 404 view, the app root goes to welcome, future-state
+URLs still lazy load, and URLs left unmatched _after_ a lazy load land on the
+404 view too. The sample app's `not_found.cy.js` Cypress spec pins each case.

--- a/docs/guides/unmatched-urls.md
+++ b/docs/guides/unmatched-urls.md
@@ -64,28 +64,34 @@ urlService.rules.when(/^\/?$/, () => ({
 with and without a trailing slash on the base href. `location: 'replace'` makes
 Back from `/welcome` leave the app, rather than bouncing off the root.
 
-### Making `replace` work under the hash plugin
+### `replace` under the hash plugin
 
-`location: 'replace'` is a no-op with the stock `hashLocationPlugin`.
-`HashLocationService._set` assigns `location.hash`, which _always_ pushes an
-entry — the flag is ignored:
+`location: 'replace'` is a no-op with the stock `hashLocationPlugin`:
 
 ```ts
 // @uirouter/core
 HashLocationService.prototype._set = function (state, title, url, replace) {
-  this._location.hash = url; // `replace` never read
+  this._location.hash = url; // always pushes
 };
 ```
 
-So the root keeps its entry, Back re-enters it, the rule redirects and pushes
-again: the root becomes a Back-trap. `replaceState` writes the same hash
-without adding an entry, and the class is exported, so a three-line subclass
-fixes it:
+That is by design, not an oversight. `hashLocationPlugin` predates the
+widespread History API — assigning `location.hash` was the only way to change
+the url without a page load, and it always pushes an entry. The hash strategy
+exists _for_ browsers that lack `replaceState`, so it cannot lean on it.
+
+The consequence is that the root keeps its history entry: Back re-enters it,
+the rule redirects and pushes again, and the root becomes a Back-trap. If your
+support target does have the History API, you can opt in. `HashLocationService`
+is exported, so a subclass can write the same hash through `replaceState`, and
+fall back to the inherited behavior where it is missing:
 
 ```ts
 class ReplaceAwareHashLocationService extends HashLocationService {
   _set(state: unknown, title: string, url: string, replace: boolean) {
-    if (!replace) return super._set(state, title, url, replace);
+    if (!replace || typeof this._history.replaceState !== 'function') {
+      return super._set(state, title, url, replace);
+    }
     const { pathname, search } = this._location;
     this._history.replaceState(state, title, `${pathname}${search}#${url}`);
   }
@@ -102,8 +108,9 @@ export const replaceAwareHashLocationPlugin = locationPluginFactory(
 Reaching for `history.go(-2)` to hop over the entry instead is a trap of its
 own: neither `popstate` nor `hashchange` tells you which direction you arrived
 from, so it cannot tell Back from Forward or from a fresh load — and if the
-root is the session's first entry, it walks the user off the site. Not creating
-the entry is the fix.
+root is the session's first entry, it walks the user off the site. It also
+needs the very History API the hash strategy is there to do without. Not
+creating the entry is the better answer.
 
 ## The 404 state
 


### PR DESCRIPTION
## The bug

Navigating **Back** to the app root — `/app` or `/app-mobx`, the no-trailing-slash entry the docs site nav links to and `_headers` declares canonical — rendered the **404 page**.

Introduced by #184, which added `urlService.rules.otherwise()`.

## Why

`urlService.rules.initial()` matches only while `globals.transitionHistory.size() === 0`:

```js
// @uirouter/core/lib-esm/url/urlRules.js
var matchFn = function (urlParts, router) {
  return router.globals.transitionHistory.size() === 0 && !!/^\/?$/.exec(urlParts.path);
};
```

So on first load `/app` → path `''` → `initial` → `go('welcome')`, which **pushes** `/app/welcome` as a *new* history entry. `/app` stays in history. Press Back → popstate → `sync()` on path `''` → `initial` no longer matches → nothing else matches the empty path → `otherwise()` → `notFound`, with an empty `attemptedPath` ("No state matched the URL ``").

Before `otherwise()` existed, that same Back was a silent no-op, which is why this only appeared after the 404 work.

## The fix

Match the empty path on *every* sync instead of only the first, and replace the history entry so the root never occupies one:

```ts
urlService.rules.when(/^\/?$/, () => ({
  state: 'welcome',
  options: { location: 'replace' },
}));
```

`/^\/?$/` covers `''` and `'/'` — the empty path with and without a trailing slash on the base href.

## `replace` under the hash plugin

`location: 'replace'` is a no-op with the stock `hashLocationPlugin`:

```js
HashLocationService.prototype._set = function (state, title, url, replace) {
  this._location.hash = url; // always pushes
};
```

**This is by design, not a core defect.** `hashLocationPlugin` predates the widespread History API — assigning `location.hash` was the only way to change the url without a page load, and it always pushes. The hash strategy exists *for* browsers that lack `replaceState`, so it cannot lean on it.

The consequence is that the root kept its entry under `hashLocation`: Back re-entered it, the rule redirected and pushed again — the root became a **Back-trap** (measured: `history.length` pinned at 4, two `goBack()` calls never left `#/welcome`).

The sample app targets browsers that *do* have the History API, so it opts in. `HashLocationService` is exported, so a subclass (`replaceAwareHashLocation.ts`) writes the same hash through `replaceState` — and falls back to the inherited push when `replaceState` is absent, rather than silently assuming the API the strategy is there to do without.

Verified after: `history.length` 2 → **3** (was 4), the first Back reaches `#/login`, the second exits the app — and ordinary in-app hash navigation still pushes (+1), so this did not turn every hash nav into a replace.

`history.go(-2)` to hop over the entry was considered and rejected: neither `popstate` nor `hashchange` reports which direction you arrived from, so it can't distinguish Back from Forward or from a fresh load; if the root is the session's first entry it walks the user off the site; and it needs the same History API anyway.

## Second bug: the 404 route errored

The deployed site logged this on every 404:

```
Transition Rejection($id: 0 type: 6, message: The transition errored,
  detail: TypeError: Cannot read properties of null (reading 'format'))
```

The analytics `onSuccess` hook did `trans.$to().url.format(trans.params())`. The `notFound` state deliberately declares **no `url`**, so its `UrlMatcher` is `null` — every 404 transition was rejected as errored. Guarded, and noted in the guide.

## Verification

Reproduced and fixed with a real browser (Playwright) against the dev server, and pinned with Cypress against `wrangler dev` (which serves the actual `_redirects` rewrite: `/app` → 200, no trailing-slash redirect).

- **Before the fix:** Back rendered the 404 in **6/6** browser scenarios (`/app` and `/app/`, × pushState/navigation/direct-load).
- **After the fix:** 0/6.
- The new `does not 404 when navigating back to the app root` spec was **confirmed failing** against the pre-fix code, then passing.
- `TypeError`/`Transition Rejection` gone from the 404 route; lazy loading (`/mymessages` → login) and the happy path unaffected.

Full Cypress suite:

| suite | result |
| --- | --- |
| vanilla, pushState | 27/27 |
| vanilla, navigation | 27/27 |
| mobx, pushState | 27/27 |
| vanilla, hash | 25/27 — `not_found` 6/6 |

The two hash failures are `feature_flags_panel.cy.js`, which **fails identically on `main`** (the panel disables its selects while `?feature-location-plugin=` is in `location.search`, and the hash plugin never rewrites the query away). Pre-existing and out of scope; CI does not run hash mode.

`turbo lint typecheck format:check`: 25/25.

## Notes

- New `visitRootWithFeatures()` e2e helper — `baseUrl` carries the trailing slash, so the bare root can't be reached with a relative `cy.visit`.
- Docs guide gains an "app root" caveat section explaining the `initial()` trap and the hash `replace` opt-in.

Closes the regression from #184.