### PR TITLE
feat(tooling): put the cwd workspace member's node_modules/.bin on PATH

### DIFF
--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -2,7 +2,11 @@
 [env]
 # Workspace binaries win over mise tools/globals; absolute via config_root
 # (repo root), so bare `turbo` etc. stay spawn-safe in any cwd or worktree.
-_.path = ["{{config_root}}/node_modules/.bin"]
+# The cwd entry puts a workspace member's own .bin first when cd'd into it
+# (isolated node_modules: member-only bins like vitest/typedoc/vitepress
+# aren't at root), matching pnpm-script resolution; elsewhere it's a dead
+# entry, and at the repo root a harmless duplicate of the config_root one.
+_.path = ["{{cwd}}/node_modules/.bin", "{{config_root}}/node_modules/.bin"]
 
 [settings]
 # read the node version from .nvmrc instead of pinning it here

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,9 @@ mise run setup   # corepack-installs the pinned pnpm, then pnpm install
 turbo build
 ```
 
-`mise install` provisions the pinned Node and corepack. `mise run setup` is the bootstrap layer pnpm scripts can't own (there is no `node_modules` yet): its `corepack` dependency task enables corepack and installs the `packageManager`-pinned pnpm, then `pnpm install` runs — frozen-lockfile automatically in CI. No separate `nvm use`, `pnpm add --global`, or global turbo needed. With mise active, `node_modules/.bin` is on `PATH`, so bare `turbo` (and every other workspace binary) runs the workspace-pinned version; everything after bootstrap belongs to turbo/pnpm scripts. See [TURBO.md](./TURBO.md) for detailed turbo commands and workflows.
+`mise install` provisions the pinned Node and corepack. `mise run setup` is the bootstrap layer pnpm scripts can't own (there is no `node_modules` yet): its `corepack` dependency task enables corepack and installs the `packageManager`-pinned pnpm, then `pnpm install` runs — frozen-lockfile automatically in CI. No separate `nvm use`, `pnpm add --global`, or global turbo needed. With mise active, `node_modules/.bin` is on `PATH`, so bare `turbo` (and every other workspace binary) runs the workspace-pinned version; everything after bootstrap belongs to turbo/pnpm scripts.
+
+pnpm's isolated `node_modules` means a workspace member's devDep binaries (`vitest`, `typedoc`, `vitepress`, …) live in that member's own `node_modules/.bin`, not the root one. When your shell is cd'd into a member directory, mise also puts that member's `.bin` first on `PATH`, so bare invocations resolve exactly as the member's own pnpm scripts would — including a member-local version shadowing the root one (e.g. `tools/vue-check`'s TypeScript 6 `tsc`). This only applies at the member's root directory, not its subdirectories; `pnpm run` inside the member works everywhere regardless. See [TURBO.md](./TURBO.md) for detailed turbo commands and workflows.
 
 ## Running Tests
 


### PR DESCRIPTION
## What

Adds `{{cwd}}/node_modules/.bin` ahead of the existing `{{config_root}}/node_modules/.bin` in mise's `_.path`, so cd'ing into a workspace member puts that member's own devDep bins on `PATH` — direct shell invocation (humans and agents) resolves the same bins the member's pnpm scripts already see. One line in the existing root config; no new files.

## Why: the inventory

pnpm's isolated `node_modules` means these bins exist only in a member's `.bin`, not root's (root has 15 bins: turbo, tsc, vite, oxlint/oxfmt, eslint, cypress, playwright, wrangler*, commitlint, husky, bundle-analyzer):

<sub>\*wrangler is a devDep of both root and `docs` (same `catalog:` version), so it appears in both `.bin`s — inside `docs/` the member copy shadows root's, a no-op by construction.</sub>

| Member | Bins absent from root `.bin` |
| --- | --- |
| `packages/lit-ui-router` | `vitest`, `typedoc`, `release-it`, `rimraf`, `cem`, `custom-elements-manifest`, `tsc6` |
| `packages/lit-ui-router-mobx` | `vitest`, `typedoc`, `release-it`, `rimraf`, `tsc6` |
| `packages/navigation-location-plugin` | `vitest`, `typedoc`, `release-it`, `rimraf`, `tsc6` |
| `docs` | `vitepress`, `vue-check` |
| `tools/vue-check` | `vue-tsc`, `tsserver` |
| `tools/dts-backtest` | `tsserver` |
| `tools/typedoc-plugin-lit-ui-router` | `typedoc`, `tsc6` |
| `apps/sample-app-lit-e2e` | `concurrently`, `conc`, `start-server-and-test` (+aliases), `tsc6` |
| `apps/sample-app-lit-{vanilla,mobx}` | `tsc6` |
| `examples` | `concurrently`, `conc` |

Before this change, `cd packages/lit-ui-router && vitest` failed with `command not found`.

## Semantics findings (mise 2026.6.14, verified by experiment in a worktree)

- **Nested config merging**: mise loads every `mise.toml` up the tree; `_.path` entries **accumulate**, with the nested (closer) config's entries prepended ahead of parents'.
- **Trust is per-directory, not per-repo**: a trusted repo root does **not** cover a nested `mise.toml` — each directory containing one needs its own `mise trust`, and any `[env]` section (even template-free) hard-errors every mise invocation/hook-env until trusted. `mise trust --all` only walks *up* (cwd and parents), never down. Trust survives file edits. CI auto-trusts.
- **Relative `_.path` entries** (e.g. `"node_modules/.bin"`) resolve against that file's `config_root`, never cwd — so there is no template-free cwd-relative form.
- **`{{cwd}}` is a documented template variable** and re-evaluates per hook-env run: `mise activate`'s chpwd/precmd hooks recompute `PATH` on every directory change, adding the member entry on the way in and removing it on the way out (no stale entries — verified).
- **mise monorepo tasks** (`monorepo_root = true`, `//path:task` addressing) is task discovery/addressing only — orthogonal to env/PATH, and unchanged by this PR (task names here stay colon-free per #315).

