### PR TITLE
feat(docs): typecheck the Vue SFCs with vue-tsc

### DIFF
--- a/docs/.vitepress/theme/components/ExampleEmbed.vue
+++ b/docs/.vitepress/theme/components/ExampleEmbed.vue
@@ -30,7 +30,8 @@ const handleFullscreenChange = () => {
 
 const iframe = useTemplateRef('iframe');
 function restartIframe() {
-  iframe.value.src += '';
+  const el = iframe.value;
+  if (el) el.src += '';
 }
 
 async function loadIcons() {

--- a/docs/.vitepress/theme/components/StackBlitzEmbed.vue
+++ b/docs/.vitepress/theme/components/StackBlitzEmbed.vue
@@ -24,7 +24,8 @@ const handleFullscreenChange = () => {
 
 const iframe = useTemplateRef('iframe');
 function refreshIframe() {
-  iframe.value.src += '';
+  const el = iframe.value;
+  if (el) el.src += '';
 }
 
 async function loadIcons() {

--- a/docs/package.json
+++ b/docs/package.json
@@ -11,6 +11,7 @@
     "format:check": "oxfmt --check \"**/*.{md,json,ts,vue}\"",
     "lint": "oxlint .",
     "typecheck": "tsc -p tsconfig.json --noEmit",
+    "typecheck:vue": "vue-check docs/tsconfig.vue.json",
     "wrangler": "wrangler --config ../wrangler.jsonc",
     "wrangler:dev": "pnpm run wrangler dev"
   },
@@ -27,6 +28,7 @@
     "vite": "catalog:",
     "vite-plugin-static-copy": "catalog:vitepress1",
     "vitepress": "^1.6.4",
+    "vue-check": "workspace:*",
     "wrangler": "catalog:"
   }
 }

--- a/docs/tsconfig.vue.json
+++ b/docs/tsconfig.vue.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [".vitepress/env.d.ts", ".vitepress/theme/components/*.vue"]
+}

--- a/docs/turbo.json
+++ b/docs/turbo.json
@@ -21,12 +21,22 @@
       "env": ["VITE_GOOGLE_ANALYTICS_TRACKING_ID"]
     },
     "typecheck": {
-      "dependsOn": ["^build", "^docs:api"]
+      "dependsOn": ["^build", "^docs:api"],
+      "with": ["typecheck:vue"]
     },
     "docs": {
       "dependsOn": ["^build", "^docs:api", "examples#build:embeds"],
       "cache": false,
       "persistent": true
+    },
+    "typecheck:vue": {
+      "dependsOn": ["^build"],
+      "inputs": [
+        ".vitepress/env.d.ts",
+        ".vitepress/theme/components/*.vue",
+        "tsconfig.json",
+        "tsconfig.vue.json"
+      ]
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -251,7 +251,7 @@ importers:
         version: 8.1.3(@types/node@25.0.9)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)
       vite-plugin-checker:
         specifier: 'catalog:'
