### PR TITLE
refactor(release): extract increment parsing to a tested script

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -92,27 +92,18 @@ jobs:
           else
             echo "BRANCH_PREFIX=release/$PACKAGE/v" >> "$GITHUB_ENV"
           fi
-      - name: Parse increment inputs
-        # Handle the various increment input combinations:
-        # - major/minor/patch: Standard semver bumps
-        # - other: Custom version string from 'other' input
-        # - none: No bump, use current version. No-op unless `other` provided
-        run: |
-          echo "ACTUAL_INCREMENT=$(
-            if [ "$INCREMENT" != "other" ]; then
-              if [ "$INCREMENT" != "none" ]; then
-                echo "--increment $INCREMENT"
-              else
-                echo "$OTHER_INCREMENT"
-              fi
-            else
-              echo "--increment $OTHER_INCREMENT"
-            fi
-          )" >> "$GITHUB_ENV"
       - name: Calculate bumped version
-        # Dry-run release-it to get the new version without making changes
+        # scripts/release-increment-args.ts maps the increment/other inputs to
+        # release-it args (validating the free-text `other` input against a
+        # strict semver allowlist) and prints them one per line; `mapfile -t`
+        # reads them verbatim — no word-splitting of user input into argv.
+        # release-it then dry-runs to get the new version without changes.
         run: |
-          read -r -a INCREMENT_ARGS <<< "$ACTUAL_INCREMENT"
+          INCREMENT_OUTPUT="$(node scripts/release-increment-args.ts "$INCREMENT" "$OTHER_INCREMENT")"
+          INCREMENT_ARGS=()
+          if [ -n "$INCREMENT_OUTPUT" ]; then
+            mapfile -t INCREMENT_ARGS <<< "$INCREMENT_OUTPUT"
+          fi
           echo "BUMPED_VERSION=$(pnpm --filter "$PACKAGE" exec release-it --release-version "${INCREMENT_ARGS[@]}")" >> "$GITHUB_ENV"
       - name: Switch branches
         # Create release branch: release/{package}/vX.Y.Z

