### PR TITLE
perf(sample-app-routes): measure deep-import savings for the worker simulation tier

### DIFF
--- a/apps/sample-app-routes/package.json
+++ b/apps/sample-app-routes/package.json
@@ -3,6 +3,12 @@
   "version": "0.0.0",
   "private": true,
   "type": "module",
+  "imports": {
+    "#uirouter/*": {
+      "node": "@uirouter/core/lib/*",
+      "default": "@uirouter/core/lib-esm/*"
+    }
+  },
   "exports": {
     ".": "./src/routes.ts",
     "./matchers.js": "./src/matchers.ts"

--- a/apps/sample-app-routes/src/matchers.ts
+++ b/apps/sample-app-routes/src/matchers.ts
@@ -8,11 +8,13 @@ import { services } from '#uirouter/common/coreservices.js';
 // lib and lib-esm d.ts declare privates separately; barrel types won't unify.
 import type { ParamFactory } from '#uirouter/url/urlMatcherFactory.js';
 import type { ParamType } from '#uirouter/params/paramType.js';
+import type { RawParams } from '#uirouter/params/interface.js';
 import type { StateDeclaration } from '#uirouter/state/interface.js';
 import type { UrlConfig } from '#uirouter/url/urlConfig.js';
 
 // .ts extension: node --test runs this graph directly via type stripping.
-import { routePathPatterns } from './routes.ts';
+import { routePathPattern, routeSegments } from './routes.ts';
+import type { AppRouteName } from './routes.ts';
 
 // Core routes even static param defaults through services.$injector.invoke
 // (params/param.ts); no framework installs one here, so exec() would throw
@@ -52,12 +54,28 @@ export function compileAppPattern(
   });
 }
 
-const matchers = routePathPatterns.map((pattern) => compileAppPattern(pattern));
+// UrlMatcher.compare is the router's specificity sort (static segments before
+// params), so '/contacts/new' resolves to contacts.new, not contacts.contact.
+const matchers = (Object.keys(routeSegments) as AppRouteName[])
+  .map((state) => ({
+    state,
+    matcher: compileAppPattern(routePathPattern(state)),
+  }))
+  .sort((a, b) => UrlMatcher.compare(a.matcher, b.matcher));
 
-// The app root has no state url; router.config.ts matches it with when(/^\/?$/).
+// The app root has no state url (router.config.ts matches it with
+// when(/^\/?$/)), so it reports the empty state name.
+export function matchAppRoute(
+  path: string,
+): { state: string; params: RawParams } | null {
+  if (/^\/?$/.test(path)) return { state: '', params: {} };
+  for (const { state, matcher } of matchers) {
+    const params = matcher.exec(path);
+    if (params !== null) return { state, params };
+  }
+  return null;
+}
+
 export function matchesAppRoute(path: string): boolean {
-  return (
-    /^\/?$/.test(path) ||
-    matchers.some((matcher) => matcher.exec(path) !== null)
-  );
+  return matchAppRoute(path) !== null;
 }

--- a/apps/sample-app-routes/src/matchers.ts
+++ b/apps/sample-app-routes/src/matchers.ts
@@ -1,4 +1,3 @@
-// Deep imports keep the router out of the worker bundle (~57 KiB vs ~202 KiB).
 // #uirouter/* maps to lib-esm/* for bundlers and lib/* (CJS) under node,
 // whose ESM loader can't resolve lib-esm's extensionless relative imports.
 // Either way these are internal layout, not part of @uirouter/core's semver.
@@ -6,8 +5,7 @@ import { UrlMatcher } from '#uirouter/url/urlMatcher.js';
 import { ParamTypes } from '#uirouter/params/paramTypes.js';
 import { Param, DefType } from '#uirouter/params/param.js';
 import { services } from '#uirouter/common/coreservices.js';
-// Types from the same #uirouter universe: lib and lib-esm declare private
-// members separately, so mixing them with the barrel's types won't unify.
+// lib and lib-esm d.ts declare privates separately; barrel types won't unify.
 import type { ParamFactory } from '#uirouter/url/urlMatcherFactory.js';
 import type { ParamType } from '#uirouter/params/paramType.js';
 import type { StateDeclaration } from '#uirouter/state/interface.js';

