### PR TITLE
fix(release): pin the changelog range to the package's own previous tag

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -122,4 +122,17 @@ jobs:
         # a bare `npm publish` re-packs from source and ships raw
         # catalog:/workspace: refs npm can't resolve (broke 1.3.0–1.5.0)
         # inputs.dryRun is only set for manual workflow_dispatch runs; real tag pushes always publish for real.
-        run: pnpm --filter ${{ env.PACKAGE_NAME }} exec -- release-it --no-increment --npm.publish true --npm.skipChecks true --npm.publishPath "$TARBALL" --github.release true --github.assets "*.tgz" --git.tagExclude "\${npm.name}@$RELEASE_VERSION" ${{ inputs.dryRun && '--dry-run' || '' }}
+        # gitRawCommitsOpts.from: release-it's secondLatestTag is computed
+        # without tagMatch (repo-wide `rev-list --tags`), so in this monorepo
+        # the conventional-changelog plugin's commit range can start at ANOTHER
+        # package's newer tag, come up empty after path filtering, and silently
+        # fall back to the flat git-log changelog (#302). Pin the range to this
+        # package's own previous tag; a first release has none and skips the
+        # override.
+        run: |
+          PREV_TAG=$(git describe --tags --match="${PACKAGE_NAME}@*" --exclude="${PACKAGE_NAME}@${RELEASE_VERSION}" --abbrev=0 2>/dev/null || true)
+          CHANGELOG_ARGS=()
+          if [ -n "$PREV_TAG" ]; then
+            CHANGELOG_ARGS+=("--plugins.@release-it/conventional-changelog.gitRawCommitsOpts.from=$PREV_TAG")
+          fi
+          pnpm --filter ${{ env.PACKAGE_NAME }} exec -- release-it --no-increment --npm.publish true --npm.skipChecks true --npm.publishPath "$TARBALL" --github.release true --github.assets "*.tgz" --git.tagExclude "\${npm.name}@$RELEASE_VERSION" "${CHANGELOG_ARGS[@]}" ${{ inputs.dryRun && '--dry-run' || '' }}

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -127,10 +127,11 @@ jobs:
         # the conventional-changelog plugin's commit range can start at ANOTHER
         # package's newer tag, come up empty after path filtering, and silently
         # fall back to the flat git-log changelog (#302). Pin the range to this
-        # package's own previous tag; a first release has none and skips the
-        # override.
+        # package's own previous tag, computed by the unit-tested
+        # scripts/release-prev-tag.ts; a first release prints nothing and
+        # skips the override.
         run: |
-          PREV_TAG=$(git describe --tags --match="${PACKAGE_NAME}@*" --exclude="${PACKAGE_NAME}@${RELEASE_VERSION}" --abbrev=0 2>/dev/null || true)
+          PREV_TAG=$(node scripts/release-prev-tag.ts "$PACKAGE_NAME" "$RELEASE_VERSION")
           CHANGELOG_ARGS=()
           if [ -n "$PREV_TAG" ]; then
             CHANGELOG_ARGS+=("--plugins.@release-it/conventional-changelog.gitRawCommitsOpts.from=$PREV_TAG")

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -72,7 +72,7 @@ jobs:
           echo "$PACKAGE_DIR"
           echo "PACKAGE_DIR=$PACKAGE_DIR" >> "$GITHUB_ENV"
       - name: Build
-        run: npm exec -- turbo run ${{ env.PACKAGE_NAME }}#build
+        run: npm exec -- turbo run "$PACKAGE_NAME#build"
         env:
           TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
           TURBO_API: ${{ vars.TURBO_API }}
@@ -87,7 +87,7 @@ jobs:
         # the turbo step above instead.
         run: |
           (cd "$PACKAGE_DIR" && npm pkg delete devDependencies scripts)
-          pnpm --filter ${{ env.PACKAGE_NAME }} pack --pack-destination ${{ env.PACKAGE_DIR }}
+          pnpm --filter "$PACKAGE_NAME" pack --pack-destination "$PACKAGE_DIR"
           echo "TARBALL=$(realpath "$PACKAGE_DIR"/*.tgz)" >> "$GITHUB_ENV"
           # restore the stripped manifest: release-it requires a clean working dir
           git checkout -- "$PACKAGE_DIR/package.json"
