### PR TITLE
feat(tooling): monorepo mise tasks for the release pipeline

### DIFF
--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -1,4 +1,15 @@
 # One version authority per tool — see the toolchain table in CONTRIBUTING.md.
+
+# Monorepo task addressing (`mise run '//tools/release:pack'`): task defs live
+# beside the code they run. Root trust covers every config_root below, so the
+# usual `mise trust` (or mise-action's MISE_TRUSTED_CONFIG_PATHS) is enough.
+monorepo_root = true
+
+[monorepo]
+# Explicit roots — mise deprecated filesystem auto-discovery. A glob only
+# matches directories that actually carry a mise config.
+config_roots = ["tools/*"]
+
 [env]
 # Workspace binaries win over mise tools/globals; absolute via config_root
 # (repo root), so bare `turbo` etc. stay spawn-safe in any cwd or worktree.
@@ -23,8 +34,8 @@ idiomatic_version_file_enable_tools = ["node"]
 
 # Provisioning tasks, not hooks: hooks warn-and-continue, task failures are
 # loud; and tool-only bumps (actionlint) skip the corepack ceremony.
-# snake_case names (bazel target convention, where mise monorepo tasks are
-# trending); no colons — mise monorepo task addressing claims `:`.
+# snake_case names (bazel target convention); no colons in task names — mise
+# monorepo task addressing owns `:` (see the config_roots above).
 [tasks.corepack_enable]
 description = "Shim the corepack-managed package managers onto PATH"
 run = "corepack enable"
@@ -64,66 +75,6 @@ description = "Lint and audit GitHub Actions workflows"
 depends = ["lint_actionlint", "lint_zizmor"]
 
 # ── Release pipeline ────────────────────────────────────────────────────────
-# One task per release-workflow step; the workflows are triggers/permissions/
-# secrets/environments/concurrency plus single-line `mise run` steps. Inputs
-# arrive via step `env:` blocks (never `${{ }}` interpolated into run lines);
-# results flow forward as GITHUB_OUTPUT step outputs written by the tools.
-# Each task's env contract is noted below; secrets stay in workflow step env,
-# NEVER in [env] here (mise [env] would override the step's).
-# `depends = ["setup"]` keeps every task runnable from a fresh clone; a warm
-# re-run of setup is a sub-second no-op.
-
-[tasks.release_git_user]
-# env: none. Refuses outside GITHUB_ACTIONS — writes --global git config.
-description = "Configure the github-actions[bot] git identity (CI only)"
-run = "node tools/release/src/steps/release-git-user.ts"
-
-[tasks.release_package_info]
-# env: PACKAGE_INPUT (manual dispatch) | GITHUB_REF (tag push).
-# outputs: package_name, package_dir.
-description = "Resolve the target package name and workspace directory"
-depends = ["setup"]
-run = "node tools/release/src/steps/release-package-info.ts"
-
-[tasks.release_build]
-# env: PACKAGE_NAME (+ TURBO_TOKEN/TURBO_API/TURBO_TEAM for remote cache).
-description = "Build one package and its workspace deps via turbo"
-depends = ["setup"]
-run = 'turbo run "${PACKAGE_NAME:?}#build"'
-
-[tasks.release_pack]
-# env: PACKAGE_NAME, PACKAGE_DIR. outputs: tarball.
-description = "Pack the publish tarball with a dev-stripped manifest"
-depends = ["setup"]
-run = "node tools/release/src/steps/release-pack.ts"
-
-[tasks.release_check_tarball]
-# env: TARBALL. Gates devDependencies/scripts/catalog:/workspace: leaks.
-description = "Check the packed tarball's manifest before publishing"
-depends = ["setup"]
-run = 'node tools/release/src/checks/check-packed-manifest.ts "${TARBALL:?}"'
-
-[tasks.release_tag]
-# env: PACKAGE, DRY_RUN. Tags locally only; release_tag_push pushes the ref.
-description = "Tag the current version of a package (local tag only)"
-depends = ["setup"]
-run = "node tools/release/src/steps/release-tag.ts"
-
-[tasks.release_tag_push]
-# env: PACKAGE, DRY_RUN. Pushes exactly refs/tags/<package>@<version>.
-description = "Push a package's release tag ref"
-depends = ["setup"]
-run = "node tools/release/src/steps/release-tag-push.ts"
-
-[tasks.release_publish]
-# env: PACKAGE_NAME, TARBALL, DRY_RUN, GITHUB_TOKEN (GitHub release; npm is OIDC).
-description = "Publish the packed tarball to npm and cut the GitHub release"
-depends = ["setup"]
-run = "node tools/release/src/steps/release-publish.ts"
-
-[tasks.release_bump]
-# env: PACKAGE, INCREMENT, OTHER_INCREMENT, PR_BASE, BRANCH_PREFIX_INPUT,
-# DRY_RUN, GH_TOKEN (gh pr create; the branch push rides checkout's PAT).
-description = "Compute the bumped version, branch, commit, push, and open the release PR"
-depends = ["setup"]
-run = "node tools/release/src/steps/release-bump.ts"
+# The nine release-workflow tasks live beside their code in
+# tools/release/mise.toml, addressed as //tools/release:<step>
+# (e.g. `mise run '//tools/release:pack'`). `mise tasks ls --all` lists them.

