### PR TITLE
chore(ci): drop vitest-coverage-report-action

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,5 +1,5 @@
 # CI pipeline for pull requests and branch/main pushes.
-# Runs build, tests (Vitest + Playwright + Cypress), and coverage reporting.
+# Runs build, tests (Vitest + Playwright + Cypress), and Codecov upload.
 name: Build and Test
 
 on:
@@ -37,7 +37,6 @@ jobs:
     timeout-minutes: 30
     permissions:
       contents: read
-      pull-requests: write # Required for PR coverage comments
 
     steps:
       - name: 'Checkout code'
@@ -77,16 +76,6 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
           # Silence per-request [wrangler:info] logging from the e2e dev server.
           WRANGLER_LOG: warn
-      - name: lit-ui-router Vitest Coverage Report
-        uses: davelosert/vitest-coverage-report-action@v2
-        if: github.event_name == 'pull_request'
-        with:
-          working-directory: packages/lit-ui-router
-      - name: ui-router-navigation-location-plugin Vitest Coverage Report
-        uses: davelosert/vitest-coverage-report-action@v2
-        if: github.event_name == 'pull_request'
-        with:
-          working-directory: packages/navigation-location-plugin
       - name: Upload to Codecov
         # Branch-head runs skip upload; merge-head/main covers the same SHA.
         if: ${{ github.event_name != 'push' || github.ref == 'refs/heads/main' }}

--- a/packages/lit-ui-router-mobx/vitest.config.ts
+++ b/packages/lit-ui-router-mobx/vitest.config.ts
@@ -20,7 +20,7 @@ export default defineConfig({
     // hanging-process logs the open handles in CI
     reporters: process.env.CI ? ['default', 'hanging-process'] : ['default'],
     coverage: {
-      reporter: ['text', 'json', 'json-summary', 'lcov'],
+      reporter: ['text', 'json', 'lcov'],
       reportsDirectory: './coverage',
       exclude: ['src/specs/**'],
     },

--- a/packages/lit-ui-router/vitest.config.ts
+++ b/packages/lit-ui-router/vitest.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
     // hanging-process logs the open handles in CI
     reporters: process.env.CI ? ['default', 'hanging-process'] : ['default'],
     coverage: {
-      reporter: ['text', 'json', 'json-summary', 'lcov', 'html'],
+      reporter: ['text', 'json', 'lcov', 'html'],
       reportsDirectory: './coverage',
       exclude: ['src/specs/**'],
     },

--- a/packages/navigation-location-plugin/vitest.config.ts
+++ b/packages/navigation-location-plugin/vitest.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
     // hanging-process logs the open handles in CI
     reporters: process.env.CI ? ['default', 'hanging-process'] : ['default'],
     coverage: {
-      reporter: ['text', 'json', 'json-summary', 'lcov'],
+      reporter: ['text', 'json', 'lcov'],
       reportsDirectory: './coverage',
       exclude: ['src/specs/**'],
     },


### PR DESCRIPTION
The two `davelosert/vitest-coverage-report-action` steps posted a PR comment per package on every run. The comments were noisy relative to what they told us, and they never covered `lit-ui-router-mobx` — only `lit-ui-router` and `navigation-location-plugin` were wired up. Codecov already uploads all three packages and reports on the PR.

Two things existed only to feed that action, so they go too:

- **`pull-requests: write` on the job.** `codecov-action` authenticates with `CODECOV_TOKEN` rather than the workflow token, and nothing else in the workflow writes to a PR, so the job drops to `contents: read`.
- **The `json-summary` coverage reporter** in all three vitest configs. Nothing else in the repo reads `coverage-summary.json`. `lcov` and `json` remain for Codecov; `lit-ui-router` keeps `html` for local browsing.

Coverage reporting itself is unchanged — the Codecov upload step still runs and still lists all three packages.

`actionlint` is clean on the resulting workflow. The check on this PR is that Codecov still comments and the two per-package coverage comments do not appear.