### PR TITLE
fix(turbo): hash the root oxfmt config into format task inputs

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -84,14 +84,16 @@
       "with": ["//#format:root"],
       "inputs": [
         "**/*.{ts,js,mjs,cjs,json,jsonc,md,yml,yaml,html,vue}",
-        ".oxfmtrc.json"
+        ".oxfmtrc.json",
+        "$TURBO_ROOT$/.oxfmtrc.json"
       ]
     },
     "format:check": {
       "with": ["//#format:check:root"],
       "inputs": [
         "**/*.{ts,js,mjs,cjs,json,jsonc,md,yml,yaml,html,vue}",
-        ".oxfmtrc.json"
+        ".oxfmtrc.json",
+        "$TURBO_ROOT$/.oxfmtrc.json"
       ]
     },
     "//#format:root": {


### PR DESCRIPTION
The `format`/`format:check` tasks list `.oxfmtrc.json` package-relative only, and no package has its own copy — the entry never matches anything. Editing the ROOT `.oxfmtrc.json` therefore cannot invalidate any package's cached `format:check`: the task silently replays a stale pass with the old formatting rules. (Surfaced in #293 review, where a root ignorePatterns entry became load-bearing; split out here because the fix is independent of that work.)

Fix: add `$TURBO_ROOT$/.oxfmtrc.json` to both tasks' inputs — the same shape `lint` already uses for `$TURBO_ROOT$/.oxlintrc.json`. Inputs stay over-approximated.

Verification: `--dry=json` shows `docs#format:check` resolving `../.oxfmtrc.json` as an input, and its hash flips on a root config edit (`1943c367bd247f36` -> `1c95b87235788c89`, reverting with the edit). `turbo run format:check` green across the repo.