### PR TITLE
fix(docs): drop the unused props binding in StackBlitzEmbed

### DIFF
--- a/docs/.vitepress/theme/components/StackBlitzEmbed.vue
+++ b/docs/.vitepress/theme/components/StackBlitzEmbed.vue
@@ -2,7 +2,7 @@
 import { useTemplateRef, ref, onMounted, onUnmounted } from 'vue';
 import screenfull from 'screenfull';
 
-const props = defineProps<{
+defineProps<{
   src: string;
   title: string;
 }>();


### PR DESCRIPTION
WebStorm reports `TS6133: 'props' is declared but its value is never read.` in `StackBlitzEmbed.vue`, while `turbo run typecheck --filter=docs` is green on `main`. Both are correct — the disagreement is about `defineProps`, not about our config.

## The binding really is dead

```ts
const props = defineProps<{ src: string; title: string }>();
```

`props` is never read. The template binds `:src="src"` and `:title="title"`, which resolve off the props type directly.

## Why CI doesn't see it

`vue-tsc` is not blind to unused locals. Injecting `const __probeUnused = 42;` into the same `<script setup>` fails the check:

```
StackBlitzEmbed.vue:10:7 - error TS6133: '__probeUnused' is declared but its value is never read.
```

It specifically exempts the result of the `defineProps` macro, because Volar's generated component code references it. WebStorm's TypeScript service applies `noUnusedLocals` to the authored script block instead, so it flags what `vue-tsc` deliberately allows.

There is no config gap to close: `noUnusedLocals` and `noUnusedParameters` are `true` in `tsconfig.base.json` and resolve through `docs/tsconfig.vue.json`.

## The fix

Drop the binding. `defineProps` is a compiler macro, so the assignment was erased at build time — this is a no-op at runtime.

## Verification

- `turbo run typecheck lint format:check --filter=docs` → 17/17 successful (covers `docs#typecheck` and, via `with`, `docs#typecheck:vue`).
- Template bindings are still checked: renaming the prop to `srcX` while leaving `:src="src"` fails `typecheck:vue` with `TS2551: Property 'src' does not exist ... Did you mean 'srcX'?` (exit 2).
- `StackBlitzEmbed.vue` was the only component with a dead `defineProps`/`defineEmits` binding; `ExampleEmbed.vue` is clean.

Unrelated to #260; branched from `main`.