### PR TITLE
feat(tooling): check:published-diff reports package drift from the latest npm publish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,8 +42,6 @@ certs/
 .claude
 
 lit-ui-router-*.tgz
-# resolved registry state, written by tools/release/resolve-published.ts
-tools/release/published-versions.json
 **/specs/__screenshots__
 coverage
 .wrangler

--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,8 @@ certs/
 .claude
 
 lit-ui-router-*.tgz
+# resolved registry state, written by tools/release/resolve-published.ts
+tools/release/published-versions.json
 **/specs/__screenshots__
 coverage
 .wrangler

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "build": "turbo run build",
     "check:pack": "turbo run check:pack",
+    "check:published-diff": "turbo run check:published-diff",
     "check:workers-builds": "turbo run workers-builds#check",
     "ci": "turbo run ci",
     "dev": "turbo run dev",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "turbo run build",
     "check:pack": "turbo run check:pack",
-    "check:published-diff": "turbo run check:published-diff",
+    "check:published-diff": "turbo run resolve:published && turbo run check:published-diff",
     "check:workers-builds": "turbo run workers-builds#check",
     "ci": "turbo run ci",
     "dev": "turbo run dev",

--- a/tools/release/check-published-diff.core.ts
+++ b/tools/release/check-published-diff.core.ts
@@ -1,0 +1,94 @@
+// Pure logic for the published-diff report — no filesystem, registry, or
+// process spawning here, so every unit is directly testable with plain string
+// fixtures (see check-published-diff.test.ts). The IO (building, packing with
+// the publish workflow's manifest strip, running `npm diff`) lives in
+// check-published-diff.ts.
+
+import type { Report } from './types.ts';
+
+// `npm diff` exits 0 whether or not the tarballs differ, so the verdict must
+// come from its output: an empty diff is the only "nothing would ship" signal.
+export function isCleanDiff(diffOutput: string): boolean {
+  return diffOutput.trim().length === 0;
+}
+
+/**
+ * Paths changed in a unified diff, taken from `+++` headers (additions and
+ * modifications) plus `---` headers for deletions that have no `+++` side.
+ * npm prefixes both sides with the package spec, e.g.
+ * `+++ lit-ui-router@1.7.0/package/dist/index.js` — the leading spec and
+ * `package/` segment are stripped so the report reads as tarball paths.
+ */
+export function changedFiles(diffOutput: string): string[] {
+  const files = new Set<string>();
+  for (const line of diffOutput.split('\n')) {
+    const marker = line.startsWith('+++ ') || line.startsWith('--- ');
+    if (!marker) continue;
+    const rawPath = line.slice(4).trim();
+    if (rawPath === '/dev/null') continue;
+    files.add(rawPath.replace(/^[^/]*\//, '').replace(/^package\//, ''));
+  }
+  return [...files].sort();
+}
+
+// One package's comparison against its published `latest`.
+export type DiffResult = {
+  name: string;
+  dir: string;
+  /** Version currently on the `latest` dist-tag; absent when unpublished. */
+  latest?: string;
+  /** Version in the working tree's manifest. */
+  localVersion?: string;
+  status: 'clean' | 'drift' | 'unpublished';
+  /** Tarball paths that differ; only meaningful for `drift`. */
+  files?: string[];
+};
+
+export type ReportOptions = {
+  /** When true, drift fails the report instead of merely being listed. */
+  strict?: boolean;
+};
+
+/** Render the human-readable report. */
+export function formatReport(
+  results: DiffResult[],
+  options: ReportOptions = {},
+): Report {
+  if (results.length === 0) {
+    return {
+      ok: false,
+      text: '✗ published-diff check failed — no publishable workspace packages found (broken workspace globs?).',
+    };
+  }
+
+  const drifted = results.filter((result) => result.status === 'drift');
+  const lines: string[] = [];
+  for (const result of results) {
+    const { name, latest, localVersion, status, files } = result;
+    if (status === 'unpublished') {
+      lines.push(`  ${name}: never published — skipped`);
+      continue;
+    }
+    const ahead =
+      localVersion && latest && localVersion !== latest
+        ? ` (local ${localVersion} ahead of published — release in flight?)`
+        : '';
+    if (status === 'clean') {
+      lines.push(`  ${name}: clean vs ${latest}${ahead}`);
+    } else {
+      const count = files?.length ?? 0;
+      lines.push(
+        `  ${name}: SHIPS CHANGES vs ${latest}${ahead} — ${count} file(s):`,
+      );
+      for (const file of files ?? []) lines.push(`      • ${file}`);
+    }
+  }
+
+  const ok = !options.strict || drifted.length === 0;
+  const headline = ok
+    ? drifted.length === 0
+      ? `✓ published-diff check passed — ${results.length} packages match their published tarballs.`
+      : `published-diff report — ${drifted.length} of ${results.length} packages would ship changes if released:`
+    : `✗ published-diff check failed — ${drifted.length} of ${results.length} packages drift from their published tarballs:`;
+  return { ok, text: [headline, ...lines].join('\n') };
+}

--- a/tools/release/check-published-diff.test.ts
+++ b/tools/release/check-published-diff.test.ts
@@ -1,0 +1,120 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+  changedFiles,
+  formatReport,
+  isCleanDiff,
+} from './check-published-diff.core.ts';
+
+// Shape of real `npm diff --diff=<spec> --diff=<tarball>` output: both sides
+// carry the compared spec as prefix, paths inside the tarball under package/.
+const DRIFT_DIFF = [
+  'diff --git a/package/dist/index.js b/package/dist/index.js',
+  'index 07f105a..a56241c 100644',
+  '--- lit-ui-router-mobx@0.3.2/package/dist/router-store.js',
+  '+++ lit-ui-router-mobx-0.3.2.tgz/package/dist/router-store.js',
+  '@@ -1,3 +1,4 @@',
+  '-old',
+  '+new',
+  '--- lit-ui-router-mobx@0.3.2/package/package.json',
+  '+++ lit-ui-router-mobx-0.3.2.tgz/package/package.json',
+  '@@ -10,2 +10,3 @@',
+  '+  "keywords": [],',
+  '--- lit-ui-router-mobx@0.3.2/package/dist/removed.js',
+  '+++ /dev/null',
+].join('\n');
+
+describe('isCleanDiff', () => {
+  it('treats empty and whitespace-only output as clean', () => {
+    assert.equal(isCleanDiff(''), true);
+    assert.equal(isCleanDiff('\n'), true);
+  });
+
+  it('treats any diff content as drift', () => {
+    assert.equal(isCleanDiff(DRIFT_DIFF), false);
+  });
+});
+
+describe('changedFiles', () => {
+  it('extracts deduplicated tarball paths from header lines', () => {
+    assert.deepEqual(changedFiles(DRIFT_DIFF), [
+      'dist/removed.js',
+      'dist/router-store.js',
+      'package.json',
+    ]);
+  });
+
+  it('returns nothing for an empty diff', () => {
+    assert.deepEqual(changedFiles(''), []);
+  });
+});
+
+describe('formatReport', () => {
+  const clean = {
+    name: 'lit-ui-router',
+    dir: 'packages/lit-ui-router',
+    latest: '1.7.0',
+    localVersion: '1.7.0',
+    status: 'clean' as const,
+  };
+  const drift = {
+    name: 'lit-ui-router-mobx',
+    dir: 'packages/lit-ui-router-mobx',
+    latest: '0.3.2',
+    localVersion: '0.3.2',
+    status: 'drift' as const,
+    files: ['dist/router-store.js', 'package.json'],
+  };
+
+  it('passes when every package matches its published tarball', () => {
+    const { ok, text } = formatReport([clean]);
+    assert.equal(ok, true);
+    assert.match(text, /✓ published-diff check passed — 1 packages match/);
+    assert.match(text, /lit-ui-router: clean vs 1\.7\.0/);
+  });
+
+  it('reports drift without failing by default', () => {
+    const { ok, text } = formatReport([clean, drift]);
+    assert.equal(ok, true);
+    assert.match(text, /1 of 2 packages would ship changes/);
+    assert.match(text, /SHIPS CHANGES vs 0\.3\.2 — 2 file\(s\):/);
+    assert.match(text, /• dist\/router-store\.js/);
+  });
+
+  it('fails on drift under --strict', () => {
+    const { ok, text } = formatReport([clean, drift], { strict: true });
+    assert.equal(ok, false);
+    assert.match(text, /✗ published-diff check failed — 1 of 2 packages/);
+  });
+
+  it('flags a local version ahead of the published latest', () => {
+    const { text } = formatReport([
+      { ...clean, localVersion: '1.7.1', status: 'drift', files: [] },
+    ]);
+    assert.match(
+      text,
+      /local 1\.7\.1 ahead of published — release in flight\?/,
+    );
+  });
+
+  it('skips unpublished packages without failing', () => {
+    const { ok, text } = formatReport([
+      clean,
+      {
+        name: 'ui-router-server',
+        dir: 'packages/ui-router-server',
+        localVersion: '0.0.0',
+        status: 'unpublished' as const,
+      },
+    ]);
+    assert.equal(ok, true);
+    assert.match(text, /ui-router-server: never published — skipped/);
+  });
+
+  it('fails when no publishable packages were found', () => {
+    const { ok, text } = formatReport([]);
+    assert.equal(ok, false);
+    assert.match(text, /no publishable workspace packages/);
+  });
+});

--- a/tools/release/check-published-diff.ts
+++ b/tools/release/check-published-diff.ts
@@ -1,0 +1,145 @@
+#!/usr/bin/env node
+// Report whether a publish from the working tree would ship different bytes
+// than each package's `latest` on npm. This mechanizes release triage: a
+// devDependency- or script-only change is provably a no-op (the publish
+// workflow strips those fields before packing), while dist drift from a
+// "cosmetic" refactor is caught even when the git log looks harmless.
+//
+// Method (validated against the 1.7.0 release, whose local rebuild reproduces
+// the registry tarball byte-for-byte): reproduce the Pack step of
+// .github/workflows/publish-npm.yml — `npm pkg delete` the
+// STRIPPED_MANIFEST_FIELDS then `pnpm pack` — and `npm diff` the tarball
+// against the published spec. The strip stays in lockstep with that workflow
+// because both build their delete args from the same list in
+// check-pack.core.ts. Comparing anything other than pack output (the source
+// manifest, `npm view` fields) false-positives on catalog:/workspace:
+// substitution and registry-injected fields.
+//
+// Run `turbo run build` first so dist is current; `--strict` turns drift into
+// a failing exit (default is an informational report — drift usually means "a
+// release is owed", not "the tree is broken").
+//
+// This file is the IO shell; verdicts and rendering live in the pure,
+// unit-tested ./check-published-diff.core.ts.
+
+import { execFile } from 'node:child_process';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { promisify } from 'node:util';
+
+import { STRIPPED_MANIFEST_FIELDS } from './check-pack.core.ts';
+import {
+  changedFiles,
+  type DiffResult,
+  formatReport,
+  isCleanDiff,
+} from './check-published-diff.core.ts';
+import { pnpmPack } from './pack.ts';
+import { loadWorkspace, workspaceRoot } from './workspace.ts';
+
+const run = promisify(execFile);
+const MAX_BUFFER = 64 * 1024 * 1024;
+
+/** The `latest` dist-tag for `name`, or undefined when never published. */
+async function publishedLatest(name: string): Promise<string | undefined> {
+  try {
+    const { stdout } = await run('npm', ['view', name, 'dist-tags.latest']);
+    return stdout.trim() || undefined;
+  } catch (error) {
+    // promisified execFile rejects with the child's captured output attached.
+    const { stderr } = (error ?? {}) as { stderr?: string };
+    if (stderr?.includes('E404')) return undefined;
+    throw error;
+  }
+}
+
+/**
+ * Pack `dir` the way the publish workflow does and diff against `spec`.
+ * The manifest strip mutates package.json in place, so the original bytes are
+ * restored afterwards no matter what — user edits and formatting included.
+ */
+async function diffAgainstPublished(
+  dir: string,
+  spec: string,
+): Promise<string> {
+  const manifestPath = join(dir, 'package.json');
+  const originalManifest = await readFile(manifestPath);
+  const destination = await mkdtemp(join(tmpdir(), 'check-published-diff-'));
+  const tarball = join(destination, 'package.tgz');
+  try {
+    await run('npm', ['pkg', 'delete', ...STRIPPED_MANIFEST_FIELDS], {
+      cwd: dir,
+    });
+    await pnpmPack(dir, tarball);
+    const { stdout } = await run(
+      'npm',
+      ['diff', `--diff=${spec}`, `--diff=${tarball}`],
+      { cwd: workspaceRoot, maxBuffer: MAX_BUFFER },
+    );
+    return stdout;
+  } finally {
+    await writeFile(manifestPath, originalManifest);
+    await rm(destination, { recursive: true, force: true });
+  }
+}
+
+async function main() {
+  const strict = process.argv.includes('--strict');
+  const skipBuild = process.argv.includes('--no-build');
+
+  const { members } = await loadWorkspace(workspaceRoot);
+  const publishable = members.filter(
+    (member) =>
+      member.dir !== '<root>' &&
+      member.manifest &&
+      member.manifest.private !== true,
+  );
+
+  if (!skipBuild && publishable.length > 0) {
+    // Bare turbo (mise-provisioned), never through pnpm run — pnpm's relative
+    // .bin PATH breaks turbo's child process spawning.
+    await run(
+      'turbo',
+      ['run', ...publishable.map(({ name }) => `${name}#build`)],
+      { cwd: workspaceRoot, maxBuffer: MAX_BUFFER },
+    );
+  }
+
+  const results: DiffResult[] = [];
+  for (const { name, dir } of publishable) {
+    const packageDir = join(workspaceRoot, dir);
+    const localVersion = (
+      JSON.parse(await readFile(join(packageDir, 'package.json'), 'utf8')) as {
+        version?: string;
+      }
+    ).version;
+    const latest = await publishedLatest(name);
+    if (!latest) {
+      results.push({ name, dir, localVersion, status: 'unpublished' });
+      continue;
+    }
+    const diff = await diffAgainstPublished(packageDir, `${name}@${latest}`);
+    results.push(
+      isCleanDiff(diff)
+        ? { name, dir, latest, localVersion, status: 'clean' }
+        : {
+            name,
+            dir,
+            latest,
+            localVersion,
+            status: 'drift',
+            files: changedFiles(diff),
+          },
+    );
+  }
+
+  const { ok, text } = formatReport(results, { strict });
+  (ok ? console.log : console.error)(text);
+  if (!ok) process.exitCode = 1;
+}
+
+main().catch((error: unknown) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/tools/release/check-published-diff.ts
+++ b/tools/release/check-published-diff.ts
@@ -19,6 +19,11 @@
 // a failing exit (default is an informational report — drift usually means "a
 // release is owed", not "the tree is broken").
 //
+// Registry state arrives through published-versions.json, written by
+// resolve-published.ts just before this runs (the root script chains them) —
+// no npm lookups here, so the turbo task caching this check stays a pure
+// function of its file inputs.
+//
 // This file is the IO shell; verdicts and rendering live in the pure,
 // unit-tested ./check-published-diff.core.ts.
 
@@ -36,23 +41,11 @@ import {
   isCleanDiff,
 } from './check-published-diff.core.ts';
 import { pnpmPack } from './pack.ts';
+import { readPublishedVersions } from './published-versions.ts';
 import { loadWorkspace, workspaceRoot } from './workspace.ts';
 
 const run = promisify(execFile);
 const MAX_BUFFER = 64 * 1024 * 1024;
-
-/** The `latest` dist-tag for `name`, or undefined when never published. */
-async function publishedLatest(name: string): Promise<string | undefined> {
-  try {
-    const { stdout } = await run('npm', ['view', name, 'dist-tags.latest']);
-    return stdout.trim() || undefined;
-  } catch (error) {
-    // promisified execFile rejects with the child's captured output attached.
-    const { stderr } = (error ?? {}) as { stderr?: string };
-    if (stderr?.includes('E404')) return undefined;
-    throw error;
-  }
-}
 
 /**
  * Pack `dir` the way the publish workflow does and diff against `spec`.
@@ -88,6 +81,7 @@ async function main() {
   const strict = process.argv.includes('--strict');
   const skipBuild = process.argv.includes('--no-build');
 
+  const published = await readPublishedVersions();
   const { members } = await loadWorkspace(workspaceRoot);
   const publishable = members.filter(
     (member) =>
@@ -114,7 +108,12 @@ async function main() {
         version?: string;
       }
     ).version;
-    const latest = await publishedLatest(name);
+    if (!(name in published)) {
+      throw new Error(
+        `${name} missing from published-versions.json — stale manifest; re-run the resolve:published task.`,
+      );
+    }
+    const latest = published[name];
     if (!latest) {
       results.push({ name, dir, localVersion, status: 'unpublished' });
       continue;

--- a/tools/release/package.json
+++ b/tools/release/package.json
@@ -9,6 +9,7 @@
   },
   "scripts": {
     "check:pack": "node check-pack.ts",
+    "check:published-diff": "node check-published-diff.ts",
     "format": "oxfmt \"**/*.{ts,js,json,jsonc,md}\"",
     "format:check": "oxfmt --check \"**/*.{ts,js,json,jsonc,md}\"",
     "lint": "oxlint .",

--- a/tools/release/package.json
+++ b/tools/release/package.json
@@ -13,6 +13,7 @@
     "format": "oxfmt \"**/*.{ts,js,json,jsonc,md}\"",
     "format:check": "oxfmt --check \"**/*.{ts,js,json,jsonc,md}\"",
     "lint": "oxlint .",
+    "resolve:published": "node resolve-published.ts",
     "test": "node --test \"*.test.ts\"",
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },

--- a/tools/release/published-versions.core.ts
+++ b/tools/release/published-versions.core.ts
@@ -1,0 +1,39 @@
+// Pure logic for the published-versions manifest — the file that carries the
+// resolved `latest` dist-tags from resolve-published.ts (registry IO) to
+// check-published-diff.ts (cached turbo task). Rendering is canonical
+// (bytewise-sorted keys, fixed indentation, trailing newline) so identical
+// registry state always produces identical bytes — the file is a cache key.
+
+/** Package name → `latest` version, or null when never published. */
+export type PublishedVersions = Record<string, string | null>;
+
+/** Canonical manifest text: bytewise-sorted keys, 2-space indent, final newline. */
+export function renderManifest(versions: PublishedVersions): string {
+  const sorted = Object.fromEntries(
+    Object.entries(versions).sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0)),
+  );
+  return `${JSON.stringify(sorted, null, 2)}\n`;
+}
+
+/** Parse and validate manifest text; throws on any shape drift. */
+export function parseManifest(text: string): PublishedVersions {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    throw new Error('published-versions.json is not valid JSON');
+  }
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    throw new Error(
+      'published-versions.json must be an object of package name → version',
+    );
+  }
+  for (const [name, version] of Object.entries(parsed)) {
+    if (version !== null && typeof version !== 'string') {
+      throw new Error(
+        `published-versions.json: "${name}" must map to a version string or null`,
+      );
+    }
+  }
+  return parsed as PublishedVersions;
+}