--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -75,6 +75,6 @@ description = "Lint and audit GitHub Actions workflows"
 depends = ["lint_actionlint", "lint_zizmor"]
 
 # ── Release pipeline ────────────────────────────────────────────────────────
-# The nine release-workflow tasks live beside their code in
+# The release-workflow tasks live beside their code in
 # tools/release/mise.toml, addressed as //tools/release:<step>
 # (e.g. `mise run '//tools/release:pack'`). `mise tasks ls --all` lists them.

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -3,7 +3,7 @@
 # Creates a release branch and PR that, when merged, triggers tagging.
 #
 # YAML here is triggers/permissions/secrets/environment only; the pipeline
-# logic lives in tools/release (mise task release_bump), inputs flow through
+# logic lives in tools/release (mise task //tools/release:bump), inputs flow through
 # step env — never `${{ }}` inside run lines.
 name: Bump version
 
@@ -82,11 +82,11 @@ jobs:
       - name: Install dependencies
         run: mise run setup
       - name: Setup Git user
-        run: mise run release_git_user
+        run: mise run //tools/release:git_user
       - name: Bump version
         # version calc, release branch, release-it commit+push, gh pr create —
         # see tools/release/src/steps/release-bump.ts for the phase-by-phase contract
-        run: mise run release_bump
+        run: mise run //tools/release:bump
         env:
           PACKAGE: ${{ inputs.package }}
           INCREMENT: ${{ inputs.increment }}

--- a/.github/workflows/publish-gh.yml
+++ b/.github/workflows/publish-gh.yml
@@ -3,8 +3,8 @@
 # Uses release-it with --no-increment to tag the current version without bumping.
 #
 # YAML here is triggers/permissions/secrets/environment/concurrency only; the
-# pipeline logic lives in tools/release (mise tasks release_tag and
-# release_tag_push), inputs flow through step env — never `${{ }}` inside run
+# pipeline logic lives in tools/release (mise tasks //tools/release:tag and
+# :tag_push), inputs flow through step env — never `${{ }}` inside run
 # lines.
 name: Tag & push
 
@@ -29,8 +29,8 @@ env:
 # then deletes the tag from the remote.
 # The queue alone is not enough: release-it's own push sends main + tag
 # together, so a main push that lands mid-run rejects the whole push and the
