### PR TITLE
test(e2e): PASS/FAIL banner + timing for concurrent Cypress suites

### DIFF
--- a/apps/sample-app-lit-e2e/package.json
+++ b/apps/sample-app-lit-e2e/package.json
@@ -12,7 +12,7 @@
     "lint": "oxlint .",
     "test": "start-server-and-test docs:start-server 'http://localhost:8787/app/|http://localhost:8787/app-mobx/' test:cypress:all",
     "test:cypress": "cypress run",
-    "test:cypress:all": "concurrently --names vanilla,mobx,docs,hash,navigation --prefix-colors auto \"pnpm run test:cypress\" \"pnpm run test:cypress:mobx\" \"pnpm run test:cypress:docs\" \"pnpm run test:cypress:hash\" \"pnpm run test:cypress:navigation\"",
+    "test:cypress:all": "node ./scripts/run-cypress-suites.ts",
     "test:cypress:docs": "cypress run --config-file cypress.docs.config.ts",
     "test:cypress:hash": "cypress run --expose LOCATION_PLUGIN=hash --config videosFolder=cypress/videos-hash,screenshotsFolder=cypress/screenshots-hash",
     "test:cypress:mobx": "cypress run --config baseUrl=http://localhost:8787/app-mobx/,videosFolder=cypress/videos-mobx,screenshotsFolder=cypress/screenshots-mobx",
@@ -25,6 +25,7 @@
   },
   "devDependencies": {
     "@types/lodash": "catalog:",
+    "@types/node": "catalog:",
     "concurrently": "catalog:",
     "cypress": "catalog:",
     "oxfmt": "catalog:",

--- a/apps/sample-app-lit-e2e/scripts/run-cypress-suites.ts
+++ b/apps/sample-app-lit-e2e/scripts/run-cypress-suites.ts
@@ -1,0 +1,71 @@
+import { concurrently, type CloseEvent } from 'concurrently';
+
+// The five Cypress suites share one dev server (started by `test` via
+// start-server-and-test), so running them concurrently is pure wall-clock win.
+// concurrently already fails the run when any suite exits non-zero; this wrapper
+// adds a per-suite timing table and an unambiguous PASS/FAIL banner on top, and
+// propagates the failure through process.exitCode.
+const suites = [
+  { name: 'vanilla', command: 'pnpm run test:cypress' },
+  { name: 'mobx', command: 'pnpm run test:cypress:mobx' },
+  { name: 'docs', command: 'pnpm run test:cypress:docs' },
+  { name: 'hash', command: 'pnpm run test:cypress:hash' },
+  { name: 'navigation', command: 'pnpm run test:cypress:navigation' },
+];
+
+const passed = (event: CloseEvent) => event.exitCode === 0;
+
+function summarize(events: CloseEvent[]): void {
+  if (events.length === 0) {
+    console.error('\n✗ e2e tests failed — no Cypress suites spawned\n');
+    process.exitCode = 1;
+    return;
+  }
+
+  const ordered = [...events].sort((a, b) => a.index - b.index);
+  const failures = ordered.filter((event) => !passed(event));
+  const nameWidth = Math.max(
+    ...ordered.map((event) => event.command.name.length),
+  );
+  // True wall clock across the concurrent run, not the sum of suite durations.
+  const startMs = Math.min(
+    ...ordered.map((event) => event.timings.startDate.getTime()),
+  );
+  const endMs = Math.max(
+    ...ordered.map((event) => event.timings.endDate.getTime()),
+  );
+  const wall = `${((endMs - startMs) / 1000).toFixed(1)}s`;
+
+  console.log('\ne2e cypress suites:');
+  for (const event of ordered) {
+    const mark = passed(event) ? '✓' : '✗';
+    const name = event.command.name.padEnd(nameWidth);
+    const secs = `${event.timings.durationSeconds.toFixed(1)}s`.padStart(7);
+    const detail = passed(event) ? '' : `  (exit ${event.exitCode})`;
+    console.log(`  ${mark} ${name}  ${secs}${detail}`);
+  }
+
+  if (failures.length === 0) {
+    console.log(
+      `\n✓ e2e tests passed — ${ordered.length}/${ordered.length} suites in ${wall}\n`,
+    );
+  } else {
+    console.log(
+      `\n✗ e2e tests failed — ${failures.length}/${ordered.length} suites failed in ${wall}\n`,
+    );
+    process.exitCode = 1;
+  }
+}
+
+try {
+  summarize(await concurrently(suites, { prefixColors: 'auto' }).result);
+} catch (reason) {
+  // concurrently rejects with the CloseEvent[] on suite failure; anything else
+  // (e.g. a spawn error) is a genuine harness failure.
+  if (Array.isArray(reason)) {
+    summarize(reason as CloseEvent[]);
+  } else {
+    console.error('\n✗ e2e tests failed to run:', reason);
+    process.exitCode = 1;
+  }
+}

--- a/apps/sample-app-lit-e2e/tsconfig.json
+++ b/apps/sample-app-lit-e2e/tsconfig.json
@@ -2,11 +2,11 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "allowJs": true,
-    "types": ["cypress"],
+    "types": ["cypress", "node"],
     "noEmit": true,
     "outDir": "dist",
     "rootDir": "."
   },
