### PR TITLE
feat(ui-router-server): connect middleware + vite dev/preview plugin (#309)

### DIFF
--- a/packages/ui-router-server/package.json
+++ b/packages/ui-router-server/package.json
@@ -6,9 +6,11 @@
   "sideEffects": false,
   "exports": {
     ".": "./src/index.ts",
+    "./connect": "./src/connect.ts",
     "./matcher": "./src/url-matcher.ts",
     "./redirects": "./src/redirects.ts",
-    "./simulate": "./src/simulate.ts"
+    "./simulate": "./src/simulate.ts",
+    "./vite": "./src/vite.ts"
   },
   "scripts": {
     "format": "oxfmt \"**/*.{ts,json,md}\"",

--- a/packages/ui-router-server/src/connect.ts
+++ b/packages/ui-router-server/src/connect.ts
@@ -1,0 +1,201 @@
+/**
+ * The Connect adapter: verdicts as Node-style `(req, res, next)` middleware.
+ * One artifact covers every Connect-shaped stack — Express 4/5, bare
+ * Connect, Koa via `koa-connect`, Fastify via `@fastify/middie`, and Vite's
+ * dev/preview servers (see `./vite`) — and it is the honest-status upgrade
+ * of the classic always-200 SPA fallback: redirect verdicts answer 302,
+ * mount-owned misses answer 404, and only real routes reach the shell.
+ *
+ * The adapter owns verdict → response mechanics (status mapping,
+ * [[mergeSearch]] on redirect Locations, validator stripping and status
+ * relabeling on status'd shells); the HOST supplies asset IO. The default
+ * host is the downstream stack itself: shells rewrite `req.url` to the
+ * mount's shell path and `next()` into `express.static`/`sirv`/Vite —
+ * which is why this middleware mounts BEFORE the static layer, exactly
+ * where `connect-history-api-fallback` sits. Override [[serveShell]] /
+ * [[serveNotFound]] to take asset IO in hand.
+ *
+ * Dependency-free, like the tiers it fronts: the request/response types
+ * below declare the minimal structural surface the adapter touches (the
+ * `globals.d.ts` discipline applied to `node:http`), so Node, Express and
+ * Connect objects all fit without this package needing node types — and
+ * the DOM-free compile keeps enforcing runtime-neutrality everywhere else.
+ */
+
+import { mergeSearch } from './index.ts';
+import type { ServerRouter } from './index.ts';
+
+/** The subset of `http.IncomingMessage` the middleware reads (and rewrites). */
+export interface ConnectRequest {
+  url?: string;
+  method?: string;
+  headers: Record<string, string | string[] | undefined>;
+}
+
+/**
+ * The subset of `http.ServerResponse` the middleware writes. `writeHead` is
+ * variadic to admit Node's `(status, statusMessage?, headers?)` overloads —
+ * the relabeling patch must forward whichever shape the downstream used.
+ */
+export interface ConnectResponse {
+  writeHead(statusCode: number, ...rest: unknown[]): unknown;
+  setHeader(name: string, value: string): unknown;
+  end(body?: string): unknown;
+}
+
+/** Connect's continuation: call with no argument to pass, with an error to fail. */
+export type ConnectNext = (error?: unknown) => void;
+
+export type ConnectMiddleware = (
+  req: ConnectRequest,
+  res: ConnectResponse,
+  next: ConnectNext,
+) => void;
+
+export interface ConnectAdapterOptions {
+  /**
+   * Maps a shell verdict's mount to the path the default [[serveShell]]
+   * rewrites `req.url` to (default: the mount base itself). The hook for
+   * aliased mounts whose shell lives under another prefix.
+   */
+  shellPath?: (mount: string) => string;
+  /**
+   * Serve the mount's shell. The default rewrites `req.url` to
+   * [[shellPath]] and `next()`s into the downstream static layer. By the
+   * time this runs the adapter has already done the status'd-shell
+   * mechanics: request validators stripped and the response relabeled to
+   * the verdict's status — a host override only owns the asset IO.
+   */
+  serveShell?: (
+    mount: string,
+    req: ConnectRequest,
+    res: ConnectResponse,
+    next: ConnectNext,
+  ) => void;
+  /**
+   * Serve a mount-owned miss (`notFound` with a mount: the mount owned the
+   * pathname but no route matched). The default answers a minimal
+   * `text/plain` 404 — override to serve a real 404 page. A `notFound`
+   * without a mount is never routed here: the pathname isn't this router's,
+   * so the middleware always passes it through untouched.
+   */
+  serveNotFound?: (
+    mount: string,
+    req: ConnectRequest,
+    res: ConnectResponse,
+    next: ConnectNext,
+  ) => void;
+  /**
+   * Which requests get verdicts. The default is the navigation heuristic
+   * `connect-history-api-fallback` established (and Vite's own HTML
+   * fallback mirrors): GET/HEAD requests whose Accept includes
+   * `text/html`. Module and asset fetches (`Accept: *​/*`) pass through
+   * untouched — essential under Vite, where a mount's module URLs live on
+   * the same paths as its routes. Override with `() => true` when the
+   * middleware sits behind the static layer and should judge everything.
+   */
+  shouldHandle?: (req: ConnectRequest) => boolean;
+}
+
+const acceptsHtml = (req: ConnectRequest): boolean => {
+  const accept = req.headers.accept;
+  return typeof accept === 'string' && accept.includes('text/html');
+};
+
+const isNavigation = (req: ConnectRequest): boolean =>
+  (req.method === 'GET' || req.method === 'HEAD') && acceptsHtml(req);
+
+// Status'd shells must suppress the conditional path (Verdict contract):
+// the downstream serve has to answer 200 + full body so the relabel never
+// manufactures a bodied 304 — or a body-less 404.
+const stripValidators = (req: ConnectRequest): void => {
+  delete req.headers['if-none-match'];
+  delete req.headers['if-modified-since'];
+};
+
+// The verdict's status wins outright over whatever the downstream layer
+// writes — express.static and sirv both decide their own status, so the
+// override has to happen at writeHead (Node's implicit header flush funnels
+// through it too). A 304 passes unrelabeled per the Verdict contract: it
+// has no body, and the stripped validators make one unreachable anyway.
+const relabel = (res: ConnectResponse, status: number): void => {
+  const writeHead = res.writeHead.bind(res);
+  res.writeHead = (downstream: number, ...rest: unknown[]) =>
+    writeHead(downstream === 304 ? downstream : status, ...rest);
+};
+
+const defaultServeNotFound = (
+  mount: string,
+  req: ConnectRequest,
+  res: ConnectResponse,
+): void => {
+  res.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' });
+  res.end(req.method === 'HEAD' ? undefined : `404 Not Found — ${mount}\n`);
+};
+
+/**
+ * Wraps a [[ServerRouter]] as Connect middleware. Mount it BEFORE the
+ * static layer; the default host serves shells by rewriting `req.url` and
+ * `next()`ing into it. `resolve()` is always async (the simulate tier's
+ * lazy boundary), which Connect absorbs naturally — with matcher-tier
+ * mounts nothing async ever actually runs.
+ *
+ * - `redirect` → `writeHead(302, { Location })`, the request's search
+ *   MERGED into the verdict's location via [[mergeSearch]] (targets that
+ *   declare their own query keep it — never `?a=1?b=2`).
+ * - `shell` → `Link: <mount>; rel="canonical"` (the shell is the same
+ *   representation at every route path), then [[serveShell]].
+ * - `shell` with status (the otherwise projection) → validators stripped,
+ *   downstream status relabeled, no canonical Link (a 404 is not an
+ *   alternate representation of the mount root), then [[serveShell]].
+ * - `notFound` with a mount → [[serveNotFound]] (honest 404).
+ * - `notFound` without a mount, or a non-navigation request → `next()`.
+ */
+export function createConnectMiddleware(
+  router: ServerRouter,
+  options: ConnectAdapterOptions = {},
+): ConnectMiddleware {
+  const {
+    shellPath = (mount) => mount,
+    serveShell = (mount, req, _res, next) => {
+      req.url = shellPath(mount);
+      next();
+    },
+    serveNotFound = defaultServeNotFound,
+    shouldHandle = isNavigation,
+  } = options;
+
+  return (req, res, next) => {
+    if (!shouldHandle(req)) {
+      next();
+      return;
+    }
+    const url = req.url ?? '/';
+    const cut = url.indexOf('?');
+    const search = cut === -1 ? '' : url.substring(cut);
+    router.resolve(url).then((verdict) => {
+      if (verdict.kind === 'redirect') {
+        res.writeHead(verdict.status, {
+          Location: mergeSearch(verdict.location, search),
+        });
+        res.end();
+        return;
+      }
+      if (verdict.kind === 'shell') {
+        if (verdict.status === undefined) {
+          res.setHeader('Link', `<${verdict.mount}>; rel="canonical"`);
+        } else {
+          stripValidators(req);
+          relabel(res, verdict.status);
+        }
+        serveShell(verdict.mount, req, res, next);
+        return;
+      }
+      if (verdict.mount === undefined) {
+        next();
+        return;
+      }
+      serveNotFound(verdict.mount, req, res, next);
+    }, next);
+  };
+}

--- a/packages/ui-router-server/src/vite.ts
+++ b/packages/ui-router-server/src/vite.ts
@@ -1,0 +1,60 @@
+/**
+ * The Vite plugin: the Connect adapter (see `./connect`) wired into Vite's
+ * dev and preview middleware stacks, both of which are Connect-shaped. It is
+ * the honest-status upgrade of Vite's built-in SPA fallback — `vite dev` and
+ * `vite preview` answer the same 302s and mount-owned 404s the production
+ * worker does, so a mounted app has dev/prod routing parity from one mounts
+ * table.
+ *
+ * Dependency-free like the tiers it fronts: the structural types below
+ * declare the sliver of Vite's plugin surface the plugin touches
+ * (`server.middlewares.use`), so Vite stays a type-only peer this package
+ * never imports. The returned object is a structural subset of Vite's
+ * `Plugin` — spread it straight into `plugins: [...]`.
+ */
+
+import { createConnectMiddleware } from './connect.ts';
+import type { ConnectAdapterOptions, ConnectMiddleware } from './connect.ts';
+import type { ServerRouter } from './index.ts';
+
+/** The sliver of Vite's dev/preview server the plugin uses: the Connect stack. */
+export interface ViteMiddlewareServer {
+  middlewares: { use(middleware: ConnectMiddleware): unknown };
+}
+
+/** A structural subset of Vite's `Plugin` — assignable into `plugins: [...]`. */
+export interface ServerRouterPlugin {
+  name: string;
+  configureServer(server: ViteMiddlewareServer): void;
+  configurePreviewServer(server: ViteMiddlewareServer): void;
+}
+
+/**
+ * Wraps a [[ServerRouter]] as a Vite plugin. The middleware installs in the
+ * PRE position — synchronously inside `configureServer`, before Vite adds
+ * its own middlewares — which is exactly where `connect-history-api-fallback`
+ * sits and the only position that beats Vite's always-200 HTML fallback: a
+ * redirect answers 302 and a mount-owned miss answers 404 before Vite can
+ * serve `index.html`. The adapter's `shouldHandle` still lets module and
+ * asset fetches pass untouched, essential under Vite where a mount's module
+ * URLs share paths with its routes.
+ *
+ * `serveShell` defaults to rewriting `req.url` to the mount base and
+ * `next()`ing into Vite's HTML/transform layer (dev) or `sirv` (preview);
+ * point [[ConnectAdapterOptions.shellPath]] at the mount's actual HTML entry
+ * when it isn't served at the base.
+ */
+export function serverRouterPlugin(
+  router: ServerRouter,
+  options?: ConnectAdapterOptions,
+): ServerRouterPlugin {
+  const middleware = createConnectMiddleware(router, options);
+  const install = (server: ViteMiddlewareServer): void => {
+    server.middlewares.use(middleware);
+  };
+  return {
+    name: 'ui-router-server',
+    configureServer: install,
+    configurePreviewServer: install,
+  };
+}

--- a/packages/ui-router-server/test/connect.test.ts
+++ b/packages/ui-router-server/test/connect.test.ts
@@ -1,0 +1,253 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { createServerRouter } from '../src/index.ts';
+import type { ServerRouter, Verdict } from '../src/index.ts';
+import { createConnectMiddleware } from '../src/connect.ts';
+import type { ConnectRequest, ConnectResponse } from '../src/connect.ts';
+
+// A router that answers every request with one fixed verdict — isolates the
+// adapter's verdict → response mechanics from the resolver under test.
+const routerOf = (verdict: Verdict): ServerRouter => ({
+  resolve: () => Promise.resolve(verdict),
+});
+
+interface Harness {
+  req: ConnectRequest;
+  res: ConnectResponse;
+  next: (...args: unknown[]) => void;
+  // Resolves the moment the request is answered (res.end) or passed (next).
+  done: Promise<void>;
+  writeHead: Array<{ status: number; rest: unknown[] }>;
+  headers: Record<string, string>;
+  ended: boolean;
+  body?: string;
+  nextArgs: unknown[][];
+}
+
+// Builds a req/res/next triple that records everything the middleware touches.
+// Headers default to a GET navigation so the middleware engages.
+const harness = (overrides: Partial<ConnectRequest> = {}): Harness => {
+  let settle!: () => void;
+  const h: Harness = {
+    req: {
+      url: '/app/about',
+      method: 'GET',
+      headers: { accept: 'text/html' },
+      ...overrides,
+    },
+    res: {
+      writeHead(status: number, ...rest: unknown[]) {
+        h.writeHead.push({ status, rest });
+        return h.res;
+      },
+      setHeader(name: string, value: string) {
+        h.headers[name] = value;
+        return h.res;
+      },
+      end(body?: string) {
+        h.ended = true;
+        h.body = body;
+        settle();
+        return h.res;
+      },
+    },
+    next: (...args: unknown[]) => {
+      h.nextArgs.push(args);
+      settle();
+    },
+    done: new Promise<void>((resolve) => {
+      settle = resolve;
+    }),
+    writeHead: [],
+    headers: {},
+    ended: false,
+    nextArgs: [],
+  };
+  return h;
+};
+
+const CANONICAL_APP = '</app>; rel="canonical"';
+
+describe('createConnectMiddleware', () => {
+  it('answers redirects 302 with the request search merged into the Location', async () => {
+    const mw = createConnectMiddleware(
+      routerOf({
+        kind: 'redirect',
+        mount: '/app',
+        location: '/app/home',
+        status: 302,
+      }),
+    );
+    const h = harness({ url: '/app/old?ref=email' });
+    mw(h.req, h.res, h.next);
+    await h.done;
+    assert.deepEqual(h.writeHead, [
+      { status: 302, rest: [{ Location: '/app/home?ref=email' }] },
+    ]);
+    assert.equal(h.ended, true);
+    assert.equal(h.nextArgs.length, 0);
+  });
+
+  it('does not double-append search when the redirect target carries its own query', async () => {
+    const mw = createConnectMiddleware(
+      routerOf({
+        kind: 'redirect',
+        mount: '/app',
+        location: '/app/home?tab=1',
+        status: 302,
+      }),
+    );
+    const h = harness({ url: '/app/old?tab=2' });
+    mw(h.req, h.res, h.next);
+    await h.done;
+    const location = (h.writeHead[0].rest[0] as { Location: string }).Location;
+    assert.equal(location, '/app/home?tab=1');
+  });
+
+  it('serves a plain shell with a canonical Link and rewrites req.url into the static layer', async () => {
+    const mw = createConnectMiddleware(
+      routerOf({ kind: 'shell', mount: '/app' }),
+    );
+    const h = harness({ url: '/app/about' });
+    mw(h.req, h.res, h.next);
+    await h.done;
+    assert.equal(h.headers.Link, CANONICAL_APP);
+    assert.equal(h.req.url, '/app'); // default shellPath = mount base
+    assert.equal(h.nextArgs.length, 1);
+    assert.equal(h.ended, false); // the static layer ends it
+  });
+
+  it('strips validators and relabels the downstream status for a status’d shell', async () => {
+    const mw = createConnectMiddleware(
+      routerOf({ kind: 'shell', mount: '/app', status: 404 }),
+    );
+    const h = harness({
+      url: '/app/missing',
+      headers: {
+        accept: 'text/html',
+        'if-none-match': '"abc"',
+        'if-modified-since': 'yesterday',
+      },
+    });
+    mw(h.req, h.res, h.next);
+    await h.done;
+    // No canonical Link for an error representation.
+    assert.equal(h.headers.Link, undefined);
+    // Conditional validators gone so the assets fetch answers a full body.
+    assert.equal(h.req.headers['if-none-match'], undefined);
+    assert.equal(h.req.headers['if-modified-since'], undefined);
+    assert.equal(h.nextArgs.length, 1);
+    // The downstream 200 is relabeled to the verdict's 404; a 304 passes.
+    h.res.writeHead(200, { 'Content-Type': 'text/html' });
+    h.res.writeHead(304);
+    assert.deepEqual(
+      h.writeHead.map((call) => call.status),
+      [404, 304],
+    );
+  });
+
+  it('answers a mount-owned miss with an honest 404', async () => {
+    const mw = createConnectMiddleware(
+      routerOf({ kind: 'notFound', mount: '/app' }),
+    );
+    const h = harness({ url: '/app/nope' });
+    mw(h.req, h.res, h.next);
+    await h.done;
+    assert.equal(h.writeHead[0].status, 404);
+    assert.match(h.body ?? '', /404 Not Found — \/app/);
+    assert.equal(h.nextArgs.length, 0);
+  });
+
+  it('sends no 404 body for a HEAD miss', async () => {
+    const mw = createConnectMiddleware(
+      routerOf({ kind: 'notFound', mount: '/app' }),
+    );
+    const h = harness({ url: '/app/nope', method: 'HEAD' });
+    mw(h.req, h.res, h.next);
+    await h.done;
+    assert.equal(h.writeHead[0].status, 404);
+    assert.equal(h.body, undefined);
+  });
+
+  it('passes a mountless miss straight through', async () => {
+    const mw = createConnectMiddleware(routerOf({ kind: 'notFound' }));
+    const h = harness({ url: '/elsewhere' });
+    mw(h.req, h.res, h.next);
+    await h.done;
+    assert.equal(h.nextArgs.length, 1);
+    assert.equal(h.writeHead.length, 0);
+    assert.equal(h.ended, false);
+  });
+
+  it('never judges non-navigation requests (module and asset fetches pass)', async () => {
+    const mw = createConnectMiddleware(
+      routerOf({ kind: 'shell', mount: '/app' }),
+    );
+    // A Vite module fetch on a route-shaped path: Accept: */*.
+    const h = harness({ url: '/app/about', headers: { accept: '*/*' } });
+    mw(h.req, h.res, h.next);
+    await h.done;
+    assert.equal(h.nextArgs.length, 1);
+    assert.equal(h.req.url, '/app/about'); // untouched, not rewritten
+    assert.equal(h.headers.Link, undefined);
+  });
+
+  it('honours shellPath and shouldHandle overrides', async () => {
+    const mw = createConnectMiddleware(
+      routerOf({ kind: 'shell', mount: '/app' }),
+      {
+        shellPath: (mount) => `${mount}/index.html`,
+        shouldHandle: () => true,
+      },
+    );
+    // A non-navigation POST the default heuristic would skip.
+    const h = harness({ url: '/app/deep', method: 'POST', headers: {} });
+    mw(h.req, h.res, h.next);
+    await h.done;
+    assert.equal(h.req.url, '/app/index.html');
+    assert.equal(h.nextArgs.length, 1);
+  });
+
+  it('routes real createServerRouter verdicts end to end', async () => {
+    const router = createServerRouter({
+      mounts: {
+        '/app': {
+          routes: [
+            { name: 'home', url: '' },
+            { name: 'about', url: '/about' },
+            { name: 'missing' },
+          ],
+          redirects: [{ pattern: '/legacy', to: { state: 'about' } }],
+          otherwise: { state: 'missing' },
+        },
+      },
+    });
+    const mw = createConnectMiddleware(router);
+
+    // A matched route → shell, rewritten to the mount base.
+    {
+      const h = harness({ url: '/app/about' });
+      mw(h.req, h.res, h.next);
+      await h.done;
+      assert.equal(h.req.url, '/app');
+      assert.equal(h.headers.Link, CANONICAL_APP);
+    }
+    // A redirect rule → 302.
+    {
+      const h = harness({ url: '/app/legacy' });
+      mw(h.req, h.res, h.next);
+      await h.done;
+      assert.equal(h.writeHead[0].status, 302);
+    }
+    // An unknown path under a mount with `otherwise` → status’d 404 shell.
+    {
+      const h = harness({ url: '/app/ghost' });
+      mw(h.req, h.res, h.next);
+      await h.done;
+      assert.equal(h.req.url, '/app'); // shell rewrite
+      h.res.writeHead(200);
+      assert.equal(h.writeHead.at(-1)?.status, 404); // relabeled
+    }
+  });
+});

--- a/packages/ui-router-server/test/treeshake.test.ts
+++ b/packages/ui-router-server/test/treeshake.test.ts
@@ -64,4 +64,19 @@ describe('tree-shaking probe', () => {
       }
     }
   });