--- a/tools/release/published-versions.test.ts
+++ b/tools/release/published-versions.test.ts
@@ -1,0 +1,58 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { parseManifest, renderManifest } from './published-versions.core.ts';
+
+describe('renderManifest', () => {
+  it('renders bytewise-sorted keys with a trailing newline', () => {
+    const text = renderManifest({
+      'ui-router-navigation-location-plugin': '0.2.2',
+      'lit-ui-router': '1.7.0',
+      'lit-ui-router-mobx': '0.3.3',
+    });
+    assert.equal(
+      text,
+      `${JSON.stringify(
+        {
+          'lit-ui-router': '1.7.0',
+          'lit-ui-router-mobx': '0.3.3',
+          'ui-router-navigation-location-plugin': '0.2.2',
+        },
+        null,
+        2,
+      )}\n`,
+    );
+  });
+
+  it('is canonical: key insertion order never changes the bytes', () => {
+    const a = renderManifest({ b: '1.0.0', a: null });
+    const b = renderManifest({ a: null, b: '1.0.0' });
+    assert.equal(a, b);
+  });
+
+  it('round-trips through parseManifest', () => {
+    const versions = { 'lit-ui-router': '1.7.0', 'never-published': null };
+    assert.deepEqual(parseManifest(renderManifest(versions)), versions);
+  });
+});
+
+describe('parseManifest', () => {
+  it('rejects invalid JSON', () => {
+    assert.throws(() => parseManifest('not json'), /not valid JSON/);
+  });
+
+  it('rejects non-object shapes', () => {
+    assert.throws(
+      () => parseManifest('["lit-ui-router"]'),
+      /must be an object/,
+    );
+    assert.throws(() => parseManifest('null'), /must be an object/);
+  });
+
+  it('rejects non-string, non-null versions', () => {
+    assert.throws(
+      () => parseManifest('{"lit-ui-router": 1.7}'),
+      /version string or null/,
+    );
+  });
+});

