### PR TITLE
chore(docs): drop typedoc's prettier formatting options

### DIFF
--- a/apps/sample-app-lit-e2e/.prettierignore
+++ b/apps/sample-app-lit-e2e/.prettierignore
@@ -1,2 +1,0 @@
-dist
-node_modules

--- a/apps/sample-app-lit-mobx/.prettierignore
+++ b/apps/sample-app-lit-mobx/.prettierignore
@@ -1,2 +1,0 @@
-dist
-node_modules

--- a/apps/sample-app-lit-vanilla/.prettierignore
+++ b/apps/sample-app-lit-vanilla/.prettierignore
@@ -1,2 +1,0 @@
-dist
-node_modules

--- a/apps/sample-app-shared/.prettierignore
+++ b/apps/sample-app-shared/.prettierignore
@@ -1,2 +1,0 @@
-dist
-node_modules

--- a/docs/.prettierignore
+++ b/docs/.prettierignore
@@ -1,3 +1,0 @@
-dist
-node_modules
-.vitepress/cache

--- a/examples/.prettierignore
+++ b/examples/.prettierignore
@@ -1,2 +1,0 @@
-**/dist
-**/node_modules

--- a/packages/lit-ui-router-mobx/.prettierignore
+++ b/packages/lit-ui-router-mobx/.prettierignore
@@ -1,3 +1,0 @@
-dist
-node_modules
-coverage

--- a/packages/lit-ui-router-mobx/typedoc.json
+++ b/packages/lit-ui-router-mobx/typedoc.json
@@ -48,8 +48,6 @@
       "UIRouterLitElement": "/api/reference/components/UIRouterLitElement"
     }
   },
-  "formatWithPrettier": true,
-  "prettierConfigFile": "../../.prettierrc",
   "sidebar": {
     "pretty": true
   }

--- a/packages/lit-ui-router/.prettierignore
+++ b/packages/lit-ui-router/.prettierignore
@@ -1,3 +1,0 @@
-dist
-node_modules
-coverage

--- a/packages/lit-ui-router/typedoc.json
+++ b/packages/lit-ui-router/typedoc.json
@@ -71,8 +71,6 @@
       "ElementPart": "https://lit.dev/docs/api/custom-directives/#ElementPart"
     }
   },
-  "formatWithPrettier": true,
-  "prettierConfigFile": "../../.prettierrc",
   "sidebar": {
     "pretty": true
   }

--- a/packages/navigation-location-plugin/.prettierignore
+++ b/packages/navigation-location-plugin/.prettierignore
@@ -1,3 +1,0 @@
-dist
-node_modules
-coverage

--- a/packages/navigation-location-plugin/typedoc.json
+++ b/packages/navigation-location-plugin/typedoc.json
@@ -35,8 +35,6 @@
       "NavigateEvent": "https://developer.mozilla.org/en-US/docs/Web/API/NavigateEvent"
     }
   },
-  "formatWithPrettier": true,
-  "prettierConfigFile": "../../.prettierrc",
   "sidebar": {
     "pretty": true
   }

--- a/tools/typedoc-plugin-lit-ui-router/.prettierignore
+++ b/tools/typedoc-plugin-lit-ui-router/.prettierignore
@@ -1,3 +1,0 @@
-dist
-node_modules
-coverage


### PR DESCRIPTION
Removes dead prettier config from the three `typedoc.json` files. Independent of the TypeScript 7 work (#249) — this warns on `main` today.

## The noise

Every `docs:api` run, once per package:

```
[typedoc-plugin-markdown] Prettier formatting skipped as Prettier must be
installed for the `formatWithPrettier` option to work. Please npm i prettier --save-dev.
```

Prettier stopped being a dependency in #232 (migrate prettier → oxfmt), so `formatWithPrettier: true` has been a no-op ever since. Its companion `prettierConfigFile: "../../.prettierrc"` points at a file that no longer exists.

## Change

Both keys removed from `packages/lit-ui-router`, `packages/lit-ui-router-mobx`, and `packages/navigation-location-plugin`. Removed rather than set to `false`, since `false` is the plugin's default.

Generated markdown is byte-for-byte unaffected — the formatting was already being skipped, which is what the warning was telling us.

## Verification

`turbo run build` 13/13, then `docs:api` for all three packages: exit 0, **0** prettier warnings, 0 typedoc errors. Only `docs/api/index.md` is tracked and it is untouched.

## Second commit: the ten `.prettierignore` files

They were *not* inert, which is worth stating plainly: `oxfmt` reads `.gitignore` **and** `.prettierignore` by default when `--ignore-path` isn't passed, so it was still honoring them.

They're redundant rather than load-bearing. Every path they list — `dist`, `node_modules`, `coverage`, `.vitepress/cache` — is already in the root `.gitignore`, which oxfmt picks up on its own.

Checked rather than assumed: counted the files oxfmt matches in each of the ten packages, with and without the `.prettierignore` present.

| package | files before | files after |
|---|---|---|
| apps/sample-app-lit-e2e | 11 | 11 |
| apps/sample-app-lit-mobx | 14 | 14 |
| apps/sample-app-lit-vanilla | 14 | 14 |
| apps/sample-app-shared | 44 | 44 |
| docs | 24 | 24 |
| examples | 19 | 19 |
| packages/lit-ui-router | 26 | 26 |
| packages/lit-ui-router-mobx | 16 | 16 |
| packages/navigation-location-plugin | 9 | 9 |
| tools/typedoc-plugin-lit-ui-router | 8 | 8 |

Identical in all ten, all passing. `turbo run format:check` 12/12 and `turbo run lint` 25/25 after removal.

`.vscode/extensions.json` still recommends `esbenp.prettier-vscode`. Left alone — that's an editor suggestion, not build config.

