### PR TITLE
feat(tooling): guard tracked .mjs/.cjs files behind an allowlist (parked)

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "type": "module",
   "scripts": {
     "build": "turbo run build",
+    "check:mjs": "node scripts/check-mjs.ts",
     "check:pack": "node scripts/check-pack.ts",
     "check:workers-builds": "turbo run workers-builds#check",
     "ci": "turbo run ci",

--- a/scripts/check-mjs.core.ts
+++ b/scripts/check-mjs.core.ts
@@ -1,0 +1,60 @@
+// Pure logic for the .mjs/.cjs guard — no git or filesystem here, so every
+// unit is directly testable with plain fixtures (see check-mjs.test.ts).
+// The IO (enumerating tracked files via git ls-files) lives in check-mjs.ts
+// and feeds plain arrays into these functions.
+//
+// Policy: prefer .ts. Tracked .mjs/.cjs files sit outside every tsconfig, so
+// oxlint's type-aware rules never see them — each survivor is a documented
+// static-analysis hole and needs an explicit, reasoned allowlist entry.
+
+import type { Report } from './types.ts';
+
+// path -> one-line reason. The escape hatch: add an entry when a file truly
+// cannot be .ts, delete it when the file goes. Keep this list short.
+export const MJS_ALLOWLIST: ReadonlyMap<string, string> = new Map();
+
+export type MjsFindings = {
+  // Tracked .mjs/.cjs files with no allowlist entry.
+  unlisted: string[];
+  // Allowlist entries whose file is no longer tracked.
+  stale: string[];
+};
+
+/** Diff the tracked .mjs/.cjs files against the allowlist. */
+export function findMjsFindings(
+  trackedFiles: string[],
+  allowlist: ReadonlyMap<string, string> = MJS_ALLOWLIST,
+): MjsFindings {
+  const tracked = new Set(trackedFiles);
+  return {
+    unlisted: trackedFiles.filter((file) => !allowlist.has(file)).sort(),
+    stale: [...allowlist.keys()].filter((file) => !tracked.has(file)).sort(),
+  };
+}
+
+/** Render the findings; ok is false when anything needs fixing. */
+export function formatReport(
+  findings: MjsFindings,
+  allowlist: ReadonlyMap<string, string> = MJS_ALLOWLIST,
+): Report {
+  const lines: string[] = [];
+  for (const file of findings.unlisted) {
+    lines.push(
+      `✖ ${file} is a tracked .mjs/.cjs file. Convert it to .ts, or add it to`,
+      `  MJS_ALLOWLIST in scripts/check-mjs.core.ts with a one-line reason.`,
+    );
+  }
+  for (const file of findings.stale) {
+    lines.push(
+      `✖ ${file} is allowlisted but no longer tracked. Delete its MJS_ALLOWLIST entry.`,
+    );
+  }
+  if (lines.length > 0) {
+    return { ok: false, text: lines.join('\n') };
+  }
+  const allowed = allowlist.size;
+  return {
+    ok: true,
+    text: `✓ mjs check passed — no unlisted .mjs/.cjs files, ${allowed} allowlisted.`,
+  };
+}

--- a/scripts/check-mjs.test.ts
+++ b/scripts/check-mjs.test.ts
@@ -1,0 +1,65 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { findMjsFindings, formatReport } from './check-mjs.core.ts';
+
+const allow = (entries: Record<string, string>) =>
+  new Map(Object.entries(entries));
+
+describe('findMjsFindings', () => {
+  it('passes when nothing is tracked and nothing is allowlisted', () => {
+    const findings = findMjsFindings([], allow({}));
+    assert.deepEqual(findings, { unlisted: [], stale: [] });
+  });
+
+  it('flags tracked files missing from the allowlist, sorted', () => {
+    const findings = findMjsFindings(['b.mjs', 'a.cjs'], allow({}));
+    assert.deepEqual(findings.unlisted, ['a.cjs', 'b.mjs']);
+    assert.deepEqual(findings.stale, []);
+  });
+
+  it('accepts allowlisted files', () => {
+    const findings = findMjsFindings(
+      ['tools/legacy.mjs'],
+      allow({ 'tools/legacy.mjs': 'loader X cannot parse TS' }),
+    );
+    assert.deepEqual(findings, { unlisted: [], stale: [] });
+  });
+
+  it('flags stale allowlist entries so the list stays short', () => {
+    const findings = findMjsFindings(
+      [],
+      allow({ 'gone.mjs': 'was needed once' }),
+    );
+    assert.deepEqual(findings.unlisted, []);
+    assert.deepEqual(findings.stale, ['gone.mjs']);
+  });
+});
+
+describe('formatReport', () => {
+  it('reports ok with the allowlist size when clean', () => {
+    const list = allow({ 'kept.mjs': 'reason' });
+    const { ok, text } = formatReport(
+      findMjsFindings(['kept.mjs'], list),
+      list,
+    );
+    assert.equal(ok, true);
+    assert.match(text, /mjs check passed/);
+    assert.match(text, /1 allowlisted/);
+  });
+
+  it('names the file and both options for unlisted files', () => {
+    const { ok, text } = formatReport(findMjsFindings(['new.mjs'], allow({})));
+    assert.equal(ok, false);
+    assert.match(text, /new\.mjs/);
+    assert.match(text, /Convert it to \.ts/);
+    assert.match(text, /MJS_ALLOWLIST/);
+  });
+
+  it('tells the fix for stale entries and reports not ok', () => {
+    const list = allow({ 'gone.mjs': 'was needed once' });
+    const { ok, text } = formatReport(findMjsFindings([], list), list);
+    assert.equal(ok, false);
+    assert.match(text, /gone\.mjs is allowlisted but no longer tracked/);
+  });
+});

--- a/scripts/check-mjs.ts
+++ b/scripts/check-mjs.ts
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+// Guard against untracked-by-tooling module flavors: every tracked .mjs/.cjs
+// file must either become .ts or carry an allowlist entry with a reason.
+//
+// This file is the IO shell: it enumerates tracked files via git ls-files
+// (so node_modules and build output never enter), then delegates all
+// decisions to the pure, unit-tested functions in ./check-mjs.core.ts.
+
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { fileURLToPath } from 'node:url';
+
+import { findMjsFindings, formatReport } from './check-mjs.core.ts';
+
+const execFileAsync = promisify(execFile);
+const repoRoot = fileURLToPath(new URL('..', import.meta.url));
+
+async function main() {
+  const { stdout } = await execFileAsync(
+    'git',
+    ['ls-files', '-z', '--', '*.mjs', '*.cjs'],
+    { cwd: repoRoot },
+  );
+  const trackedFiles = stdout.split('\0').filter((file) => file.length > 0);
+  const findings = findMjsFindings(trackedFiles);
+  const { ok, text } = formatReport(findings);
+  (ok ? console.log : console.error)(text);
+  if (!ok) process.exitCode = 1;
+}
+
+main().catch((error: unknown) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/turbo.json
+++ b/turbo.json
@@ -67,6 +67,7 @@
         "typecheck",
         "format:check",
         "codecov:bundle",
+        "//#check:mjs",
         "//#check:pack"
       ]
     },
