### PR TITLE
docs: transition-lifecycle and nested-views diagrams

### DIFF
--- a/docs/guides/route-guards.md
+++ b/docs/guides/route-guards.md
@@ -79,6 +79,56 @@ offers the full lifecycle — `onBefore`, `onStart`, `onEnter`, `onRetain`,
 `onExit`, `onFinish`, `onSuccess`, `onError` — and all of them accept the
 same criteria/callback shape.
 
+<svg viewBox="0 0 720 256" width="100%" style="max-width: 720px" role="img" aria-label="The transition lifecycle: onBefore, onStart, onExit/onRetain/onEnter, onFinish, then onSuccess or onError. A route guard is an onBefore hook: returning a TargetState redirects, false cancels, nothing proceeds. Resolves fetch during the transition." xmlns="http://www.w3.org/2000/svg">
+  <title>The transition lifecycle and where guards run</title>
+  <defs>
+    <marker id="arr-lifecycle" viewBox="0 0 8 8" refX="7" refY="4" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0 0L8 4L0 8z" fill="var(--vp-c-text-3, #929295)" />
+    </marker>
+  </defs>
+  <g font-family="var(--vp-font-family-base, ui-sans-serif, system-ui, sans-serif)">
+    <!-- chain -->
+    <rect x="16" y="52" width="88" height="36" rx="8" fill="var(--vp-c-brand-soft, rgba(100,108,255,0.14))" stroke="var(--vp-c-brand-1, #3451b2)" />
+    <text x="60" y="74" font-size="12" font-family="var(--vp-font-family-mono, ui-monospace, monospace)" fill="var(--vp-c-brand-1, #3451b2)" text-anchor="middle">onBefore</text>
+    <line x1="104" y1="70" x2="118" y2="70" stroke="var(--vp-c-text-3, #929295)" stroke-width="1.25" marker-end="url(#arr-lifecycle)" />
+    <rect x="122" y="52" width="78" height="36" rx="8" fill="var(--vp-c-bg-soft, #f6f6f7)" stroke="var(--vp-c-divider, #e2e2e3)" />
+    <text x="161" y="74" font-size="12" font-family="var(--vp-font-family-mono, ui-monospace, monospace)" fill="var(--vp-c-text-1, #3c3c43)" text-anchor="middle">onStart</text>
+    <line x1="200" y1="70" x2="214" y2="70" stroke="var(--vp-c-text-3, #929295)" stroke-width="1.25" marker-end="url(#arr-lifecycle)" />
+    <rect x="218" y="52" width="186" height="36" rx="8" fill="var(--vp-c-bg-soft, #f6f6f7)" stroke="var(--vp-c-divider, #e2e2e3)" />
+    <text x="311" y="74" font-size="11" font-family="var(--vp-font-family-mono, ui-monospace, monospace)" fill="var(--vp-c-text-1, #3c3c43)" text-anchor="middle">onExit &#183; onRetain &#183; onEnter</text>
+    <line x1="404" y1="70" x2="418" y2="70" stroke="var(--vp-c-text-3, #929295)" stroke-width="1.25" marker-end="url(#arr-lifecycle)" />
+    <rect x="422" y="52" width="80" height="36" rx="8" fill="var(--vp-c-bg-soft, #f6f6f7)" stroke="var(--vp-c-divider, #e2e2e3)" />
+    <text x="462" y="74" font-size="12" font-family="var(--vp-font-family-mono, ui-monospace, monospace)" fill="var(--vp-c-text-1, #3c3c43)" text-anchor="middle">onFinish</text>
+    <!-- fork -->
+    <line x1="502" y1="64" x2="540" y2="42" stroke="var(--vp-c-text-3, #929295)" stroke-width="1.25" marker-end="url(#arr-lifecycle)" />
+    <line x1="502" y1="76" x2="540" y2="98" stroke="var(--vp-c-text-3, #929295)" stroke-width="1.25" marker-end="url(#arr-lifecycle)" />
+    <rect x="546" y="20" width="112" height="36" rx="8" fill="var(--vp-c-green-soft, rgba(16,185,129,0.14))" />
+    <text x="602" y="42" font-size="12" font-weight="600" font-family="var(--vp-font-family-mono, ui-monospace, monospace)" fill="var(--vp-c-green-1, #18794e)" text-anchor="middle">onSuccess</text>
+    <rect x="546" y="84" width="112" height="36" rx="8" fill="var(--vp-c-red-soft, rgba(244,63,94,0.14))" />
+    <text x="602" y="106" font-size="12" font-weight="600" font-family="var(--vp-font-family-mono, ui-monospace, monospace)" fill="var(--vp-c-red-1, #b8272c)" text-anchor="middle">onError</text>
+    <text x="666" y="42" font-size="10" fill="var(--vp-c-text-3, #929295)">views</text>
+    <text x="666" y="54" font-size="10" fill="var(--vp-c-text-3, #929295)">render</text>
+    <text x="666" y="106" font-size="10" fill="var(--vp-c-text-3, #929295)">cancelled</text>
+    <text x="666" y="118" font-size="10" fill="var(--vp-c-text-3, #929295)">or failed</text>
+    <!-- resolves bracket -->
+    <line x1="122" y1="112" x2="122" y2="106" stroke="var(--vp-c-divider, #e2e2e3)" />
+    <line x1="122" y1="112" x2="502" y2="112" stroke="var(--vp-c-divider, #e2e2e3)" />
+    <line x1="502" y1="112" x2="502" y2="106" stroke="var(--vp-c-divider, #e2e2e3)" />
+    <text x="312" y="130" font-size="11" fill="var(--vp-c-text-2, #67676c)" text-anchor="middle">resolves fetch during the transition &#8212; data arrives before any view renders</text>
+    <!-- guard callout -->
+    <line x1="60" y1="148" x2="60" y2="94" stroke="var(--vp-c-brand-1, #3451b2)" stroke-width="1.25" marker-end="url(#arr-lifecycle)" />
+    <rect x="16" y="150" width="330" height="94" rx="8" fill="var(--vp-c-brand-soft, rgba(100,108,255,0.14))" stroke="var(--vp-c-brand-1, #3451b2)" />
+    <text x="30" y="172" font-size="12" font-weight="600" fill="var(--vp-c-brand-1, #3451b2)">a route guard is an onBefore hook</text>
+    <text x="30" y="188" font-size="10" font-family="var(--vp-font-family-mono, ui-monospace, monospace)" fill="var(--vp-c-text-3, #929295)">criteria: { to: (s) =&gt; s.data.requiresAuth }</text>
+    <text x="30" y="208" font-size="11" fill="var(--vp-c-text-1, #3c3c43)"><tspan font-family="var(--vp-font-family-mono, ui-monospace, monospace)">TargetState</tspan> &#8594; redirect (e.g. to login)</text>
+    <text x="30" y="224" font-size="11" fill="var(--vp-c-text-1, #3c3c43)"><tspan font-family="var(--vp-font-family-mono, ui-monospace, monospace)">false</tspan> &#8594; cancel the transition</text>
+    <text x="30" y="240" font-size="11" fill="var(--vp-c-text-1, #3c3c43)"><tspan font-family="var(--vp-font-family-mono, ui-monospace, monospace)">nothing</tspan> &#8594; proceed</text>
+    <!-- async note -->
+    <text x="368" y="208" font-size="10" fill="var(--vp-c-text-3, #929295)">guards can be async &#8212; the transition</text>
+    <text x="368" y="221" font-size="10" fill="var(--vp-c-text-3, #929295)">waits for the returned Promise</text>
+  </g>
+</svg>
+
 ## Return the user after login
 
 The redirect above targets a `login` state. To send the user back where they

--- a/docs/tutorial/hellogalaxy.md
+++ b/docs/tutorial/hellogalaxy.md
@@ -360,20 +360,70 @@ The complete source — including the full ten-star catalog and the deep-space s
 
 Here's how our states form a hierarchy:
 
-```
-app-root
-└── <ui-view> (root viewport)
-    └── galaxy (/galaxy)
-        └── galaxy-shell
-            └── <ui-view> (nested viewport)
-                ├── galaxy.stars (/galaxy/stars)
-                │   └── stars-container
-                │       └── <ui-view> (nested viewport)
-                │           └── galaxy.stars.star (/galaxy/stars/:starId)
-                │               └── star-detail
-                └── galaxy.astronaut (/galaxy/astronaut)
-                    └── astronaut-view
-```
+<svg viewBox="0 0 720 400" width="100%" style="max-width: 720px" role="img" aria-label="Nested states render in nested ui-view viewports: galaxy renders in the root viewport, galaxy.stars in the shell's viewport, galaxy.stars.star in the list's viewport; galaxy.astronaut is a sibling that swaps into the shell's viewport. Each child URL appends to its parent's." xmlns="http://www.w3.org/2000/svg">
+  <title>Nested states, nested viewports</title>
+  <defs>
+    <marker id="arr-nested" viewBox="0 0 8 8" refX="7" refY="4" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0 0L8 4L0 8z" fill="var(--vp-c-text-3, #929295)" />
+    </marker>
+  </defs>
+  <g font-family="var(--vp-font-family-base, ui-sans-serif, system-ui, sans-serif)">
+    <!-- root viewport -->
+    <rect x="12" y="20" width="564" height="344" rx="8" fill="none" stroke="var(--vp-c-brand-1, #3451b2)" stroke-dasharray="5 4" />
+    <rect x="20" y="26" width="66" height="16" rx="5" fill="var(--vp-c-brand-soft, rgba(100,108,255,0.14))" />
+    <text x="53" y="38" font-size="10" font-family="var(--vp-font-family-mono, ui-monospace, monospace)" fill="var(--vp-c-brand-1, #3451b2)" text-anchor="middle">&lt;ui-view&gt;</text>
+    <text x="94" y="38" font-size="10" fill="var(--vp-c-text-3, #929295)">root viewport, in app-root</text>
+    <!-- galaxy -->
+    <rect x="24" y="50" width="540" height="302" rx="8" fill="var(--vp-c-bg-soft, #f6f6f7)" stroke="var(--vp-c-divider, #e2e2e3)" />
+    <text x="36" y="70" font-size="13" font-weight="600" fill="var(--vp-c-text-1, #3c3c43)">galaxy</text>
+    <text x="36" y="85" font-size="10" font-family="var(--vp-font-family-mono, ui-monospace, monospace)" fill="var(--vp-c-text-3, #929295)">galaxy-shell</text>
+    <text x="552" y="70" font-size="11" font-weight="600" font-family="var(--vp-font-family-mono, ui-monospace, monospace)" fill="var(--vp-c-brand-1, #3451b2)" text-anchor="end">/galaxy</text>
+    <rect x="36" y="94" width="516" height="24" rx="5" fill="var(--vp-c-bg, #ffffff)" stroke="var(--vp-c-divider, #e2e2e3)" />
+    <text x="44" y="110" font-size="11" fill="var(--vp-c-text-2, #67676c)">nav: Stars &#183; Astronaut &#8212; uiSrefActive matches by inclusion</text>
+    <!-- shell viewport -->
+    <rect x="36" y="126" width="516" height="214" rx="8" fill="none" stroke="var(--vp-c-brand-1, #3451b2)" stroke-dasharray="5 4" />
+    <rect x="44" y="132" width="66" height="16" rx="5" fill="var(--vp-c-brand-soft, rgba(100,108,255,0.14))" />
+    <text x="77" y="144" font-size="10" font-family="var(--vp-font-family-mono, ui-monospace, monospace)" fill="var(--vp-c-brand-1, #3451b2)" text-anchor="middle">&lt;ui-view&gt;</text>
+    <text x="118" y="144" font-size="10" fill="var(--vp-c-text-3, #929295)">children of galaxy render here</text>
+    <!-- galaxy.stars -->
+    <rect x="48" y="154" width="428" height="174" rx="8" fill="var(--vp-c-bg-soft, #f6f6f7)" stroke="var(--vp-c-divider, #e2e2e3)" />
+    <text x="60" y="174" font-size="13" font-weight="600" fill="var(--vp-c-text-1, #3c3c43)">galaxy.stars</text>
+    <text x="60" y="189" font-size="10" font-family="var(--vp-font-family-mono, ui-monospace, monospace)" fill="var(--vp-c-text-3, #929295)">stars-container</text>
+    <text x="464" y="174" font-size="11" font-family="var(--vp-font-family-mono, ui-monospace, monospace)" text-anchor="end"><tspan fill="var(--vp-c-text-3, #929295)">/galaxy</tspan><tspan font-weight="600" fill="var(--vp-c-brand-1, #3451b2)"> + /stars</tspan></text>
+    <!-- list column -->
+    <rect x="60" y="196" width="120" height="118" rx="5" fill="var(--vp-c-bg, #ffffff)" stroke="var(--vp-c-divider, #e2e2e3)" />
+    <text x="70" y="213" font-size="10" font-weight="600" fill="var(--vp-c-text-2, #67676c)">star list</text>
+    <text x="70" y="230" font-size="10" fill="var(--vp-c-text-2, #67676c)">Sirius</text>
+    <text x="70" y="245" font-size="10" fill="var(--vp-c-text-2, #67676c)">Vega</text>
+    <text x="70" y="260" font-size="10" fill="var(--vp-c-text-2, #67676c)">&#8230;</text>
+    <text x="70" y="284" font-size="9" font-family="var(--vp-font-family-mono, ui-monospace, monospace)" fill="var(--vp-c-text-3, #929295)">uiSref('.star')</text>
+    <text x="70" y="298" font-size="9" fill="var(--vp-c-text-3, #929295)">relative sref</text>
+    <!-- stars viewport -->
+    <rect x="192" y="196" width="272" height="118" rx="8" fill="none" stroke="var(--vp-c-brand-1, #3451b2)" stroke-dasharray="5 4" />
+    <rect x="200" y="202" width="66" height="16" rx="5" fill="var(--vp-c-brand-soft, rgba(100,108,255,0.14))" />
+    <text x="233" y="214" font-size="10" font-family="var(--vp-font-family-mono, ui-monospace, monospace)" fill="var(--vp-c-brand-1, #3451b2)" text-anchor="middle">&lt;ui-view&gt;</text>
+    <text x="274" y="214" font-size="10" fill="var(--vp-c-text-3, #929295)">slotted fallback until a child activates</text>
+    <!-- galaxy.stars.star -->
+    <rect x="204" y="224" width="248" height="80" rx="8" fill="var(--vp-c-bg-soft, #f6f6f7)" stroke="var(--vp-c-divider, #e2e2e3)" />
+    <text x="216" y="244" font-size="12" font-weight="600" fill="var(--vp-c-text-1, #3c3c43)">galaxy.stars.star</text>
+    <text x="216" y="258" font-size="10" font-family="var(--vp-font-family-mono, ui-monospace, monospace)" fill="var(--vp-c-text-3, #929295)">star-detail</text>
+    <text x="440" y="244" font-size="11" font-weight="600" font-family="var(--vp-font-family-mono, ui-monospace, monospace)" fill="var(--vp-c-brand-1, #3451b2)" text-anchor="end">+ /:starId</text>
+    <text x="216" y="280" font-size="10" fill="var(--vp-c-text-2, #67676c)">its star resolve reads :starId and the</text>
+    <text x="216" y="294" font-size="10" fill="var(--vp-c-text-2, #67676c)">parent's stars resolve &#8212; inherited</text>
+    <!-- astronaut sibling -->
+    <rect x="584" y="126" width="128" height="110" rx="8" fill="var(--vp-c-bg-soft, #f6f6f7)" stroke="var(--vp-c-divider, #e2e2e3)" />
+    <text x="594" y="146" font-size="11" font-weight="600" fill="var(--vp-c-text-1, #3c3c43)">galaxy.astronaut</text>
+    <text x="594" y="160" font-size="10" font-family="var(--vp-font-family-mono, ui-monospace, monospace)" fill="var(--vp-c-text-3, #929295)">astronaut-view</text>
+    <text x="594" y="178" font-size="11" font-weight="600" font-family="var(--vp-font-family-mono, ui-monospace, monospace)" fill="var(--vp-c-brand-1, #3451b2)">+ /astronaut</text>
+    <text x="594" y="198" font-size="10" fill="var(--vp-c-text-2, #67676c)">a sibling of</text>
+    <text x="594" y="212" font-size="10" fill="var(--vp-c-text-2, #67676c)">galaxy.stars</text>
+    <line x1="584" y1="226" x2="481" y2="247" stroke="var(--vp-c-text-3, #929295)" stroke-width="1.25" stroke-dasharray="4 3" marker-end="url(#arr-nested)" />
+    <text x="586" y="256" font-size="10" fill="var(--vp-c-text-3, #929295)">siblings swap in the</text>
+    <text x="586" y="269" font-size="10" fill="var(--vp-c-text-3, #929295)">same nested viewport</text>
+    <!-- URL composition -->
+    <text x="24" y="388" font-size="12" font-family="var(--vp-font-family-mono, ui-monospace, monospace)"><tspan fill="var(--vp-c-text-2, #67676c)">URLs compose:  </tspan><tspan fill="var(--vp-c-brand-1, #3451b2)">/galaxy</tspan><tspan fill="var(--vp-c-text-3, #929295)"> + </tspan><tspan fill="var(--vp-c-brand-1, #3451b2)">/stars</tspan><tspan fill="var(--vp-c-text-3, #929295)"> + </tspan><tspan fill="var(--vp-c-brand-1, #3451b2)">/:starId</tspan><tspan fill="var(--vp-c-text-3, #929295)"> &#8594; </tspan><tspan font-weight="600" fill="var(--vp-c-text-1, #3c3c43)">/galaxy/stars/:starId</tspan></text>
+  </g>
+</svg>
 
 When navigating to `/galaxy/stars/sirius`:
 


### PR DESCRIPTION
Inserts two audited inline-SVG diagrams into the main-branch docs pages.

## Placements

- **`docs/guides/route-guards.md`** — the transition-lifecycle diagram lands directly after the "Register it" paragraph that enumerates the full hook chain (`onBefore` … `onError`), illustrating where in that chain a guard runs and what its return values do.
- **`docs/tutorial/hellogalaxy.md`** — the nested-views diagram lands in "The State Tree" section, **replacing the ASCII tree**. The diagram carries every fact the ASCII block had (state names, component tags, all three nested `<ui-view>` viewports, URL composition) plus the astronaut sibling-swap and resolve inheritance; its `aria-label` preserves a textual description, so the ASCII fallback was redundant.

## oxfmt verdict

Compatible, with one adjustment: blank lines inside the SVG had to be stripped. A blank line ends a CommonMark HTML block, and the 4-space-indented SVG lines after it rendered as indented code blocks (verified in the built HTML before the fix). With blank lines removed, `oxfmt` (both `format:check` and write mode) is a byte-for-byte no-op on both files — idempotent, no ignore mechanism needed.

## Verification

- `format:check`, `vitepress build`, and `typecheck` green.
- Built HTML inspected for both pages: SVG elements land as real DOM (no escaped entities, no `<pre>` leakage), marker IDs (`arr-lifecycle`, `arr-nested`) unique per page, no `<style>` tags, no pre-existing `id=` collisions on either page.
- The SVGs are the canonical `final/` versions, pre-audited for text overflow across font stacks (default/Arial/Verdana/Georgia) and themed via `--vp-*` tokens with light-theme fallbacks, which is why they are inlined rather than referenced via `<img>`.

Existing page content is otherwise untouched.