+
+  it('keeps the adapter subpaths core-free at the entry (core stays lazy)', async () => {
+    // The Connect and Vite adapters front the root verdict API, so they
+    // inherit its boundary: a matcher-only mount table drives them without
+    // ever loading core, which lives behind the same dynamic simulate import.
+    for (const entry of ['connect.ts', 'vite.ts']) {
+      const result = await bundle(entry);
+      const name = entry.replace(/\.ts$/, '.js');
+      const chunk = result.outputFiles.find((file) =>
+        file.path.endsWith(`/${name}`),
+      );
+      assert.ok(chunk, `expected a ${name} entry chunk`);
+      assert.doesNotMatch(chunk.text, /uirouter/i, `${entry} entry loads core`);
+    }
+  });
 });

--- a/packages/ui-router-server/test/vite.test.ts
+++ b/packages/ui-router-server/test/vite.test.ts
@@ -1,0 +1,112 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import type { ServerRouter, Verdict } from '../src/index.ts';
+import type { ConnectMiddleware } from '../src/connect.ts';
+import { serverRouterPlugin } from '../src/vite.ts';
+
+const routerOf = (verdict: Verdict): ServerRouter => ({
+  resolve: () => Promise.resolve(verdict),
+});
+
+// A fake Vite server that just captures whatever middleware the plugin installs.
+const fakeServer = () => {
+  const installed: ConnectMiddleware[] = [];
+  return {
+    installed,
+    middlewares: { use: (mw: ConnectMiddleware) => installed.push(mw) },
+  };
+};
+
+describe('serverRouterPlugin', () => {
+  it('is a structural Vite plugin naming the package', () => {
+    const plugin = serverRouterPlugin(routerOf({ kind: 'notFound' }));
+    assert.equal(plugin.name, 'ui-router-server');
+    assert.equal(typeof plugin.configureServer, 'function');
+    assert.equal(typeof plugin.configurePreviewServer, 'function');
+  });
+
+  it('installs one middleware into both the dev and preview stacks', () => {
+    const plugin = serverRouterPlugin(routerOf({ kind: 'notFound' }));
+    const dev = fakeServer();
+    const preview = fakeServer();
+    plugin.configureServer(dev);
+    plugin.configurePreviewServer(preview);
+    assert.equal(dev.installed.length, 1);
+    assert.equal(preview.installed.length, 1);
+  });
+
+  it('installs the Connect adapter behaviour (a redirect answers 302)', async () => {
+    const plugin = serverRouterPlugin(
+      routerOf({
+        kind: 'redirect',
+        mount: '/app',
+        location: '/app/home',
+        status: 302,
+      }),
+    );
+    const server = fakeServer();
+    plugin.configureServer(server);
+    const middleware = server.installed[0];
+
+    let status = 0;
+    let location = '';
+    let nexted = false;
+    const req = {
+      url: '/app/legacy?ref=x',
+      method: 'GET',
+      headers: { accept: 'text/html' },
+    };
+    await new Promise<void>((resolve) => {
+      const res = {
+        writeHead: (s: number, headers?: unknown) => {
+          status = s;
+          location =
+            (headers as { Location?: string } | undefined)?.Location ?? '';
+          return res;
+        },
+        setHeader: () => res,
+        end: () => {
+          resolve();
+          return res;
+        },
+      };
+      middleware(req, res, () => {
+        nexted = true;
+        resolve();
+      });
+    });
+    assert.equal(status, 302);
+    assert.equal(location, '/app/home?ref=x'); // search merged, not passed through
+    assert.equal(nexted, false);
+  });
+
+  it('rewrites req.url and passes a shell into the downstream layer', async () => {
+    const plugin = serverRouterPlugin(
+      routerOf({ kind: 'shell', mount: '/app' }),
+    );
+    const server = fakeServer();
+    plugin.configureServer(server);
+    const middleware = server.installed[0];
+
+    const req = {
+      url: '/app/about',
+      method: 'GET',
+      headers: { accept: 'text/html' },
+    };
+    const link: string[] = [];
+    await new Promise<void>((resolve) => {
+      const res = {
+        writeHead: () => res,
+        setHeader: (_name: string, value: string) => {
+          link.push(value);
+          return res;
+        },
+        end: () => res,
+      };
+      middleware(req, res, () => resolve());
+    });
+    assert.equal(req.url, '/app'); // rewritten to the mount shell
+    assert.deepEqual(link, ['</app>; rel="canonical"']);
+  });
+});


