### PR TITLE
chore(tooling): own the pnpm install bootstrap with a mise setup task

### DIFF
--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -12,12 +12,24 @@ idiomatic_version_file_enable_tools = ["node"]
 # mise-provided corepack: no npx per-invocation resolution, Node-25-proof
 "npm:corepack" = "0.35.0"
 
+# Provisioning tasks, not hooks: hooks warn-and-continue, task failures are
+# loud; and tool-only bumps (actionlint) skip the corepack ceremony.
+# snake_case names (bazel target convention, where mise monorepo tasks are
+# trending); no colons — mise monorepo task addressing claims `:`.
+[tasks.corepack_enable]
+description = "Shim the corepack-managed package managers onto PATH"
+run = "corepack enable"
+
+[tasks.corepack_install]
+# Materializes the packageManager pin (sha512-verified) in corepack's cache.
+description = "Install the packageManager-pinned pnpm into the corepack cache"
+run = "corepack install"
+
 [tasks.corepack]
-# Provisioning leg: shims pnpm and materializes the packageManager pin
-# (sha512-verified) into corepack's cache. A task, not a hook: hooks
-# warn-and-continue, task failures are loud; and tool-only bumps skip it.
-description = "Enable corepack and install the packageManager-pinned pnpm"
-run = "corepack enable && corepack install"
+# Virtual grouping task; the two legs are order-independent and may run
+# in parallel (enable writes shims, install populates COREPACK_HOME).
+description = "Provision the packageManager-pinned pnpm via corepack"
+depends = ["corepack_enable", "corepack_install"]
 
 [tasks.setup]
 # Bootstrap layer: the one step pnpm scripts can't own (no node_modules yet).

--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -3,23 +3,27 @@
 # (repo root), so bare `turbo` etc. stay spawn-safe in any cwd or worktree.
 _.path = ["{{config_root}}/node_modules/.bin"]
 
-[hooks]
-# Corepack shims pnpm into node's bin dir and pre-installs the packageManager
-# pin (sha512-verified) from the repo root; fires on every `mise install`
-# (local and mise-action), even no-ops.
-postinstall = "cd {{config_root}} && npx corepack enable && npx corepack install"
-
 [settings]
 # read the node version from .nvmrc instead of pinning it here
 idiomatic_version_file_enable_tools = ["node"]
 
 [tools]
 "aqua:rhysd/actionlint" = "1.7.12"
+# mise-provided corepack: no npx per-invocation resolution, Node-25-proof
+"npm:corepack" = "0.35.0"
+
+[tasks.corepack]
+# Provisioning leg: shims pnpm and materializes the packageManager pin
+# (sha512-verified) into corepack's cache. A task, not a hook: hooks
+# warn-and-continue, task failures are loud; and tool-only bumps skip it.
+description = "Enable corepack and install the packageManager-pinned pnpm"
+run = "corepack enable && corepack install"
 
 [tasks.setup]
 # Bootstrap layer: the one step pnpm scripts can't own (no node_modules yet).
-# Ordering: mise install -> postinstall hook (corepack) -> mise run setup.
+# Flow: mise trust && mise install && mise run setup.
 # pnpm auto-enables --frozen-lockfile when CI is set (ci-info detection),
 # so one task serves local (plain) and CI (frozen) alike.
 description = "Install workspace dependencies with the corepack-provisioned pnpm"
+depends = ["corepack"]
 run = "pnpm install"

--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -15,3 +15,11 @@ idiomatic_version_file_enable_tools = ["node"]
 
 [tools]
 "aqua:rhysd/actionlint" = "1.7.12"
+
+[tasks.setup]
+# Bootstrap layer: the one step pnpm scripts can't own (no node_modules yet).
+# Ordering: mise install -> postinstall hook (corepack) -> mise run setup.
+# pnpm auto-enables --frozen-lockfile when CI is set (ci-info detection),
+# so one task serves local (plain) and CI (frozen) alike.
+description = "Install workspace dependencies with the corepack-provisioned pnpm"
+run = "pnpm install"

--- a/.config/mise/mise.lock
+++ b/.config/mise/mise.lock
@@ -70,3 +70,7 @@ url = "https://nodejs.org/dist/v24.18.0/node-v24.18.0-darwin-x64.tar.gz"
 [tools.node."platforms.windows-x64"]
 checksum = "sha256:0ae68406b42d7725661da979b1403ec9926da205c6770827f33aac9d8f26e821"
 url = "https://nodejs.org/dist/v24.18.0/node-v24.18.0-win-x64.zip"
+
+[[tools."npm:corepack"]]
+version = "0.35.0"
+backend = "npm:corepack"

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Setup mise
         uses: jdx/mise-action@v4
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: mise run setup
         env:
           # The Install Cypress step below downloads the binary; skipping it
           # here keeps download noise out of the pnpm postinstall output.

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -83,7 +83,7 @@ jobs:
       - name: Setup mise
         uses: jdx/mise-action@v4
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: mise run setup
       - name: Set branch prefix
         # Use input if provided, otherwise derive from package name
         run: |

