### PR TITLE
fix(lit-ui-router): flag the dist/index.js barrel in sideEffects

### DIFF
--- a/packages/lit-ui-router/package.json
+++ b/packages/lit-ui-router/package.json
@@ -14,8 +14,9 @@
   ],
   "type": "module",
   "sideEffects": [
-    "**/ui-router.js",
-    "**/ui-view.js"
+    "./dist/index.js",
+    "./dist/ui-router.js",
+    "./dist/ui-view.js"
   ],
   "main": "./dist/index.js",
   "module": "./dist/index.js",


### PR DESCRIPTION
Closes #284.

#167 added the `sideEffects` fields, but bundler verification shows the published lit-ui-router list is broken: **vite (rollup), webpack, and esbuild all skip a sideEffects-pure re-export barrel wholesale — they never traverse into the effectful modules it re-exports.** With 1.6.0's `["**/ui-router.js", "**/ui-view.js"]`, a production build of `import 'lit-ui-router'` (or of code using only `UIRouterLit` plus `<ui-view>` markup) emits **zero element registration**. Rollup attaches `moduleSideEffects: true` to `dist/ui-view.js`/`dist/ui-router.js` correctly (probed via `getModuleInfo`), but drops them because the only path in runs through the pure `dist/index.js`. A direct deep import (`lit-ui-router/dist/ui-view.js`) is retained — the failure is barrel traversal, not glob syntax (exact `./dist/...` paths reproduce it).

Fix: flag `./dist/index.js` too, and switch to exact published paths. Registration then survives any barrel import while the directive modules still shake out.

## Side-effect inventory (published `dist/*.js`)

| package / module | module-scope effect | classification |
|---|---|---|
| lit-ui-router `ui-router.js` | `__decorate([customElement('ui-router')], …)` → `customElements.define` | **effectful** |
| lit-ui-router `ui-view.js` | `__decorate([customElement('ui-view')], …)` → `customElements.define` | **effectful** |
| lit-ui-router `index.js` | none (pure re-export barrel) | **flagged anyway** — a pure barrel severs the bundler path to the effectful leaves (all three bundlers) |
| lit-ui-router `core.js`, `interface.js`, `transition-controller.js`, `ui-sref.js`, `ui-sref-active.js`, `specs/test-utils.js` | consts, class decls, `directive()` wrappers (pure closures); all `addEventListener` calls are constructor/connectedCallback-scoped | pure |
| lit-ui-router-mobx (all 4 modules) | none — `makeAutoObservable` is constructor-scoped | pure → `false` stays |
| ui-router-navigation-location-plugin `index.js` | none — `locationPluginFactory(...)` returns a closure; the `navigation` listener registers in the service constructor | pure → `false` stays |

## Bundle measurements (fixture: packed tarballs, real installs)

Entry `import 'lit-ui-router'` / `import { UIRouterLit } …` (minified; vite lib-ES unminified):

| field variant | vite 7 (bare) | webpack 5 (bare / core-only) | esbuild (bare / core-only) | registration |
|---|---|---|---|---|
| 1.6.0 published list | **77 B** | **98 B** / 108,058 B | **76 B** / 110,250 B | **dropped** (`customElements.get('ui-view')` → `undefined` under happy-dom) |
| `false` (naive) | 77 B | — | — | dropped |
| no field | 158,660 B | 122,507 / 122,491 B | 125,514 / 125,496 B | kept, nothing shakes |
| **this PR** | 158,553 B | **114,949 / 114,664 B** | **117,395 / 117,377 B** | **kept** (runtime-verified via happy-dom; both elements) |

- Honest payoff vs no field: modest, −7.6 KB webpack / −8.1 KB esbuild min (`ui-sref.js` + `ui-sref-active.js` + `transition-controller.js` shake out; vite's statement-level analysis already shook most of that). The load-bearing delta is vs the **published** list: registration restored.
- The big enabled win is downstream: with the barrel flagged here, lit-ui-router-mobx's verified `sideEffects: false` lets a `RouterStore`-only consumer drop the entire lit + element subtree — **104,353 B vs 263,231 B (−60.4%)** — while `RouterReactionController` users still pull registration through the module graph (verified `REGISTERED`).

## Why the in-repo net never caught it

The sample apps and examples import `uiSref`/`uiSrefActive`/`TransitionController` as values; those modules import `UiView`/`UIRouterLitElement` as values, so the decorated initializers ride along incidentally in built apps. Only barrel-effect consumers (bare import, or core-API + template markup) hit the breakage — none exist in-repo.

## Version impact

- **lit-ui-router → PATCH**: metadata-only but bundler-behavior-changing; it *restores* 1.6.0's intended (and 1.5.x's actual, pre-field) production behavior. No API or runtime code change; d.ts untouched. Bundles grow only where 1.6.0 was silently broken.
- **lit-ui-router-mobx, ui-router-navigation-location-plugin → no change, no release**: audit confirms `false` is correct for both.

Sibling: #283 / #285 (HTMLElementTagNameMap) touches the same element modules with pure ambient type declarations — zero runtime effect, no interaction with this audit; d.ts inclusion follows the type graph, not the bundler graph, so the tag map survives tree-shaking in either merge order.

## Verification

- Fixture matrix (job tmp, not committed): vite 7 / webpack 5 / esbuild across {published list, exact-path list, `false`, no field, this PR} × {bare, core-only, mobx-store, mobx-controller} entries; module inclusion read from rollup `chunk.modules` and marker strings; registration proven at runtime with happy-dom (`customElements.get('ui-view')`/`('ui-router')` defined).
- Full `turbo run ci` green locally: 64/64 tasks, all five Cypress suites (vanilla, mobx, docs, hash, navigation) against the **built** apps served by wrangler, `check:pack`, and dts-backtest.
