### PR TITLE
test(e2e): smoke the rendered docs site

### DIFF
--- a/apps/sample-app-lit-e2e/cypress.docs.config.ts
+++ b/apps/sample-app-lit-e2e/cypress.docs.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from 'cypress';
+
+export default defineConfig({
+  allowCypressEnv: false,
+  fileServerFolder: '.',
+  videosFolder: 'cypress/videos-docs',
+  screenshotsFolder: 'cypress/screenshots-docs',
+  video: true,
+  chromeWebSecurity: false,
+  e2e: {
+    // Wrangler serves all of docs/dist at :8787; the sample-app suites scope
+    // themselves to /app/ and /app-mobx/, so nothing renders the docs pages.
+    baseUrl: `http://localhost:8787/`,
+    specPattern: './src/docs/**/*.cy.{js,jsx,ts,tsx}',
+    // The sample-app support file adds feature-flag query helpers the docs
+    // site has no use for.
+    supportFile: false,
+  },
+});

--- a/apps/sample-app-lit-e2e/package.json
+++ b/apps/sample-app-lit-e2e/package.json
@@ -12,7 +12,8 @@
     "lint": "oxlint .",
     "test": "start-server-and-test docs:start-server 'http://localhost:8787/app/|http://localhost:8787/app-mobx/' test:cypress:all",
     "test:cypress": "cypress run",
