### PR TITLE
docs: collapse top nav into a Docs dropdown

### DIFF
--- a/apps/sample-app-lit-e2e/src/docs/docs_site.cy.js
+++ b/apps/sample-app-lit-e2e/src/docs/docs_site.cy.js
@@ -16,6 +16,10 @@ describe('docs site', () => {
     cy.window().then((win) => {
       win.hydrationProbe = true;
     });
+    // "Guides" now lives in the "Docs" nav flyout, which VitePress opens on
+    // mouseenter. A plain button click races that handler — mouseenter opens
+    // it, then the button's own click toggles it shut — so hover to reveal.
+    cy.contains('.VPNavBar .VPFlyout', 'Docs').trigger('mouseenter');
     cy.get('a[href="/guides/"]').first().click();
     cy.location('pathname').should('eq', '/guides/');
     // A full reload drops the probe; surviving it proves the client router

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -103,10 +103,15 @@ const config = {
     logo: '/images/lit-ui-router.svg',
     nav: [
       { text: 'Home', link: '/' },
-      { text: 'Introduction', link: '/introduction' },
-      { text: 'Tutorial', link: '/tutorial/helloworld' },
-      { text: 'Guides', link: '/guides/' },
-      { text: 'API', link: '/api/' },
+      {
+        text: 'Docs',
+        items: [
+          { text: 'Introduction', link: '/introduction' },
+          { text: 'Tutorial', link: '/tutorial/helloworld' },
+          { text: 'Guides', link: '/guides/' },
+          { text: 'API', link: '/api/' },
+        ],
+      },
       {
         text: 'Sample App',
         items: [


### PR DESCRIPTION
Collapses the four top-nav links **Introduction · Tutorial · Guides · API** into a single **Docs** dropdown, positioned between **Home** and the existing **Sample App** dropdown.

Follows the VitePress nav convention already used by the Sample App dropdown (a `{ text, items: [...] }` group). The four destination links are unchanged; only their top-level grouping changes. Sidebar is untouched.

## Nav before
`Home · Introduction · Tutorial · Guides · API · Sample App▾`

## Nav after
`Home · Docs▾ (Introduction, Tutorial, Guides, API) · Sample App▾`