### PR TITLE
chore(tooling): replace stale VS Code extension recommendations

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,7 +1,3 @@
 {
-  "recommendations": [
-    "ms-vscode.vscode-typescript-tslint-plugin",
-    "esbenp.prettier-vscode",
-    "firsttris.vscode-jest-runner"
-  ]
+  "recommendations": ["oxc.oxc-vscode", "vitest.explorer", "Vue.volar"]
 }


### PR DESCRIPTION
## What was stale

`.vscode/extensions.json` was untouched since the initial commit (noted as "left alone" in #253) and recommended:

- `ms-vscode.vscode-typescript-tslint-plugin` — deprecated extension for a tool (tslint) the repo never uses
- `esbenp.prettier-vscode` — repo formats with **oxfmt** (`.oxfmtrc.json`)
- `firsttris.vscode-jest-runner` — repo tests with **vitest** (all three `packages/*`)

## Keep vs drop

**Kept, with a minimal list.** There is no `.vscode/settings.json` to wire editor behavior, but recommendations still carry real onboarding value here because VS Code has zero built-in support for the three things a contributor hits immediately:

| Recommendation | Backs |
|---|---|
| `oxc.oxc-vscode` (Oxc) | oxlint diagnostics (`.oxlintrc.json`) + oxfmt formatting (`.oxfmtrc.json`) |
| `vitest.explorer` (Vitest) | test runner in every `packages/*` package |
| `Vue.volar` (Vue Official) | docs-site SFCs, typechecked via `vue-tsc` |

All three IDs verified against the marketplace gallery API.

**No TypeScript extension recommendation**: the repo is on TS 7 (native, no JS API), and editor integration is planned to move to the native TS LSP client — tracked in #270. Recommending `TypeScriptTeam.native-preview` now would front-run that migration; VS Code's bundled TS remains fine for editing in the meantime.

## Verification

- `node -e 'JSON.parse(...)'` — parses
- `oxfmt --check .vscode/extensions.json` — clean
- `pnpm run format:check:root` + `pnpm run lint:root` — exit 0