-  "include": ["src/**/*", "cypress*.config.ts"],
+  "include": ["src/**/*", "scripts/**/*", "cypress*.config.ts"],
   "exclude": ["node_modules", "dist"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -299,6 +299,9 @@ importers:
       '@types/lodash':
         specifier: 'catalog:'
         version: 4.17.24
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.13.2
       concurrently:
         specifier: 'catalog:'
         version: 10.0.3
@@ -316,7 +319,7 @@ importers:
         version: '@typescript/typescript6@6.0.2'
       vite:
         specifier: 'catalog:'
-        version: 8.1.3(@types/node@25.0.9)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)
+        version: 8.1.3(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)
 
   apps/sample-app-lit-mobx:
     dependencies:


### PR DESCRIPTION
## What

`apps/sample-app-lit-e2e` fanned its five Cypress suites (vanilla, mobx, docs, hash, navigation) out through a raw `concurrently` CLI line. That leaf `test` script is the last thing `turbo run ci` drives, and its only end-of-run signal was five `… exited with code N` lines — no at-a-glance verdict.

This swaps the CLI line for a thin wrapper on concurrently's **programmatic API** (`apps/sample-app-lit-e2e/scripts/run-cypress-suites.ts`), invoked via `test:cypress:all = node ./scripts/run-cypress-suites.ts`. Same parallelism, same colored prefixes, plus:

- a **per-suite timing table** (✓/✗, wall-clock duration, exit code on failure),
- an unambiguous **PASS/FAIL banner** (`✓ e2e tests passed — 5/5 suites in Ns` / `✗ e2e tests failed — k/5 suites failed`),
- failure propagated through `process.exitCode`.

```
e2e cypress suites:
  ✓ vanilla     38.2s
  ✓ mobx        40.1s
  ✗ docs        12.4s  (exit 1)
  ✓ hash        35.0s
  ✓ navigation  36.7s

✗ e2e tests failed — 1/5 suites failed in 40.1s
```

## Why here, not `tools/`

The wrapper is the e2e app's own test orchestration, so it lives in the app rather than graduating to a shared tool — per the scripts-vs-tools boundary (own deps/config/turbo task, not merely a second file). `concurrently` already exited non-zero on any suite failure; this only adds reporting.

## Verification

- Smoke run against the pinned `concurrently@10.0.3`: all-green → exit **0** + `✓ … 5/5 suites`; one injected failure → exit **1** + `✗ … 1/5 suites failed` with the failing suite flagged `(exit 1)`.
- `tsc` (build), `oxlint`, `oxfmt --check`, and `node --check` on the real file: all clean.
- Did **not** run the full 5-suite e2e (needs Playwright browsers + Cypress binary + wrangler dev server) — the underlying suite commands are unchanged; only their orchestration/reporting changed.

## Note

Branched off `main`. Aware of the in-flight tooling overhaul in **#340** (`tools/build_and_test` + `tools/shared`, retiring `scripts/`) and **#331**. This change is independent of both; if those land first, this wrapper is an easy candidate to migrate into `tools/build_and_test` behind a `workspace:*` bin.