--- a/tools/release/published-versions.ts
+++ b/tools/release/published-versions.ts
@@ -1,12 +1,16 @@
 // Shared IO for the published-versions manifest: the one path both the
-// resolver (writer) and the diff check (reader) agree on. Gitignored — it is
-// resolved registry state, not source.
+// resolver (writer) and the diff check (reader) agree on. It is resolved
+// registry state, not source, so it lives in the ecosystem-conventional
+// node_modules/.cache — already ignored, out of the package's source
+// listing, no gitignore entry needed. Turbo still hashes it: explicitly
+// listed inputs under node_modules are hashed (probed on turbo 2.10.4).
 
-import { readFile } from 'node:fs/promises';
-import { join } from 'node:path';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
 
 import {
   parseManifest,
+  renderManifest,
   type PublishedVersions,
 } from './published-versions.core.ts';
 import { workspaceRoot } from './workspace.ts';
@@ -14,10 +18,19 @@ import { workspaceRoot } from './workspace.ts';
 /** Where resolve-published.ts writes and check-published-diff.ts reads. */
 export const publishedVersionsPath = join(
   workspaceRoot,
-  'tools',
+  'node_modules',
+  '.cache',
   'release',
   'published-versions.json',
 );
+
+/** Write the canonical manifest, creating the cache directory as needed. */
+export async function writePublishedVersions(
+  versions: PublishedVersions,
+): Promise<void> {
+  await mkdir(dirname(publishedVersionsPath), { recursive: true });
+  await writeFile(publishedVersionsPath, renderManifest(versions));
+}
 
 /** Read the manifest; a missing file points at the resolve step. */
 export async function readPublishedVersions(): Promise<PublishedVersions> {
@@ -26,7 +39,7 @@ export async function readPublishedVersions(): Promise<PublishedVersions> {
     text = await readFile(publishedVersionsPath, 'utf8');
   } catch {
     throw new Error(
-      'tools/release/published-versions.json missing — run the resolve:published task first (the root check:published-diff script chains it).',
+      'node_modules/.cache/release/published-versions.json missing — run the resolve:published task first (the root check:published-diff script chains it).',
     );
   }
   return parseManifest(text);

--- a/tools/release/published-versions.ts
+++ b/tools/release/published-versions.ts
@@ -1,0 +1,33 @@
+// Shared IO for the published-versions manifest: the one path both the
+// resolver (writer) and the diff check (reader) agree on. Gitignored — it is
+// resolved registry state, not source.
+
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import {
+  parseManifest,
+  type PublishedVersions,
+} from './published-versions.core.ts';
+import { workspaceRoot } from './workspace.ts';
+
+/** Where resolve-published.ts writes and check-published-diff.ts reads. */
+export const publishedVersionsPath = join(
+  workspaceRoot,
+  'tools',
+  'release',
+  'published-versions.json',
+);
+
+/** Read the manifest; a missing file points at the resolve step. */
+export async function readPublishedVersions(): Promise<PublishedVersions> {
+  let text: string;
+  try {
+    text = await readFile(publishedVersionsPath, 'utf8');
+  } catch {
+    throw new Error(
+      'tools/release/published-versions.json missing — run the resolve:published task first (the root check:published-diff script chains it).',
+    );
+  }
+  return parseManifest(text);
+}

--- a/tools/release/resolve-published.ts
+++ b/tools/release/resolve-published.ts
@@ -8,14 +8,10 @@
 // task's inputs, its cache key is sound.
 
 import { execFile } from 'node:child_process';
-import { writeFile } from 'node:fs/promises';
 import { promisify } from 'node:util';
 
-import {
-  renderManifest,
-  type PublishedVersions,
-} from './published-versions.core.ts';
-import { publishedVersionsPath } from './published-versions.ts';
+import type { PublishedVersions } from './published-versions.core.ts';
+import { writePublishedVersions } from './published-versions.ts';
 import { loadWorkspace, workspaceRoot } from './workspace.ts';
 
 const run = promisify(execFile);
@@ -45,7 +41,7 @@ async function main() {
   for (const { name } of publishable) {
     versions[name] = await publishedLatest(name);
   }
-  await writeFile(publishedVersionsPath, renderManifest(versions));
+  await writePublishedVersions(versions);
   const summary = publishable
     .map(({ name }) => `${name}@${versions[name] ?? 'unpublished'}`)
     .join(', ');

--- a/tools/release/resolve-published.ts
+++ b/tools/release/resolve-published.ts
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+// Resolve each publishable package's `latest` dist-tag into
+// published-versions.json — the registry-reading half of check:published-diff,
+// split out so the diff itself can be a cached turbo task. npm enforces
+// per-version tarball immutability (and we practice it as publishers: a
+// published version is never mutated), so the only registry state that can
+// move is the dist-tag pointer captured here; with this file in the check
+// task's inputs, its cache key is sound.
+
+import { execFile } from 'node:child_process';
+import { writeFile } from 'node:fs/promises';
+import { promisify } from 'node:util';
+
+import {
+  renderManifest,
+  type PublishedVersions,
+} from './published-versions.core.ts';
+import { publishedVersionsPath } from './published-versions.ts';
+import { loadWorkspace, workspaceRoot } from './workspace.ts';
+
+const run = promisify(execFile);
+
+/** The `latest` dist-tag for `name`, or null when never published. */
+async function publishedLatest(name: string): Promise<string | null> {
+  try {
+    const { stdout } = await run('npm', ['view', name, 'dist-tags.latest']);
+    return stdout.trim() || null;
+  } catch (error) {
+    // promisified execFile rejects with the child's captured output attached.
+    const { stderr } = (error ?? {}) as { stderr?: string };
+    if (stderr?.includes('E404')) return null;
+    throw error;
+  }
+}
+
+async function main() {
+  const { members } = await loadWorkspace(workspaceRoot);
+  const publishable = members.filter(
+    (member) =>
+      member.dir !== '<root>' &&
+      member.manifest &&
+      member.manifest.private !== true,
+  );
+  const versions: PublishedVersions = {};
+  for (const { name } of publishable) {
+    versions[name] = await publishedLatest(name);
+  }
+  await writeFile(publishedVersionsPath, renderManifest(versions));
+  const summary = publishable
+    .map(({ name }) => `${name}@${versions[name] ?? 'unpublished'}`)
+    .join(', ');
+  console.log(
+    `resolved latest dist-tags → published-versions.json: ${summary}`,
+  );
+}
+
+main().catch((error: unknown) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/tools/release/turbo.json
+++ b/tools/release/turbo.json
@@ -25,12 +25,14 @@
       // Cached: the verdict is a pure function of the pack surface and the
       // resolved published versions. Sound because npm tarballs are immutable
       // per version (and we practice publisher immutability) — the movable
-      // `latest` pointer is captured in published-versions.json, written by
-      // resolve:published just before this task and hashed as an input.
+      // `latest` pointer is captured in node_modules/.cache/release/
+      // published-versions.json, written by resolve:published just before
+      // this task and hashed as an input (turbo hashes explicitly listed
+      // node_modules inputs; probed on 2.10.4).
       // Escape hatch: `turbo run check:published-diff --force`.
       "inputs": [
         "$TURBO_DEFAULT$",
-        "published-versions.json",
+        "$TURBO_ROOT$/node_modules/.cache/release/published-versions.json",
         "$TURBO_ROOT$/packages/**",
         "$TURBO_ROOT$/**/package.json",
         "$TURBO_ROOT$/pnpm-workspace.yaml",

--- a/tools/release/turbo.json
+++ b/tools/release/turbo.json
@@ -16,6 +16,11 @@
         "$TURBO_ROOT$/**/package.json",
         "$TURBO_ROOT$/pnpm-workspace.yaml"
       ]
+    },
+    "check:published-diff": {
+      // Diffs against the live npm registry: a cached "clean" against a
+      // registry state that has since changed would be wrong, so never cache.
+      "cache": false
     }
   }
 }