-# rollback deletes the tag. Hence tagging (release_tag, --git.push false) and
-# pushing (release_tag_push, tag ref only) are separate tasks.
+# rollback deletes the tag. Hence tagging (:tag, --git.push false) and
+# pushing (:tag_push, tag ref only) are separate tasks.
 concurrency:
   group: tag-release
 
@@ -56,7 +56,7 @@ jobs:
           fetch-tags: true
           # PAT (not GITHUB_TOKEN): the pushed tag must trigger publish-npm,
           # and the default token can't trigger other workflows. The push in
-          # release_tag_push rides these persisted credentials.
+          # //tools/release:tag_push rides these persisted credentials.
           token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
       - name: Setup mise
         uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
@@ -66,9 +66,9 @@ jobs:
       - name: Install dependencies
         run: mise run setup
       - name: Setup Git user
-        run: mise run release_git_user
+        run: mise run //tools/release:git_user
       - name: Tag
-        run: mise run release_tag
+        run: mise run //tools/release:tag
         # continue-on-error: Tagging is idempotent - if tag exists, we succeed anyway
         continue-on-error: true
         env:
@@ -77,7 +77,7 @@ jobs:
           DRY_RUN: ${{ inputs.dryRun }}
           GITHUB_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
       - name: Push tag
-        run: mise run release_tag_push
+        run: mise run //tools/release:tag_push
         # continue-on-error: a tag existing on the remote at a different commit is
         # rejected here, matching the previous tag-exists behavior
         continue-on-error: true

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -68,11 +68,11 @@ jobs:
       - name: Resolve package
         # tag → package name (hostile-refname safe) → workspace directory
         id: info
-        run: mise run release_package_info
+        run: mise run //tools/release:package_info
         env:
           PACKAGE_INPUT: ${{ inputs.package }}
       - name: Build
-        run: mise run release_build
+        run: mise run //tools/release:build
         env:
           PACKAGE_NAME: ${{ steps.info.outputs.package_name }}
           TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
@@ -82,13 +82,13 @@ jobs:
         # strip devDependencies/scripts → pnpm pack → restore (try/finally);
         # the tarball feeds the attestation, the manifest gate, and the publish
         id: pack
-        run: mise run release_pack
+        run: mise run //tools/release:pack
         env:
           PACKAGE_NAME: ${{ steps.info.outputs.package_name }}
           PACKAGE_DIR: ${{ steps.info.outputs.package_dir }}
       - name: Check packed manifest
         # no devDependencies, no scripts, and no unsubstituted catalog:/workspace: refs may ship
-        run: mise run release_check_tarball
+        run: mise run //tools/release:check_tarball
         env:
           TARBALL: ${{ steps.pack.outputs.tarball }}
       - name: Attest build provenance
@@ -102,7 +102,7 @@ jobs:
         # release-it publishes the attested tarball and cuts the GitHub
         # release in one invocation; the argv (and the #302 changelog-range
         # pin) is built by the engine seam — see tools/release/src/steps/release-publish.ts
-        run: mise run release_publish
+        run: mise run //tools/release:publish
         env:
           PACKAGE_NAME: ${{ steps.info.outputs.package_name }}
           TARBALL: ${{ steps.pack.outputs.tarball }}