@@ -111,7 +111,7 @@ jobs:
           subject-path: '${{ env.PACKAGE_DIR }}/*.tgz'
       - name: Release version
         run: |
-          echo "RELEASE_VERSION=$(pnpm --filter ${{ env.PACKAGE_NAME }} exec release-it --release-version --no-increment)" >> "$GITHUB_ENV"
+          echo "RELEASE_VERSION=$(pnpm --filter "$PACKAGE_NAME" exec release-it --release-version --no-increment)" >> "$GITHUB_ENV"
       - name: Publish
         # release-it >= 20.1 handles immutable releases natively when assets
         # are configured: create draft, upload assets, publish — one
@@ -135,4 +135,4 @@ jobs:
           if [ -n "$PREV_TAG" ]; then
             CHANGELOG_ARGS+=("--plugins.@release-it/conventional-changelog.gitRawCommitsOpts.from=$PREV_TAG")
           fi
-          pnpm --filter ${{ env.PACKAGE_NAME }} exec -- release-it --no-increment --npm.publish true --npm.skipChecks true --npm.publishPath "$TARBALL" --github.release true --github.assets "*.tgz" --git.tagExclude "\${npm.name}@$RELEASE_VERSION" "${CHANGELOG_ARGS[@]}" ${{ inputs.dryRun && '--dry-run' || '' }}
+          pnpm --filter "$PACKAGE_NAME" exec -- release-it --no-increment --npm.publish true --npm.skipChecks true --npm.publishPath "$TARBALL" --github.release true --github.assets "*.tgz" --git.tagExclude "\${npm.name}@$RELEASE_VERSION" "${CHANGELOG_ARGS[@]}" ${{ inputs.dryRun && '--dry-run' || '' }}

--- a/scripts/release-prev-tag.core.ts
+++ b/scripts/release-prev-tag.core.ts
@@ -1,0 +1,51 @@
+// Pure logic for the previous-release-tag lookup the publish workflow uses to
+// pin the conventional-changelog commit range (#302): release-it's own
+// secondLatestTag is computed repo-wide, so in this monorepo the range can
+// start at ANOTHER package's newer tag and come up empty. The IO (running
+// `git describe`) lives in release-prev-tag.ts.
+
+/**
+ * `git describe` args selecting the nearest tag of THIS package while
+ * skipping the tag being released (re-runs of a publish already have it).
+ *
+ * The `--match` glob is anchored by the literal `@`, so `lit-ui-router@*`
+ * cannot match `lit-ui-router-mobx@…` tags. Prerelease tags match too — a
+ * `pkg@1.1.0-canary.0` between releases becomes the range start, which is
+ * the intended behavior: commits already summarized in a canary's notes are
+ * not repeated in the next stable's.
+ */
+export function describeArgs(
+  packageName: string,
+  releaseVersion: string,
+): string[] {
+  if (packageName.trim() === '') {
+    throw new Error('packageName must be non-empty');
+  }
+  if (releaseVersion.trim() === '') {
+    throw new Error('releaseVersion must be non-empty');
+  }
+  return [
+    'describe',
+    '--tags',
+    `--match=${packageName}@*`,
+    `--exclude=${packageName}@${releaseVersion}`,
+    '--abbrev=0',
+  ];
+}
+
+/** The previous tag from `git describe` stdout; empty output → no override. */
+export function parsePrevTag(stdout: string): string | undefined {
+  const tag = stdout.trim();
+  return tag === '' ? undefined : tag;
+}
+
+/**
+ * Whether a failed `git describe` just means "no previous release" — no tags
+ * at all, or none surviving the match/exclude filters. Anything else is a
+ * genuine git error worth surfacing on stderr.
+ */
+export function isFirstReleaseError(stderr: string): boolean {
+  return /No names found|No tags can describe|No annotated tags can describe/i.test(
+    stderr,
+  );
+}

