### PR TITLE
feat(docs): dev server adopts ui-router-server/vite (#309 dogfood)

### DIFF
--- a/docs/.vitepress/vite.config.ts
+++ b/docs/.vitepress/vite.config.ts
@@ -1,3 +1,6 @@
+import { createServerRouter } from 'ui-router-server';
+import { serverRouterPlugin } from 'ui-router-server/vite';
+import { mounts } from 'sample-app-routes';
 import { defineConfig, Plugin } from 'vite';
 import { viteStaticCopy } from 'vite-plugin-static-copy';
 
@@ -10,27 +13,40 @@ const EMBEDDED_EXAMPLES = ['helloworld', 'hellosolarsystem', 'hellogalaxy'];
 // compat-table/compat-table#2008) and has no lowering transform for it.
 const TARGET = ['chrome87', 'edge88', 'es2020', 'firefox78', 'safari14.1'];
 
+// The mount shells as the dev server serves them. Production (docs/worker)
+// serves each at its bare mount via Cloudflare's html_handling; the dev
+// server serves the static-copied files, so the paths carry `.html` and the
+// borrowed exhibits (/not-found-spa, /simulated-routing) point at the vanilla
+// shell — the SHELL_PATHS aliasing the worker does, in the dev host's terms.
+const SHELL_PATHS: Record<string, string> = {
+  '/app': '/app.html',
+  '/app-mobx': '/app-mobx.html',
+  '/not-found-spa': '/app.html',
+  '/simulated-routing': '/app.html',
+};
+
+// The dev-server twin of the docs worker: the SAME mounts table, resolved by
+// the SAME ui-router-server engine, so `vitepress dev` answers the honest
+// 302s and mount-owned 404s the production worker does — dev/prod routing
+// parity from one config, and the retirement of the always-200 SPA fallback
+// this file used to hand-roll. The plugin installs its middleware in the pre
+// position (before Vite's own HTML fallback); asset/module fetches pass
+// through its navigation gate untouched.
+const router = createServerRouter({ mounts });
+
 /**
- * Vite plugin to handle /app/* and /app-mobx/* deep linking in dev server.
- * Approximates the Cloudflare Worker (docs/worker/index.ts): deep links
- * under a sample-app mount serve that app's SPA html (no verdict logic here;
- * the worker owns 302s and real 404s, verified by the wrangler-backed e2e).
- * Also resolves /examples/<name>/ directory requests to their index.html
- * (production gets this from Cloudflare's static-asset index resolution).
+ * Directory requests for the embedded tutorial examples resolve to their
+ * built index.html (production gets this from Cloudflare's static-asset index
+ * resolution). Unrelated to routing — the examples use hash routing and carry
+ * no server verdicts — so it stays a plain rewrite beside the router plugin.
  */
-function spaFallbackPlugin(): Plugin {
+function examplesIndexPlugin(): Plugin {
   return {
-    name: 'spa-fallback',
+    name: 'examples-index-fallback',
     configureServer(server) {
       server.middlewares.use((req, _res, next) => {
-        const exampleDir = req.url?.match(/^\/examples\/([\w-]+)\/?$/);
-        if (exampleDir) {
-          req.url = `/examples/${exampleDir[1]}/index.html`;
-        } else if (req.url?.startsWith('/app-mobx')) {
-          req.url = '/app-mobx.html';
-        } else if (req.url?.startsWith('/app')) {
-          req.url = '/app.html';
-        }
+        const dir = req.url?.match(/^\/examples\/([\w-]+)\/?$/);
+        if (dir) req.url = `/examples/${dir[1]}/index.html`;
         next();
       });
     },
@@ -39,7 +55,20 @@ function spaFallbackPlugin(): Plugin {
 
 export default defineConfig({
   plugins: [
-    spaFallbackPlugin(),
+    serverRouterPlugin(router, {
+      shellPath: (mount) => SHELL_PATHS[mount] ?? mount,
+      // Dev parity with the worker's mount-owned 404: serve the mount's
+      // static-copied 404 page relabeled to an honest 404, not the adapter's
+      // text/plain default. The 304 guard mirrors the adapter's own relabel.
+      serveNotFound: (mount, req, res, next) => {
+        req.url = `${mount}/404.html`;
+        const writeHead = res.writeHead.bind(res);
+        res.writeHead = (status: number, ...rest: unknown[]) =>
+          writeHead(status === 304 ? 304 : 404, ...rest);
+        next();
+      },
+    }),
+    examplesIndexPlugin(),
     viteStaticCopy({
       targets: [
         {

--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -3,6 +3,10 @@
   "compilerOptions": {
     "module": "es2022",
     "moduleResolution": "bundler",
+    // The vite config consumes ui-router-server/sample-app-routes as source
+    // (workspace exports point at .ts), whose imports carry .ts extensions —
+    // the same allowance docs/worker/tsconfig.json already makes.
+    "allowImportingTsExtensions": true,
     "outDir": "dist",
     "rootDir": ".",
     "noEmit": true,


### PR DESCRIPTION
Stacks on **#341** (connect + vite) → **#342** (fetch + hono). First of the two dogfood layers; **review/merge after #341**.

## What

Retires the vitepress dev server's hand-rolled always-200 SPA fallback (`spaFallbackPlugin`) for `serverRouterPlugin` from `ui-router-server/vite`, fed the **same `sample-app-routes` mounts table** the docs worker resolves. `vitepress dev` now answers the honest **302s** and mount-owned **404s** production does — dev/prod routing parity from one table, and the first real consumer of the connect+vite adapter pair.

The retired plugin's own docstring conceded it *"approximates the Cloudflare Worker (docs/worker/index.ts)... no verdict logic here."* This closes that gap: the dev server and the worker are now twins over one routing engine.

## Division of labor (the dogfood lesson)

Generic verdict → HTTP mechanics live in the adapter; **host-specific policy rides its hooks**:

- **`shellPath`** maps each mount to the `.html` the dev server static-copies (the borrowed exhibits `/not-found-spa`, `/simulated-routing` point at the vanilla shell — the worker's `SHELL_PATHS` aliasing, in the dev host's terms).
- **`serveNotFound`** serves the mount's 404 page relabeled to an honest 404, not the adapter's `text/plain` default (304 guard mirrors the adapter's own relabel).
- The unrelated `/examples/<name>/` directory resolution stays a plain rewrite in its own small plugin beside the router.

`docs/tsconfig.json` gains `allowImportingTsExtensions` so the vite config can consume `ui-router-server`/`sample-app-routes` as source — the same allowance `docs/worker/tsconfig.json` already makes.

## Verification

Live `vitepress dev` (Accept: text/html):

| Request | Result |
|---|---|
| `/app` | `302` → `/app/welcome` |
| `/app?ref=hero` | `302` → `/app/welcome?ref=hero` (search merged) |
| `/app/<miss>` | `404` (mount-owned, via `serveNotFound`) |
| `/simulated-routing` | `302` → `/simulated-routing/welcome` (simulate tier) |
| `/not-found-spa/deep/link` | `404` (otherwise → status'd shell) |
| `/app-mobx/contacts` | `200` + `Link: </app-mobx>; rel="canonical"` |
| `/introduction`, `/guides/` | `200` pass-through to vitepress |
| `/app/foo.js` (Accept `*/*`) | `200` pass-through (navigation gate) |

`turbo`-scoped typecheck / lint / oxfmt clean for `docs` (the `typedoc-sidebar.json` "cannot find module" errors are the pre-existing fresh-checkout gap the config comment notes, generated by `docs:api`).

## Follow-up

The docs **worker** adopting `./fetch` is the second dogfood — stacked next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)