--- a/scripts/release-increment-args.core.ts
+++ b/scripts/release-increment-args.core.ts
@@ -1,0 +1,63 @@
+// Pure logic for turning bump-version.yml's `increment`/`other` inputs into
+// release-it argv. Replaces the workflow's inline if/else that built a flag
+// string in GITHUB_ENV and later re-split it with `read -a` — a round-trip
+// that word-split the free-text `other` input into arbitrary release-it
+// flags. The IO (printing argv for the workflow) lives in
+// release-increment-args.ts.
+
+// Official semver.org version pattern (no leading `v`), anchored.
+const SEMVER_VERSION =
+  /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*)?(?:\+[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*)?$/;
+
+// The workflow's choice list already offers major/minor/patch, so `other`
+// only ever carries what the list can't express: an exact version literal
+// (the historical use — alpha prereleases like 1.0.3-alpha.0) or a semver
+// pre-increment keyword. Anything else — in particular anything with
+// whitespace or a leading dash — is rejected instead of word-split into argv.
+const PRE_INCREMENT_KEYWORDS = new Set([
+  'premajor',
+  'preminor',
+  'prepatch',
+  'prerelease',
+]);
+
+function validatedOther(other: string): string {
+  // The old word-splitting trimmed surrounding whitespace; keep that.
+  const value = other.trim();
+  if (SEMVER_VERSION.test(value) || PRE_INCREMENT_KEYWORDS.has(value)) {
+    return value;
+  }
+  throw new Error(
+    `invalid 'other' increment ${JSON.stringify(other)}: expected an exact ` +
+      `semver version (e.g. 1.2.3-alpha.0) or one of ` +
+      `premajor|preminor|prepatch|prerelease`,
+  );
+}
+
+/**
+ * The release-it args for a bump-version run:
+ * - major/minor/patch → `--increment <value>`
+ * - other → `--increment <other>` (validated custom version / pre-keyword)
+ * - none → no args, unless `other` is provided — then `other` is passed as
+ *   release-it's POSITIONAL increment, preserving the workflow's historical
+ *   `none`+`other` behavior (equivalent to `--increment`, but pinned as-is)
+ */
+export function incrementArgs(increment: string, other: string): string[] {
+  switch (increment) {
+    case 'major':
+    case 'minor':
+    case 'patch':
+      return ['--increment', increment];
+    case 'other':
+      return ['--increment', validatedOther(other)];
+    case 'none':
+      return other.trim() === '' ? [] : [validatedOther(other)];
+    default:
+      // Unreachable from the workflow (choice input), so fail loudly rather
+      // than pass an unknown value through to release-it.
+      throw new Error(
+        `unknown increment ${JSON.stringify(increment)}: expected ` +
+          `major|minor|patch|other|none`,
+      );
+  }
+}

--- a/scripts/release-increment-args.test.ts
+++ b/scripts/release-increment-args.test.ts
@@ -1,0 +1,151 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import { incrementArgs } from './release-increment-args.core.ts';
+
+// Baseline equivalence: expectations below for major/minor/patch/other/none
+// match the argv the workflow's old GITHUB_ENV string + `read -a` round-trip
+// produced for the same inputs (captured before the extraction).
+
+describe('incrementArgs', () => {
+  it('maps each standard choice-list increment to an --increment flag', () => {
+    // every non-custom value bump-version.yml's `options` list offers
+    assert.deepEqual(incrementArgs('major', ''), ['--increment', 'major']);
+    assert.deepEqual(incrementArgs('minor', ''), ['--increment', 'minor']);
+    assert.deepEqual(incrementArgs('patch', ''), ['--increment', 'patch']);
+  });
+
+  it('ignores a stray `other` value alongside a standard increment', () => {
+    // the old shell never looked at OTHER_INCREMENT on this branch
+    assert.deepEqual(incrementArgs('patch', '9.9.9'), ['--increment', 'patch']);
+  });
+
+  it('passes a custom version through --increment', () => {
+    assert.deepEqual(incrementArgs('other', '1.2.3'), ['--increment', '1.2.3']);
+    assert.deepEqual(incrementArgs('other', '1.0.3-alpha.0'), [
+      '--increment',
+      '1.0.3-alpha.0',
+    ]);
+    assert.deepEqual(incrementArgs('other', '2.0.0-rc.1+build.5'), [
+      '--increment',
+      '2.0.0-rc.1+build.5',
+    ]);
+  });
+
+  it('accepts the semver pre-increment keywords the choice list lacks', () => {
+    for (const kw of ['premajor', 'preminor', 'prepatch', 'prerelease']) {
+      assert.deepEqual(incrementArgs('other', kw), ['--increment', kw]);
+    }
+  });
+
+  it('trims surrounding whitespace like the old word-splitting did', () => {
+    assert.deepEqual(incrementArgs('other', '  1.2.3 '), [
+      '--increment',
+      '1.2.3',
+    ]);
+  });
+
+  it('produces no args for none without other (use current version)', () => {
+    assert.deepEqual(incrementArgs('none', ''), []);
+    assert.deepEqual(incrementArgs('none', '   '), []);
+  });
+
+  it('pins none+other passing the version POSITIONALLY, not via flag', () => {
+    // odd but load-bearing: the workflow has always emitted the bare value
+    assert.deepEqual(incrementArgs('none', '1.2.3'), ['1.2.3']);
+    assert.deepEqual(incrementArgs('none', 'prerelease'), ['prerelease']);
+  });
+
+  it('rejects flag injection through the free-text other input', () => {
+    // pre-extraction these word-split into extra release-it argv
+    assert.throws(
+      () =>
+        incrementArgs('other', '1.2.3 --no-git.requireCleanWorkingDir --ci'),
+      /invalid 'other' increment "1\.2\.3 --no-git\.requireCleanWorkingDir --ci"/,
+    );
+    assert.throws(
+      () => incrementArgs('none', '--ci --no-npm'),
+      /invalid 'other' increment/,
+    );
+    assert.throws(
+      () => incrementArgs('other', '--preRelease=alpha'),
+      /invalid 'other' increment/,
+    );
+  });
+
+  it('rejects non-semver other values with the offending value in the error', () => {
+    for (const bad of ['v1.2.3', '1.2', 'latest', 'major.minor']) {
+      assert.throws(
+        () => incrementArgs('other', bad),
+        new RegExp(`invalid 'other' increment "${bad.replace(/\./g, '\\.')}"`),
+      );
+    }
+  });
+
+  it('rejects other-mode without a value (was a broken bare --increment)', () => {
+    assert.throws(() => incrementArgs('other', ''), /invalid 'other'/);
+    assert.throws(() => incrementArgs('other', '  '), /invalid 'other'/);
+  });
+
+  it('rejects increments outside the workflow choice list', () => {
+    assert.throws(() => incrementArgs('', ''), /unknown increment ""/);
+    assert.throws(
+      () => incrementArgs('--help', ''),
+      /unknown increment "--help"/,
+    );
+  });
+});
+
+// End-to-end: pins the newline-delimited stdout contract the workflow's
+// `mapfile -t` consumes, and the loud non-zero exit on bad input.
+const scriptPath = fileURLToPath(
+  new URL('./release-increment-args.ts', import.meta.url),
+);
+
+function run(...args: string[]) {
+  return spawnSync(process.execPath, [scriptPath, ...args], {
+    encoding: 'utf8',
+  });
+}
+
+describe('release-increment-args.ts', () => {
+  it('prints one arg per line', () => {
+    const result = run('patch', '');
+    assert.equal(result.status, 0);
+    assert.equal(result.stdout, '--increment\npatch\n');
+  });
+
+  it('prints the positional none+other arg on a single line', () => {
+    const result = run('none', '1.2.3');
+    assert.equal(result.status, 0);
+    assert.equal(result.stdout, '1.2.3\n');
+  });
+
+  it('prints nothing for none without other', () => {
+    const result = run('none', '');
+    assert.equal(result.status, 0);
+    assert.equal(result.stdout, '');
+  });
+
+  it('accepts a missing other argument as empty', () => {
+    const result = run('minor');
+    assert.equal(result.status, 0);
+    assert.equal(result.stdout, '--increment\nminor\n');
+  });
+
+  it('fails loudly on an invalid other value', () => {
+    const result = run('other', '1.2.3 --github.release');
+    assert.equal(result.status, 1);
+    assert.equal(result.stdout, '');
+    assert.match(result.stderr, /invalid 'other' increment/);
+    assert.match(result.stderr, /--github\.release/);
+  });
+
+  it('fails loudly when invoked without an increment', () => {
+    const result = run();
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /usage:/);
+  });
+});