@@ -74,6 +75,11 @@
       "dependsOn": ["build"],
       "cache": false,
       "passThroughEnv": ["CODECOV_TOKEN", "CI", "GITHUB_*"]
+    },
+      "inputs": ["$TURBO_DEFAULT$", "**/package.json"]
+    },
+    "//#check:mjs": {
+      "inputs": ["$TURBO_DEFAULT$", "**/*.mjs", "**/*.cjs"]
     },
     "//#check:pack": {
       "inputs": ["$TURBO_DEFAULT$", "**/package.json"]


### PR DESCRIPTION
**PARKED** — split out of #295 per owner direction. After #295 moves the commitlint config to TypeScript, the repo tracks no `.mjs`/`.cjs` files, so this guard has nothing to guard. Unpark whenever a plain-JS module file is added for real.

## What it does

`check:mjs` (root script + `//#check:mjs` turbo task with `**/*.mjs`/`**/*.cjs` inputs) fails when a tracked `.mjs`/`.cjs` file isn't on an explicit allowlist — closing the known blind spot where plain-JS config files dodge the type-aware lint setup (the `.mjs` override hid `no-unsafe-*` until the commitlint config was renamed).

## Stacking

Based on `ci/commitlint-config-ts` (#295); this branch is a clean revert-of-the-revert (`0c2f6a0`), so the diff is exactly the guard: `scripts/check-mjs.{core,test,}.ts`, the `check:mjs` package script, and the turbo wiring. When #295 merges, retarget to main and rebase.

Verified on the reduced #295 base: `test:root` 26 pass / 0 fail with the guard's tests removed there; this branch re-adds them.