-        version: 0.14.4(@typescript/typescript6@6.0.2)(eslint@10.6.0(jiti@2.7.0))(optionator@0.9.4)(oxlint@1.73.0(oxlint-tsgolint@0.24.0))(vite@8.1.3(@types/node@25.0.9)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 0.14.4(@typescript/typescript6@6.0.2)(eslint@10.6.0(jiti@2.7.0))(optionator@0.9.4)(oxlint@1.73.0(oxlint-tsgolint@0.24.0))(vite@8.1.3(@types/node@25.0.9)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(vue-tsc@3.3.7(@typescript/typescript6@6.0.2))
       vite-plugin-static-copy:
         specifier: 'catalog:'
         version: 4.1.1(vite@8.1.3(@types/node@25.0.9)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
@@ -291,7 +291,7 @@ importers:
         version: 8.1.3(@types/node@25.0.9)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)
       vite-plugin-checker:
         specifier: 'catalog:'
-        version: 0.14.4(@typescript/typescript6@6.0.2)(eslint@10.6.0(jiti@2.7.0))(optionator@0.9.4)(oxlint@1.73.0(oxlint-tsgolint@0.24.0))(vite@8.1.3(@types/node@25.0.9)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 0.14.4(@typescript/typescript6@6.0.2)(eslint@10.6.0(jiti@2.7.0))(optionator@0.9.4)(oxlint@1.73.0(oxlint-tsgolint@0.24.0))(vite@8.1.3(@types/node@25.0.9)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(vue-tsc@3.3.7(@typescript/typescript6@6.0.2))
       vite-plugin-static-copy:
         specifier: 'catalog:'
         version: 4.1.1(vite@8.1.3(@types/node@25.0.9)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
@@ -381,6 +381,9 @@ importers:
       vitepress:
         specifier: ^1.6.4
         version: 1.6.4(@algolia/client-search@5.55.1)(@types/node@25.0.9)(axios@1.18.1)(change-case@5.4.4)(jiti@2.7.0)(lightningcss@1.32.0)(postcss@8.5.16)(search-insights@2.17.3)(typescript@7.0.2)(yaml@2.9.0)
+      vue-check:
+        specifier: workspace:*
+        version: link:../tools/vue-check
       wrangler:
         specifier: 'catalog:'
         version: 4.107.0
@@ -579,6 +582,15 @@ importers:
       typescript:
         specifier: catalog:typescript6-compat
         version: '@typescript/typescript6@6.0.2'
+
+  tools/vue-check:
+    devDependencies:
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vue-tsc:
+        specifier: ^3.3.7
+        version: 3.3.7(typescript@6.0.3)
 
 packages:
 
@@ -2514,6 +2526,15 @@ packages:
   '@vitest/utils@4.1.10':
     resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
 
+  '@volar/language-core@2.4.28':
+    resolution: {integrity: sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ==}
+
+  '@volar/source-map@2.4.28':
+    resolution: {integrity: sha512-yX2BDBqJkRXfKw8my8VarTyjv48QwxdJtvRgUpNE5erCsgEUdI2DsLbpa+rOQVAJYshY99szEcRDmyHbF10ggQ==}
+
+  '@volar/typescript@2.4.28':
+    resolution: {integrity: sha512-Ja6yvWrbis2QtN4ClAKreeUZPVYMARDYZl9LMEv1iQ1QdepB6wn0jTRxA9MftYmYa4DQ4k/DaSZpFPUfxl8giw==}
+
   '@vue/compiler-core@3.5.39':
     resolution: {integrity: sha512-16KBTEXAJCpDr0mwlw+AZyhu8iyC7R3S2vBwsI7QnWJU6X3WKc9VKeNEZpiMdZ569qWhz9574L3vV55qRL0Vtw==}
 
@@ -2534,6 +2555,9 @@ packages:
 
   '@vue/devtools-shared@7.7.10':
     resolution: {integrity: sha512-wOPslzB8vTvpxwdaOcR2qAbwmuSP0L+rhpoC6Cf56V3Jip+HWb7PQQXOUPgBNQARpXsbQX/+mvi8kKucmBGRwQ==}
+
+  '@vue/language-core@3.3.7':
+    resolution: {integrity: sha512-LzmkKinXAMMoh8Jfi/jMUSDUjuPdv8mynH5WJGKfXyZtDw3hQ6GBaoI6Bcnl/Xqlu32q/0Z6i/trp4VXykzyLw==}
 
   '@vue/reactivity@3.5.39':
     resolution: {integrity: sha512-TpsuBJ9gGlZa5d23XcM2y8EXanz9dZeVDQBXRwzy46ItgvM+rWpzs+UVM0wcRLxGvcav0HE5jz2gNL53xlRAog==}
@@ -2684,6 +2708,9 @@ packages:
   algoliasearch@5.55.1:
     resolution: {integrity: sha512-FyaFnnsbVPtevQwqSj/SdxE3jAsSsY0BEH8IVLf9rXxEBdAhAmT6VKCVSMWoaPIHVN1Eufh/1w8q6k8URpIkWw==}
     engines: {node: '>= 14.0.0'}
+
+  alien-signals@3.2.1:
+    resolution: {integrity: sha512-I8FjmltrfnDFoZedi5CG8DghVYNhzb/Ijluz7tCSJH0xpd0484Kowhbb1XDYOxfJpU1p5wnM2X54dA+IfGyD1g==}
 
   ansi-escapes@7.3.0:
     resolution: {integrity: sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==}
@@ -4038,6 +4065,9 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
+  muggle-string@0.4.1:
+    resolution: {integrity: sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==}
+
   mute-stream@3.0.0:
     resolution: {integrity: sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==}
     engines: {node: ^20.17.0 || >=22.9.0}
@@ -4206,6 +4236,9 @@ packages:
   parse-url@9.2.0:
     resolution: {integrity: sha512-bCgsFI+GeGWPAvAiUv63ZorMeif3/U0zaXABGJbOWt5OH2KCaPHF6S+0ok4aqM9RuIPGyZdx9tR9l13PsW4AYQ==}
     engines: {node: '>=14.13.0'}
+
+  path-browserify@1.0.1:
+    resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
 
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
@@ -5052,6 +5085,15 @@ packages:
         optional: true
       jsdom:
         optional: true
+
+  vscode-uri@3.1.0:
+    resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
+
+  vue-tsc@3.3.7:
+    resolution: {integrity: sha512-+C+rgD49wAQ5bUTl2sp5a8Bzg4YoldMNXM+g7CFe604MYcQ8PrZPMQhIjJSzKXtPBCa+C5ayMipqjbA7splekQ==}
+    hasBin: true
+    peerDependencies:
+      typescript: '>=5.0.0'
 
   vue@3.5.39:
     resolution: {integrity: sha512-xmZCYabFGcirU8r0fTuvl/LICc1OU620rnqepaJDL/a141ZigkG7AyaxQLdqJ02ZRYzWe6YPaDHeQx7MfknQfA==}
@@ -6785,6 +6827,18 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
+  '@volar/language-core@2.4.28':
+    dependencies:
+      '@volar/source-map': 2.4.28
+
+  '@volar/source-map@2.4.28': {}
+
+  '@volar/typescript@2.4.28':
+    dependencies:
+      '@volar/language-core': 2.4.28
+      path-browserify: 1.0.1
+      vscode-uri: 3.1.0
+
   '@vue/compiler-core@3.5.39':
     dependencies:
       '@babel/parser': 7.29.7
@@ -6832,6 +6886,16 @@ snapshots:
   '@vue/devtools-shared@7.7.10':
     dependencies:
       rfdc: 1.4.1
+
+  '@vue/language-core@3.3.7':
+    dependencies:
+      '@volar/language-core': 2.4.28
+      '@vue/compiler-dom': 3.5.39
+      '@vue/shared': 3.5.39
+      alien-signals: 3.2.1
+      muggle-string: 0.4.1
+      path-browserify: 1.0.1
+      picomatch: 4.0.5
 
   '@vue/reactivity@3.5.39':
     dependencies:
@@ -6954,6 +7018,8 @@ snapshots:
       '@algolia/requester-browser-xhr': 5.55.1
       '@algolia/requester-fetch': 5.55.1
       '@algolia/requester-node-http': 5.55.1
+
+  alien-signals@3.2.1: {}
 
   ansi-escapes@7.3.0:
     dependencies:
@@ -8355,6 +8421,8 @@ snapshots:
 
   ms@2.1.3: {}
 
+  muggle-string@0.4.1: {}
+
   mute-stream@3.0.0: {}
 
   nanoid@3.3.15: {}
@@ -8590,6 +8658,8 @@ snapshots:
     dependencies:
       '@types/parse-path': 7.1.0
       parse-path: 7.1.0
+
+  path-browserify@1.0.1: {}
 
   path-exists@4.0.0: {}
 
@@ -9318,7 +9388,7 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite-plugin-checker@0.14.4(@typescript/typescript6@6.0.2)(eslint@10.6.0(jiti@2.7.0))(optionator@0.9.4)(oxlint@1.73.0(oxlint-tsgolint@0.24.0))(vite@8.1.3(@types/node@25.0.9)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)):
+  vite-plugin-checker@0.14.4(@typescript/typescript6@6.0.2)(eslint@10.6.0(jiti@2.7.0))(optionator@0.9.4)(oxlint@1.73.0(oxlint-tsgolint@0.24.0))(vite@8.1.3(@types/node@25.0.9)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(vue-tsc@3.3.7(@typescript/typescript6@6.0.2)):
     dependencies:
       '@babel/code-frame': 7.29.7
       chokidar: 5.0.0
@@ -9333,6 +9403,7 @@ snapshots:
       optionator: 0.9.4
       oxlint: 1.73.0(oxlint-tsgolint@0.24.0)
       typescript: '@typescript/typescript6@6.0.2'
+      vue-tsc: 3.3.7(@typescript/typescript6@6.0.2)
 
   vite-plugin-static-copy@3.4.0(vite@8.1.3(@types/node@25.0.9)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)):
     dependencies:
@@ -9459,6 +9530,21 @@ snapshots:
       '@vitest/coverage-v8': 4.1.10(@vitest/browser@4.1.10)(vitest@4.1.10)
     transitivePeerDependencies:
       - msw
+
+  vscode-uri@3.1.0: {}
+
+  vue-tsc@3.3.7(@typescript/typescript6@6.0.2):
+    dependencies:
+      '@volar/typescript': 2.4.28
+      '@vue/language-core': 3.3.7
+      typescript: '@typescript/typescript6@6.0.2'
+    optional: true
+
+  vue-tsc@3.3.7(typescript@6.0.3):
+    dependencies:
+      '@volar/typescript': 2.4.28
+      '@vue/language-core': 3.3.7
+      typescript: 6.0.3
 
   vue@3.5.39(typescript@7.0.2):
     dependencies:

--- a/scripts/check-catalog.mjs
+++ b/scripts/check-catalog.mjs
@@ -12,21 +12,16 @@
 // ./workspace.mjs, then delegates all decisions to the pure, unit-tested
 // functions in ./check-catalog.core.mjs.
 
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
-
 import {
   catalogDepNames,
   collectInlineUsage,
   findViolations,
   formatReport,
 } from './check-catalog.core.mjs';
-import { loadWorkspace } from './workspace.mjs';
-
-const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+import { loadWorkspace, workspaceRoot } from './workspace.mjs';
 
 async function main() {
-  const { members, workspaceManifest } = await loadWorkspace(ROOT);
+  const { members, workspaceManifest } = await loadWorkspace(workspaceRoot);
   const violations = findViolations(collectInlineUsage(members));
   const { ok, text } = formatReport(violations, {
     memberCount: members.length,

--- a/scripts/check-pack.mjs
+++ b/scripts/check-pack.mjs
@@ -13,15 +13,13 @@
 import { execFile } from 'node:child_process';
 import { mkdtemp, readdir, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { join } from 'node:path';
 import { promisify } from 'node:util';
 
 import { findUnsubstitutedRefs, formatReport } from './check-pack.core.mjs';
-import { loadWorkspace } from './workspace.mjs';
+import { loadWorkspace, workspaceRoot } from './workspace.mjs';
 
 const run = promisify(execFile);
-const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 
 /** `pnpm pack` in `cwd`; falls back to corepack when pnpm is not on PATH. */
 async function pnpmPack(cwd, destination) {
@@ -54,7 +52,7 @@ async function packedManifest(packageDir) {
 }
 
 async function main() {
-  const { members } = await loadWorkspace(ROOT);
+  const { members } = await loadWorkspace(workspaceRoot);
   const publishable = members.filter(
     (member) =>
       member.dir !== '<root>' &&
@@ -63,7 +61,7 @@ async function main() {
   );
   const results = [];
   for (const { name, dir } of publishable) {
-    const manifest = await packedManifest(join(ROOT, dir));
+    const manifest = await packedManifest(join(workspaceRoot, dir));
     results.push({ name, dir, refs: findUnsubstitutedRefs(manifest) });
   }
   const { ok, text } = formatReport(results);

--- a/scripts/workspace.mjs
+++ b/scripts/workspace.mjs
@@ -1,4 +1,4 @@
-// Shared workspace enumeration for the check:* scripts, via the pnpm SDK.
+// Shared workspace root and enumeration for the check:* scripts and tools.
 //
 // Why the SDK (not the lockfile, not hand-parsed YAML): pnpm-lock.yaml has
 // already resolved `catalog:` refs to concrete versions, so it can't distinguish
@@ -6,13 +6,26 @@
 // `findPackages` is pnpm's own workspace resolver, so we inherit its glob
 // handling, including that the standalone tutorials under examples/* are NOT
 // members (the glob is `examples`, not `examples/*`).
+//
+// The SDK is imported lazily so that `workspaceRoot` costs nothing to import:
+// consumers that only need the path don't load ~60ms of pnpm internals, and
+// don't depend on the root's devDependencies being installed.
 
-import { findPackages } from '@pnpm/fs.find-packages';
-import { readWorkspaceManifest } from '@pnpm/workspace.read-manifest';
-import { relative } from 'node:path';
+import { dirname, join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/** Absolute path to the workspace root. This file lives in <root>/scripts. */
+export const workspaceRoot = join(
+  dirname(fileURLToPath(import.meta.url)),
+  '..',
+);
 
 /** Enumerate workspace members (incl. root) and the parsed workspace manifest. */
 export async function loadWorkspace(root) {
+  const [{ findPackages }, { readWorkspaceManifest }] = await Promise.all([
+    import('@pnpm/fs.find-packages'),
+    import('@pnpm/workspace.read-manifest'),
+  ]);
   const workspaceManifest = await readWorkspaceManifest(root);
   const projects = await findPackages(root, {
     patterns: workspaceManifest?.packages,

--- a/tools/vue-check/bin.mjs
+++ b/tools/vue-check/bin.mjs
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+// Runs vue-tsc over a workspace package's Vue SFCs.
+//
+// vue-tsc embeds the compiler through @volar/typescript, so it needs a real
+// TypeScript 6: TS 7 exposes no `typescript/lib/tsc` subpath, and the
+// @typescript/typescript6 compat package re-exports it (`require("@typescript/
+// old/lib/tsc.js")`) rather than providing the file Volar's shim resolves.
+// Owning that dependency here keeps callers on the TS 7 catalog, so their
+// .ts files are still checked by the native compiler.
+//
+// Usage: vue-check <project> [...vue-tsc args]
+//   <project> resolves from the workspace root, and is either a tsconfig file
+//   or a directory containing tsconfig.json.
+
+import { spawnSync } from 'node:child_process';
+import { existsSync, statSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { dirname, join, resolve } from 'node:path';
+
+import { workspaceRoot } from '../../scripts/workspace.mjs';
+
+const require = createRequire(import.meta.url);
+
+function fail(message) {
+  console.error(`vue-check: ${message}`);
+  console.error('usage: vue-check <project> [...vue-tsc args]');
+  process.exit(2);
+}
+
+const [projectArg, ...forwarded] = process.argv.slice(2);
+if (!projectArg) fail('missing <project>');
+
+const project = resolve(workspaceRoot, projectArg);
+if (!existsSync(project)) fail(`no such project: ${projectArg}`);
+const projectDir = statSync(project).isDirectory() ? project : dirname(project);
+
+const vueTscDir = dirname(require.resolve('vue-tsc/package.json'));
+const { bin } = require(join(vueTscDir, 'package.json'));
+const vueTsc = join(vueTscDir, typeof bin === 'string' ? bin : bin['vue-tsc']);
+
+const result = spawnSync(
+  process.execPath,
+  [vueTsc, '--noEmit', '-p', project, ...forwarded],
+  { cwd: projectDir, stdio: 'inherit' },
+);
+
+if (result.error) throw result.error;
+process.exit(result.status ?? 1);

--- a/tools/vue-check/package.json
+++ b/tools/vue-check/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "vue-check",
+  "version": "0.0.1",
+  "private": true,
+  "description": "Typechecks a workspace package's Vue SFCs with vue-tsc, which embeds the TypeScript 6 API",
+  "bin": {
+    "vue-check": "./bin.mjs"
+  },
+  "type": "module",
+  "scripts": {
+    "format": "oxfmt \"**/*.{ts,js,mjs,json,md}\"",
+    "format:check": "oxfmt --check \"**/*.{ts,js,mjs,json,md}\"",
+    "lint": "oxlint ."
+  },
+  "devDependencies": {
+    "typescript": "^6.0.3",
+    "vue-tsc": "^3.3.7"
+  }
+}


### PR DESCRIPTION
Follows #249, now merged. Rebased onto `main`; this PR is a single commit.

## The gap

`docs/.vitepress/theme/components/{ExampleEmbed,StackBlitzEmbed}.vue` were compiled by nothing. `vitepress build` only transpiles, and `tsc` ignores `.vue` outright — `--listFiles` loads **zero** of them. They reached the rest of the docs through the `declare module '*.vue'` shim in `env.d.ts`, typed as a bare `DefineComponent`, so even their props went unchecked.

vue-tsc immediately found two real errors that had been sitting there:

```
ExampleEmbed.vue:33:3    - error TS18047: 'iframe.value' is possibly 'null'.
StackBlitzEmbed.vue:27:3 - error TS18047: 'iframe.value' is possibly 'null'.
```

Both fixed here.

## Why a separate package

vue-tsc embeds the compiler through `@volar/typescript`, so it needs a real TypeScript 6. Two things that look like they'd work, don't:

| attempt | result |
|---|---|
| vue-tsc on TS 7 | installs fine (peer is `>=5.0.0`), then `ERR_PACKAGE_PATH_NOT_EXPORTED: './lib/tsc'` at runtime |
| vue-tsc on `catalog:typescript6-compat` | `Error: Failed to locate tsc module path from shim` |

The compat package's `lib/tsc.js` is a one-line re-export — `require("@typescript/old/lib/tsc.js")` — and Volar's shim resolves that subpath as a *file*, not a module. typedoc, vite-plugin-checker and Cypress's ts-loader all reach the compat package through its `main`, which is why they work and this doesn't.

So `tools/vue-check` owns a real `typescript@^6.0.3` and a `vue-tsc`, and exposes a `vue-check` bin that takes the project to check as a workspace-root-relative path. `docs` keeps `typescript: catalog:` — **its `.ts` files are still checked by native TS 7.** `check:catalog` is satisfied because only one package declares those ranges inline.

The root it resolves against comes from `scripts/workspace.mjs`, which now exports `workspaceRoot` instead of leaving `check-catalog` and `check-pack` to recompute the same `join(dirname(fileURLToPath(import.meta.url)), '..')` each. Its pnpm SDK imports moved inside `loadWorkspace`, so importing the path is free — `vue-check` doesn't load ~60ms of pnpm internals, or depend on the root's devDependencies being installed, just to resolve a directory. `test:root` (26 tests), `check:catalog` and `check:pack` all still pass.

## Not paying for it twice

`tsconfig.vue.json` narrows the vue program to `env.d.ts` + the two SFCs: **123 files instead of 496**. It doesn't even load `config.ts` or `theme/index.ts`, so the `.ts` are compiled once, by TS 7 — not twice.

`docs#typecheck` pulls `typecheck:vue` along with `with`, so they run concurrently instead of in sequence, the same way `test` and `lint` already bring in their root siblings.

```json
"typecheck":     { "dependsOn": ["^build", "^docs:api"], "with": ["typecheck:vue"] },
"typecheck:vue": { "dependsOn": ["^build"], "inputs": [...] }
```

`typecheck:vue` needs no `^docs:api` — the generated sidebars are imported by `config.ts`, which its program excludes.

## Cost

Median wall-clock, same code, same tsconfig, only the compiler swapped:

| what | compiler | files | median |
|---|---|---|---|
| docs `.ts` | TS 7 native | 449 | **154 ms** |
| docs `.ts` | TS 6 | 449 | 978 ms |
| docs everything | vue-tsc (TS 6) | 496 | 1181 ms |
| docs `.vue` only | vue-tsc (TS 6) | **123** | **703 ms** |

No TS 7 speed is given up on the `.ts`. The `.vue` coverage costs ~0.7 s in a task that runs concurrently with the rest.

## Verification

- `turbo run typecheck` — 19 → **20 tasks**, all pass
- `turbo run build` 13/13, `turbo run lint` 26/26, `format:check` 13/13, `check:catalog` and `check:pack` pass
- Mutation-tested both halves: a planted `TS2322` in a `.vue` fails `typecheck:vue` (exit 2), while native `tsc` on `docs/tsconfig.json` stays at exit 0 with 0 errors — confirming TS 7 is genuinely blind to `.vue` and the vue task is what catches it.

## Follow-up

When Volar adopts TS 7.1's API, `tools/vue-check` goes away and `docs` runs `vue-tsc` directly off the bare catalog.



