### PR TITLE
fix(turbo): stable app-build hashes via transit deps + cached docs:api

### DIFF
--- a/apps/sample-app-lit-mobx/turbo.json
+++ b/apps/sample-app-lit-mobx/turbo.json
@@ -8,7 +8,7 @@
         "VITE_SAMPLE_APP_BASE_URL",
         "VITE_SAMPLE_APP_PUSH_STATE"
       ],
-      "inputs": ["$TURBO_DEFAULT$", "../sample-app-shared/**"]
+      "dependsOn": ["^build", "^transit"]
     }
   }
 }

--- a/apps/sample-app-lit-vanilla/turbo.json
+++ b/apps/sample-app-lit-vanilla/turbo.json
@@ -8,7 +8,7 @@
         "VITE_SAMPLE_APP_BASE_URL",
         "VITE_SAMPLE_APP_PUSH_STATE"
       ],
-      "inputs": ["$TURBO_DEFAULT$", "../sample-app-shared/**"]
+      "dependsOn": ["^build", "^transit"]
     }
   }
 }

--- a/packages/lit-ui-router-mobx/turbo.json
+++ b/packages/lit-ui-router-mobx/turbo.json
@@ -3,10 +3,7 @@
   "extends": ["//"],
   "tasks": {
     "docs:api": {
-      "inputs": ["typedoc.json", "src/**/*.ts"],
-      "outputs": ["../../docs/api/lit-ui-router-mobx/**"],
-      "dependsOn": ["^build"],
-      "cache": true
+      "outputs": ["../../docs/api/lit-ui-router-mobx/**"]
     }
   }
 }

--- a/packages/lit-ui-router-mobx/turbo.json
+++ b/packages/lit-ui-router-mobx/turbo.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://turborepo.com/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "docs:api": {
+      "inputs": ["typedoc.json", "src/**/*.ts"],
+      "outputs": ["../../docs/api/lit-ui-router-mobx/**"],
+      "dependsOn": ["^build"],
+      "cache": true
+    }
+  }
+}

--- a/packages/lit-ui-router/turbo.json
+++ b/packages/lit-ui-router/turbo.json
@@ -10,10 +10,7 @@
       "outputs": ["dist/custom-elements.json"]
     },
     "docs:api": {
-      "inputs": ["typedoc.json", "tsdoc.json", "src/**/*.ts"],
-      "outputs": ["../../docs/api/reference/**"],
-      "dependsOn": ["^build"],
-      "cache": true
+      "outputs": ["../../docs/api/reference/**"]
     }
   }
 }

--- a/packages/navigation-location-plugin/turbo.json
+++ b/packages/navigation-location-plugin/turbo.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://turborepo.com/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "docs:api": {
+      "inputs": ["typedoc.json", "src/**/*.ts"],
+      "outputs": ["../../docs/api/navigation-location-plugin/**"],
+      "dependsOn": ["^build"],
+      "cache": true
+    }
+  }
+}

--- a/packages/navigation-location-plugin/turbo.json
+++ b/packages/navigation-location-plugin/turbo.json
@@ -3,10 +3,7 @@
   "extends": ["//"],
   "tasks": {
     "docs:api": {
-      "inputs": ["typedoc.json", "src/**/*.ts"],
-      "outputs": ["../../docs/api/navigation-location-plugin/**"],
-      "dependsOn": ["^build"],
-      "cache": true
+      "outputs": ["../../docs/api/navigation-location-plugin/**"]
     }
   }
 }

--- a/turbo.json
+++ b/turbo.json
@@ -114,7 +114,7 @@
     },
     "docs:api": {
       "dependsOn": ["^build", "^docs:api"],
-      "cache": false
+      "inputs": ["$TURBO_DEFAULT$"]
     }
   }
 }


