### PR TITLE
fix(tooling): typecheck docs and the sample apps

### DIFF
--- a/apps/sample-app-lit-mobx/package.json
+++ b/apps/sample-app-lit-mobx/package.json
@@ -9,7 +9,8 @@
     "dev": "vite",
     "format": "oxfmt \"**/*.{js,ts,json,md,html}\"",
     "format:check": "oxfmt --check \"**/*.{js,ts,json,md,html}\"",
-    "lint": "oxlint ."
+    "lint": "oxlint .",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
     "lit": "catalog:",

--- a/apps/sample-app-lit-vanilla/package.json
+++ b/apps/sample-app-lit-vanilla/package.json
@@ -9,7 +9,8 @@
     "dev": "vite",
     "format": "oxfmt \"**/*.{js,ts,json,md,html}\"",
     "format:check": "oxfmt --check \"**/*.{js,ts,json,md,html}\"",
-    "lint": "oxlint ."
+    "lint": "oxlint .",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
     "lit": "catalog:",

--- a/apps/sample-app-shared/package.json
+++ b/apps/sample-app-shared/package.json
@@ -10,7 +10,8 @@
   "scripts": {
     "format": "oxfmt \"**/*.{js,ts,json,md,css}\"",
     "format:check": "oxfmt --check \"**/*.{js,ts,json,md,css}\"",
-    "lint": "oxlint ."
+    "lint": "oxlint .",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
     "@api-viewer/docs": "catalog:",

--- a/docs/.vitepress/env.d.ts
+++ b/docs/.vitepress/env.d.ts
@@ -1,3 +1,5 @@
+/// <reference types="vite/client" />
+
 declare module '*.vue' {
   import type { DefineComponent } from 'vue';
   const component: DefineComponent;

--- a/docs/package.json
+++ b/docs/package.json
@@ -10,6 +10,7 @@
     "format": "oxfmt \"**/*.{md,json,ts,vue}\"",
     "format:check": "oxfmt --check \"**/*.{md,json,ts,vue}\"",
     "lint": "oxlint .",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
     "wrangler": "wrangler --config ../wrangler.jsonc",
     "wrangler:dev": "pnpm run wrangler dev"
   },


### PR DESCRIPTION
Answers "are the docs TS files typechecked?" — they were not. Independent of #249; this gap exists on `main` today.

## The gap

`turbo run ci` depends on `typecheck`, but only the three `packages/*` defined the script. Turbo happily reports `<NONEXISTENT>` for everyone else and moves on:

```
docs                -> <NONEXISTENT>
sample-app-shared   -> <NONEXISTENT>
dts-backtest        -> <NONEXISTENT>
```

So nothing compiled `docs/.vitepress/*.ts` (4 files) or `apps/sample-app-shared/**/*.ts` (34 files). `vitepress build` only transpiles, and `sample-app-shared` has no build step at all. Your editor loads `docs/tsconfig.json` and was the sole thing typechecking it — hence errors visible in the editor and nowhere else.

## The one real error

```
.vitepress/theme/index.ts:3:8 - error TS2882: Cannot find module or type
declarations for side-effect import of './custom.css'.
```

**Not a TypeScript 7 regression** — 6.0.3 reports it identically. vite ships `declare module '*.css' {}` in its ambient client types, and `docs` already has `vite` as a devDependency, so `.vitepress/env.d.ts` now carries `/// <reference types="vite/client" />`.

## Change

`typecheck` added to `docs`, `sample-app-shared`, `sample-app-lit-vanilla`, `sample-app-lit-mobx`. The latter three already typechecked clean — they were never asked. (`sample-app-lit-vanilla`/`-mobx` were covered indirectly by `vite-plugin-checker` during `vite build`; now they're checked directly too, so a type error fails without a full build.)

Already covered, left alone: `sample-app-lit-e2e` and `typedoc-plugin-lit-ui-router` (their `build` is `tsc`), `packages/*` (had it), and `dts-backtest` (its fixtures are checked by every leg of `run.mjs`).

## Verification

- `turbo run typecheck`: **3 → 19 tasks**, all pass
- `turbo run format:check`: 12/12 (oxfmt's `sortPackageJson` is happy with the edited manifests)
- Mutation-tested, so the new tasks aren't decorative: planting `const __probe: number = "not a number"` in `docs/.vitepress/config.ts` turns the run red with `TS2322` and exit 2. Reverted; green again.