--- a/tools/release/turbo.json
+++ b/tools/release/turbo.json
@@ -17,10 +17,25 @@
         "$TURBO_ROOT$/pnpm-workspace.yaml"
       ]
     },
-    "check:published-diff": {
-      // Diffs against the live npm registry: a cached "clean" against a
-      // registry state that has since changed would be wrong, so never cache.
+    "resolve:published": {
+      // Reads the live registry (the only mutable state here); never cache.
       "cache": false
+    },
+    "check:published-diff": {
+      // Cached: the verdict is a pure function of the pack surface and the
+      // resolved published versions. Sound because npm tarballs are immutable
+      // per version (and we practice publisher immutability) — the movable
+      // `latest` pointer is captured in published-versions.json, written by
+      // resolve:published just before this task and hashed as an input.
+      // Escape hatch: `turbo run check:published-diff --force`.
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "published-versions.json",
+        "$TURBO_ROOT$/packages/**",
+        "$TURBO_ROOT$/**/package.json",
+        "$TURBO_ROOT$/pnpm-workspace.yaml",
+        "$TURBO_ROOT$/pnpm-lock.yaml"
+      ]
     }
   }
 }


### PR DESCRIPTION
Mechanizes the release-triage judgment "has anything ship-affecting changed since the last publish?" — previously done by eyeballing `git log <tag>..main -- <pkg>/src <pkg>/package.json` and reasoning about which edits survive the publish pipeline.