--- a/.github/workflows/publish-gh.yml
+++ b/.github/workflows/publish-gh.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Setup mise
         uses: jdx/mise-action@v4
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: mise run setup
       - name: Tag
         # --no-increment: Don't bump version, tag current version
         # --git.tag true: Create git tag ({package}@X.Y.Z), locally only

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -65,7 +65,7 @@ jobs:
         # npm >= 11.5.1 required for OIDC trusted publishing
         run: npm install -g npm@latest
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: mise run setup
       - name: Map npm name to directory
         run: |
           PACKAGE_DIR="$(realpath -s --relative-to="." "$(pnpm list --depth -1 --parseable --filter "$PACKAGE_NAME")")"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,12 +7,12 @@ This repo uses [mise](https://mise.jdx.dev) to provision the toolchain used by c
 ```bash
 # Install mise: https://mise.jdx.dev/getting-started.html
 mise trust
-mise install
-pnpm install
+mise install     # provisions node + corepack-pinned pnpm
+mise run setup   # installs workspace dependencies
 turbo build
 ```
 
-`mise install` provisions the pinned Node and runs `corepack enable`, which shims the `packageManager`-pinned pnpm into node's bin dir — no separate `nvm use`, `pnpm add --global`, or global turbo needed. With mise active, `node_modules/.bin` is on `PATH`, so bare `turbo` (and every other workspace binary) runs the workspace-pinned version. See [TURBO.md](./TURBO.md) for detailed turbo commands and workflows.
+`mise install` provisions the pinned Node and runs `corepack enable`, which shims the `packageManager`-pinned pnpm into node's bin dir — no separate `nvm use`, `pnpm add --global`, or global turbo needed. `mise run setup` is the bootstrap layer pnpm scripts can't own (there is no `node_modules` yet): it runs `pnpm install`, frozen-lockfile automatically in CI. With mise active, `node_modules/.bin` is on `PATH`, so bare `turbo` (and every other workspace binary) runs the workspace-pinned version; everything after bootstrap belongs to turbo/pnpm scripts. See [TURBO.md](./TURBO.md) for detailed turbo commands and workflows.
 
 ## Running Tests
 
@@ -82,7 +82,7 @@ for hand-typed `merge <x> into <y>` freshens. To check a message locally:
 echo "feat(scope): my subject" | pnpm exec commitlint
 ```
 
-Commits are also checked at commit time: `pnpm install` installs a
+Commits are also checked at commit time: `mise run setup` (pnpm install) installs a
 [husky](https://typicode.github.io/husky/) `commit-msg` hook (via the root
 `prepare` script) that runs commitlint locally, and CI re-checks the same
 messages via the `lint_pr_commits` job. If the hook is missing — pnpm 11

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,17 +2,17 @@
 
 ## Development
 
-This repo uses [mise](https://mise.jdx.dev) to provision the toolchain used by contributors and CI. Node comes from [`.nvmrc`](./.nvmrc) (mise reads it automatically); pnpm is pinned (with an integrity hash) by `packageManager` in [`package.json`](./package.json) and provisioned by corepack, which a mise `postinstall` hook enables; turbo is the workspace devDependency, resolved from `node_modules/.bin`, which mise puts on `PATH`.
+This repo uses [mise](https://mise.jdx.dev) to provision the toolchain used by contributors and CI. Node comes from [`.nvmrc`](./.nvmrc) (mise reads it automatically); pnpm is pinned (with an integrity hash) by `packageManager` in [`package.json`](./package.json) and provisioned by corepack (itself a mise-pinned tool); turbo is the workspace devDependency, resolved from `node_modules/.bin`, which mise puts on `PATH`.
 
 ```bash
 # Install mise: https://mise.jdx.dev/getting-started.html
 mise trust
-mise install     # provisions node + corepack-pinned pnpm
-mise run setup   # installs workspace dependencies
+mise install     # provisions node, corepack, actionlint
+mise run setup   # corepack-installs the pinned pnpm, then pnpm install
 turbo build
 ```
 
-`mise install` provisions the pinned Node and runs `corepack enable`, which shims the `packageManager`-pinned pnpm into node's bin dir — no separate `nvm use`, `pnpm add --global`, or global turbo needed. `mise run setup` is the bootstrap layer pnpm scripts can't own (there is no `node_modules` yet): it runs `pnpm install`, frozen-lockfile automatically in CI. With mise active, `node_modules/.bin` is on `PATH`, so bare `turbo` (and every other workspace binary) runs the workspace-pinned version; everything after bootstrap belongs to turbo/pnpm scripts. See [TURBO.md](./TURBO.md) for detailed turbo commands and workflows.
+`mise install` provisions the pinned Node and corepack. `mise run setup` is the bootstrap layer pnpm scripts can't own (there is no `node_modules` yet): its `corepack` dependency task enables corepack and installs the `packageManager`-pinned pnpm, then `pnpm install` runs — frozen-lockfile automatically in CI. No separate `nvm use`, `pnpm add --global`, or global turbo needed. With mise active, `node_modules/.bin` is on `PATH`, so bare `turbo` (and every other workspace binary) runs the workspace-pinned version; everything after bootstrap belongs to turbo/pnpm scripts. See [TURBO.md](./TURBO.md) for detailed turbo commands and workflows.
 
 ## Running Tests
 

--- a/TURBO.md
+++ b/TURBO.md
@@ -4,7 +4,7 @@ This monorepo uses [Turborepo](https://turbo.build/) for orchestrating builds, t
 
 ## Installation
 
-Turbo is the workspace devDependency (pinned in the pnpm catalog), resolved from `node_modules/.bin`, which [mise](https://mise.jdx.dev) puts on `PATH` (see [`.config/mise/config.toml`](./.config/mise/config.toml) and [CONTRIBUTING.md](./CONTRIBUTING.md#development) for setup). After `mise install` and `pnpm install`, bare `turbo` runs the workspace-pinned version — no separate global install needed.
+Turbo is the workspace devDependency (pinned in the pnpm catalog), resolved from `node_modules/.bin`, which [mise](https://mise.jdx.dev) puts on `PATH` (see [`.config/mise/config.toml`](./.config/mise/config.toml) and [CONTRIBUTING.md](./CONTRIBUTING.md#development) for setup). After `mise install` and `mise run setup`, bare `turbo` runs the workspace-pinned version — no separate global install needed.
 
 ## Workspace Structure
 
@@ -148,7 +148,7 @@ turbo build --summarize
 The GitHub Actions workflow (`.github/workflows/build-test.yml`) runs the full CI pipeline:
 
 1. **Checkout** - Clone repository
-2. **Setup** - mise installs Node.js (version pinned in `.nvmrc`) and enables corepack (pnpm pinned by `packageManager`); `pnpm install` installs dependencies
+2. **Setup** - mise installs Node.js (version pinned in `.nvmrc`) and corepack; `mise run setup` corepack-installs the `packageManager`-pinned pnpm, then installs dependencies
 3. **Install browsers** - Playwright and Cypress for e2e tests
 4. **Build and Test** - `turbo run ci`
 5. **Coverage reports** - Vitest coverage for PR comments, Codecov upload


### PR DESCRIPTION
**Parked** (the #296/#298 pattern): stacked on #315 (`chore/mise-bin-path`), re-applying the mise setup-task round that was split out of it. **Unpark trigger: when bootstrap needs more than a single `pnpm install` command.** GitHub auto-retargets this PR to `main` when #315 merges.

## What it adds

The repo's first mise task — `[tasks.setup]` running `pnpm install` — and points all four installing workflows' `Install dependencies` step at `mise run setup` (one shared bootstrap definition for local and CI). CONTRIBUTING's quick-start becomes `mise trust` → `mise install` → `mise run setup` → `turbo build`.

## Layering rationale

- **Hooks warn-and-continue** (proven in #315: a failing `postinstall` leaves `mise install` exit 0), so provisioning stays in the hook while the install that must fail loud gets its own task.
- **Bootstrap is the layer pnpm scripts can't own** — there is no `node_modules` yet — making mise tasks its natural home.
- Boundary principle: mise tasks = pre-`node_modules` bootstrap; turbo/pnpm scripts = everything after.

## Proofs (carried over from the #315 verification)

- **Frozen-lockfile decision — one task suffices**: pnpm auto-enables `--frozen-lockfile` when `CI` is set (ci-info detection; pnpm 11 docs: "For non-CI: false. For CI: true, if a lockfile is present"). Verified empirically on pnpm 11.10.0: with a deliberate manifest/lockfile mismatch, `CI=true mise run setup` fails `ERR_PNPM_OUTDATED_LOCKFILE` with **exit 1 propagated through `mise run`**; the same tree without `CI` installs plain (exit 0). CI gets frozen semantics, local stays ergonomic, zero conditionals.
- **Task cwd**: unlike hooks (which inherit the invocation cwd), tasks run from **config_root** regardless of where they're invoked (proven from a subdirectory) — no `cd` needed.
- **CI**: `mise run` is available to workflow steps because mise-action puts mise on PATH; per-step env (`CYPRESS_INSTALL_BINARY`) passes through unchanged. When this ran on #315's branch, Build and Test's `Install dependencies` log showed `mise run setup` → `[setup] $ pnpm install` → `Done in 16.7s using pnpm v11.10.0`, all checks green.
- Fresh-worktree flow verified: `mise trust` → `mise install` (hook) → `mise run setup` (exit 0) → `turbo` from the worktree's own `.bin`.
