### PR TITLE
fix(release): pin conventionalcommits preset 9 into the preset loader's tree

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -150,6 +150,8 @@ overrides:
   undici@7: 7.28.0
   vitepress>vite: ^6.4.3
 
+packageExtensionsChecksum: sha256-GeoK+J1KFKE+e2SY5vm8ItXeXnBlw5N6FlT+iEHePoo=
+
 patchedDependencies:
   '@api-viewer/docs': 6cfa0893375a4ba334488a5b9e4a56178c62231d864b5271bf4c7a25a0e4f9ac
   '@uirouter/dsr': 85054b266dee7294d59dc8e0c386367422777df9777a26acb607455cb8217761
@@ -7904,7 +7906,9 @@ snapshots:
     dependencies:
       compare-func: 2.0.0
 
-  conventional-changelog-preset-loader@5.0.0: {}
+  conventional-changelog-preset-loader@5.0.0:
+    dependencies:
+      conventional-changelog-conventionalcommits: 9.3.1
 
   conventional-changelog-writer@8.4.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -76,7 +76,6 @@ overrides:
   'undici@7': 7.28.0
   'vitepress>vite': ^6.4.3
 
-# preset 9 must resolve inside the preset loader's own tree, not commitlint's 10 via the hidden hoist (#302)
 packageExtensions:
   conventional-changelog-preset-loader:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -76,6 +76,12 @@ overrides:
   'undici@7': 7.28.0
   'vitepress>vite': ^6.4.3
 
+# preset 9 must resolve inside the preset loader's own tree, not commitlint's 10 via the hidden hoist (#302)
+packageExtensions:
+  conventional-changelog-preset-loader:
+    dependencies:
+      conventional-changelog-conventionalcommits: ^9.3.1
+
 verifyDepsBeforeRun: false
 
 patchedDependencies:


### PR DESCRIPTION
Fixes #302.

## Root cause (full diagnosis in #302)

The `conventionalcommits` preset is loaded by name via a bare `import(preset)` and, being a dependency of `@release-it/conventional-changelog` (9.3.1) rather than of the importing package, is missing from the importer's isolated `.pnpm` tree — resolution falls through to pnpm's hidden hoist at `node_modules/.pnpm/node_modules`, which holds `@commitlint/config-conventional@21`'s preset **10.2.1**. Preset 10 renders header-only against `conventional-changelog-writer@8`, the config's empty `headerPartial` erases that, and release-it silently fell back to the flat git log that shipped in the 1.7.0 notes. A `packageExtensions` entry injects preset `^9.3.1` into the importer's own tree, ahead of the hoist, while commitlint keeps its 10.x.

**One correction to #302's recommended fix:** the by-name `import(preset)` lives in `conventional-changelog-preset-loader@5` (`dist/presetLoader.js`: `createPresetLoader(preset => import(preset))`), not in `conventional-changelog` itself, and `@release-it/conventional-changelog` passes no custom loader. Extending `conventional-changelog` places the 9.3.1 symlink in a tree the import never consults (verified: still flat). The extension therefore targets **`conventional-changelog-preset-loader`** — which also feeds `conventional-recommended-bump`, so the bumper gets the intended preset 9 too.

## Before / after (`corepack pnpm --filter lit-ui-router run changelog`)

Both captured at `35dc903` (the 1.7.0 release's commit range, `lit-ui-router@1.6.0..`), since current `HEAD` has no `packages/lit-ui-router` commits after the `lit-ui-router@1.7.0` tag.

**Before (main):**

```
* ci(tooling): commit-msg hook runs commitlint locally (#294) (35dc903)
* feat(tooling): dashboard-as-code check for the Workers Builds triggers (#268) (89ac5d9)
* refactor(tooling): typecheck the commitlint config (#295) (4c585d9)
* ci(github): lint PR commits with commitlint (#269) (fe5cd3a)
* feat(exports): pure entry plus per-element registration modules (#287) (7edf2eb)
…
```

**After (this branch):**

```
### Features

* **exports:** pure entry plus per-element registration modules (#287) (7edf2eb)
* **lint:** triage and enable the remaining tsgolint type-aware rules (#277) (f5b3331)
* **release:** conventional-changelog release notes (#207) (6a6e7bc)
* **tooling:** typescript 7.0 with a typescript6-compat catalog for API consumers (#249) (f6bd36a)
* **types:** register custom elements in HTMLElementTagNameMap (#285) (cf44b92)

### Bug Fixes

* **lit-ui-router:** flag the dist/index.js barrel in sideEffects (#286) (c06c653)
…
```

`lit-ui-router-mobx` and `ui-router-navigation-location-plugin` produce grouped, path-filtered sections over their own tag ranges as well.

## Dual-major coexistence

`pnpm why -r conventional-changelog-conventionalcommits`:

- **9.3.1** ← `@release-it/conventional-changelog@11.0.1` and (via the extension) `conventional-changelog-preset-loader@5.0.0` → `conventional-changelog@7.2.1` / `conventional-recommended-bump@11.2.0`
- **10.2.1** ← `@commitlint/config-conventional@21.2.0` (unchanged)

This is the point of the targeted extension over the repo-wide override #302 rejected: both majors coexist.

## Verification

| Check | Result |
| --- | --- |
| `pnpm --filter <pkg> run changelog` grouped, all 3 publishable packages | pass |
| Preset 9.3.1 symlinked into the loader's `.pnpm` tree; hidden hoist still 10.2.1 | pass |
| `echo "feat: x" \| pnpm exec commitlint` passes; malformed message still fails | pass |
| `corepack pnpm install --frozen-lockfile` | pass |
| `turbo run ci` | 68/68 green |

Remaining verification (not run here): `publish-npm.yml` `workflow_dispatch` with `dryRun: true` logs the computed `Changelog:` on CI, and full e2e proof rides the next real release, as #207's did.

Note: the upstream reports suggested in #302 (loader resolving a hoisted incompatible major; preset-10/writer-8 silently dropping all commits) are held pending the repo's outreach policy.
