### PR TITLE
fix(ci): order docs#typecheck after the typedoc sidebars it reads

### DIFF
--- a/docs/turbo.json
+++ b/docs/turbo.json
@@ -20,6 +20,9 @@
       "dependsOn": ["^build", "^docs:api", "examples#build:embeds"],
       "env": ["VITE_GOOGLE_ANALYTICS_TRACKING_ID"]
     },
+    "typecheck": {
+      "dependsOn": ["^build", "^docs:api"]
+    },
     "docs": {
       "dependsOn": ["^build", "^docs:api", "examples#build:embeds"],
       "cache": false,


### PR DESCRIPTION
Regression from #255. Independent of the TypeScript 7 work.

## The race

`docs/.vitepress/config.ts` imports `api/*/typedoc-sidebar.json`. Those files are generated by `docs:api` and excluded by `docs/.gitignore`.

`docs/turbo.json` already orders the docs build after them:

```json
"build": { "dependsOn": ["^build", "^docs:api", "examples#build:embeds"] }
```

But `typecheck` had no override, so it fell through to the root definition — `dependsOn: ["^build"]`. Nothing sequenced `docs#typecheck` after the files it reads.

It has been passing by luck: `turbo run ci` depends on both `build` and `typecheck`, and `docs#build` *does* wait for `docs:api`, leaving the sidebars on disk as a side effect. Nothing orders the two relative to each other, so a schedule that starts `docs#typecheck` first fails. On a clean checkout it fails deterministically:

```
$ rm -rf docs/api/{reference,lit-ui-router-mobx,navigation-location-plugin}
$ turbo run typecheck --force
docs:typecheck: .vitepress/config.ts:5:34 - error TS2307: Cannot find module
  '../api/lit-ui-router-mobx/typedoc-sidebar.json' or its corresponding type declarations.
Failed: docs#typecheck
```

## Fix

Give `docs#typecheck` the same `^docs:api` edge the docs build already has.

```json
"typecheck": { "dependsOn": ["^build", "^docs:api"] }
```

`docs` depends on the two sample apps, which have no `docs:api` script; turbo resolves through those to `lit-ui-router#docs:api` and friends, exactly as it already does for `docs#build`.

## Verification

Same reproduction, after the fix — `typecheck` alone, from a wiped tree, with no prior `build`:

```
turbo run typecheck --force
 Tasks:    19 successful, 19 total
```

Sidebars generated (3), `TS2307` count 0. `turbo run format:check --filter=docs` green.