-    "test:cypress:all": "concurrently --names vanilla,mobx --prefix-colors auto \"pnpm run test:cypress\" \"pnpm run test:cypress:mobx\"",
+    "test:cypress:all": "concurrently --names vanilla,mobx,docs --prefix-colors auto \"pnpm run test:cypress\" \"pnpm run test:cypress:mobx\" \"pnpm run test:cypress:docs\"",
+    "test:cypress:docs": "cypress run --config-file cypress.docs.config.ts",
     "test:cypress:mobx": "cypress run --config baseUrl=http://localhost:8787/app-mobx/,videosFolder=cypress/videos-mobx,screenshotsFolder=cypress/screenshots-mobx"
   },
   "dependencies": {

--- a/apps/sample-app-lit-e2e/src/docs/docs_site.cy.js
+++ b/apps/sample-app-lit-e2e/src/docs/docs_site.cy.js
@@ -9,7 +9,10 @@ describe('docs site', () => {
   });
 
   it('navigates without a full page load', () => {
-    cy.visit('/');
+    cy.visit('/tutorial/live-examples');
+    // The refresh icon only renders after Vue mounts (see the ExampleEmbed
+    // spec below), so waiting on it keeps the click from racing hydration.
+    cy.get('.restart-btn sp-icon-refresh').should('exist');
     cy.window().then((win) => {
       win.hydrationProbe = true;
     });
@@ -24,6 +27,11 @@ describe('docs site', () => {
     cy.visit('/api/');
     cy.title().should('match', /API Overview/);
     cy.get('h1').should('exist');
+    // A typedoc-authored page must list real exports; an empty or stale
+    // generation would render the shell without them.
+    cy.visit('/api/reference/');
+    // Scoped to main: the sidebar also links UIRouterLit, but collapsed.
+    cy.contains('main a', 'UIRouterLit').should('be.visible');
   });
 
   it('mounts the ExampleEmbed theme component', () => {
@@ -37,6 +45,10 @@ describe('docs site', () => {
   });
 
   it('serves the embedded example apps same-origin', () => {
-    cy.request('/examples/helloworld/').its('status').should('eq', 200);
+    // Wrangler's SPA fallback answers every path with 200 + the docs
+    // homepage, so only embed-unique content proves the asset deployed.
+    cy.request('/examples/helloworld/')
+      .its('body')
+      .should('include', 'Hello World - lit-ui-router Tutorial');
   });
 });

--- a/apps/sample-app-lit-e2e/src/docs/docs_site.cy.js
+++ b/apps/sample-app-lit-e2e/src/docs/docs_site.cy.js
@@ -1,0 +1,42 @@
+describe('docs site', () => {
+  it('renders the home page', () => {
+    cy.visit('/');
+    cy.title().should('match', /Lit UI Router/);
+    // VitePress 1 emits `class="VPNavBar"`, VitePress 2 `class="VPNavBar home
+    // top"` — match the prefix so the smoke survives a major bump.
+    cy.get('[class*="VPNavBar"]').should('be.visible');
+    cy.get('#app').should('not.be.empty');
+  });
+
+  it('navigates without a full page load', () => {
+    cy.visit('/');
+    cy.window().then((win) => {
+      win.hydrationProbe = true;
+    });
+    cy.get('a[href="/guides/"]').first().click();
+    cy.location('pathname').should('eq', '/guides/');
+    // A full reload drops the probe; surviving it proves the client router
+    // took the navigation, so the page hydrated.
+    cy.window().its('hydrationProbe').should('be.true');
+  });
+
+  it('renders the generated api reference', () => {
+    cy.visit('/api/');
+    cy.title().should('match', /API Overview/);
+    cy.get('h1').should('exist');
+  });
+
+  it('mounts the ExampleEmbed theme component', () => {
+    cy.visit('/tutorial/live-examples');
+    cy.get('.example-embed iframe[src="/examples/helloworld/"]').should(
+      'exist',
+    );
+    // The iframe and .restart-btn are server-rendered. The icon inside it is a
+    // client-only dynamic import, so it appears only once Vue has mounted.
+    cy.get('.restart-btn sp-icon-refresh').should('exist');
+  });
+
+  it('serves the embedded example apps same-origin', () => {
+    cy.request('/examples/helloworld/').its('status').should('eq', 200);
+  });
+});

--- a/apps/sample-app-lit-e2e/tsconfig.json
+++ b/apps/sample-app-lit-e2e/tsconfig.json
@@ -7,6 +7,6 @@
     "outDir": "dist",
     "rootDir": "."
   },
-  "include": ["src/**/*"],
+  "include": ["src/**/*", "cypress*.config.ts"],
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
## Motivation

`docs/dist` **is** lit-ui-router.dev — `wrangler.jsonc` points `assets.directory` at it, and `Workers Builds: lit-ui-router` is Cloudflare building this repo. There is no deploy workflow; merging to `main` ships to production.

Nothing rendered it. The Cypress `baseUrl` is `http://localhost:8787/app/`, so the e2e suite reaches `docs/dist` exclusively through the two sample-app SPAs that `vite-plugin-static-copy` drops into it. The 73 vitepress-rendered pages, the client bundle, and the custom theme components have never been loaded by a test. `vue-check` (#257) proves the SFCs typecheck against vitepress's types; it does not prove they mount.

This surfaced while assessing #229 (vitepress 2 alpha) for the live site. Landing independently — the gate is worth having regardless of when, or whether, the alpha merges.

## What changed

- **`cypress.docs.config.ts`** (new): `baseUrl` at the site root, its own `specPattern` and artifact dirs. Wrangler already serves the whole `dist`, so this needs no new infrastructure. It can't live in `src/integration/` because the mobx run re-runs those specs with `baseUrl` overridden to `/app-mobx/`.
- **`src/docs/docs_site.cy.js`** (new): five specs — home page renders, client-side navigation, generated api reference, `ExampleEmbed` theme component mounts, embedded examples served same-origin.
- **`package.json`**: `test:cypress:docs` script; `test:cypress:all` now runs `vanilla,mobx,docs` concurrently. `start-server-and-test` needed no change.

## Design notes

**Assertions are behavior-based, not markup-based**, so they survive a vitepress major. Concretely: vitepress 1 emits `class="VPNavBar"` where vitepress 2 emits `class="VPNavBar home top"`, so the nav check matches on the prefix.

**Hydration** is checked by setting a property on `window`, clicking an internal link, and asserting the property survives — a full page load would drop it, so surviving proves the client router took the navigation.

**Theme mount** is checked with `.restart-btn sp-icon-refresh`. The iframe and the button are server-rendered; the icon is a client-only dynamic import, so it appears *only* once Vue has mounted. Asserting on the iframe alone would have passed against a completely dead bundle.

## Verification

- **The suite discriminates.** Removed the client entry bundle (`assets/app.*.js`) and re-ran: the two hydration specs fail, the three SSR/static specs still pass. A passing test proves nothing if it cannot fail, and this one fails for the right reason.
- Green against **vitepress 1.6.4** (`main`) and against **vitepress 2.0.0-alpha.18** (#229), running the same specs against each `dist` through `wrangler dev`.
- Full three-way run: **docs 5, vanilla 27, mobx 27**, all passing. Adding a third concurrent Cypress process does not disturb the existing suites.
- `turbo run lint format:check typecheck --filter=sample-app-lit-e2e` — 17/17.

## Notes

- Docs-site coverage is deliberately a smoke, not a suite. The libraries deserve the coverage budget more than the marketing site; this is the minimum that makes "the public site is verified each release" enforced by CI rather than remembered.
- Pre-existing, out of scope: `not_found_handling: single-page-application` shadows the `404.html` vitepress builds, so unknown URLs return **HTTP 200 with the homepage** rather than a 404. Same on both vitepress majors. Not great for SEO; worth its own issue.
