### PR TITLE
fix(tooling): stop format:check:root passing from a stale cache

### DIFF
--- a/examples/package.json
+++ b/examples/package.json
@@ -5,8 +5,8 @@
   "type": "module",
   "scripts": {
     "build:embeds": "node build-embeds.ts",
-    "format": "oxfmt \"**/*.{ts,js,mjs,json,md,html}\"",
-    "format:check": "oxfmt --check \"**/*.{ts,js,mjs,json,md,html}\"",
+    "format": "oxfmt \"**/*.{ts,js,json,md,html}\"",
+    "format:check": "oxfmt --check \"**/*.{ts,js,json,md,html}\"",
     "lint": "oxlint ."
   }
 }

--- a/tools/dts-backtest/package.json
+++ b/tools/dts-backtest/package.json
@@ -5,8 +5,8 @@
   "description": "Typechecks the published packages' built .d.ts with the oldest supported consumer TypeScript",
   "type": "module",
   "scripts": {
-    "format": "oxfmt \"**/*.{ts,js,mjs,json,md}\"",
-    "format:check": "oxfmt --check \"**/*.{ts,js,mjs,json,md}\"",
+    "format": "oxfmt \"**/*.{ts,js,json,md}\"",
+    "format:check": "oxfmt --check \"**/*.{ts,js,json,md}\"",
     "lint": "oxlint .",
     "test": "node run.ts"
   },

--- a/tools/vue-check/package.json
+++ b/tools/vue-check/package.json
@@ -8,8 +8,8 @@
   },
   "type": "module",
   "scripts": {
-    "format": "oxfmt \"**/*.{ts,js,mjs,json,md}\"",
-    "format:check": "oxfmt --check \"**/*.{ts,js,mjs,json,md}\"",
+    "format": "oxfmt \"**/*.{ts,js,json,md}\"",
+    "format:check": "oxfmt --check \"**/*.{ts,js,json,md}\"",
     "lint": "oxlint ."
   },
   "devDependencies": {

--- a/turbo.json
+++ b/turbo.json
@@ -112,20 +112,10 @@
       ]
     },
     "//#format:root": {
-      "inputs": [
-        "*.{ts,js,json,jsonc,md,yml,yaml,html,vue}",
-        "examples/**/*.{ts,js,json,jsonc,md,yml,yaml,html,vue}",
-        "scripts/**",
-        ".oxfmtrc.json"
-      ]
+      "inputs": ["$TURBO_DEFAULT$"]
     },
     "//#format:check:root": {
-      "inputs": [
-        "*.{ts,js,json,jsonc,md,yml,yaml,html,vue}",
-        "examples/**/*.{ts,js,json,jsonc,md,yml,yaml,html,vue}",
-        "scripts/**",
-        ".oxfmtrc.json"
-      ]
+      "inputs": ["$TURBO_DEFAULT$"]
     },
     "e2e": {
       "dependsOn": ["^build", "^docs", "^e2e"],

--- a/turbo.json
+++ b/turbo.json
@@ -115,6 +115,7 @@
       "inputs": [
         "*.{ts,js,json,jsonc,md,yml,yaml,html,vue}",
         "examples/**/*.{ts,js,json,jsonc,md,yml,yaml,html,vue}",
+        "scripts/**",
         ".oxfmtrc.json"
       ]
     },
@@ -122,6 +123,7 @@
       "inputs": [
         "*.{ts,js,json,jsonc,md,yml,yaml,html,vue}",
         "examples/**/*.{ts,js,json,jsonc,md,yml,yaml,html,vue}",
+        "scripts/**",
         ".oxfmtrc.json"
       ]
     },


### PR DESCRIPTION
PR 3 of 3. **Stacked on #261 → #260.**

## The bug

`//#format:check:root`'s turbo inputs enumerated directories by hand, but oxfmt's own glob is recursive and works by *exclusion* (`!apps/** !docs/** !examples/** !packages/** !tools/**`). Its real scope is "everything not excluded" — so the cache key never covered the files the task actually reads.

Latent until now: `scripts/` held only `.mjs`, which wasn't in oxfmt's extension list, so nothing there was formattable. #260 renamed those 14 files to `.ts`, pulling them into oxfmt's scope and turning a dormant mismatch into a live hole.

### Demonstrated — two probes, both against the original inputs

Badly format `scripts/workspace.ts`:
```
$ pnpm format:check:root                 # exit 1  ✅ catches it
$ turbo run '//#format:check:root'
cache hit                                # exit 0  ❌ CI would pass
```

Add a badly formatted file in a **new top-level directory**, `bin/tool.ts`:
```
$ pnpm format:check:root
bin/tool.ts (4ms)
Format issues found in above 1 files.    # exit 1  ✅  (34 files scanned)
$ turbo run '//#format:check:root'
cache hit                                # exit 0  ❌
```

Adding `scripts/**` to the inputs fixes the first probe but not the second — it patches the hole, not the class.

### The fix

`"inputs": ["$TURBO_DEFAULT$"]` for both `//#format:root` and `//#format:check:root`. Enumerating a tool's own recursive glob in turbo inputs is the same mistake as enumerating tsc's import graph (see #261). `$TURBO_DEFAULT$` is the superset that cannot drift. Both probes now cache-miss and exit 1; the clean tree stays green; the task runs in **~790ms**.

`//#lint:root` was checked for the same defect and is already fine — it uses `$TURBO_DEFAULT$`.

## Also

Drops the now-dead `mjs` from the oxfmt globs in `examples/`, `tools/dts-backtest/`, `tools/vue-check/`. No tracked `.mjs` files remain in the repo.

## Deliberately left alone

The `["**/*.js", "**/*.mjs", "**/*.cjs"]` override in `.oxlintrc.json`. It still guards the 10 remaining `.js`/`.cjs` files, and removing only the `.mjs` entry would silently subject any future `.mjs` file to type-aware rules with no tsconfig backing them — the same trap that made #260 atomic.

## Verification

`format:check:root`, `lint:root`, `lint:package-json`, `typecheck:root`, the three per-package `format:check` tasks, `turbo run format:check`, `turbo run lint`, and `turbo run ci --dry` all exit 0.