--- a/tools/release/mise.toml
+++ b/tools/release/mise.toml
@@ -1,0 +1,72 @@
+# Release pipeline tasks — one per release-workflow step, addressed as
+# //tools/release:<step> (monorepo task addressing; the root config declares
+# this directory in [monorepo].config_roots). Tasks run from THIS directory,
+# so run lines are src/-relative. The workflows are triggers/permissions/
+# secrets/environments/concurrency plus single-line `mise run` steps. Inputs
+# arrive via step `env:` blocks (never `${{ }}` interpolated into run lines);
+# results flow forward as GITHUB_OUTPUT step outputs written by the tools.
+# Each task's env contract is noted below; secrets stay in workflow step env,
+# NEVER in mise [env] (which would override the step's). Keep this file
+# [tasks]-only: root [env]/_.path and [tools] are inherited, and a tasks-only
+# config stays inert for shells that merely cd in here.
+# `depends = ["//:setup"]` keeps every task runnable from a fresh clone; a
+# warm re-run of setup is a sub-second no-op.
+
+[tasks.git_user]
+# env: none. Refuses outside GITHUB_ACTIONS — writes --global git config.
+description = "Configure the github-actions[bot] git identity (CI only)"
+run = "node src/steps/release-git-user.ts"
+
+[tasks.package_info]
+# env: PACKAGE_INPUT (manual dispatch) | GITHUB_REF (tag push).
+# outputs: package_name, package_dir.
+description = "Resolve the target package name and workspace directory"
+depends = ["//:setup"]
+run = "node src/steps/release-package-info.ts"
+
+[tasks.build]
+# env: PACKAGE_NAME (+ TURBO_TOKEN/TURBO_API/TURBO_TEAM for remote cache).
+# dir: workspace root — turbo run from inside a package adds that package to
+# the scope alongside the explicit <pkg>#build spec; pin the cwd instead.
+description = "Build one package and its workspace deps via turbo"
+depends = ["//:setup"]
+dir = "../.."
+run = 'turbo run "${PACKAGE_NAME:?}#build"'
+
+[tasks.pack]
+# env: PACKAGE_NAME, PACKAGE_DIR. outputs: tarball.
+description = "Pack the publish tarball with a dev-stripped manifest"
+depends = ["//:setup"]
+run = "node src/steps/release-pack.ts"
+
+[tasks.check_tarball]
+# env: TARBALL (absolute, from pack's output). Gates devDependencies/
+# scripts/catalog:/workspace: leaks.
+description = "Check the packed tarball's manifest before publishing"
+depends = ["//:setup"]
+run = 'node src/checks/check-packed-manifest.ts "${TARBALL:?}"'
+
+[tasks.tag]
+# env: PACKAGE, DRY_RUN. Tags locally only; tag_push pushes the ref.
+description = "Tag the current version of a package (local tag only)"
+depends = ["//:setup"]
+run = "node src/steps/release-tag.ts"
+
+[tasks.tag_push]
+# env: PACKAGE, DRY_RUN. Pushes exactly refs/tags/<package>@<version>.
+description = "Push a package's release tag ref"
+depends = ["//:setup"]
+run = "node src/steps/release-tag-push.ts"
+
+[tasks.publish]
+# env: PACKAGE_NAME, TARBALL, DRY_RUN, GITHUB_TOKEN (GitHub release; npm is OIDC).
+description = "Publish the packed tarball to npm and cut the GitHub release"
+depends = ["//:setup"]
+run = "node src/steps/release-publish.ts"
+
+[tasks.bump]
+# env: PACKAGE, INCREMENT, OTHER_INCREMENT, PR_BASE, BRANCH_PREFIX_INPUT,
+# DRY_RUN, GH_TOKEN (gh pr create; the branch push rides checkout's PAT).
+description = "Compute the bumped version, branch, commit, push, and open the release PR"
+depends = ["//:setup"]
+run = "node src/steps/release-bump.ts"

--- a/tools/release/src/steps/release-git-user.ts
+++ b/tools/release/src/steps/release-git-user.ts
@@ -2,7 +2,7 @@
 // Configure the github-actions[bot] git identity — the duplicated Setup Git
 // user step of bump-version.yml and publish-gh.yml, now one task. env in:
 // none. Guarded to Actions runners: the writes are `git config --global`,
-// and a stray local `mise run release_git_user` must not clobber a
+// and a stray local `mise run //tools/release:git_user` must not clobber a
 // developer's identity. argv lives in ./release-git-user.core.ts.
 
 import { defaultExec } from '../lib/exec.ts';


