### PR TITLE
feat(types): register custom elements in HTMLElementTagNameMap

### DIFF
--- a/apps/sample-app-shared/src/main.ts
+++ b/apps/sample-app-shared/src/main.ts
@@ -1,7 +1,7 @@
 import './styles.css';
 import { html, render } from 'lit';
 import '@api-viewer/docs';
-import { UIRouterLit, UIRouterLitElement } from 'lit-ui-router';
+import { UIRouterLit } from 'lit-ui-router';
 import customElementsJsonUrl from 'lit-ui-router/dist/custom-elements.json?url';
 
 import { configureRouter } from './router.config.js';
@@ -38,7 +38,7 @@ render(
   root,
 );
 
-const element = root.querySelector('ui-router') as UIRouterLitElement | null;
+const element = root.querySelector('ui-router');
 const routerFromElement = element?.uiRouter;
 router = router || routerFromElement!;
 

--- a/packages/lit-ui-router-mobx/src/specs/reaction-controller.spec.ts
+++ b/packages/lit-ui-router-mobx/src/specs/reaction-controller.spec.ts
@@ -16,12 +16,16 @@ class ReactionControllerHost extends LitElement {
   }
 }
 
+declare global {
+  interface HTMLElementTagNameMap {
+    'reaction-controller-host': ReactionControllerHost;
+  }
+}
+
 const cleanups: (() => void)[] = [];
 
 async function mountHost(): Promise<ReactionControllerHost> {
-  const host = document.createElement(
-    'reaction-controller-host',
-  ) as ReactionControllerHost;
+  const host = document.createElement('reaction-controller-host');
   document.body.appendChild(host);
   cleanups.push(() => host.remove());
   await waitForUpdate(host);
@@ -35,9 +39,7 @@ afterEach(() => {
 describe('ReactionController', () => {
   it('selects the current value immediately on connect', async () => {
     const state = observable({ count: 7 });
-    const host = document.createElement(
-      'reaction-controller-host',
-    ) as ReactionControllerHost;
+    const host = document.createElement('reaction-controller-host');
     const controller = new ReactionController(host, () => state.count);
 
     document.body.appendChild(host);

--- a/packages/lit-ui-router-mobx/src/specs/router-reaction-controller.spec.ts
+++ b/packages/lit-ui-router-mobx/src/specs/router-reaction-controller.spec.ts
@@ -22,6 +22,12 @@ class RouterReactionHost extends LitElement {
   }
 }
 
+declare global {
+  interface HTMLElementTagNameMap {
+    'router-reaction-host': RouterReactionHost;
+  }
+}
+
 const cleanups: (() => void)[] = [];
 
 afterEach(() => {
@@ -29,7 +35,7 @@ afterEach(() => {
 });
 
 function createHost(): RouterReactionHost {
-  return document.createElement('router-reaction-host') as RouterReactionHost;
+  return document.createElement('router-reaction-host');
 }
 
 /** Mounts the host inside a <ui-router> providing the given router. */
@@ -37,7 +43,7 @@ async function mountInRouter(
   host: RouterReactionHost,
   router: UIRouterLit,
 ): Promise<UIRouterLitElement> {
-  const uiRouterEl = document.createElement('ui-router') as UIRouterLitElement;
+  const uiRouterEl = document.createElement('ui-router');
   uiRouterEl.uiRouter = router;
   uiRouterEl.appendChild(host);
   document.body.appendChild(uiRouterEl);

--- a/packages/lit-ui-router/src/specs/test-utils.ts
+++ b/packages/lit-ui-router/src/specs/test-utils.ts
@@ -3,7 +3,7 @@ import { customElement } from 'lit/decorators.js';
 import { memoryLocationPlugin, pushStateLocationPlugin } from '@uirouter/core';
 import { page, UserEventClickOptions } from 'vitest/browser';
 import { UIRouterLit } from '../core.js';
-import { UIRouterLitElement } from '../ui-router.js';
+import '../ui-router.js';
 import { LitStateDeclaration } from '../interface.js';
 
 /**
@@ -94,6 +94,12 @@ export class TestRouterContainer extends LitElement {
   }
 }
 
+declare global {
+  interface HTMLElementTagNameMap {
+    'test-router-container': TestRouterContainer;
+  }
+}
+
 /**
  * Creates a test fixture with a router and container element.
  */
@@ -113,7 +119,7 @@ export async function createTestFixture(
 
   if (template) {
     const wrapper = document.createElement('test-router-container');
-    (wrapper as TestRouterContainer).router = router;
+    wrapper.router = router;
     container.appendChild(wrapper);
 
     // Create a temporary element to render the template into
@@ -126,11 +132,9 @@ export async function createTestFixture(
       wrapper.appendChild(tempContainer.firstChild);
     }
 
-    await waitForUpdate(wrapper as LitElement);
+    await waitForUpdate(wrapper);
   } else {
-    const uiRouterEl = document.createElement(
-      'ui-router',
-    ) as UIRouterLitElement;
+    const uiRouterEl = document.createElement('ui-router');
     uiRouterEl.uiRouter = router;
     container.appendChild(uiRouterEl);
     await waitForUpdate(uiRouterEl);
@@ -148,18 +152,22 @@ export async function createTestFixture(
 /**
  * Mounts an element inside a ui-router context and returns it.
  */
-export async function mountInRouter<T extends HTMLElement>(
-  tagName: string,
+export async function mountInRouter<K extends keyof HTMLElementTagNameMap>(
+  tagName: K,
   router: UIRouterLit,
   attributes: Record<string, string> = {},
-): Promise<{ element: T; container: HTMLElement; cleanup: () => void }> {
+): Promise<{
+  element: HTMLElementTagNameMap[K];
+  container: HTMLElement;
+  cleanup: () => void;
+}> {
   const container = document.createElement('div');
   document.body.appendChild(container);
 
-  const uiRouterEl = document.createElement('ui-router') as UIRouterLitElement;
+  const uiRouterEl = document.createElement('ui-router');
   uiRouterEl.uiRouter = router;
 
-  const element = document.createElement(tagName) as T;
+  const element = document.createElement(tagName);
   Object.entries(attributes).forEach(([key, value]) => {
     element.setAttribute(key, value);
   });

--- a/packages/lit-ui-router/src/specs/transition-controller.spec.ts
+++ b/packages/lit-ui-router/src/specs/transition-controller.spec.ts
@@ -7,7 +7,7 @@ import {
   TransitionController,
   TransitionControllerOptions,
 } from '../transition-controller.js';
-import { UIRouterLitElement } from '../ui-router.js';
+import '../ui-router.js';
 import { UIRouterLit } from '../core.js';
 import { LitStateDeclaration } from '../interface.js';
 import {
@@ -30,6 +30,12 @@ class TransitionControllerHost extends LitElement {
   render() {
     this.renderCount++;
     return html`<span>${this.controller?.current?.name ?? ''}</span>`;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'test-transition-controller-host': TransitionControllerHost;
   }
 }
 
@@ -57,15 +63,11 @@ describe('TransitionController', () => {
     options?: TransitionControllerOptions,
     { withContext = true }: { withContext?: boolean } = {},
   ) {
-    const host = document.createElement(
-      'test-transition-controller-host',
-    ) as TransitionControllerHost;
+    const host = document.createElement('test-transition-controller-host');
     host.controller = new TransitionController(host, options);
 
     if (withContext) {
-      const uiRouterEl = document.createElement(
-        'ui-router',
-      ) as UIRouterLitElement;
+      const uiRouterEl = document.createElement('ui-router');
       uiRouterEl.uiRouter = router;
       container.appendChild(uiRouterEl);
       await waitForUpdate(uiRouterEl);

--- a/packages/lit-ui-router/src/specs/ui-router.spec.ts
+++ b/packages/lit-ui-router/src/specs/ui-router.spec.ts
@@ -22,7 +22,7 @@ describe('UIRouterLitElement', () => {
     });
 
     it('should create router instance if not provided', async () => {
-      const element = document.createElement('ui-router') as UIRouterLitElement;
+      const element = document.createElement('ui-router');
       container.appendChild(element);
       await waitForUpdate(element);
 
@@ -31,7 +31,7 @@ describe('UIRouterLitElement', () => {
 
     it('should use provided router instance', async () => {
       const router = createTestRouter();
-      const element = document.createElement('ui-router') as UIRouterLitElement;
+      const element = document.createElement('ui-router');
       element.uiRouter = router;
       container.appendChild(element);
       await waitForUpdate(element);
@@ -40,7 +40,7 @@ describe('UIRouterLitElement', () => {
     });
 
     it('should render slot content', async () => {
-      const element = document.createElement('ui-router') as UIRouterLitElement;
+      const element = document.createElement('ui-router');
       element.innerHTML = '<div id="test-content">Hello</div>';
       container.appendChild(element);
       await waitForUpdate(element);
@@ -53,7 +53,7 @@ describe('UIRouterLitElement', () => {
   describe('ui-router-context event', () => {
     it('should dispatch ui-router-context event on connect', async () => {
       const router = createTestRouter();
-      const element = document.createElement('ui-router') as UIRouterLitElement;
+      const element = document.createElement('ui-router');
       element.uiRouter = router;
 
       const eventSpy = vi.fn();
@@ -67,7 +67,7 @@ describe('UIRouterLitElement', () => {
 
     it('should provide router in event detail', async () => {
       const router = createTestRouter();
-      const element = document.createElement('ui-router') as UIRouterLitElement;
+      const element = document.createElement('ui-router');
       element.uiRouter = router;
 
       let receivedRouter: UIRouterLit | undefined;
@@ -85,7 +85,7 @@ describe('UIRouterLitElement', () => {
 
     it('should stop propagation and provide router to child events', async () => {
       const router = createTestRouter();
-      const element = document.createElement('ui-router') as UIRouterLitElement;
+      const element = document.createElement('ui-router');
       element.uiRouter = router;
       container.appendChild(element);
       await waitForUpdate(element);
@@ -106,7 +106,7 @@ describe('UIRouterLitElement', () => {
   describe('seekRouter static method', () => {
     it('should find router from descendant element', async () => {
       const router = createTestRouter();
-      const element = document.createElement('ui-router') as UIRouterLitElement;
+      const element = document.createElement('ui-router');
       element.uiRouter = router;
       container.appendChild(element);
       await waitForUpdate(element);
@@ -184,14 +184,10 @@ describe('UIRouterLitElement', () => {
       const outerRouter = createTestRouter();
       const innerRouter = createTestRouter();
 
-      const outerElement = document.createElement(
-        'ui-router',
-      ) as UIRouterLitElement;
+      const outerElement = document.createElement('ui-router');
       outerElement.uiRouter = outerRouter;
 
-      const innerElement = document.createElement(
-        'ui-router',
-      ) as UIRouterLitElement;
+      const innerElement = document.createElement('ui-router');
       innerElement.uiRouter = innerRouter;
 
       outerElement.appendChild(innerElement);
@@ -212,17 +208,13 @@ describe('UIRouterLitElement', () => {
       const outerRouter = createTestRouter();
       const innerRouter = createTestRouter();
 
-      const outerElement = document.createElement(
-        'ui-router',
-      ) as UIRouterLitElement;
+      const outerElement = document.createElement('ui-router');
       outerElement.uiRouter = outerRouter;
 
       const middleDiv = document.createElement('div');
       outerElement.appendChild(middleDiv);
 
-      const innerElement = document.createElement(
-        'ui-router',
-      ) as UIRouterLitElement;
+      const innerElement = document.createElement('ui-router');
       innerElement.uiRouter = innerRouter;
       middleDiv.appendChild(innerElement);
 

--- a/packages/lit-ui-router/src/specs/ui-sref-active.spec.ts
+++ b/packages/lit-ui-router/src/specs/ui-sref-active.spec.ts
@@ -44,7 +44,7 @@ describe('uiSrefActive directive', () => {
   ): Promise<{ wrapper: HTMLElement; uiRouter: UIRouterLitElement }> {
     router = createTestRouter(states);
 
-    const uiRouter = document.createElement('ui-router') as UIRouterLitElement;
+    const uiRouter = document.createElement('ui-router');
     uiRouter.uiRouter = router;
     container.appendChild(uiRouter);
 
@@ -621,7 +621,7 @@ describe('UiSrefActiveDirective methods', () => {
     document.body.appendChild(container);
     router = createTestRouter([{ name: 'home', url: '/home' }]);
 
-    const uiRouter = document.createElement('ui-router') as UIRouterLitElement;
+    const uiRouter = document.createElement('ui-router');
     uiRouter.uiRouter = router;
     container.appendChild(uiRouter);
     await waitForUpdate(uiRouter);

--- a/packages/lit-ui-router/src/specs/ui-sref.spec.ts
+++ b/packages/lit-ui-router/src/specs/ui-sref.spec.ts
@@ -10,7 +10,7 @@ import {
   UiSrefTargetEvent,
 } from '../ui-sref.js';
 import { UIRouterLitElement } from '../ui-router.js';
-import { UiView } from '../ui-view.js';
+import '../ui-view.js';
 import { UIRouterLit } from '../core.js';
 import { LitStateDeclaration } from '../interface.js';
 import {
@@ -52,7 +52,7 @@ describe('uiSref directive', () => {
   ): Promise<{ anchor: HTMLAnchorElement; uiRouter: UIRouterLitElement }> {
     router = createTestRouter(states);
 
-    const uiRouter = document.createElement('ui-router') as UIRouterLitElement;
+    const uiRouter = document.createElement('ui-router');
     uiRouter.uiRouter = router;
     container.appendChild(uiRouter);
 
@@ -105,9 +105,7 @@ describe('uiSref directive', () => {
     it('should update href when state params change', async () => {
       router = createTestRouter([{ name: 'user', url: '/user/:id' }]);
 
-      const uiRouter = document.createElement(
-        'ui-router',
-      ) as UIRouterLitElement;
+      const uiRouter = document.createElement('ui-router');
       uiRouter.uiRouter = router;
       container.appendChild(uiRouter);
       await waitForUpdate(uiRouter);
@@ -136,9 +134,7 @@ describe('uiSref directive', () => {
       ];
 
       router = createTestRouter(states);
-      const uiRouter = document.createElement(
-        'ui-router',
-      ) as UIRouterLitElement;
+      const uiRouter = document.createElement('ui-router');
       uiRouter.uiRouter = router;
       container.appendChild(uiRouter);
       await waitForUpdate(uiRouter);
@@ -261,9 +257,7 @@ describe('uiSref directive', () => {
     it('should ignore click with target="_blank"', async () => {
       router = createTestRouter([{ name: 'home', url: '/home' }]);
 
-      const uiRouter = document.createElement(
-        'ui-router',
-      ) as UIRouterLitElement;
+      const uiRouter = document.createElement('ui-router');
       uiRouter.uiRouter = router;
       container.appendChild(uiRouter);
       await waitForUpdate(uiRouter);
@@ -287,9 +281,7 @@ describe('uiSref directive', () => {
     it('should ignore click with rel="external"', async () => {
       router = createTestRouter([{ name: 'home', url: '/home' }]);
 
-      const uiRouter = document.createElement(
-        'ui-router',
-      ) as UIRouterLitElement;
+      const uiRouter = document.createElement('ui-router');
       uiRouter.uiRouter = router;
       container.appendChild(uiRouter);
       await waitForUpdate(uiRouter);
@@ -318,9 +310,7 @@ describe('uiSref directive', () => {
         { name: 'about', url: '/about' },
       ]);
 
-      const uiRouter = document.createElement(
-        'ui-router',
-      ) as UIRouterLitElement;
+      const uiRouter = document.createElement('ui-router');
       uiRouter.uiRouter = router;
       container.appendChild(uiRouter);
       await waitForUpdate(uiRouter);
@@ -348,9 +338,7 @@ describe('uiSref directive', () => {
     it('should include targetState in event detail', async () => {
       router = createTestRouter([{ name: 'home', url: '/home' }]);
 
-      const uiRouter = document.createElement(
-        'ui-router',
-      ) as UIRouterLitElement;
+      const uiRouter = document.createElement('ui-router');
       uiRouter.uiRouter = router;
       container.appendChild(uiRouter);
       await waitForUpdate(uiRouter);
@@ -420,12 +408,10 @@ describe('uiSref directive', () => {
         },
       ]);
 
-      const uiRouter = document.createElement(
-        'ui-router',
-      ) as UIRouterLitElement;
+      const uiRouter = document.createElement('ui-router');
       uiRouter.uiRouter = router;
 
-      const uiView = document.createElement('ui-view') as UiView;
+      const uiView = document.createElement('ui-view');
       uiRouter.appendChild(uiView);
       container.appendChild(uiRouter);
 
@@ -474,9 +460,7 @@ describe('uiSref directive', () => {
         { name: 'about', url: '/about' },
       ]);
 
-      const uiRouter = document.createElement(
-        'ui-router',
-      ) as UIRouterLitElement;
+      const uiRouter = document.createElement('ui-router');
       uiRouter.uiRouter = router;
       container.appendChild(uiRouter);
       await waitForUpdate(uiRouter);

--- a/packages/lit-ui-router/src/specs/ui-view.spec.ts
+++ b/packages/lit-ui-router/src/specs/ui-view.spec.ts
@@ -37,10 +37,10 @@ describe('UiView', () => {
   ): Promise<{ uiRouter: UIRouterLitElement; uiView: UiView }> {
     router = createTestRouter(states);
 
-    const uiRouter = document.createElement('ui-router') as UIRouterLitElement;
+    const uiRouter = document.createElement('ui-router');
     uiRouter.uiRouter = router;
 
-    const uiView = document.createElement('ui-view') as UiView;
+    const uiView = document.createElement('ui-view');
     uiRouter.appendChild(uiView);
     container.appendChild(uiRouter);
 
@@ -59,7 +59,7 @@ describe('UiView', () => {
     });
 
     it('should render without router context', async () => {
-      const uiView = document.createElement('ui-view') as UiView;
+      const uiView = document.createElement('ui-view');
       container.appendChild(uiView);
       await waitForUpdate(uiView);
 
@@ -97,12 +97,10 @@ describe('UiView', () => {
         },
       ]);
 
-      const uiRouter = document.createElement(
-        'ui-router',
-      ) as UIRouterLitElement;
+      const uiRouter = document.createElement('ui-router');
       uiRouter.uiRouter = router;
 
-      const uiView = document.createElement('ui-view') as UiView;
+      const uiView = document.createElement('ui-view');
       uiView.setAttribute('name', 'sidebar');
       uiRouter.appendChild(uiView);
       container.appendChild(uiRouter);
@@ -286,12 +284,10 @@ describe('UiView', () => {
     it('should render slot content when no component is active', async () => {
       router = createTestRouter([]);
 
-      const uiRouter = document.createElement(
-        'ui-router',
-      ) as UIRouterLitElement;
+      const uiRouter = document.createElement('ui-router');
       uiRouter.uiRouter = router;
 
-      const uiView = document.createElement('ui-view') as UiView;
+      const uiView = document.createElement('ui-view');
       uiView.innerHTML = '<div class="fallback">Loading...</div>';
       uiRouter.appendChild(uiView);
       container.appendChild(uiRouter);

--- a/packages/lit-ui-router/src/ui-router.ts
+++ b/packages/lit-ui-router/src/ui-router.ts
@@ -107,3 +107,9 @@ export interface UIRouterLitElement {
   /** @internal */
   constructor: typeof UIRouterLitElement;
 }
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'ui-router': UIRouterLitElement;
+  }
+}

--- a/packages/lit-ui-router/src/ui-view.ts
+++ b/packages/lit-ui-router/src/ui-view.ts
@@ -389,3 +389,9 @@ export interface UiView {
   /** @internal */
   constructor: typeof UiView;
 }
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'ui-view': UiView;
+  }
+}


### PR DESCRIPTION
Closes #283.

## What

Registers every custom element the published packages define in the global `HTMLElementTagNameMap` — the idiomatic Lit-library declaration that gives consumers typed `document.createElement('ui-view')` / `querySelector('ui-router')` for free.

**Inventory** (repo-wide sweep of `customElements.define` / `@customElement`):

| Package | Elements registered |
|---|---|
| `lit-ui-router` | `'ui-view': UiView` (ui-view.ts), `'ui-router': UIRouterLitElement` (ui-router.ts) |
| `lit-ui-router-mobx` | none published — spec-only hosts (`reaction-controller-host`, `router-reaction-host`) get spec-local augmentations |
| `ui-router-navigation-location-plugin` | none — defines no elements |

Each `declare global` lives in the module that defines the element, so the declaration ships in that module's d.ts and only applies once the consumer imports the package (which also registers the element).

## mountInRouter rework

`specs/test-utils.ts` `mountInRouter` becomes

```ts
mountInRouter<K extends keyof HTMLElementTagNameMap>(
  tagName: K, router: UIRouterLit, attributes?: Record<string, string>,
): Promise<{ element: HTMLElementTagNameMap[K]; container: HTMLElement; cleanup: () => void }>
```

The type parameter now sits in an input position, `document.createElement(tagName)` returns the mapped type with no cast, and callers with a known tag need no explicit type argument. This makes the signature #277 had to suppress (`typescript/no-unnecessary-type-parameters` on the old return-only `<T extends HTMLElement>`) legitimately pass the rule — #277 is still open, so there is no suppression on main to delete; once both land, the suppression and its reason comment can drop from #277 (or on whichever side rebases second).

Spec-local test hosts follow the same convention consistently: every element that is looked up by tag name (`test-router-container`, `test-transition-controller-host`, `reaction-controller-host`, `router-reaction-host`) declares a local `HTMLElementTagNameMap` augmentation in its defining file; dynamically-named `createTestComponent` elements are never looked up by tag and stay unregistered.

## Self-demonstrating cast cleanup

With the map in place, `typescript/no-unnecessary-type-assertion` (already enforced) flagged **31 sites** on the next lint run — 30 in `packages/lit-ui-router` specs (`ui-router.spec.ts`, `ui-view.spec.ts`, `ui-sref.spec.ts`, `ui-sref-active.spec.ts`) plus `apps/sample-app-shared/src/main.ts:41` (`querySelector('ui-router') as UIRouterLitElement | null`). All removed; same payoff pattern as #245/#277. Imports left value-unused by the cast removals became side-effect imports (element registration is still required).

## Version impact

- **lit-ui-router → MINOR**: additive published d.ts change — `declare global { interface HTMLElementTagNameMap { … } }` entries for `ui-view` and `ui-router`. No runtime change (`declare global` emits no JS). New consumer capability = minor.
- **lit-ui-router-mobx → no release needed**: spec-only changes, zero d.ts-visible or runtime change.
- **ui-router-navigation-location-plugin → untouched.**

**Sibling: #284 (sideEffects audit)** — being implemented in parallel; its diff is package.json-only and this one touches no package.json, so the two merge cleanly in either order. The map declarations here are pure ambient `declare global` blocks (zero JS emit, no new runtime side effect), and no element definition/registration moved between modules — the published-module graph #284 audits is unchanged. Spec/app imports that lost their last value use were converted to side-effect imports of the same modules, which keeps element registration explicit.

**Sibling: #284 (sideEffects audit)** — being implemented in parallel; its diff is package.json-only and this one touches no package.json, so the two merge cleanly in either order. The map declarations here are pure ambient `declare global` blocks (zero JS emit, no new runtime side effect), and no element definition/registration moved between modules — the published-module graph #284 audits is unchanged. Spec/app imports that lost their last value use were converted to side-effect imports of the same modules, which keeps element registration explicit.

Compatibility proof down to the TS 5.0 consumer floor: dts-backtest green (TS 5.0.4, 5.9.3, 6.0.3, 7.0.2 × both fixtures) in the full ci run.

## Verification

- `turbo run ci`: green, 64/64 tasks (lint, format:check, typecheck, unit + browser tests, e2e, check:catalog, check:pack, dts-backtest).
- Scratch consumer-style check (uncommitted, against the built `dist/index.d.ts` via `paths`): `const view: UiView = document.createElement('ui-view')` and `const found: UiView | null = document.querySelector('ui-view')` typecheck clean; negative control `const bad: HTMLDivElement = document.createElement('ui-view')` fails with `TS2741 … 'align' is missing in type 'UiView'`, proving the concrete mapped type (not `HTMLElement`).
