### PR TITLE
chore(deps): drop the release-age exclusions now TypeScript 7.0.2 has aged

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -77,26 +77,3 @@ patchedDependencies:
   lit-dialog: patches/lit-dialog.patch
 
 minimumReleaseAgeStrict: true
-
-minimumReleaseAgeExclude:
-  - '@typescript/typescript-aix-ppc64@7.0.2'
-  - '@typescript/typescript-darwin-arm64@7.0.2'
-  - '@typescript/typescript-darwin-x64@7.0.2'
-  - '@typescript/typescript-freebsd-arm64@7.0.2'
-  - '@typescript/typescript-freebsd-x64@7.0.2'
-  - '@typescript/typescript-linux-arm64@7.0.2'
-  - '@typescript/typescript-linux-arm@7.0.2'
-  - '@typescript/typescript-linux-loong64@7.0.2'
-  - '@typescript/typescript-linux-mips64el@7.0.2'
-  - '@typescript/typescript-linux-ppc64@7.0.2'
-  - '@typescript/typescript-linux-riscv64@7.0.2'
-  - '@typescript/typescript-linux-s390x@7.0.2'
-  - '@typescript/typescript-linux-x64@7.0.2'
-  - '@typescript/typescript-netbsd-arm64@7.0.2'
-  - '@typescript/typescript-netbsd-x64@7.0.2'
-  - '@typescript/typescript-openbsd-arm64@7.0.2'
-  - '@typescript/typescript-openbsd-x64@7.0.2'
-  - '@typescript/typescript-sunos-x64@7.0.2'
-  - '@typescript/typescript-win32-arm64@7.0.2'
-  - '@typescript/typescript-win32-x64@7.0.2'
-  - typescript@7.0.2


### PR DESCRIPTION
Follows #249, now merged. Rebased onto `main`. Housekeeping: the release-age exclusions that PR needed are now obsolete.

## Why they existed

pnpm wrote them, not a human. pnpm 11 defaults `minimumReleaseAge` to 1440 minutes, and when that default is *inherited* rather than set explicitly it records an exception and installs anyway:

```
Added 21 entries to minimumReleaseAgeExclude in pnpm-workspace.yaml
 (set minimumReleaseAgeStrict to true to gate these updates with a prompt)
```

TypeScript 7.0.2 was hours old when #249 opened, and the gate applies to `pnpm install --frozen-lockfile` too — so those 21 entries were what kept CI green.

## Why they can go

| package | published | age |
|---|---|---|
| `typescript@7.0.2` | 2026-07-08T15:55Z | ~24.5h |
| 20 × `@typescript/typescript-*@7.0.2` | 2026-07-08T15:49–15:51Z | ~24.6h |

All past the 1440-minute window, so the entries are inert no-ops.

## Verification

- `pnpm install --frozen-lockfile` (how CI installs) — exit 0 with the block removed ✅
- forced re-resolution (`--lockfile-only --force`) — exit 0, does **not** re-add the block, leaves `pnpm-lock.yaml` byte-identical ✅
- the diff is one file, 23 deletions; no lockfile churn ✅

## The gate is still live

Green here means "aged past the window", not "gate disabled". Re-running the same resolution with the window raised past the release date fails loudly:

```
$ pnpm install --lockfile-only --force --config.minimumReleaseAge=100000
ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION  332 lockfile entries failed verification
```

`minimumReleaseAgeStrict: true` stays, so the next too-fresh dependency errors out instead of quietly earning itself an exception.