## Design chosen and rejected alternatives

**Chosen (b): one `{{cwd}}` entry in the existing root config.** Zero new files, zero added trust burden (the root config is already the one thing a fresh worktree trusts), one authority preserved. Where cwd is not a member root the entry is a dead `PATH` segment (harmless); at the repo root it duplicates the `config_root` entry (harmless).

**Rejected (a): per-member `mise.toml` files.** ~11 new files and — the killer — ~11 per-directory `mise trust` grants *per contributor per worktree*, with hard mise errors from any untrusted subtree until granted. This repo already fights per-worktree trust friction.

**Rejected (c): generated per-member configs.** Same trust cost as (a) plus drift risk.

**Rejected (d): do nothing.** The inventory is substantial and the failure mode (bare `vitest`/`typedoc`/`vitepress` not found, or a hoisted-by-luck version) hits every cd'd-in shell session.

## Shadowing (intentional)

The cwd entry is first, so a member-local bin shadows a root bin of the same name — exactly what `pnpm run` inside that member sees. Concretely: `cd tools/vue-check && tsc --version` → **6.0.3** (its deliberate TS6 compat pin) while root `tsc` stays **7.0.2**. This makes direct invocation agree with the member's own scripts instead of silently using the root version. Applies at the member's root directory only, not subdirectories (`{{cwd}}` is literal, no upward search).

## Verification

- Interactive-shell probes: `docs` → `vitepress` resolves to `docs/node_modules/.bin`; `packages/lit-ui-router` → `vitest` 4.1.10; `tools/vue-check` → `tsc` 6.0.3; back at root → `tsc` 7.0.2, `turbo`/`tsc` from root `.bin`, member entries dropped from `PATH` (no staleness).
- `turbo run build typecheck lint format` — 42/42 green.
- No workflow changes (CI steps run at repo root; mise-action behavior unchanged, and CI auto-trusts).