--- a/apps/sample-app-routes/src/matchers.ts
+++ b/apps/sample-app-routes/src/matchers.ts
@@ -63,12 +63,12 @@ const matchers = (Object.keys(routeSegments) as AppRouteName[])
   }))
   .sort((a, b) => UrlMatcher.compare(a.matcher, b.matcher));
 
-// The app root has no state url (router.config.ts matches it with
-// when(/^\/?$/)), so it reports the empty state name.
+// The app root has no state url (router.config.ts matches it with a
+// when(/^\/?$/) rule), so it has no match identity: matchAppRoute reports
+// null there while matchesAppRoute stays true.
 export function matchAppRoute(
   path: string,
 ): { state: string; params: RawParams } | null {
-  if (/^\/?$/.test(path)) return { state: '', params: {} };
   for (const { state, matcher } of matchers) {
     const params = matcher.exec(path);
     if (params !== null) return { state, params };
@@ -77,5 +77,5 @@ export function matchAppRoute(
 }
 
 export function matchesAppRoute(path: string): boolean {
-  return matchAppRoute(path) !== null;
+  return /^\/?$/.test(path) || matchAppRoute(path) !== null;
 }

--- a/apps/sample-app-routes/src/matchers.ts
+++ b/apps/sample-app-routes/src/matchers.ts
@@ -1,4 +1,17 @@
-import { services, UIRouter } from '@uirouter/core';
+// Deep imports keep the router out of the worker bundle (~57 KiB vs ~202 KiB).
+// #uirouter/* maps to lib-esm/* for bundlers and lib/* (CJS) under node,
+// whose ESM loader can't resolve lib-esm's extensionless relative imports.
+// Either way these are internal layout, not part of @uirouter/core's semver.
+import { UrlMatcher } from '#uirouter/url/urlMatcher.js';
+import { ParamTypes } from '#uirouter/params/paramTypes.js';
+import { Param, DefType } from '#uirouter/params/param.js';
+import { services } from '#uirouter/common/coreservices.js';
+// Types from the same #uirouter universe: lib and lib-esm declare private
+// members separately, so mixing them with the barrel's types won't unify.
+import type { ParamFactory } from '#uirouter/url/urlMatcherFactory.js';
+import type { ParamType } from '#uirouter/params/paramType.js';
+import type { StateDeclaration } from '#uirouter/state/interface.js';
+import type { UrlConfig } from '#uirouter/url/urlConfig.js';
 
 // .ts extension: node --test runs this graph directly via type stripping.
 import { routePathPatterns } from './routes.ts';
@@ -10,13 +23,38 @@ services.$injector = {
   invoke: (fn: () => unknown) => fn(),
 } as typeof services.$injector;
 
-// The default location services are inert stubs, so compiling matchers this
-// way needs no DOM and is safe in the docs worker.
-const { urlMatcherFactory } = new UIRouter();
+const paramTypes = new ParamTypes();
 
-const matchers = routePathPatterns.map((pattern) =>
-  urlMatcherFactory.compile(pattern),
-);
+// Param construction reads only paramTypes and defaultSquashPolicy() (whose
+// factory default is false), so this duck-typed UrlConfig suffices.
+const urlConfig = {
+  paramTypes,
+  defaultSquashPolicy: () => false,
+} as unknown as UrlConfig;
+
+// UrlMatcher only calls fromPath/fromSearch; fromConfig and the private
+// router that the class type carries are never reached.
+const paramFactory = {
+  fromPath: (id: string, type: ParamType, state: StateDeclaration) =>
+    new Param(id, type, DefType.PATH, urlConfig, state),
+  fromSearch: (id: string, type: ParamType, state: StateDeclaration) =>
+    new Param(id, type, DefType.SEARCH, urlConfig, state),
+} as unknown as ParamFactory;
+
+// Bare UrlMatcher defaults caseInsensitive to TRUE; match the factory's (and
+// so the client router's) compile defaults instead.
+export function compileAppPattern(
+  pattern: string,
+  state: StateDeclaration = { params: {} },
+): UrlMatcher {
+  return new UrlMatcher(pattern, paramTypes, paramFactory, {
+    strict: true,
+    caseInsensitive: false,
+    state,
+  });
+}
+
+const matchers = routePathPatterns.map((pattern) => compileAppPattern(pattern));
 
 // The app root has no state url; router.config.ts matches it with when(/^\/?$/).
 export function matchesAppRoute(path: string): boolean {

--- a/apps/sample-app-routes/test/matchers.test.ts
+++ b/apps/sample-app-routes/test/matchers.test.ts
@@ -1,31 +1,34 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
-import { UIRouter } from '@uirouter/core';
+import { compileAppPattern } from '../src/matchers.ts';
 
-// Importing the matchers module installs its $injector shim.
-import '../src/matchers.ts';
-
-// Regression net for the shim: without it, core routes even static param
-// defaults through the (absent) injector and exec() throws "Injectable
+// Regression net for the $injector shim: without it, core routes even static
+// param defaults through the (absent) injector and exec() throws "Injectable
 // functions cannot be called at configuration time".
-describe('UrlMatcher exec without a framework injector', () => {
-  const { urlMatcherFactory } = new UIRouter();
-
+describe('compileAppPattern without a framework injector', () => {
   it('matches query-suffixed patterns without throwing', () => {
-    const matcher = urlMatcherFactory.compile('/welcome?flag');
+    const matcher = compileAppPattern('/welcome?flag');
     assert.notEqual(matcher.exec('/welcome'), null);
     assert.equal(matcher.exec('/nope'), null);
   });
 
   it('applies defaulted params without throwing', () => {
-    const matcher = urlMatcherFactory.compile('/x/:id', {
-      state: { params: { id: { value: 'fallback', squash: true } } },
+    const matcher = compileAppPattern('/x/:id', {
+      params: { id: { value: 'fallback', squash: true } },
     });
     const defaulted = matcher.exec('/x') as Record<string, string> | null;
     assert.equal(defaulted?.id, 'fallback');
     const explicit = matcher.exec('/x/7') as Record<string, string> | null;
     assert.equal(explicit?.id, '7');
     assert.equal(matcher.exec('/y'), null);
+  });
+
+  // A bare UrlMatcher defaults caseInsensitive to true; the factory (and so
+  // the client router) defaults it to false. Guard the explicit override.
+  it('stays case-sensitive and strict like the factory', () => {
+    const matcher = compileAppPattern('/welcome');
+    assert.equal(matcher.exec('/WELCOME'), null);
+    assert.equal(matcher.exec('/welcome/extra'), null);
   });
 });

--- a/apps/sample-app-routes/test/routes.test.ts
+++ b/apps/sample-app-routes/test/routes.test.ts
@@ -8,7 +8,7 @@ import {
   routePathPatterns,
   routeSegments,
 } from '../src/routes.ts';
-import { matchesAppRoute } from '../src/matchers.ts';
+import { matchAppRoute, matchesAppRoute } from '../src/matchers.ts';
 
 const ACCEPTED = [
   '/welcome',
@@ -74,6 +74,44 @@ describe('matchesAppRoute', () => {
   it('rejects paths no state url matches', () => {
     for (const path of REJECTED) {
       assert.equal(matchesAppRoute(path), false, path);
+    }
+  });
+
+  it('reports which state matched, with its params', () => {
+    assert.deepEqual(matchAppRoute('/welcome'), {
+      state: 'welcome',
+      params: {},
+    });
+    assert.deepEqual(matchAppRoute('/contacts/3'), {
+      state: 'contacts.contact',
+      params: { contactId: '3' },
+    });
+    assert.deepEqual(matchAppRoute('/contacts/3/edit'), {
+      state: 'contacts.contact.edit',
+      params: { contactId: '3' },
+    });
+    assert.deepEqual(matchAppRoute('/mymessages/inbox/5'), {
+      state: 'mymessages.messagelist.message',
+      params: { folderId: 'inbox', messageId: '5' },
+    });
+  });
+
+  it('prefers static segments over params, like the router', () => {
+    assert.equal(matchAppRoute('/contacts/new')?.state, 'contacts.new');
+    assert.equal(
+      matchAppRoute('/mymessages/compose')?.state,
+      'mymessages.compose',
+    );
+  });
+
+  it('reports the app root as the empty state name', () => {
+    assert.deepEqual(matchAppRoute(''), { state: '', params: {} });
+    assert.deepEqual(matchAppRoute('/'), { state: '', params: {} });
+  });
+
+  it('reports null for every rejected path', () => {
+    for (const path of REJECTED) {
+      assert.equal(matchAppRoute(path), null, path);
     }
   });
 

--- a/apps/sample-app-routes/test/routes.test.ts
+++ b/apps/sample-app-routes/test/routes.test.ts
@@ -104,9 +104,13 @@ describe('matchesAppRoute', () => {
     );
   });
 
-  it('reports the app root as the empty state name', () => {
-    assert.deepEqual(matchAppRoute(''), { state: '', params: {} });
-    assert.deepEqual(matchAppRoute('/'), { state: '', params: {} });
+  // The root is matched by a when-rule, not a state url: it has match truth
+  // but no match identity, and must never be treated as a state.
+  it('reports no identity for the app root, which still matches', () => {
+    for (const root of ['', '/']) {
+      assert.equal(matchAppRoute(root), null, root);
+      assert.equal(matchesAppRoute(root), true, root);
+    }
   });
 
   it('reports null for every rejected path', () => {

--- a/apps/sample-app-routes/test/routes.test.ts
+++ b/apps/sample-app-routes/test/routes.test.ts
@@ -1,12 +1,38 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
+import { UIRouter } from '@uirouter/core';
+
 import {
   routePathPattern,
   routePathPatterns,
   routeSegments,
 } from '../src/routes.ts';
 import { matchesAppRoute } from '../src/matchers.ts';
+
+const ACCEPTED = [
+  '/welcome',
+  '/home',
+  '/login',
+  '/prefs',
+  '/contacts',
+  '/contacts/3',
+  '/contacts/3/edit',
+  '/contacts/new',
+  '/mymessages',
+  '/mymessages/compose',
+  '/mymessages/inbox',
+  '/mymessages/inbox/5',
+];
+
+const REJECTED = [
+  '/definitely-not-a-route',
+  '/welcome/nope',
+  '/contacts/3/edit/extra',
+  '/mymessages/inbox/5/extra',
+  '/welcomeextra',
+  '/WELCOME',
+];
 
 describe('routePathPattern', () => {
   it('passes top-level segments through', () => {
@@ -40,33 +66,29 @@ describe('matchesAppRoute', () => {
   });
 
   it('accepts static and parameterized routes', () => {
-    for (const path of [
-      '/welcome',
-      '/home',
-      '/login',
-      '/prefs',
-      '/contacts',
-      '/contacts/3',
-      '/contacts/3/edit',
-      '/contacts/new',
-      '/mymessages',
-      '/mymessages/compose',
-      '/mymessages/inbox',
-      '/mymessages/inbox/5',
-    ]) {
+    for (const path of ACCEPTED) {
       assert.equal(matchesAppRoute(path), true, path);
     }
   });
 
   it('rejects paths no state url matches', () => {
-    for (const path of [
-      '/definitely-not-a-route',
-      '/welcome/nope',
-      '/contacts/3/edit/extra',
-      '/mymessages/inbox/5/extra',
-      '/welcomeextra',
-    ]) {
+    for (const path of REJECTED) {
       assert.equal(matchesAppRoute(path), false, path);
+    }
+  });
+
+  // Differential leg: the deep-import compile in matchers.ts must keep the
+  // exact verdicts of urlMatcherFactory.compile, which the client router uses.
+  it('agrees with a factory-compiled control on every path', () => {
+    const { urlMatcherFactory } = new UIRouter();
+    const control = routePathPatterns.map((pattern) =>
+      urlMatcherFactory.compile(pattern),
+    );
+    for (const path of ['', '/', ...ACCEPTED, ...REJECTED]) {
+      const controlVerdict =
+        /^\/?$/.test(path) ||
+        control.some((matcher) => matcher.exec(path) !== null);
+      assert.equal(matchesAppRoute(path), controlVerdict, path);
     }
   });
 });


### PR DESCRIPTION
**Measurement report — verdict: negligible, keep the barrel.** Per the A/B resolution (#292 takes matchers.ts and the light tiers), this PR's deep-import technique was re-aimed at the tier that genuinely needs core: the headless simulation layer #297 added (`headless.ts`/`simulate.ts`). Measured honestly, deep imports buy ~0.3 KiB gzip there, so the barrel stays and this PR closes as evidence rather than code.

## The question

The matcher tier proved deep imports can be dramatic when a tier needs a sliver of core. Does the same hold for the simulation tier, which constructs a real `UIRouter` (vanilla `$q`/`$injector`, memory location, state registration, transition settling)?

## Measured answer

Standalone closure bundles (esbuild, `--format=esm --platform=browser`, unminified to mirror wrangler):

| tier | barrel import | deep `#uirouter/*` import | gzip delta |
| --- | --- | --- | --- |
| matcher (earlier phase of this PR, head `b246056`) | 201.75 KiB / 43.25 KiB gzip (whole worker) | 57.63 KiB / **14.12 KiB gzip** | **−67%** |
| simulation (`computeAppRedirect` closure) | 197,326 B / 43,066 B gzip | 197,019 B / 42,775 B gzip | **−291 B (~0.7%)** |

Whole-worker `wrangler deploy --dry-run` on the #297 base: **207.35 KiB / 44.86 KiB gzip both before and after** — the delta vanishes in wrangler's rounding.

## Why the difference

The esbuild metafile diff explains it: the deep variant drops exactly **11 modules, all empty re-export shims** (`index.js`/`interface.js` barrels, `vanilla.js`); all **73 substantive modules are shared**. `UIRouter`'s constructor closure *is* the library — `router.js` reaches the state machine, transition + hook machinery, resolve, view, trace, url, params. There is nothing outside it to shake off. The matcher tier won big because `UrlMatcher` + `ParamTypes` + `Param` sit near the leaves of that graph; the simulation tier sits at its root.

The auth rung rides free either way: future hook-driven redirects use `transitionService` hooks, which are already inside this closure — zero marginal bundle cost, no trimming needed (or possible).

## The technique still works

The tested patch (46 lines: `#uirouter/*` conditional imports map — `node` → `lib/*` CJS for `node --test`, `default` → `lib-esm/*` for bundlers — plus deep imports in `headless.ts`/`simulate.ts` of `router.js`, `vanilla/plugins.js`, `state/interface.js`) passed all 17 package tests and `tsc` unchanged. It just doesn't pay here.

<details><summary>Tested patch</summary>

```diff
diff --git a/apps/sample-app-routes/package.json b/apps/sample-app-routes/package.json
@@
   "type": "module",
+  "imports": {
+    "#uirouter/*": {
+      "node": "@uirouter/core/lib/*",
+      "default": "@uirouter/core/lib-esm/*"
+    }
+  },
   "exports": {
diff --git a/apps/sample-app-routes/src/headless.ts b/apps/sample-app-routes/src/headless.ts
@@
-import { memoryLocationPlugin, servicesPlugin, UIRouter } from '@uirouter/core';
-import type { StateDeclaration } from '@uirouter/core';
+import { UIRouter } from '#uirouter/router.js';
+import { memoryLocationPlugin, servicesPlugin } from '#uirouter/vanilla/plugins.js';
+import type { StateDeclaration } from '#uirouter/state/interface.js';
diff --git a/apps/sample-app-routes/src/simulate.ts b/apps/sample-app-routes/src/simulate.ts
@@
-import type { StateDeclaration, UIRouter } from '@uirouter/core';
+import type { UIRouter } from '#uirouter/router.js';
+import type { StateDeclaration } from '#uirouter/state/interface.js';
```

</details>

## Upstream exhibit (#25 evidence)

This is the strongest data point yet for "core's granularity forces deep paths": deep imports carve a *matching-only* consumer from 43 KiB gzip down to 14, but **cannot carve a headless router below ~43 KiB gzip**, because everything hangs off the `UIRouter` constructor. A future `ui-router-server` package's `./simulate` subpath will carry that full weight unless upstream splits the router itself — and if it ever does adopt deep paths, the same caveat from this PR's matcher phase applies: `lib/`/`lib-esm/` layout is internal, not semver-guarded.

## Disposition

- Simulation tier keeps the barrel import (no code change ships from this PR).
- Matcher-tier deep imports are superseded by #292's standalone package.
- Head `b246056` remains the reproducible artifact for the matcher-tier numbers (all checks green on it).