## What it does

`pnpm run check:published-diff`, per non-private workspace package:

1. `turbo run <pkg>#build` (skippable with `--no-build`; cached in a warm tree)
2. Reproduces the **Pack step of `publish-npm.yml`**: `npm pkg delete devDependencies scripts`, `pnpm pack`, then restores the manifest's original bytes (try/finally — survives failures mid-pack)
3. `npm diff --diff=<pkg>@<latest> --diff=<local-tarball>` — **pass iff the output is empty**. `npm diff` exits 0 whether or not the tarballs differ, so the verdict must come from stdout, not the exit code.
4. Prints a per-package report; `--strict` turns drift into exit 1 (default is informational — drift usually means "a release is owed", not "the tree is broken"). Unpublished packages (e.g. a private→public candidate) are skipped with a note; a local version ahead of `latest` is flagged as a release in flight.

Follows the `check-pack` conventions: pure verdict/rendering logic in `check-published-diff.core.ts` with unit tests picked up by `test:root`; process/registry IO in the shell script; workspace enumeration via `scripts/workspace.ts`.

## Why tarball-vs-tarball

- Diffing the **package dir** or source manifest false-positives on `catalog:`/`workspace:` substitution and the stripped `scripts`/`devDependencies` (47-line phantom diff on a clean package).
- Diffing against **registry API manifests** needs a ~14-field ignore list (`_id`, `dist`, `gitHead`, normalized `bugs`, …) and still misses dist/README changes.
- The tarball comparison is exact: a local rebuild of the 1.7.0 tag reproduces the registry tarball **byte-for-byte** (macOS/node-24 vs CI ubuntu), because the pipeline is lockfile-pinned tsc with no timestamps or content hashes. (Tarball *hashes* still differ from gzip metadata — always compare contents.)