--- a/scripts/release-increment-args.ts
+++ b/scripts/release-increment-args.ts
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+// Prints the release-it args for bump-version.yml's increment/other inputs,
+// ONE ARG PER LINE. Newline-delimited is the least-clever safe transport for
+// a multi-token argv: the core validates every arg to a whitespace-free
+// allowlist, so lines and args are 1:1, and the workflow reads them with
+// `mapfile -t` — no `read -a` word-splitting, no eval, no jq dependency.
+// Zero args (increment=none without `other`) prints nothing.
+//
+// This file is the IO shell: all decisions live in the pure, unit-tested
+// functions in ./release-increment-args.core.ts.
+
+import { incrementArgs } from './release-increment-args.core.ts';
+
+const [increment, other, ...extra] = process.argv.slice(2);
+if (increment === undefined || extra.length > 0) {
+  console.error(
+    'usage: node scripts/release-increment-args.ts <increment> [other]',
+  );
+  process.exit(1);
+}
+
+try {
+  const args = incrementArgs(increment, other ?? '');
+  if (args.length > 0) console.log(args.join('\n'));
+} catch (error) {
+  console.error(error instanceof Error ? error.message : error);
+  process.exit(1);
+}


### PR DESCRIPTION
Extracts bump-version.yml's "Parse increment inputs" + "Calculate bumped version" arg-building into `scripts/release-increment-args.{core,test,}.ts`, following the `release-prev-tag.*` shell+core+test shape.

