### PR TITLE
ci(tooling): typecheck the tooling scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
     "lint:package-json": "eslint --format tap \"**/package.json\"",
     "lint:root": "oxlint --ignore-pattern apps --ignore-pattern tools --ignore-pattern docs --ignore-pattern packages --ignore-pattern examples .",
     "test:coverage": "turbo run test:coverage",
-    "test:root": "node --test \"scripts/**/*.test.ts\""
+    "test:root": "node --test \"scripts/**/*.test.ts\"",
+    "typecheck": "turbo run typecheck",
+    "typecheck:root": "tsc -p tsconfig.json --noEmit"
   },
   "devDependencies": {
     "@codecov/bundle-analyzer": "catalog:",

--- a/turbo.json
+++ b/turbo.json
@@ -44,7 +44,18 @@
     },
     "typecheck": {
       "dependsOn": ["^build"],
-      "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/tsconfig.base.json"]
+      "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/tsconfig.base.json"],
+      "with": ["//#typecheck:root"]
+    },
+    "//#typecheck:root": {
+      "inputs": [
+        "scripts/**/*.ts",
+        "examples/build-embeds.ts",
+        "tools/dts-backtest/run.ts",
+        "tools/vue-check/bin.ts",
+        "tsconfig.json",
+        "tsconfig.base.json"
+      ]
     },
     "ci": {
       "dependsOn": [

--- a/turbo.json
+++ b/turbo.json
@@ -48,14 +48,7 @@
       "with": ["//#typecheck:root"]
     },
     "//#typecheck:root": {
-      "inputs": [
-        "scripts/**/*.ts",
-        "examples/build-embeds.ts",
-        "tools/dts-backtest/run.ts",
-        "tools/vue-check/bin.ts",
-        "tsconfig.json",
-        "tsconfig.base.json"
-      ]
+      "inputs": ["$TURBO_DEFAULT$"]
     },
     "ci": {
       "dependsOn": [


### PR DESCRIPTION
PR 2 of 3. **Stacked on #260** — review that first; this diff is `package.json` + `turbo.json`.

## Why

#260 added a root `tsconfig.json`, but it was load-bearing only for oxlint's type-aware rules. Nothing ever ran `tsc` over the tooling scripts, so their types could rot silently while lint stayed green.

## What

- `typecheck:root` → `tsc -p tsconfig.json --noEmit` in root `package.json`.
- `//#typecheck:root` in `turbo.json`, attached to the existing `typecheck` task via `with` — the same pattern `//#test:root` and `//#lint:root` already use. That puts it in the `ci` graph, which is what `build-test.yml` invokes (`turbo run ci`).

No `dependsOn: ["^build"]`: the tooling scripts import only node builtins and the pnpm SDK, never a package's `dist`.

## On the task inputs

Initially these mirrored `tsconfig.json`'s `include`, one path per entry. **That was wrong**, and it's worth spelling out because it's the same defect #262 fixes for `format:check:root`.

`include` names *entry points*; `tsc` additionally reads everything those entry points import. So any imported module absent from the input list was invisible to the cache key. Demonstrated on the old inputs — add `tools/vue-check/helper.ts`, import it from `bin.ts`, prime the cache green, then break only the helper:

```
$ pnpm typecheck:root
tools/vue-check/helper.ts:4:14 - error TS2322: ...   # exit 1  ✅

$ turbo run '//#typecheck:root'
cache hit                                             # exit 0  ❌ CI green
```

**A tsconfig `include` must under-approximate; turbo inputs must over-approximate.** Reproducing tsc's import graph in a glob by hand is exactly the trap. So the inputs are now just `$TURBO_DEFAULT$`, matching `//#lint:root`. Same probe afterwards:

```
$ turbo run '//#typecheck:root'
cache miss
//:typecheck:root: tools/vue-check/helper.ts:4:14 - error TS2322: ...
Failed:    //#typecheck:root                          # exit 1  ✅
```

`$TURBO_DEFAULT$` at the root means the task invalidates on any repo file — verified, including `README.md` and unrelated package sources. It runs in **~530ms**, so never cache-hitting is a fine price for not silently skipping a typecheck.

## Verification

- `turbo run ci --dry=json` shows `//#typecheck:root` in the graph.
- `turbo run typecheck`, `typecheck:root`, `lint:root`, `lint:package-json`, `format:check:root` → all 0.
- Gate is not vacuous: injecting `export const probe: number = "not a number";` into `scripts/workspace.ts` fails the task; reverting returns it to 0.