### PR TITLE
Release 1.7.0

### DIFF
--- a/packages/lit-ui-router/package.json
+++ b/packages/lit-ui-router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lit-ui-router",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "State-based routing for Lit",
   "homepage": "https://lit-ui-router.dev",
   "license": "MIT",


### PR DESCRIPTION
* ci(tooling): commit-msg hook runs commitlint locally (#294) (35dc903)
* feat(tooling): dashboard-as-code check for the Workers Builds triggers (#268) (89ac5d9)
* refactor(tooling): typecheck the commitlint config (#295) (4c585d9)
* ci(github): lint PR commits with commitlint (#269) (fe5cd3a)
* feat(exports): pure entry plus per-element registration modules (#287) (7edf2eb)
* feat(release): conventional-changelog release notes (#207) (6a6e7bc)
* ci(github): semantic pr title check (004d61d)
* feat(lint): triage and enable the remaining tsgolint type-aware rules (#277) (f5b3331)
* fix(lit-ui-router): flag the dist/index.js barrel in sideEffects (#286) (c06c653)
* feat(types): register custom elements in HTMLElementTagNameMap (#285) (cf44b92)
* fix(e2e): make hash mode green and run it in CI (#274) (a9dc218)
* fix(turbo): stable app-build hashes via transit deps + cached docs:api (#278) (5c15100)
* chore(lint): enforce no-unsafe-* in examples, typing the 6 deferred findings (#275) (788c525)
* ci(lint): repo-owned actionlint workflow (#273) (2dcec59)
* test(examples): typecheck the standalone examples against the published package (#267) (a209688)
* chore(tooling): replace stale VS Code extension recommendations (#272) (882517d)
* fix(ci): exec wrangler directly so e2e teardown SIGINT stays silent (#266) (7390501)
* refactor(tooling): run the repo's scripts as TypeScript (#260) (aba9405)
* chore(deps): turbo 2.10.4 (#265) (9bcd79c)
* test(e2e): smoke the rendered docs site (#263) (ca1f6b1)
* fix(docs): drop the unused props binding in StackBlitzEmbed (#264) (c85366c)
* feat(docs): typecheck the Vue SFCs with vue-tsc, keeping .ts on TypeScript 7 (#257) (f134d23)
* chore(ci): drop vitest-coverage-report-action (#259) (d72a6b1)
* chore(deps): drop the release-age exclusions now TypeScript 7.0.2 has aged (#258) (0047223)
* feat(tooling): typescript 7.0 with a typescript6-compat catalog for API consumers (#249) (f6bd36a)
* fix(ci): order docs#typecheck after the typedoc sidebars it reads (#256) (91e93de)
* fix(tooling): typecheck docs and the sample apps (#255) (bae3e29)
* fix(sample-app): stop the nav header overflowing the viewport (#254) (c82f9ab)
* fix(sample-app): route the app root to welcome on every url sync (#252) (cddfbd6)
* fix(test): wire vitest.setup.ts via setupFiles (#251) (04c5bc1)
* chore(docs): drop typedoc's prettier formatting options (#253) (35ff150)
* fix(lint): ignore .claude worktrees in eslint config (#250) (3790a7c)
* chore(examples): bump typescript to ^7.0.2 (#248) (2835a81)
* chore(examples): bump lit-ui-router to ^1.6.0 (#247) (b4c85d4)
* feat(ci): token-free build hashing with guaranteed codecov bundle-stats upload (#238) (04112f9)
