### PR TITLE
chore(lint): enforce no-unsafe-* in examples, typing the 6 deferred findings

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -224,16 +224,6 @@
       }
     },
     {
-      "files": ["examples/**"],
-      "rules": {
-        "typescript/no-unsafe-argument": "off",
-        "typescript/no-unsafe-assignment": "off",
-        "typescript/no-unsafe-call": "off",
-        "typescript/no-unsafe-member-access": "off",
-        "typescript/no-unsafe-return": "off"
-      }
-    },
-    {
       "files": ["**/*.spec.ts", "**/src/specs/test-utils.ts"],
       "rules": {
         "no-unused-vars": [

--- a/examples/hellogalaxy/src/main.ts
+++ b/examples/hellogalaxy/src/main.ts
@@ -289,9 +289,9 @@ class StarsContainerComponent extends LitElement {
   `;
 
   @property({ attribute: false })
-  _uiViewProps!: UIViewInjectedProps;
+  _uiViewProps!: UIViewInjectedProps<{ stars: Star[] }>;
 
-  constructor(props: UIViewInjectedProps) {
+  constructor(props: UIViewInjectedProps<{ stars: Star[] }>) {
     super();
     this._uiViewProps = props;
   }
@@ -370,9 +370,9 @@ class StarDetailComponent extends LitElement {
   `;
 
   @property({ attribute: false })
-  _uiViewProps!: UIViewInjectedProps;
+  _uiViewProps!: UIViewInjectedProps<{ star: Star | undefined }>;
 
-  constructor(props: UIViewInjectedProps) {
+  constructor(props: UIViewInjectedProps<{ star: Star | undefined }>) {
     super();
     this._uiViewProps = props;
   }
@@ -518,7 +518,7 @@ const galaxyState: LitStateDeclaration = {
 };
 
 // Child state (nested via dot notation) renders inside galaxy's <ui-view>
-const starsState: LitStateDeclaration = {
+const starsState: LitStateDeclaration<{ stars: Star[] }> = {
   name: 'galaxy.stars',
   url: '/stars',
   component: StarsContainerComponent,
@@ -531,7 +531,7 @@ const starsState: LitStateDeclaration = {
 };
 
 // Grandchild state with a URL param, rendered inside galaxy.stars's <ui-view>
-const starState: LitStateDeclaration = {
+const starState: LitStateDeclaration<{ star: Star | undefined }> = {
   name: 'galaxy.stars.star',
   url: '/:starId',
   component: StarDetailComponent,
@@ -541,7 +541,7 @@ const starState: LitStateDeclaration = {
       // Resolve inheritance: 'stars' is injected from the parent state's resolve
       deps: ['$transition$', 'stars'],
       resolveFn: ($transition$: Transition, stars: Star[]) => {
-        const starId = $transition$.params().starId;
+        const starId = $transition$.params<{ starId: string }>().starId;
         return stars.find((s) => s.id === starId);
       },
     },

--- a/examples/hellosolarsystem/src/main.ts
+++ b/examples/hellosolarsystem/src/main.ts
@@ -200,9 +200,9 @@ class PlanetListComponent extends LitElement {
 
   // The router constructs routed components with injected props.
   @property({ attribute: false })
-  _uiViewProps!: UIViewInjectedProps;
+  _uiViewProps!: UIViewInjectedProps<{ planets: SolarBody[] }>;
 
-  constructor(props: UIViewInjectedProps) {
+  constructor(props: UIViewInjectedProps<{ planets: SolarBody[] }>) {
     super();
     this._uiViewProps = props;
   }
@@ -273,9 +273,9 @@ class PlanetDetailComponent extends LitElement {
   `;
 
   @property({ attribute: false })
-  _uiViewProps!: UIViewInjectedProps;
+  _uiViewProps!: UIViewInjectedProps<{ planet: SolarBody | undefined }>;
 
-  constructor(props: UIViewInjectedProps) {
+  constructor(props: UIViewInjectedProps<{ planet: SolarBody | undefined }>) {
     super();
     this._uiViewProps = props;
   }
@@ -356,7 +356,7 @@ export class AppRoot extends LitElement {
 }
 
 // State definitions
-const planetsState: LitStateDeclaration = {
+const planetsState: LitStateDeclaration<{ planets: SolarBody[] }> = {
   name: 'planets',
   url: '/planets',
   component: PlanetListComponent,
@@ -369,7 +369,7 @@ const planetsState: LitStateDeclaration = {
   ],
 };
 
-const planetState: LitStateDeclaration = {
+const planetState: LitStateDeclaration<{ planet: SolarBody | undefined }> = {
   name: 'planet',
   url: '/planets/:planetId',
   component: PlanetDetailComponent,
@@ -379,7 +379,9 @@ const planetState: LitStateDeclaration = {
       token: 'planet',
       deps: ['$transition$'],
       resolveFn: ($transition$: Transition) => {
-        const planetId = parseInt($transition$.params().planetId);
+        const planetId = parseInt(
+          $transition$.params<{ planetId: string }>().planetId,
+        );
         return SolarSystemService.getBody(planetId);
       },
     },


### PR DESCRIPTION
Follow-up to #267 (originally stacked on its branch; rebased onto main after it merged).

## Why

#243 flipped the five `typescript/no-unsafe-*` rules to error repo-wide but turned all five off for `examples/**`, deferring:

> The 6 real findings (hellogalaxy `main.ts` 300, 381, 544; hellosolarsystem `main.ts` 212, 285, 382) are a cheap follow-up if the program ever becomes deterministic.

The override existed because tsgolint's examples program was environment-dependent: without the examples' own node_modules (standalone npm projects), every import is error-typed — measured here as **156** bogus no-unsafe findings, vs the **6** real ones with deps installed. #267's merged design removed that nondeterminism at the root: the examples package's `postinstall` runs `npm ci` for all three examples, so any workspace install leaves the lint program fully typed. This PR fixes the 6 findings and drops the override — a 3-file diff, no task or script changes needed.

## The 6 findings, and how each was fixed

All still at #243's exact line numbers (no drift):

| Finding | Fix |
|---|---|
| `hellosolarsystem/src/main.ts:212` no-unsafe-return (`resolves.planets`) | `UIViewInjectedProps<{ planets: SolarBody[] }>` on `_uiViewProps` + constructor |
| `hellosolarsystem/src/main.ts:285` no-unsafe-return (`resolves.planet`) | `UIViewInjectedProps<{ planet: SolarBody \| undefined }>` |
| `hellosolarsystem/src/main.ts:382` no-unsafe-argument (`parseInt(params().planetId)`) | `params<{ planetId: string }>()` generic overload |
| `hellogalaxy/src/main.ts:300` no-unsafe-return (`resolves.stars`) | `UIViewInjectedProps<{ stars: Star[] }>` |
| `hellogalaxy/src/main.ts:381` no-unsafe-return (`resolves.star`) | `UIViewInjectedProps<{ star: Star \| undefined }>` |
| `hellogalaxy/src/main.ts:544` no-unsafe-assignment (`params().starId`) | `params<{ starId: string }>()` |

No casts, no `any` laundering, no disable comments — the published lit-ui-router / @uirouter/core APIs are generic at exactly these points, so every fix is a real type argument. The narrowed component constructors then require the matching `LitStateDeclaration<T>` on the four state declarations (TS2322 otherwise, caught by #267's `examples#typecheck`). Side benefit: the tutorials now demonstrate the typed-resolves API instead of the `Record<string, any>` default.

## Verification (on the rebased head, from a wiped node_modules)

- Fresh install path: `rm -rf node_modules examples/node_modules examples/*/node_modules` → `pnpm install` → postinstall restored all three examples' node_modules.
- **Rules actually execute** (an invalid tsconfig makes type-aware rules fake a clean run): seeded `export const unsafeSeed = JSON.parse("{}")` scratch files were flagged `no-unsafe-assignment` at error in **both** the hellogalaxy and hellosolarsystem programs, then removed (never committed).
- `turbo run lint` — 26/26 green.
- `turbo run typecheck --filter=examples` — green.
- `turbo run ci` — **63/63 green**.

One observation from testing, not addressed here: wiping only `examples/*/node_modules` is not self-healed — a subsequent `pnpm install` reports "Already up to date" and skips the `postinstall`, silently reverting the examples lint program to the error-typed state. Fresh installs (CI runners, new clones/worktrees) always run it, so enforcement is deterministic where it matters.