### PR DESCRIPTION
Converts the nine `release_*` tasks from root-config prefix naming to mise monorepo task addressing: the task defs now live beside the code they run, in `tools/release/mise.toml`, addressed as `//tools/release:<step>`. This resolves the root config reaching into tools/release — the run lines are config_root-relative (`node src/steps/…`), matching #338's layout. Stacked on `chore/zizmor` (#331, which absorbed #338).

## Why monorepo addressing won (vs the `dir = "tools/release"` fallback, vs `pnpm --filter exec`)

All viability gates passed empirically on the pinned mise 2026.6.14:

| Concern | Result |
| --- | --- |
| Experimental flag | **Not needed.** `monorepo_root = true` + `[monorepo].config_roots` is the stable, current shape (`experimental=false` throughout). Filesystem auto-discovery is what's deprecated — explicit `config_roots` avoids it. |
| Trust | **No new burden.** Trusting the monorepo root covers every descendant config_root (mise writes a `.monorepo` trust marker). Verified: fresh worktree + single `mise trust --quiet` runs `//tools/release:*` with zero extra prompts; an explicit `mise trust --untrust` of the nested file is overridden by root trust. |
| CI / mise-action | jdx/mise-action sets `MISE_TRUSTED_CONFIG_PATHS=$PWD`; verified that env var also covers nested config_roots. No workflow changes beyond the task names. |
| Root tasks | `mise run setup` / `lint_workflows` unprefixed at root keep working; workflows stay single-line `mise run` steps. |
| Inheritance | Root `[env]` `_.path` and `[tools]` (node via .nvmrc, npm, corepack) reach nested tasks; `depends = ["//:setup"]` crosses configs and runs the same corepack→setup graph. |
| Lockfile | No `tools/release/mise.lock` appears; root mise.lock untouched. (mise's monorepo per-subproject lockfile default only changes in 2027.6.0, and the nested config is [tasks]-only.) |

The `dir` fallback also works (probed: `dir` is config_root-relative) but keeps all nine defs in the root config — placement, not locality. `pnpm --filter exec` adds a stdout/exit-code layer for nothing; never built.

## Shape

- Root `.config/mise/config.toml`: `monorepo_root = true`, `[monorepo] config_roots = ["tools/*"]` (glob only matches dirs that carry a mise config — `tools/build_and_test` et al. can join later); provisioning + lint tasks stay; release section is now a pointer comment.
- `tools/release/mise.toml`: the nine tasks, `release_` prefix dropped in favor of path addressing (`//tools/release:pack` etc.), env-contract comments preserved, **[tasks]-only** (kept inert for shells that cd in; root env/tools inherited).
- One behavioral pin: `tasks.build` sets `dir = "../.."` — turbo run from inside a package silently adds that package to the scope alongside the explicit `<pkg>#build` spec (observed: "Packages in scope: release, ui-router-navigation-location-plugin"); pinning the cwd restores the exact previous scope.
- Workflows: `mise run release_pack` → `mise run //tools/release:pack` (still single-line; `//…:name` needs no shell quoting).

## Gates

- All nine tasks ran secret-free from repo root **before and after** the conversion; exit codes identical (`git_user` refuses outside Actions; `tag`/`publish`/`bump` reach the same interactive release-it prompt with byte-identical argv; `package_info`/`build`/`pack`/`check_tarball` green with identical GITHUB_OUTPUT).
- `mise run lint_workflows` (actionlint + zizmor --offline): no findings.
- Fresh-worktree bootstrap probe: `mise trust --quiet && mise install && CI=true mise run //tools/release:package_info` — frozen-lockfile install, correct outputs, no trust prompts.
- `turbo run lint typecheck test --filter=release`: 8/8 green.
- `mise tasks ls --all` lists all 16 tasks (`//:` root + `//tools/release:` nine).

One discovery-cost note: bare `mise tasks ls` at the repo root lists only root tasks; the nested nine need `--all` (or any subdir cwd). The root config's pointer comment says so.
