### PR TITLE
chore(examples): lit-ui-router 1.7.0

### DIFF
--- a/examples/hellogalaxy/package-lock.json
+++ b/examples/hellogalaxy/package-lock.json
@@ -12,7 +12,7 @@
         "@uirouter/core": "^6.1.2",
         "@uirouter/visualizer": "^7.2.1",
         "lit": "^3.3.3",
-        "lit-ui-router": "^1.6.0"
+        "lit-ui-router": "^1.7.0"
       },
       "devDependencies": {
         "typescript": "^7.0.2",
@@ -1180,9 +1180,9 @@
       }
     },
     "node_modules/lit-ui-router": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/lit-ui-router/-/lit-ui-router-1.6.0.tgz",
-      "integrity": "sha512-XA1i6AhncmvvFKpj+lCzh9Vb2WhMvRLZkkZ+CO4oTCHhxvx2J7XMGyLiO4ftcMPEl/zWjKqaF9QDggMAnMacKg==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/lit-ui-router/-/lit-ui-router-1.7.0.tgz",
+      "integrity": "sha512-UK69ySdMwrAILx8aG9TYcNLlg/Q2CCrs1nqwnKumFlQXeNvjf+heH5l1KdfDEyyuBYafrzGxUMOLEZ2esiX3Tw==",
       "license": "MIT",
       "dependencies": {
         "@uirouter/core": "^6.0.8",

--- a/examples/hellogalaxy/package.json
+++ b/examples/hellogalaxy/package.json
@@ -13,7 +13,7 @@
     "@uirouter/core": "^6.1.2",
     "@uirouter/visualizer": "^7.2.1",
     "lit": "^3.3.3",
-    "lit-ui-router": "^1.6.0"
+    "lit-ui-router": "^1.7.0"
   },
   "devDependencies": {
     "typescript": "^7.0.2",

--- a/examples/hellosolarsystem/package-lock.json
+++ b/examples/hellosolarsystem/package-lock.json
@@ -11,7 +11,7 @@
         "@uirouter/core": "^6.1.2",
         "@uirouter/visualizer": "^7.2.1",
         "lit": "^3.3.3",
-        "lit-ui-router": "^1.6.0"
+        "lit-ui-router": "^1.7.0"
       },
       "devDependencies": {
         "typescript": "^7.0.2",
@@ -1130,9 +1130,9 @@
       }
     },
     "node_modules/lit-ui-router": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/lit-ui-router/-/lit-ui-router-1.6.0.tgz",
-      "integrity": "sha512-XA1i6AhncmvvFKpj+lCzh9Vb2WhMvRLZkkZ+CO4oTCHhxvx2J7XMGyLiO4ftcMPEl/zWjKqaF9QDggMAnMacKg==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/lit-ui-router/-/lit-ui-router-1.7.0.tgz",
+      "integrity": "sha512-UK69ySdMwrAILx8aG9TYcNLlg/Q2CCrs1nqwnKumFlQXeNvjf+heH5l1KdfDEyyuBYafrzGxUMOLEZ2esiX3Tw==",
       "license": "MIT",
       "dependencies": {
         "@uirouter/core": "^6.0.8",

--- a/examples/hellosolarsystem/package.json
+++ b/examples/hellosolarsystem/package.json
@@ -12,7 +12,7 @@
     "@uirouter/core": "^6.1.2",
     "@uirouter/visualizer": "^7.2.1",
     "lit": "^3.3.3",
-    "lit-ui-router": "^1.6.0"
+    "lit-ui-router": "^1.7.0"
   },
   "devDependencies": {
     "typescript": "^7.0.2",

--- a/examples/helloworld/package-lock.json
+++ b/examples/helloworld/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@uirouter/core": "^6.1.2",
         "lit": "^3.3.3",
-        "lit-ui-router": "^1.6.0"
+        "lit-ui-router": "^1.7.0"
       },
       "devDependencies": {
         "typescript": "^7.0.2",
@@ -1091,9 +1091,9 @@
       }
     },
     "node_modules/lit-ui-router": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/lit-ui-router/-/lit-ui-router-1.6.0.tgz",