### PR DESCRIPTION
Closes #309. First adapter pair, stacked on #304 (`feat/ui-router-server`). Two subpaths shipped together, both fronting the runtime-agnostic verdict API and inheriting its core-free boundary.

## `./connect`
`(req, res, next)` middleware covering every Connect-shaped stack — Express 4/5, bare Connect, Koa (`koa-connect`), Fastify (`@fastify/middie`), and Vite's dev/preview servers. The honest-status upgrade of the always-200 SPA fallback:
- **redirect** → `302` with the request search merged into the Location via `mergeSearch` (never `?a=1?b=2`)
- **shell** → canonical `Link` header, `req.url` rewritten to the mount and `next()`ed into `express.static`/`sirv`
- **status'd shell** (the `otherwise` 404 projection) → request validators stripped, downstream status relabeled at `writeHead`, no canonical Link
- **mount-owned miss** → honest `404`; **mountless miss / non-navigation** → `next()`

Dependency-free: structural request/response types declare the minimal `node:http` surface touched, so Node/Express/Connect objects fit without node types and the DOM-free compile still enforces runtime-neutrality.

## `./vite`
A thin plugin wiring that middleware into Vite's dev **and** preview stacks (both Connect-shaped), so `vite dev`/`vite preview` answer the same honest 302s/404s the production worker does — dev/prod routing parity from one mounts table. Installs in the **pre-position** (inside `configureServer`, before Vite's always-200 HTML fallback), exactly where `connect-history-api-fallback` sits; `shouldHandle` passes module/asset fetches. Vite stays a **type-only peer** the plugin never imports (structural plugin surface declared locally).

## Verification
- typecheck (src + tests) · lint · test — all green via `mise exec -- turbo run … --filter ui-router-server` (257 assertions).
- Tree-shake probe **extended**: both adapter entries bundle `@uirouter/core`-free (core stays behind the lazy simulate import).

## Provenance
`connect.ts` was recovered from an interrupted agent run (written, never committed); the `./connect`/`./vite` exports, the Vite plugin, and every test are new.

## Follow-up
#310 (generic `./fetch` adapter + Hono export) stacks on this branch next — not included here.