### PR TITLE
refactor(release): unify the packed-manifest guard with check-pack

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -93,15 +93,7 @@ jobs:
           git checkout -- "$PACKAGE_DIR/package.json"
       - name: Check packed manifest
         # no devDependencies, no scripts, and no unsubstituted catalog:/workspace: refs may ship
-        run: |
-          tar -xOzf "$TARBALL" package/package.json | node -e '
-            const m = JSON.parse(require("fs").readFileSync(0));
-            if (m.devDependencies) throw new Error("devDependencies leaked into packed manifest");
-            if (m.scripts) throw new Error("scripts leaked into packed manifest");
-            const runtime = JSON.stringify([m.dependencies, m.peerDependencies, m.optionalDependencies]);
-            if (/catalog:|workspace:/.test(runtime)) throw new Error("unsubstituted refs in packed manifest");
-            console.log("packed manifest clean");
-          '
+        run: node scripts/check-packed-manifest.ts "$TARBALL"
       - name: Attest build provenance
         # Generate SLSA provenance attestation for supply chain security.
         # Skipped on manual dry runs: this hits Sigstore/rekor for real and isn't part of release-it's --dry-run.

--- a/scripts/check-pack.core.ts
+++ b/scripts/check-pack.core.ts
@@ -85,11 +85,21 @@ export function formatReport(results: PackResult[]): Report {
 // about to hand release-it. These checks are that gate.
 
 /**
+ * The manifest fields publish-npm.yml's Pack step deletes before `pnpm pack`
+ * (`npm pkg delete ...STRIPPED_MANIFEST_FIELDS`). The single source of truth
+ * for the strip: the packed-manifest gate fails when any of them survive, and
+ * anything reproducing the Pack step (e.g. check-published-diff) should build
+ * its delete args from this list.
+ */
+export const STRIPPED_MANIFEST_FIELDS = ['devDependencies', 'scripts'] as const;
+
+/**
  * Violations in the manifest npm would publish, as human-readable strings.
  *
  * Semantics match the inline workflow check this replaces:
- * - devDependencies and scripts must be absent — a present-but-empty object
- *   still fails, because the strip step should have deleted the key.
+ * - Every {@link STRIPPED_MANIFEST_FIELDS} field must be absent — a
+ *   present-but-empty object still fails, because the strip step should have
+ *   deleted the key.
  * - No `catalog:`/`workspace:` anywhere in the serialized runtime dependency
  *   fields. Deliberately blunter than {@link findUnsubstitutedRefs}: a
  *   substring test instead of a prefix test, because at publish time ANY
@@ -100,11 +110,10 @@ export function findPackedManifestViolations(
   manifest: PackageManifest,
 ): string[] {
   const violations: string[] = [];
-  if (manifest.devDependencies) {
-    violations.push('devDependencies leaked into packed manifest');
-  }
-  if (manifest.scripts) {
-    violations.push('scripts leaked into packed manifest');
+  for (const field of STRIPPED_MANIFEST_FIELDS) {
+    if (manifest[field]) {
+      violations.push(`${field} leaked into packed manifest`);
+    }
   }
   const runtime = JSON.stringify([
     manifest.dependencies,

--- a/scripts/check-pack.core.ts
+++ b/scripts/check-pack.core.ts
@@ -77,3 +77,54 @@ export function formatReport(results: PackResult[]): Report {
   }
   return { ok: false, text: lines.join('\n') };
 }
+
+// ── Packed-manifest gate (publish workflow) ─────────────────────────────────
+// The publish workflow strips devDependencies and scripts before `pnpm pack`
+// (dev-only metadata that leaks private workspace names and monorepo-only
+// commands into the published manifest), then re-checks the tarball it is
+// about to hand release-it. These checks are that gate.
+
+/**
+ * Violations in the manifest npm would publish, as human-readable strings.
+ *
+ * Semantics match the inline workflow check this replaces:
+ * - devDependencies and scripts must be absent — a present-but-empty object
+ *   still fails, because the strip step should have deleted the key.
+ * - No `catalog:`/`workspace:` anywhere in the serialized runtime dependency
+ *   fields. Deliberately blunter than {@link findUnsubstitutedRefs}: a
+ *   substring test instead of a prefix test, because at publish time ANY
+ *   trace of those protocols ships a broken release (the 1.3.0–1.5.0 class).
+ *   devDependencies are not scanned — their mere presence already fails.
+ */
+export function findPackedManifestViolations(
+  manifest: PackageManifest,
+): string[] {
+  const violations: string[] = [];
+  if (manifest.devDependencies) {
+    violations.push('devDependencies leaked into packed manifest');
+  }
+  if (manifest.scripts) {
+    violations.push('scripts leaked into packed manifest');
+  }
+  const runtime = JSON.stringify([
+    manifest.dependencies,
+    manifest.peerDependencies,
+    manifest.optionalDependencies,
+  ]);
+  if (/catalog:|workspace:/.test(runtime)) {
+    violations.push('unsubstituted refs in packed manifest');
+  }
+  return violations;
+}
+
+/** Render the packed-manifest report. */
+export function formatPackedManifestReport(violations: string[]): Report {
+  if (violations.length === 0) {
+    return { ok: true, text: '✓ packed manifest clean' };
+  }
+  const lines = [
+    '✗ packed manifest check failed — this tarball must not be published:',
+    ...violations.map((violation) => `  • ${violation}`),
+  ];
+  return { ok: false, text: lines.join('\n') };
+}

--- a/scripts/check-pack.test.ts
+++ b/scripts/check-pack.test.ts
@@ -6,6 +6,7 @@ import {
   findUnsubstitutedRefs,
   formatPackedManifestReport,
   formatReport,
+  STRIPPED_MANIFEST_FIELDS,
 } from './check-pack.core.ts';
 
 describe('findUnsubstitutedRefs', () => {
@@ -184,5 +185,14 @@ describe('formatPackedManifestReport', () => {
     assert.match(text, /✗ packed manifest check failed/);
     assert.match(text, /devDependencies leaked/);
     assert.match(text, /scripts leaked/);
+  });
+});
+
+describe('STRIPPED_MANIFEST_FIELDS', () => {
+  it("matches publish-npm.yml's `npm pkg delete` list", () => {
+    // The Pack step runs `npm pkg delete devDependencies scripts`; consumers
+    // (the packed-manifest gate, check-published-diff) derive from this list,
+    // so a change here must be mirrored in the workflow — and vice versa.
+    assert.deepEqual(STRIPPED_MANIFEST_FIELDS, ['devDependencies', 'scripts']);
   });
 });

--- a/scripts/check-pack.test.ts
+++ b/scripts/check-pack.test.ts
@@ -1,7 +1,12 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
-import { findUnsubstitutedRefs, formatReport } from './check-pack.core.ts';
+import {
+  findPackedManifestViolations,
+  findUnsubstitutedRefs,
+  formatPackedManifestReport,
+  formatReport,
+} from './check-pack.core.ts';
 
 describe('findUnsubstitutedRefs', () => {
   it('passes a fully substituted manifest', () => {
@@ -90,5 +95,94 @@ describe('formatReport', () => {
     const { ok, text } = formatReport([]);
     assert.equal(ok, false);
     assert.match(text, /no publishable workspace packages/);
+  });
+});
+
+describe('findPackedManifestViolations', () => {
+  it('passes a clean packed manifest', () => {
+    const manifest = {
+      name: 'lit-ui-router',
+      dependencies: { '@uirouter/core': '^6.0.8' },
+      peerDependencies: { lit: '^3.0.0' },
+    };
+    assert.deepEqual(findPackedManifestViolations(manifest), []);
+  });
+
+  it('flags devDependencies, even when empty (the key should be deleted)', () => {
+    assert.deepEqual(findPackedManifestViolations({ devDependencies: {} }), [
+      'devDependencies leaked into packed manifest',
+    ]);
+  });
+
+  it('flags scripts, even when empty (the key should be deleted)', () => {
+    assert.deepEqual(findPackedManifestViolations({ scripts: {} }), [
+      'scripts leaked into packed manifest',
+    ]);
+  });
+
+  it('flags catalog:/workspace: anywhere in the runtime dependency fields', () => {
+    assert.deepEqual(
+      findPackedManifestViolations({
+        dependencies: { lit: 'catalog:publishedPeer' },
+      }),
+      ['unsubstituted refs in packed manifest'],
+    );
+    assert.deepEqual(
+      findPackedManifestViolations({
+        peerDependencies: { 'lit-ui-router': 'workspace:^' },
+      }),
+      ['unsubstituted refs in packed manifest'],
+    );
+    // Substring semantics, blunter than findUnsubstitutedRefs's prefix test:
+    // an aliased spec embedding the protocol mid-string still fails.
+    assert.deepEqual(
+      findPackedManifestViolations({
+        optionalDependencies: { alias: 'npm:workspace:^1.0.0' },
+      }),
+      ['unsubstituted refs in packed manifest'],
+    );
+  });
+
+  it('does not scan devDependencies for refs — their presence alone fails', () => {
+    assert.deepEqual(
+      findPackedManifestViolations({ devDependencies: { vitest: 'catalog:' } }),
+      ['devDependencies leaked into packed manifest'],
+    );
+  });
+
+  it('reports every violation class at once', () => {
+    const manifest = {
+      scripts: { build: 'turbo run build' },
+      devDependencies: { vitest: '^4.1.9' },
+      dependencies: { lit: 'catalog:publishedPeer' },
+    };
+    assert.deepEqual(findPackedManifestViolations(manifest), [
+      'devDependencies leaked into packed manifest',
+      'scripts leaked into packed manifest',
+      'unsubstituted refs in packed manifest',
+    ]);
+  });
+
+  it('ignores an empty manifest', () => {
+    assert.deepEqual(findPackedManifestViolations({}), []);
+  });
+});
+
+describe('formatPackedManifestReport', () => {
+  it('passes when there are no violations', () => {
+    const { ok, text } = formatPackedManifestReport([]);
+    assert.equal(ok, true);
+    assert.match(text, /packed manifest clean/);
+  });
+
+  it('fails and lists every violation', () => {
+    const { ok, text } = formatPackedManifestReport([
+      'devDependencies leaked into packed manifest',
+      'scripts leaked into packed manifest',
+    ]);
+    assert.equal(ok, false);
+    assert.match(text, /✗ packed manifest check failed/);
+    assert.match(text, /devDependencies leaked/);
+    assert.match(text, /scripts leaked/);
   });
 });

--- a/scripts/check-pack.ts
+++ b/scripts/check-pack.ts
@@ -21,6 +21,7 @@ import {
   formatReport,
   type PackResult,
 } from './check-pack.core.ts';
+import { pnpmPack } from './pack.ts';
 import type { PackageManifest } from './types.ts';
 import { loadWorkspace, workspaceRoot } from './workspace.ts';
 
@@ -29,18 +30,6 @@ const run = promisify(execFile);
 // A package.json is always a JSON object; anything else can't hold dep fields.
 function isPackageManifest(value: unknown): value is PackageManifest {
   return typeof value === 'object' && value !== null;
-}
-
-/** `pnpm pack` in `cwd`; falls back to corepack when pnpm is not on PATH. */
-async function pnpmPack(cwd: string, tarball: string): Promise<void> {
-  const args = ['pack', '--out', tarball];
-  try {
-    await run('pnpm', args, { cwd });
-  } catch (error) {
-    // ENOENT means pnpm is not on PATH; any other failure is pack's own.
-    if ((error as NodeJS.ErrnoException | null)?.code !== 'ENOENT') throw error;
-    await run('corepack', ['pnpm', ...args], { cwd });
-  }
 }
 
 /** Pack one package and return the manifest from inside the tarball. */

--- a/scripts/check-packed-manifest.ts
+++ b/scripts/check-packed-manifest.ts
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+// Gate the tarball the publish workflow is about to hand release-it: the
+// workflow strips devDependencies/scripts before `pnpm pack`, and pnpm must
+// have substituted every catalog:/workspace: ref — so
+// `node scripts/check-packed-manifest.ts <tarball>` fails the publish when
+// any of that leaked into the manifest npm would ship (the 1.3.0–1.5.0
+// broken-publish class).
+//
+// This file is the IO shell: it extracts package/package.json from the
+// tarball and delegates all decisions to the pure, unit-tested functions in
+// ./check-pack.core.ts.
+
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+import {
+  findPackedManifestViolations,
+  formatPackedManifestReport,
+} from './check-pack.core.ts';
+import type { PackageManifest } from './types.ts';
+
+const run = promisify(execFile);
+
+// A package.json is always a JSON object; anything else can't hold dep fields.
+function isPackageManifest(value: unknown): value is PackageManifest {
+  return typeof value === 'object' && value !== null;
+}
+
+const [tarball, ...extra] = process.argv.slice(2);
+if (!tarball || extra.length > 0) {
+  console.error('usage: node scripts/check-packed-manifest.ts <tarball>');
+  process.exit(1);
+}
+
+const { stdout } = await run(
+  'tar',
+  ['-xzOf', tarball, 'package/package.json'],
+  { maxBuffer: 16 * 1024 * 1024 },
+);
+const parsed: unknown = JSON.parse(stdout);
+const manifest = isPackageManifest(parsed) ? parsed : {};
+const { ok, text } = formatPackedManifestReport(
+  findPackedManifestViolations(manifest),
+);
+(ok ? console.log : console.error)(text);
+if (!ok) process.exitCode = 1;

--- a/scripts/pack.ts
+++ b/scripts/pack.ts
@@ -1,0 +1,20 @@
+// Shared IO helper for scripts that reproduce the publish workflow's Pack
+// step. Kept out of the *.core.ts modules on purpose — those stay pure and
+// unit-testable; this is the one child_process wrapper they all share.
+
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const run = promisify(execFile);
+
+/** `pnpm pack` in `cwd`; falls back to corepack when pnpm is not on PATH. */
+export async function pnpmPack(cwd: string, tarball: string): Promise<void> {
+  const args = ['pack', '--out', tarball];
+  try {
+    await run('pnpm', args, { cwd });
+  } catch (error) {
+    // ENOENT means pnpm is not on PATH; any other failure is pack's own.
+    if ((error as NodeJS.ErrnoException | null)?.code !== 'ENOENT') throw error;
+    await run('corepack', ['pnpm', ...args], { cwd });
+  }
+}

--- a/scripts/types.ts
+++ b/scripts/types.ts
@@ -19,6 +19,7 @@ export type DependencyMap = Record<string, unknown>;
 export type PackageManifest = {
   name?: string;
   private?: boolean;
+  scripts?: Record<string, unknown>;
   dependencies?: DependencyMap;
   devDependencies?: DependencyMap;
   peerDependencies?: DependencyMap;


### PR DESCRIPTION
## The divergence

publish-npm.yml's "Check packed manifest" step carried a ~9-line inline `node -e` that duplicated — and had diverged from — the tested `scripts/check-pack.core.ts`:

| Guard | Inline workflow step | check-pack.core.ts |
|---|---|---|
| devDependencies stripped | yes (truthy test — even `{}` fails) | — |
| scripts stripped | yes (truthy test) | — |
| catalog:/workspace: refs | substring regex over the serialized runtime fields (dependencies/peer/optional) | prefix-only test, all 4 dep fields incl. devDependencies |

These guards protect against the 1.3.0–1.5.0 broken-publish class, and only the core half was unit-tested.

## The change

- `scripts/check-pack.core.ts` gains `findPackedManifestViolations` / `formatPackedManifestReport`, preserving the inline semantics **exactly**: absence tests for the stripped fields (present-but-empty still fails) and the deliberately blunt substring match over the runtime dep fields — at publish time any trace of those protocols is a broken release, so it stays broader than `findUnsubstitutedRefs`'s prefix test. devDependencies are not scanned for refs; their mere presence already fails.
- `scripts/check-packed-manifest.ts` is the thin IO shell (same shape as `release-prev-tag.ts` from #320): tar-extracts `package/package.json` from the tarball — exactly how the step read it — and delegates to the core.
- The workflow step shrank to `run: node scripts/check-packed-manifest.ts "$TARBALL"`.
- One deliberate behavior improvement: all violations are reported at once instead of throwing on the first.

## Third consumer: #314

Open PR #314 (`check-published-diff`) reproduces the Pack step with its own copies of the manifest strip and the `pnpmPack` helper under a "keep in lockstep" comment. To kill that manual sync without touching its branch:

- `STRIPPED_MANIFEST_FIELDS` is exported from the core — the exact `npm pkg delete` list, now driving the packed-manifest violations and locked by a test.
- `pnpmPack` (with the corepack fallback) moved to shared `scripts/pack.ts`; `check-pack.ts` imports it.

Once both PRs land, the follow-up in `check-published-diff.ts` is two one-liners: `npm pkg delete ...STRIPPED_MANIFEST_FIELDS` and `import { pnpmPack } from './pack.ts'` (deleting its local copies and the lockstep comment).

## Proof

Simulated the workflow's Pack step locally (`npm pkg delete devDependencies scripts` + `pnpm pack`) on `lit-ui-router@1.7.0`:

- genuine tarball → `✓ packed manifest clean`, exit 0
- doctored tarball (devDeps + scripts + `catalog:` ref re-injected) → exit 1, all three violations listed
- doctored tarball (only a `workspace:^` peer ref) → exit 1, refs violation only

Verified: `test:root` (34 pass), `lint:root`, `typecheck:root`, `format`, `actionlint` on publish-npm.yml, full `turbo run ci` (67/67; one e2e rerun after an unrelated ECONNREFUSED:8787 cold-server flake).