### PR DESCRIPTION
Implements the two cache fixes from the turbo 2.10.4 cache-miss investigation (PR #274 run 29119328592).

## 1. App build input-hash churn

`sample-app-lit-vanilla` and `sample-app-lit-mobx` declared `inputs: ["$TURBO_DEFAULT$", "../sample-app-shared/**"]`. In turbo 2.10.4 an explicit glob hashes gitignored + turbo-internal files, so `apps/sample-app-shared/.turbo/turbo-<task>.log` (written when shared's lint/typecheck run) churned the app build hashes between consecutive turbo invocations in one CI job. Replaced with `"dependsOn": ["^build", "^transit"]` — `sample-app-shared#transit` carries shared's file hash with git-aware semantics.

Repro on baseline (`turbo run build --dry=json`, then write junk to `apps/sample-app-shared/.turbo/turbo-lint.log`):

| task | before junk log | after junk log |
|---|---|---|
| docs#build | `0725b1b835d3a4eb` | `be5327bd6a733b00` |
| sample-app-lit-e2e#build | `53692176d63f9a51` | `38f739bd9087c9eb` |
| sample-app-lit-mobx#build | `730b7eafe34313b4` | `2723c2c8a012ab34` |
| sample-app-lit-vanilla#build | `441d484f8a618b86` | `83b26825530dddec` |

After the fix: same junk-log probe changes **zero** hashes; touching a real `apps/sample-app-shared/src/` file still changes exactly the vanilla/mobx/docs/e2e builds (plus shared's own tasks).

## 2. Cache `docs:api` — lifted to the root task

Root `docs:api` was `cache: false` (conservative default from #93) with `packages/lit-ui-router` carrying a bespoke cached override, and this PR originally duplicated that override for the other two typedoc packages. Per review, the shared shape now lives at root instead:

- root `docs:api`: `dependsOn` unchanged (`^build`, `^docs:api`), cache on, `inputs: ["$TURBO_DEFAULT$"]` — over-approximating (git-aware, whole package) rather than the enumerated `typedoc.json`/`src/**` glob, which silently omitted `package.json` and `README.md`
- each typedoc package keeps exactly one line: its `outputs` (`docs/api/reference`, `docs/api/lit-ui-router-mobx`, `docs/api/navigation-location-plugin`) — the only key turbo can't parameterize at root

Trade-off made explicit: a future package adding a `docs:api` script must declare its `outputs`, or a later cache hit will skip typedoc without restoring anything. The per-package pattern demanded the same discipline (forgetting the whole override was just as silent); root `cache: false` only protected that case by never caching anyone.

Verified:
- cache-miss run produces the three output dirs; after `rm -rf` of all three, re-run is a cache hit and `diff -r` against a pre-wipe snapshot is identical
- junk `.turbo/turbo-*.log` probe changes **zero** `docs:api` hashes ($TURBO_DEFAULT$ is git-aware)
- touching `packages/lit-ui-router-mobx/src/index.ts` misses only `lit-ui-router-mobx#docs:api` and its dependents; `lit-ui-router#docs:api` and `ui-router-navigation-location-plugin#docs:api` stay cached

## Consecutive-run stability

`turbo run build lint typecheck format:check docs:api` back to back in steady state: FULL TURBO (49/49 cached), including all three `docs:api` hits under the root-lifted definition. (First-ever run in a cold worktree still settles once because lint/format:check explicit-glob inputs hash freshly written gitignored `dist/` — pre-existing on main, untouched here.)

Local `turbo run ci --filter='!sample-app-lit-e2e'` green (58/58); e2e excluded locally due to port 8787 contention — relying on CI for it.

## CI evidence (this PR's runs)

`build_and_test (branch)` ran first (cold for the new hashes): 22/62 cached, executed the app builds + new docs:api tasks. `build_and_test` (merge-head) ran second: **54/62 cached** — cache hits for `sample-app-lit-vanilla#build`, `sample-app-lit-mobx#build`, `docs#build`, `sample-app-lit-e2e#build` (the previously-churning cascade) and both new `docs:api` tasks. Remaining 8: by-design bypasses (`e2e#test`, `codecov:bundle` x2) and root-scope tasks.