## Findings

**Fragile round-trip.** The workflow serialized release-it flags into a single `ACTUAL_INCREMENT` string in `GITHUB_ENV`, then re-split it in the next step with `read -r -a`. Any whitespace-bearing value silently changed arity, and the split point was two steps away from the build point.

**Flag injection via `other`.** Because that string was word-split, the free-text `other` workflow_dispatch input flowed into release-it argv token by token. Reproduced against the exact YAML shell (verbatim replica):

```
inputs(other, "1.2.3 --no-git.requireCleanWorkingDir --github.release")
  -> argv: <--increment> <1.2.3> <--no-git.requireCleanWorkingDir> <--github.release>
inputs(none, "--ci --no-npm") -> argv: <--ci> <--no-npm>
```

Environment-gated (`bump-version` approval), but free to close.

## What changed

- `release-increment-args.core.ts` — pure `(increment, other) → string[]`. `major|minor|patch` → `--increment <x>`; `other` → `--increment <validated other>`; `none` → no args, or **`other` as release-it's positional increment** (the workflow's historical odd case, pinned as-is in tests).
- **Validation pattern**: `other`, when used, must be an exact semver version (official semver.org regex, no leading `v` — the historical use, e.g. the `1.0.3-alpha.*` releases) **or** one of `premajor|preminor|prepatch|prerelease` (the only release-it increments the choice list can't express). Anything else fails loudly with the offending value quoted. Surrounding whitespace is trimmed, matching the old word-split.
- `release-increment-args.ts` — IO shell printing args one per line. Newline-delimited was chosen as the least-clever safe transport: every validated arg is whitespace-free so lines↔args are 1:1, and the workflow reads them with `mapfile -t` (no `read -a` word-splitting, no eval, no jq dependency).
- Workflow: the two steps collapse into one "Calculate bumped version" step — the `GITHUB_ENV` round-trip was the bug, and `ACTUAL_INCREMENT` had no other consumers. `BUMPED_VERSION` is still produced the same way (`release-it --release-version` with the args), so `Switch branches` / `Bump version` / `Create PR` downstream are untouched.

## Baseline equivalence

Captured the current YAML logic's argv (verbatim shell replica) and diffed against the new script through the `mapfile` transport for every combination:

| inputs | old argv | new argv |
|---|---|---|
| major / minor / patch | `--increment <x>` | identical |
| other, `1.2.3-alpha.0` | `--increment 1.2.3-alpha.0` | identical |
| other, `prerelease` | `--increment prerelease` | identical |
| none, empty (or blank) | *(none)* | identical |
| none, `1.2.3` | `1.2.3` (positional) | identical |
| other, empty | `--increment` (bare, broken) | **rejected loudly** |
| other, `1.2.3 --no-git.… --github.release` | 4 args (injection) | **rejected loudly** |
| none, `--ci --no-npm` | 2 flags (injection) | **rejected loudly** |

Also fed the produced args to real `release-it --release-version` per combo (with `--no-git.requireCleanWorkingDir` locally): patch→1.7.1, minor→1.8.0, major→2.0.0, other `1.8.0-alpha.0`→1.8.0-alpha.0, other `prerelease`→1.7.1-0, none+`1.8.0` (positional)→1.8.0.

Behavior deltas, all confined to previously-broken or injection inputs: `increment=other` with empty/invalid `other` now fails the step with a clear error instead of passing a bare `--increment` (or extra flags) to release-it; an increment value outside the choice list (unreachable via workflow_dispatch) also errors instead of being forwarded.

## Verification

- `test:root` (41 pass, incl. the new unit + spawned-script e2e suites), `lint:root`, `typecheck:root`, `format` — clean
- `mise exec -- actionlint .github/workflows/bump-version.yml` — clean
- `turbo run ci` — 67/67 tasks pass
