### PR TITLE
feat(docs): serve real 404s, scoping SPA fallback to a worker script

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -20,11 +20,11 @@ The Cloudflare [Github integration](https://developers.cloudflare.com/workers/ci
 
 ### Configuration Files
 
-| File                     | Purpose                                                                                                                                              |
-| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `wrangler.jsonc`         | [Wrangler configuration](https://developers.cloudflare.com/workers/wrangler/configuration/) - defines worker name, assets directory, and SPA routing |
-| `docs/public/_redirects` | [Redirects](https://developers.cloudflare.com/pages/configuration/redirects/) - configures URL rewriting for SPA routes                              |
-| `docs/public/_headers`   | [Headers](https://developers.cloudflare.com/pages/configuration/headers/) - sets security headers (COOP, COEP) and canonical links                   |
+| File                   | Purpose                                                                                                                                                                                                                                            |
+| ---------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `wrangler.jsonc`       | [Wrangler configuration](https://developers.cloudflare.com/workers/wrangler/configuration/) - defines worker name, entry point, assets directory, and routing                                                                                      |
+| `docs/worker/index.ts` | [Worker script](https://developers.cloudflare.com/workers/static-assets/routing/worker-script/) - SPA fallback for `/app/*` and `/app-mobx/*` deep links; everything else serves static assets, with misses falling back to VitePress's `404.html` |
+| `docs/public/_headers` | [Headers](https://developers.cloudflare.com/pages/configuration/headers/) - sets security headers (COOP, COEP)                                                                                                                                     |
 
 ### Wrangler Setup
 

--- a/apps/sample-app-lit-e2e/src/docs/docs_site.cy.js
+++ b/apps/sample-app-lit-e2e/src/docs/docs_site.cy.js
@@ -45,10 +45,19 @@ describe('docs site', () => {
   });
 
   it('serves the embedded example apps same-origin', () => {
-    // Wrangler's SPA fallback answers every path with 200 + the docs
-    // homepage, so only embed-unique content proves the asset deployed.
+    // Only embed-unique content proves the asset deployed, not a fallback.
     cy.request('/examples/helloworld/')
       .its('body')
       .should('include', 'Hello World - lit-ui-router Tutorial');
+  });
+
+  it('serves a real 404 for unknown urls', () => {
+    cy.request({ url: '/definitely-missing', failOnStatusCode: false }).then(
+      (response) => {
+        expect(response.status).to.eq(404);
+        // The title proves the vitepress 404 page rendered, not a null body.
+        expect(response.body).to.include('<title>404 | Lit UI Router</title>');
+      },
+    );
   });
 });

--- a/docs/.vitepress/vite.config.ts
+++ b/docs/.vitepress/vite.config.ts
@@ -2,7 +2,7 @@ import { defineConfig, Plugin } from 'vite';
 import { viteStaticCopy } from 'vite-plugin-static-copy';
 
 // Tutorial examples embedded same-origin at /examples/<name>/; built by
-// `examples#build:embeds` (hash routing, so no _redirects entries needed).
+// `examples#build:embeds` (hash routing, so no SPA fallback needed).
 const EMBEDDED_EXAMPLES = ['helloworld', 'hellosolarsystem', 'hellogalaxy'];
 
 // VitePress 1.x / vite 6 default targets list `safari14`, but esbuild >=0.27.7
@@ -12,8 +12,8 @@ const TARGET = ['chrome87', 'edge88', 'es2020', 'firefox78', 'safari14.1'];
 
 /**
  * Vite plugin to handle /app/* and /app-mobx/* deep linking in dev server.
- * Mirrors Cloudflare _redirects: `/app/* /app 200`, `/app-mobx/* /app-mobx 200`
- * Rewrites requests to serve the matching sample-app SPA html.
+ * Mirrors the Cloudflare Worker (docs/worker/index.ts): deep links under a
+ * sample-app mount serve that app's SPA html.
  * Also resolves /examples/<name>/ directory requests to their index.html
  * (production gets this from Cloudflare's static-asset index resolution).
  */

--- a/docs/package.json
+++ b/docs/package.json
@@ -10,7 +10,7 @@
     "format": "oxfmt \"**/*.{md,json,ts,vue}\"",
     "format:check": "oxfmt --check \"**/*.{md,json,ts,vue}\"",
     "lint": "oxlint .",
-    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "typecheck": "tsc -p tsconfig.json --noEmit && tsc -p worker/tsconfig.json --noEmit",
     "typecheck:vue": "vue-check docs/tsconfig.vue.json",
     "wrangler:dev": "wrangler dev"
   },
@@ -22,6 +22,7 @@
     "vue": "^3.5.39"
   },
   "devDependencies": {
+    "@cloudflare/workers-types": "catalog:",
     "oxfmt": "catalog:",
     "typescript": "catalog:",
     "vite": "catalog:",

--- a/docs/public/_headers
+++ b/docs/public/_headers
@@ -1,6 +1,3 @@
 /*
   Cross-Origin-Opener-Policy: same-origin
   Cross-Origin-Embedder-Policy: credentialless
-
-/app/*
-  Link: </app>; rel="canonical"

--- a/docs/public/_redirects
+++ b/docs/public/_redirects
@@ -1,2 +1,0 @@
-/app-mobx/* /app-mobx 200
-/app/* /app 200

--- a/docs/worker/index.ts
+++ b/docs/worker/index.ts
@@ -1,0 +1,20 @@
+interface Env {
+  ASSETS: Fetcher;
+}
+
+// Longest mount first: '/app' is a prefix of '/app-mobx'.
+const MOUNTS = ['/app-mobx', '/app'];
+
+export default {
+  async fetch(request, env) {
+    const pathname = new URL(request.url).pathname;
+    const mount = MOUNTS.find((prefix) => pathname.startsWith(`${prefix}/`));
+    if (!mount) {
+      return env.ASSETS.fetch(request);
+    }
+    const shell = await env.ASSETS.fetch(new URL(mount, request.url));
+    const headers = new Headers(shell.headers);
+    headers.set('Link', `<${mount}>; rel="canonical"`);
+    return new Response(shell.body, { status: shell.status, headers });
+  },
+} satisfies ExportedHandler<Env>;

--- a/docs/worker/index.ts
+++ b/docs/worker/index.ts
@@ -12,7 +12,9 @@ export default {
     if (!mount) {
       return env.ASSETS.fetch(request);
     }
-    const shell = await env.ASSETS.fetch(new URL(mount, request.url));
+    const shell = await env.ASSETS.fetch(
+      new Request(new URL(mount, request.url), request),
+    );
     const headers = new Headers(shell.headers);
     headers.set('Link', `<${mount}>; rel="canonical"`);
     return new Response(shell.body, { status: shell.status, headers });

--- a/docs/worker/tsconfig.json
+++ b/docs/worker/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "module": "es2022",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "types": ["@cloudflare/workers-types"]
+  },
+  "include": ["*.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,9 @@ catalogs:
     '@api-viewer/docs':
       specifier: 1.0.0-pre.10
       version: 1.0.0-pre.10
+    '@cloudflare/workers-types':
+      specifier: ^4.20260701.1
+      version: 4.20260702.1
     '@codecov/bundle-analyzer':
       specifier: ^2.0.1
       version: 2.0.1
@@ -192,7 +195,7 @@ importers:
         version: 8.1.3(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)
       wrangler:
         specifier: 'catalog:'
-        version: 4.107.0
+        version: 4.107.0(@cloudflare/workers-types@4.20260702.1)
 
   apps/sample-app-lit-e2e:
     dependencies:
@@ -266,7 +269,7 @@ importers:
         version: 4.1.1(vite@8.1.3(@types/node@25.0.9)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
       wrangler:
         specifier: 'catalog:'
-        version: 4.107.0
+        version: 4.107.0(@cloudflare/workers-types@4.20260702.1)
 
   apps/sample-app-lit-vanilla:
     dependencies:
@@ -306,7 +309,7 @@ importers:
         version: 4.1.1(vite@8.1.3(@types/node@25.0.9)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
       wrangler:
         specifier: 'catalog:'
-        version: 4.107.0
+        version: 4.107.0(@cloudflare/workers-types@4.20260702.1)
 
   apps/sample-app-shared:
     dependencies:
@@ -375,6 +378,9 @@ importers:
         specifier: ^3.5.39
         version: 3.5.39(typescript@7.0.2)
     devDependencies:
+      '@cloudflare/workers-types':
+        specifier: 'catalog:'
+        version: 4.20260702.1
       oxfmt:
         specifier: 'catalog:'
         version: 0.58.0
@@ -395,7 +401,7 @@ importers:
         version: link:../tools/vue-check
       wrangler:
         specifier: 'catalog:'
-        version: 4.107.0
+        version: 4.107.0(@cloudflare/workers-types@4.20260702.1)
 
   examples: {}
 
@@ -779,6 +785,9 @@ packages:
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
+
+  '@cloudflare/workers-types@4.20260702.1':
+    resolution: {integrity: sha512-mOhf5TUEB1m2vPrxtqoIGfz0fUC9xyxRDx5gWHy5s+OCo6dcV+g7wI1R7gYCMFohhqF/2y2xeKVwMwCJjfn/WA==}
 
   '@codecov/bundle-analyzer@2.0.1':
     resolution: {integrity: sha512-SkL0+Ccs6VuHIA9Bxb8/J110CffRXpqtKt7m18FTWC0P6gDKEsoieUerDdcd6K9BFKujj6gaUdTt5i4I/v8GTA==}
@@ -5454,6 +5463,8 @@ snapshots:
   '@cloudflare/workerd-windows-64@1.20260701.1':
     optional: true
 
+  '@cloudflare/workers-types@4.20260702.1': {}
+
   '@codecov/bundle-analyzer@2.0.1':
     dependencies:
       '@codecov/bundler-plugin-core': 2.0.1
@@ -9617,7 +9628,7 @@ snapshots:
       '@cloudflare/workerd-linux-arm64': 1.20260701.1
       '@cloudflare/workerd-windows-64': 1.20260701.1
 
-  wrangler@4.107.0:
+  wrangler@4.107.0(@cloudflare/workers-types@4.20260702.1):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.5.0
       '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260701.1)
@@ -9628,6 +9639,7 @@ snapshots:
       unenv: 2.0.0-rc.24
       workerd: 1.20260701.1
     optionalDependencies:
+      '@cloudflare/workers-types': 4.20260702.1
       fsevents: 2.3.3
     transitivePeerDependencies:
       - bufferutil

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,6 +7,7 @@ packages:
 
 catalog:
   '@api-viewer/docs': 1.0.0-pre.10
+  '@cloudflare/workers-types': ^4.20260701.1
   '@codecov/bundle-analyzer': ^2.0.1
   '@pnpm/fs.find-packages': ^1000.0.24
   '@pnpm/workspace.read-manifest': ^1000.3.1

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -8,8 +8,7 @@
     "directory": "./docs/dist",
     "binding": "ASSETS",
     "not_found_handling": "404-page",
-    // Only sample-app deep links invoke the worker; everything else is
-    // served straight from assets, with misses falling back to 404.html.
+    // Only sample-app deep links invoke the worker; other misses serve 404.html.
     "run_worker_first": ["/app/*", "/app-mobx/*"],
   },
 }

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -3,9 +3,13 @@
   "$schema": "node_modules/wrangler/config-schema.json",
   "name": "lit-ui-router",
   "compatibility_date": "2025-07-12",
+  "main": "./docs/worker/index.ts",
   "assets": {
     "directory": "./docs/dist",
-    "not_found_handling": "single-page-application",
-    // "binding": "ASSETS"
+    "binding": "ASSETS",
+    "not_found_handling": "404-page",
+    // Only sample-app deep links invoke the worker; everything else is
+    // served straight from assets, with misses falling back to 404.html.
+    "run_worker_first": ["/app/*", "/app-mobx/*"],
   },
 }


### PR DESCRIPTION
Implements the two cache fixes from the turbo 2.10.4 cache-miss investigation (PR #274 run 29119328592).

## 1. App build input-hash churn

`sample-app-lit-vanilla` and `sample-app-lit-mobx` declared `inputs: ["$TURBO_DEFAULT$", "../sample-app-shared/**"]`. In turbo 2.10.4 an explicit glob hashes gitignored + turbo-internal files, so `apps/sample-app-shared/.turbo/turbo-<task>.log` (written when shared's lint/typecheck run) churned the app build hashes between consecutive turbo invocations in one CI job. Replaced with `"dependsOn": ["^build", "^transit"]` — `sample-app-shared#transit` carries shared's file hash with git-aware semantics.

Repro on baseline (`turbo run build --dry=json`, then write junk to `apps/sample-app-shared/.turbo/turbo-lint.log`):

| task | before junk log | after junk log |
|---|---|---|
| docs#build | `0725b1b835d3a4eb` | `be5327bd6a733b00` |
| sample-app-lit-e2e#build | `53692176d63f9a51` | `38f739bd9087c9eb` |
| sample-app-lit-mobx#build | `730b7eafe34313b4` | `2723c2c8a012ab34` |
| sample-app-lit-vanilla#build | `441d484f8a618b86` | `83b26825530dddec` |

After the fix: same junk-log probe changes **zero** hashes; touching a real `apps/sample-app-shared/src/` file still changes exactly the vanilla/mobx/docs/e2e builds (plus shared's own tasks).

## 2. Cache `docs:api` for lit-ui-router-mobx and navigation-location-plugin

Root `docs:api` is `cache: false` (conservative default from #93). `packages/lit-ui-router` already overrides it with cached inputs/outputs; this adds the same package-level override for the other two typedoc packages (inputs: `typedoc.json` + `src/**/*.ts` — neither has a `tsdoc.json`; outputs: their `docs/api/<pkg>/**` dirs per each `typedoc.json` `out`). Root default stays `cache: false`.

Verified: cache-miss run produces the output dirs; after `rm -rf` of both dirs, re-run is a cache hit and `diff -r` against a pre-wipe snapshot is identical for both packages.

## Consecutive-run stability

`turbo run build lint typecheck format:check docs:api` back to back in steady state: FULL TURBO (49/49 cached), including both new `docs:api` hits. (First-ever run in a cold worktree still settles once because lint/format:check explicit-glob inputs hash freshly written gitignored `dist/` — pre-existing on main, untouched here.)

Local `turbo run ci --filter='!sample-app-lit-e2e'` green (58/58); e2e excluded locally due to port 8787 contention — relying on CI for it.

## CI evidence (this PR's runs)

`build_and_test (branch)` ran first (cold for the new hashes): 22/62 cached, executed the app builds + new docs:api tasks. `build_and_test` (merge-head) ran second: **54/62 cached** — cache hits for `sample-app-lit-vanilla#build`, `sample-app-lit-mobx#build`, `docs#build`, `sample-app-lit-e2e#build` (the previously-churning cascade) and both new `docs:api` tasks. Remaining 8: by-design bypasses (`e2e#test`, `codecov:bundle` x2) and root-scope tasks.
- Review follow-up: the docs smoke now covers the headline behavior — `serves a real 404 for unknown urls` asserts status 404 **and** that the body carries the vitepress 404 page title (catching a null-body 404 regression too). Docs suite is now **6 passing** locally against `wrangler dev`.
- Review follow-up 2: the shell fetch now forwards the original request (`new Request(new URL(mount, request.url), request)`), so:
  - **Conditional GET**: deep-link revalidations return **304** with an empty body (`If-None-Match` reaches the binding); first hits are unchanged — 200 + shell + ETag + canonical `Link`, and the `Link` header is also set on the 304. Conditional re-requests of the 404 page itself also 304.
  - **Non-GET**: `POST /app/x` returns the binding's **405** (empty body) — restoring `main`'s pre-PR behavior instead of the earlier 200 + shell.

  Verified via curl against `wrangler dev`: first hit 200/1377 bytes with ETag + `Link`; `If-None-Match` re-request **304**/0 bytes with `Link` intact; POST **405**. On the Cloudflare preview: POST → 405 and unknown URLs → 404 confirmed on the real runtime; deep-link 304s are **not observable at the edge** there because Cloudflare strips validators (ETag/Last-Modified) from HTML responses zone-wide — production `main` serves HTML without ETags today too, so nothing regressed and the fix simply stops the worker from being an *additional* validator-dropper. Edge conditionals do work where validators survive: `/vp-icons.css` → 304 on the preview. Full curl matrix and e2e (docs 6, vanilla 27, mobx 27) re-run green.