-      "integrity": "sha512-XA1i6AhncmvvFKpj+lCzh9Vb2WhMvRLZkkZ+CO4oTCHhxvx2J7XMGyLiO4ftcMPEl/zWjKqaF9QDggMAnMacKg==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/lit-ui-router/-/lit-ui-router-1.7.0.tgz",
+      "integrity": "sha512-UK69ySdMwrAILx8aG9TYcNLlg/Q2CCrs1nqwnKumFlQXeNvjf+heH5l1KdfDEyyuBYafrzGxUMOLEZ2esiX3Tw==",
       "license": "MIT",
       "dependencies": {
         "@uirouter/core": "^6.0.8",

--- a/examples/helloworld/package.json
+++ b/examples/helloworld/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@uirouter/core": "^6.1.2",
     "lit": "^3.3.3",
-    "lit-ui-router": "^1.6.0"
+    "lit-ui-router": "^1.7.0"
   },
   "devDependencies": {
     "typescript": "^7.0.2",


### PR DESCRIPTION
## Summary

Bump `lit-ui-router` to `^1.7.0` in all three standalone example projects and regenerate their npm lockfiles.

| Example | From | To |
|---|---|---|
| examples/helloworld | ^1.6.0 (locked 1.6.0) | ^1.7.0 (locked 1.7.0) |
| examples/hellosolarsystem | ^1.6.0 (locked 1.6.0) | ^1.7.0 (locked 1.7.0) |
| examples/hellogalaxy | ^1.6.0 (locked 1.6.0) | ^1.7.0 (locked 1.7.0) |

Only `lit-ui-router` is bumped. The existing `@uirouter/core@^6.1.2` and `lit@^3.3.3` pins already satisfy 1.7.0's peer ranges (`@uirouter/core ^6.0.8`, `lit ^3.0.0`). Lock diffs are minimal: 8 lines per lockfile (spec + version/resolved/integrity for the single package).

## Why this matters

1.7.0 is the first release since 1.5.x where **production bundlers retain the custom-element registrations**. 1.6.0's `sideEffects` allowlist let bundlers tree-shake the `customElements.define` module side effects away entirely. These examples build with vite (`build:embeds`), so all three were exactly the affected consumer class: **every example sat on 1.6.0, so their production embed builds were shipping bundles with no `ui-router`/`ui-view` elements defined.**

## Registration-regression evidence

Grep of the vite production output (`examples/*/dist`) after the bump — registrations present in all three:

```
helloworld:        customElements.define(`ui-router`, …)  customElements.define(`ui-view`, …)
hellosolarsystem:  customElements.define(`ui-router`, …)  customElements.define(`ui-view`, …)
hellogalaxy:       customElements.define(`ui-router`, …)  customElements.define(`ui-view`, …)
```

Negative control: reinstalling `lit-ui-router@1.6.0` in helloworld and rebuilding produced a bundle with **zero** `customElements.define(`ui-*`)` matches — confirming the 1.6.0 regression is real and this bump fixes actual production behavior, not just a version number.

## Verification

- `turbo run typecheck build:embeds --filter=examples` — 3/3 tasks successful (tsc per example + vite embed builds)
- Full `turbo run ci` — 68/68 tasks successful
- Each lockfile verified to resolve `lit-ui-router@1.7.0`; `npm ci` per example is clean

## Follow-up

StackBlitz verification of this branch is the remaining step (browser check, not attempted here):

- https://stackblitz.com/github/simshanith/lit-ui-router/tree/chore/examples-lit-ui-router-1.7.0/examples/helloworld
- https://stackblitz.com/github/simshanith/lit-ui-router/tree/chore/examples-lit-ui-router-1.7.0/examples/hellosolarsystem
- https://stackblitz.com/github/simshanith/lit-ui-router/tree/chore/examples-lit-ui-router-1.7.0/examples/hellogalaxy