## Live results on this branch (real registry, today)

```
published-diff report — 2 of 3 packages would ship changes if released:
  lit-ui-router: clean vs 1.7.0
  lit-ui-router-mobx: SHIPS CHANGES vs 0.3.2 — 10 file(s):
      • dist/router-store.{js,d.ts,js.map} … package.json, README.md
  ui-router-navigation-location-plugin: SHIPS CHANGES vs 0.2.1 — 5 file(s):
      • dist/index.{js,d.ts,js.map}, package.json, README.md
```

Both failure directions are exercised by reality:

- **True negative:** #300's devDep→`catalog:` swap in `packages/lit-ui-router/package.json` since the 1.7.0 tag is correctly invisible (stripped at pack).
- **True positives the git-log method surfaced:** mobx ships #277's `private → private readonly` d.ts changes plus an emitted eslint-disable comment, #232's README rewrap, #231's manifest key sorting, TS7 (#249) sourcemap emit differences, and a peer `lit-ui-router` range floating ^1.5.2 → ^1.7.0 via `workspace:*` pack substitution (→ patch if released); nav-plugin ships #277's tsgolint refactors in `dist/index.js` (→ patch if released). Manual triage had called all of it "cosmetic"; hunk-level reading is what settles the bump.

## Deliberately not in this PR

- **No CI wiring.** The check needs the network and two packages are currently legitimately "red", so it starts life as an on-demand report, not a gate.
- **No workflow refactor.** The strip lines are duplicated from `publish-npm.yml` (called out in comments on both sides would require touching release machinery; keeping this PR out of the release-gated bucket). If the Pack step ever changes, this check must follow — a shared script is the natural follow-up.

## Trust limits

- A toolchain bump (TS, pnpm) in the lockfile can change dist output with zero package-dir commits — the check will go red. That's *accurate* (a publish would ship those bytes) but means red needs human reading, not auto-triage.
- Any future non-deterministic build step (content hashes, build dates) would make its package permanently red until normalized.
- Needs registry availability; a just-published version can lag the CDN briefly.