--- a/scripts/release-prev-tag.test.ts
+++ b/scripts/release-prev-tag.test.ts
@@ -1,0 +1,157 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { after, before, describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import {
+  describeArgs,
+  isFirstReleaseError,
+  parsePrevTag,
+} from './release-prev-tag.core.ts';
+
+describe('describeArgs', () => {
+  it('anchors the match glob and excludes the tag being released', () => {
+    assert.deepEqual(describeArgs('lit-ui-router', '1.6.0'), [
+      'describe',
+      '--tags',
+      '--match=lit-ui-router@*',
+      '--exclude=lit-ui-router@1.6.0',
+      '--abbrev=0',
+    ]);
+  });
+
+  it('rejects empty package or version (a blank env var upstream)', () => {
+    assert.throws(() => describeArgs('', '1.0.0'), /packageName/);
+    assert.throws(() => describeArgs('lit-ui-router', ' '), /releaseVersion/);
+  });
+});
+
+describe('parsePrevTag', () => {
+  it('trims the describe output to the tag', () => {
+    assert.equal(parsePrevTag('lit-ui-router@1.5.2\n'), 'lit-ui-router@1.5.2');
+  });
+
+  it('treats empty output as no override', () => {
+    assert.equal(parsePrevTag(''), undefined);
+    assert.equal(parsePrevTag('\n'), undefined);
+  });
+});
+
+describe('isFirstReleaseError', () => {
+  it('recognizes both no-tags-at-all and none-matching messages', () => {
+    assert.equal(
+      isFirstReleaseError('fatal: No names found, cannot describe anything.'),
+      true,
+    );
+    assert.equal(
+      isFirstReleaseError("fatal: No tags can describe 'abc'."),
+      true,
+    );
+  });
+
+  it('keeps genuine git errors loud', () => {
+    assert.equal(
+      isFirstReleaseError('fatal: not a git repository (or any parent)'),
+      false,
+    );
+  });
+});
+
+// End-to-end against real git: these pin git's own glob and tag-walk
+// semantics the workflow relies on, not our reimplementation of them.
+const scriptPath = fileURLToPath(
+  new URL('./release-prev-tag.ts', import.meta.url),
+);
+
+const GIT_ENV = {
+  ...process.env,
+  GIT_AUTHOR_NAME: 'test',
+  GIT_AUTHOR_EMAIL: 'test@example.com',
+  GIT_COMMITTER_NAME: 'test',
+  GIT_COMMITTER_EMAIL: 'test@example.com',
+};
+
+function git(cwd: string, ...args: string[]): void {
+  const run = spawnSync('git', args, { cwd, encoding: 'utf8', env: GIT_ENV });
+  assert.equal(run.status, 0, `git ${args.join(' ')} failed: ${run.stderr}`);
+}
+
+function commit(cwd: string, message: string, ...tags: string[]): void {
+  git(cwd, 'commit', '--allow-empty', '-m', message);
+  for (const tag of tags) git(cwd, 'tag', tag);
+}
+
+function prevTag(cwd: string, packageName: string, version: string) {
+  return spawnSync(process.execPath, [scriptPath, packageName, version], {
+    cwd,
+    encoding: 'utf8',
+  });
+}
+
+describe('release-prev-tag.ts', () => {
+  // history: 1.0.0 (+ a mobx tag) → 1.1.0-canary.0 → 1.1.0 at HEAD
+  let repo: string;
+  // a single commit tagged only for the OTHER package
+  let mobxOnlyRepo: string;
+
+  before(() => {
+    repo = fs.mkdtempSync(path.join(os.tmpdir(), 'prev-tag-test-'));
+    git(repo, 'init', '-q');
+    commit(
+      repo,
+      'feat: first',
+      'lit-ui-router@1.0.0',
+      'lit-ui-router-mobx@0.3.0',
+    );
+    commit(repo, 'feat: canary', 'lit-ui-router@1.1.0-canary.0');
+    commit(repo, 'feat: stable', 'lit-ui-router@1.1.0');
+
+    mobxOnlyRepo = fs.mkdtempSync(path.join(os.tmpdir(), 'prev-tag-test-'));
+    git(mobxOnlyRepo, 'init', '-q');
+    commit(mobxOnlyRepo, 'feat: mobx only', 'lit-ui-router-mobx@0.3.0');
+  });
+
+  after(() => {
+    fs.rmSync(repo, { recursive: true, force: true });
+    fs.rmSync(mobxOnlyRepo, { recursive: true, force: true });
+  });
+
+  it('prints the package’s nearest previous tag', () => {
+    const run = prevTag(repo, 'lit-ui-router', '1.2.0');
+    assert.equal(run.status, 0);
+    assert.equal(run.stdout, 'lit-ui-router@1.1.0\n');
+  });
+
+  it('excludes the tag being released, so publish re-runs still range from before it', () => {
+    const run = prevTag(repo, 'lit-ui-router', '1.1.0');
+    assert.equal(run.status, 0);
+    // also pins that prerelease tags count as the previous release
+    assert.equal(run.stdout, 'lit-ui-router@1.1.0-canary.0\n');
+  });
+
+  it('does not let lit-ui-router@* leak across the prefix into lit-ui-router-mobx tags', () => {
+    const run = prevTag(repo, 'lit-ui-router-mobx', '0.4.0');
+    assert.equal(run.status, 0);
+    // nearer lit-ui-router@ tags exist on the walk; none of them may match
+    assert.equal(run.stdout, 'lit-ui-router-mobx@0.3.0\n');
+  });
+
+  it('prints nothing and exits 0 on a first release', () => {
+    const run = prevTag(mobxOnlyRepo, 'lit-ui-router', '1.0.0');
+    assert.equal(run.status, 0);
+    assert.equal(run.stdout, '');
+    assert.equal(run.stderr, '');
+  });
+
+  it('fails loudly when invoked without both arguments', () => {
+    const run = spawnSync(process.execPath, [scriptPath, 'lit-ui-router'], {
+      cwd: repo,
+      encoding: 'utf8',
+    });
+    assert.equal(run.status, 1);
+    assert.match(run.stderr, /usage:/);
+  });
+});

--- a/scripts/release-prev-tag.ts
+++ b/scripts/release-prev-tag.ts
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+// Prints the previous release tag of a package — the changelog range start
+// the publish workflow pins release-it to (#302) — or nothing on a first
+// release, so `PREV_TAG=$(node scripts/release-prev-tag.ts <pkg> <version>)`
+// can never fail the publish just because no earlier tag exists.
+//
+// This file is the IO shell: it runs `git describe` and delegates all
+// decisions to the pure, unit-tested functions in ./release-prev-tag.core.ts.
+
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+import {
+  describeArgs,
+  isFirstReleaseError,
+  parsePrevTag,
+} from './release-prev-tag.core.ts';
+
+const run = promisify(execFile);
+
+const [packageName, releaseVersion, ...extra] = process.argv.slice(2);
+if (!packageName || !releaseVersion || extra.length > 0) {
+  console.error(
+    'usage: node scripts/release-prev-tag.ts <package-name> <release-version>',
+  );
+  process.exit(1);
+}
+
+try {
+  const { stdout } = await run(
+    'git',
+    describeArgs(packageName, releaseVersion),
+  );
+  const prevTag = parsePrevTag(stdout);
+  if (prevTag !== undefined) console.log(prevTag);
+} catch (error) {
+  // First release: stay silent and exit 0 — empty output means "no override".
+  // Anything else still exits 0 (matching the inline `|| true` this replaces)
+  // but surfaces git's stderr so an unexpected failure is at least visible.
+  const stderr =
+    error !== null &&
+    typeof error === 'object' &&
+    'stderr' in error &&
+    typeof error.stderr === 'string'
+      ? error.stderr
+      : '';
+  if (!isFirstReleaseError(stderr))
+    console.error(stderr === '' ? error : stderr);
+}


### PR DESCRIPTION
Second (and remaining) root cause of #302, found by shepherding the 0.3.3 canary release: the notes came out flat again **with #303's preset pin correctly in place** — reproduced locally at the released commit `d92252a` with the exact CI invocation.

## Root cause

release-it's `GitBase.getSecondLatestTagName` is computed repo-wide:

```
git rev-list <latestTag> --tags --max-count=1   # --tags = every tag as a start point
git describe --tags --abbrev=0 "<sha>^"         # no --match / --exclude
```

Neither command respects `tagMatch`. During the 0.3.3 publish this resolved `secondLatestTag = lit-ui-router@1.7.0` — a **different package's** tag, 4 commits back. The conventional-changelog plugin uses `previousTag = secondLatestTag` as its `gitRawCommitsOpts.from`; the mobx-path-filtered range from there contains only the `Release 0.3.3` bump commit, which the `conventionalcommits` writer discards → **empty changelog** → release-it silently falls back to the git plugin's flat `git log` list (repo-wide, ungrouped). Same mechanism as 1.7.0's regression; it just needs another package to have tagged more recently, which is why #303's local verification (run before 0.3.3 was tagged) looked green.

## Fix

Compute the package's own previous tag with a scoped describe and pin the plugin's range explicitly:

```bash
PREV_TAG=$(git describe --tags --match="${PACKAGE_NAME}@*" --exclude="${PACKAGE_NAME}@${RELEASE_VERSION}" --abbrev=0 2>/dev/null || true)
# … release-it … "--plugins.@release-it/conventional-changelog.gitRawCommitsOpts.from=$PREV_TAG"
```

- The dotted CLI path deep-merges into the plugin config (verified: the `.release-it.json`'s `path: "."` filter survives).
- First release of a package: `describe` finds nothing, the override is skipped, behavior unchanged.
- The one context field that stays stale (`currentTag` compare link) never renders — the config's `headerPartial: ""` drops the header by design.

## Verification (local, at the released commit, exact CI flags + override)

```
Changelog:
### Features
* **lint:** triage and enable the remaining tsgolint type-aware rules ([#277](…)) (f5b3331)
* **types:** register custom elements in HTMLElementTagNameMap ([#285](…)) (cf44b92)
* **tooling:** migrate prettier to oxfmt ([#232](…)) (f9ce7e2)
…
### Bug Fixes
* **turbo:** stable app-build hashes via transit deps + cached docs:api ([#278](…)) (5c15100)
…
```

Grouped, transformed, and path-filtered to the package — the 0.3.2→HEAD range exactly.

## Release-gated verification plan

This PR is release machinery: the e2e proof is the held-open **#317 (Release 0.2.2, nav-plugin)** — merge this first, then #317; its GitHub release should come out grouped. The already-published `lit-ui-router-mobx@0.3.3` release body can afterwards be corrected in place with `gh release edit` using the regenerated notes.

Upstream follow-ups worth filing: release-it (`getSecondLatestTagName` ignores `tagMatch`) and @release-it/conventional-changelog (empty plugin changelog silently falls back to the flat list — a warning would have surfaced this two releases ago).


## PREV_TAG extracted to a tested script

The upcoming canary should test the **final design**, not inline YAML that would be refactored right after — so the fix's PREV_TAG computation now ships as `scripts/release-prev-tag.{ts,core.ts,test.ts}` (the house shell+core+test pattern; covered by `test:root`/`lint:root`/`typecheck:root`), and the workflow step shrinks to:

```bash
PREV_TAG=$(node scripts/release-prev-tag.ts "$PACKAGE_NAME" "$RELEASE_VERSION")
```

Tests pin the semantics this fix relies on, end-to-end against real git in a fixture repo: `--match` glob boundaries (`lit-ui-router@*` never matches `lit-ui-router-mobx@…` tags), exclude-current on publish re-runs, prerelease tags counting as the previous release, and first-release printing nothing with exit 0. One behavior delta vs the inline block: unexpected git failures still exit 0 with empty output (same as `|| true`), but git's stderr is now surfaced instead of `2>/dev/null`-discarded. Changelog verification re-run with the script-computed PREV_TAG: grouped, scoped output for both `lit-ui-router` (1.6.0→HEAD) and `lit-ui-router-mobx` (0.3.2→HEAD).
