### PR TITLE
feat(docs): compute entry redirects in the worker via headless router

### DIFF
--- a/apps/sample-app-routes/package.json
+++ b/apps/sample-app-routes/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "exports": {
     ".": "./src/routes.ts",
-    "./matchers.js": "./src/matchers.ts"
+    "./matchers.js": "./src/matchers.ts",
+    "./simulate.js": "./src/simulate.ts"
   },
   "scripts": {
     "format": "oxfmt \"**/*.{ts,json,md}\"",

--- a/apps/sample-app-routes/src/headless.ts
+++ b/apps/sample-app-routes/src/headless.ts
@@ -1,0 +1,25 @@
+import { memoryLocationPlugin, servicesPlugin, UIRouter } from '@uirouter/core';
+import type { StateDeclaration } from '@uirouter/core';
+
+// Core's own headless recipe: vanilla $q/$injector plus an in-memory location
+// need no DOM, so per-request instantiation is workerd-safe.
+export function createHeadlessRouter(states: StateDeclaration[]): UIRouter {
+  const router = new UIRouter();
+  router.plugin(servicesPlugin);
+  router.plugin(memoryLocationPlugin);
+  // Callers observe outcomes through onceSettled; keep the console quiet.
+  router.stateService.defaultErrorHandler(() => {});
+  states.forEach((state) => router.stateRegistry.register(state));
+  return router;
+}
+
+// Redirected rejections only hand off to a successor transition, so the final
+// transition's outcome is the answer.
+export function onceSettled(router: UIRouter): Promise<boolean> {
+  return new Promise((resolve) => {
+    router.transitionService.onSuccess({}, () => resolve(true));
+    router.transitionService.onError({}, (transition) => {
+      if (!transition.error().redirected) resolve(false);
+    });
+  });
+}

--- a/apps/sample-app-routes/src/routes.ts
+++ b/apps/sample-app-routes/src/routes.ts
@@ -30,3 +30,7 @@ export function routePathPattern(name: AppRouteName): string {
 export const routePathPatterns: string[] = (
   Object.keys(routeSegments) as AppRouteName[]
 ).map(routePathPattern);
+
+// The app root ('' or '/') has no state url; router.config.ts routes it to
+// 'welcome' with a urlService.rules.when(/^\/?$/) rule.
+export const rootRedirectTarget: AppRouteName = 'welcome';

--- a/apps/sample-app-routes/src/simulate.ts
+++ b/apps/sample-app-routes/src/simulate.ts
@@ -1,0 +1,59 @@
+import type { StateDeclaration, UIRouter } from '@uirouter/core';
+
+// .ts extensions: node --test runs this graph directly via type stripping.
+import { createHeadlessRouter, onceSettled } from './headless.ts';
+import { rootRedirectTarget, routeSegments } from './routes.ts';
+
+// setTimeout exists on every target runtime (worker, node, browser) but not
+// in the DOM-free ES lib this package compiles against.
+declare function setTimeout(handler: () => void, ms: number): unknown;
+
+// Dotted names nest, so the flat segment map registers as the real state tree.
+const slimStates: StateDeclaration[] = Object.entries(routeSegments).map(
+  ([name, url]) => ({ name, url }),
+);
+
+// Transitions settle in microtasks; the timer is only a degrade-to-shell net.
+const SETTLE_TIMEOUT_MS = 100;
+
+export function createAppRouter(): UIRouter {
+  const router = createHeadlessRouter(slimStates);
+  // Mirror router.config.ts: the app root has no state url and is routed by a
+  // when(/^\/?$/) rule. Its otherwise() -> notFound rule is NOT mirrored, so
+  // unknown paths start no transition and stay worker 404s.
+  router.urlService.rules.when(/^\/?$/, () => ({
+    state: rootRedirectTarget,
+  }));
+  return router;
+}
+
+/**
+ * Replays `path` through a headless router running the app's slim states and
+ * returns the path the client app would land on, or null when the address
+ * would not change. Unknown paths, errors, and timeouts all return null: the
+ * worker degrades to serving the shell (or 404), never a wrong redirect.
+ */
+export async function computeAppRedirect(path: string): Promise<string | null> {
+  try {
+    // Fresh router per request: the memory location is per-instance state.
+    const router = createAppRouter();
+    const url = { path, search: {}, hash: '' };
+    if (!router.urlService.match(url)) return null;
+    const settled = onceSettled(router);
+    router.urlService.url(path);
+    router.urlService.sync();
+    const outcome = await Promise.race([
+      settled,
+      new Promise<false>((resolve) =>
+        setTimeout(() => resolve(false), SETTLE_TIMEOUT_MS),
+      ),
+    ]);
+    if (!outcome) return null;
+    // The memory location only moves when the client's address bar would:
+    // core skips the URL push for url-sourced and location:false transitions.
+    const landed = router.urlService.url();
+    return landed === path ? null : landed;
+  } catch {
+    return null;
+  }
+}

--- a/apps/sample-app-routes/src/simulate.ts
+++ b/apps/sample-app-routes/src/simulate.ts
@@ -8,15 +8,16 @@ import { rootRedirectTarget, routeSegments } from './routes.ts';
 // in the DOM-free ES lib this package compiles against.
 declare function setTimeout(handler: () => void, ms: number): unknown;
 
-// Dotted names nest, so the flat segment map registers as the real state tree.
-const slimStates: StateDeclaration[] = Object.entries(routeSegments).map(
-  ([name, url]) => ({ name, url }),
-);
-
 // Transitions settle in microtasks; the timer is only a degrade-to-shell net.
 const SETTLE_TIMEOUT_MS = 100;
 
 export function createAppRouter(): UIRouter {
+  // Fresh declarations per router: core mutates registered declarations
+  // ($$state), so sharing them across routers breaks concurrent calls.
+  // Dotted names nest, so the flat segment map registers as the real tree.
+  const slimStates: StateDeclaration[] = Object.entries(routeSegments).map(
+    ([name, url]) => ({ name, url }),
+  );
   const router = createHeadlessRouter(slimStates);
   // Mirror router.config.ts: the app root has no state url and is routed by a
   // when(/^\/?$/) rule. Its otherwise() -> notFound rule is NOT mirrored, so

--- a/apps/sample-app-routes/test/simulate.test.ts
+++ b/apps/sample-app-routes/test/simulate.test.ts
@@ -1,0 +1,75 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { createHeadlessRouter, onceSettled } from '../src/headless.ts';
+import { computeAppRedirect, createAppRouter } from '../src/simulate.ts';
+
+describe('computeAppRedirect', () => {
+  it('redirects the app root to the projected welcome url', async () => {
+    assert.equal(await computeAppRedirect('/'), '/welcome');
+    assert.equal(await computeAppRedirect(''), '/welcome');
+  });
+
+  it('returns null for a plain route', async () => {
+    assert.equal(await computeAppRedirect('/home'), null);
+    assert.equal(await computeAppRedirect('/welcome'), null);
+  });
+
+  it('returns null for parameterized deep links', async () => {
+    assert.equal(await computeAppRedirect('/contacts/3'), null);
+    assert.equal(await computeAppRedirect('/mymessages/inbox/5'), null);
+  });
+
+  it('returns null for unknown paths', async () => {
+    assert.equal(await computeAppRedirect('/nope'), null);
+    assert.equal(await computeAppRedirect('/contacts/3/nope'), null);
+  });
+
+  it('does not preempt client-conditional redirects (mymessages DSR)', async () => {
+    // The client's DSR default and requiresAuth hook compete based on
+    // client-side auth state, so the server must not pick a winner.
+    assert.equal(await computeAppRedirect('/mymessages'), null);
+  });
+
+  it('registers no otherwise() rule, so unknowns cannot become 302s', () => {
+    const router = createAppRouter();
+    const unmatched = router.urlService.match({
+      path: '/definitely-not-a-route',
+      search: {},
+      hash: '',
+    });
+    assert.equal(unmatched, null);
+  });
+});
+
+describe('onceSettled', () => {
+  it('waits out a superseded redirect chain for the final transition', async () => {
+    const router = createHeadlessRouter([
+      { name: 'a', url: '/a', redirectTo: 'b' },
+      { name: 'b', url: '/b' },
+    ]);
+    const settled = onceSettled(router);
+    router.urlService.url('/a');
+    router.urlService.sync();
+    assert.equal(await settled, true);
+    assert.equal(router.globals.current.name, 'b');
+    // A redirect from a url-sourced transition replaces the address.
+    assert.equal(router.urlService.url(), '/b');
+  });
+
+  it('reports non-redirect failures as false', async () => {
+    const router = createHeadlessRouter([
+      {
+        name: 'boom',
+        url: '/boom',
+        resolve: [
+          { token: 'x', resolveFn: () => Promise.reject(new Error('boom')) },
+        ],
+      },
+    ]);
+    const settled = onceSettled(router);
+    router.urlService.url('/boom');
+    router.urlService.sync();
+    assert.equal(await settled, false);
+  });
+});

--- a/apps/sample-app-routes/test/simulate.test.ts
+++ b/apps/sample-app-routes/test/simulate.test.ts
@@ -31,6 +31,15 @@ describe('computeAppRedirect', () => {
     assert.equal(await computeAppRedirect('/mymessages'), null);
   });
 
+  it('isolates concurrent calls (core mutates registered declarations)', async () => {
+    const results = await Promise.all([
+      computeAppRedirect('/'),
+      computeAppRedirect('/welcome'),
+      computeAppRedirect('/'),
+    ]);
+    assert.deepEqual(results, ['/welcome', null, '/welcome']);
+  });
+
   it('registers no otherwise() rule, so unknowns cannot become 302s', () => {
     const router = createAppRouter();
     const unmatched = router.urlService.match({

--- a/docs/worker/index.ts
+++ b/docs/worker/index.ts
@@ -1,4 +1,5 @@
 import { matchesAppRoute } from 'sample-app-routes/matchers.js';
+import { computeAppRedirect } from 'sample-app-routes/simulate.js';
 
 interface Env {
   ASSETS: Fetcher;
@@ -9,11 +10,21 @@ const MOUNTS = ['/app-mobx', '/app'];
 
 export default {
   async fetch(request, env) {
-    const pathname = new URL(request.url).pathname;
+    const url = new URL(request.url);
+    const { pathname } = url;
     const mount = MOUNTS.find((prefix) => pathname.startsWith(`${prefix}/`));
     // Non-route paths under a mount fall through to assets' 404 handling.
     if (!mount || !matchesAppRoute(pathname.slice(mount.length))) {
       return env.ASSETS.fetch(request);
+    }
+    // Entry redirects (e.g. '/' -> '/welcome') answer 302 instead of serving
+    // the shell at a stale URL; the original query string is preserved.
+    const redirect = await computeAppRedirect(pathname.slice(mount.length));
+    if (redirect !== null) {
+      return new Response(null, {
+        status: 302,
+        headers: { Location: `${mount}${redirect}${url.search}` },
+      });
     }
     const shell = await env.ASSETS.fetch(
       new Request(new URL(mount, request.url), request),

--- a/docs/worker/index.ts
+++ b/docs/worker/index.ts
@@ -18,7 +18,8 @@ export default {
       return env.ASSETS.fetch(request);
     }
     // Entry redirects (e.g. '/' -> '/welcome') answer 302 instead of serving
-    // the shell at a stale URL; the original query string is preserved.
+    // the shell at a stale URL; the original query string is preserved
+    // (projected targets are path-only, so appending url.search is safe).
     const redirect = await computeAppRedirect(pathname.slice(mount.length));
     if (redirect !== null) {
       return new Response(null, {


### PR DESCRIPTION
Refs #281. Next rung on the worker capability ladder after route-pattern gating: when a matched URL would immediately redirect on entry in the client app, the worker answers **302 with the computed target** instead of serving the shell at a stale URL.

## Mechanism

Run the actual router headless per request. `@uirouter/core` ships vanilla plugins for exactly this (its own test recipe): `servicesPlugin` ($q/$injector, no DOM) and `memoryLocationPlugin`. The `UIRouter` constructor schedules nothing, so per-request instantiation is workerd-safe. Everything is per-request — the router (its memory location is stateful) **and** the state declaration objects, because core mutates registered declarations (`StateObject.create` sets `$$state`): sharing declarations across routers lets a second registration re-point an in-flight router's states and silently drop its redirect. Pinned by a concurrent-calls test.

`computeAppRedirect(path)` registers the slim projected states, syncs the requested URL, waits for the **final** transition of a redirect chain (redirected rejections just hand off to a successor), and compares where the memory location landed. The location only moves when the client's address bar would — core skips the URL push for url-sourced and `location: false` transitions — so the comparison mirrors real browser behavior.

The real redirect being projected: `router.config.ts` routes the app root (`''`/`'/'`) to `welcome` via `urlService.rules.when(/^\/?$/, ...)`.

### Redirects deliberately NOT projected

- **`otherwise()` → notFound is not mirrored.** Unknown paths start no transition and return null, so worker 404s stay 404s — a catch-all rule would turn them into 302s and break the ladder semantics. Pinned by test.
- **`mymessages`' DSR default** (`mymessages.messagelist`): on entry it races the `requiresAuth` hook (priority 10, `location: false`) on client-side auth state the server cannot see, so the server must not pick a winner. `/mymessages` serves the shell; pinned by test.
- **`requiresAuth` → login**: `location: false`, address never moves, nothing to 302.

Any error or timeout inside the simulation degrades to serving the shell — the worker never 500s on this path.

## Bundle cost (wrangler deploy --dry-run)

| | Total upload | gzip |
|---|---|---|
| base (`feat/worker-route-patterns`) | 201.75 KiB | 43.25 KiB |
| this PR | 207.34 KiB | 44.86 KiB |

The full-router-semantics tier (~43 KiB gzip vs the ~4–14 KiB matcher-only tier) was **already paid** on the base branch: `matchers.ts` imports the `@uirouter/core` barrel, which esbuild cannot tree-shake (CJS). This rung's marginal cost is **+1.61 KiB gzip**, buying real transition semantics instead of pattern matching. Independent of the #290-vs-#292 matcher A/B — the full core arrives here regardless, and this rebases trivially on whichever wins.

## Verification (curl matrix: wrangler dev + Workers Builds preview)

| Request | Response |
|---|---|
| `GET /app/` | `302` → `Location: /app/welcome` |
| `GET /app/?flag=1` | `302` → `Location: /app/welcome?flag=1` |
| `GET /app/` followed | `200` shell at `/app/welcome` |
| `GET /app/welcome` | `200` shell + canonical Link (unchanged) |
| `GET /app/contacts/3` | `200` shell + canonical Link (unchanged) |
| `GET /app/mymessages` | `200` shell (DSR not preempted) |
| `GET /app/garbage/x` | `404` (unchanged) |
| `GET /app-mobx/` | `302` → `Location: /app-mobx/welcome` |

Local-dev artifact (pre-existing base behavior, not this PR's): local miniflare answers the shell subrequest for `/app` with a 307, so `curl -L http://localhost:.../app/` can look like a redirect loop **locally**. Deployed workerd serves it 200 — the live preview matrix above is clean.

`turbo run ci` green (66/66 tasks, incl. the new node --test matrix: root → `/welcome`, plain/parameterized routes → null, unknowns → null, superseded redirect chain, no-otherwise pin). The simulate module compiles in the package's DOM-lib-free tsconfig (`lib: ["ES2022"]`, `types: []`), keeping the runtime-neutrality guarantee.

## Structure note

`headless.ts` (generic `createHeadlessRouter`/`onceSettled`, no app imports) is kept cleanly separate from `simulate.ts` (app projection + `computeAppRedirect`): the planned `ui-router-server` extraction becomes a relocation, not a rewrite.

Follow-up: the #289 worker guide gains a redirects section (separate PR — that file belongs to #289).
