### PR TITLE
feat(sample-app): dedicated /app-hash mount for hash-location routing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 # compiled output
 dist
+dist-hash
 tmp
 
 # dependencies

--- a/apps/sample-app-lit-e2e/package.json
+++ b/apps/sample-app-lit-e2e/package.json
@@ -14,7 +14,7 @@
     "test:cypress": "cypress run",
     "test:cypress:all": "node ./scripts/run-cypress-suites.ts",
     "test:cypress:docs": "cypress run --config-file cypress.docs.config.ts",
-    "test:cypress:hash": "cypress run --expose LOCATION_PLUGIN=hash --config videosFolder=cypress/videos-hash,screenshotsFolder=cypress/screenshots-hash",
+    "test:cypress:hash": "cypress run --expose LOCATION_PLUGIN=hash --config baseUrl=http://localhost:8787/app-hash/,videosFolder=cypress/videos-hash,screenshotsFolder=cypress/screenshots-hash",
     "test:cypress:mobx": "cypress run --config baseUrl=http://localhost:8787/app-mobx/,videosFolder=cypress/videos-mobx,screenshotsFolder=cypress/screenshots-mobx",
     "test:cypress:navigation": "cypress run --expose LOCATION_PLUGIN=navigation --config videosFolder=cypress/videos-navigation,screenshotsFolder=cypress/screenshots-navigation",
     "test:hash": "start-server-and-test docs:start-server http://localhost:8787/app/ test:cypress:hash",

--- a/apps/sample-app-lit-e2e/src/docs/docs_site.cy.js
+++ b/apps/sample-app-lit-e2e/src/docs/docs_site.cy.js
@@ -105,6 +105,43 @@ describe('docs site', () => {
     }
   });
 
+  it('302s the flagship mount root — hash mode is not first-class there', () => {
+    // A hash client enters at the bare mount; the browser GETs it with the
+    // route in the (unsent) fragment. The flagship root 302s to /welcome,
+    // moving the browser to a new path — so a flagship mount can't host a hash
+    // app. That limitation is the reason for the dedicated /app-hash mount.
+    for (const mount of ['/app', '/app-mobx']) {
+      cy.request({ url: mount, followRedirect: false }).then((response) => {
+        expect(response.status, mount).to.eq(302);
+        expect(response.headers.location, mount).to.eq(`${mount}/welcome`);
+      });
+    }
+  });
+
+  it('serves the hash-demo shell at 200 at its root, with no redirect', () => {
+    // The dedicated hash mount: the fragment carries the route, so the server
+    // only ever sees the bare mount and must serve the shell there without a
+    // 302 (a redirect would strip the fragment's route on entry). Both the
+    // bare and trailing-slash forms answer 200 with the hash shell; the mount
+    // is a real demo, not an exhibit, so it stays indexable.
+    for (const url of ['/app-hash', '/app-hash/']) {
+      cy.request({ url, followRedirect: false }).then((response) => {
+        expect(response.status, url).to.eq(200);
+        expect(response.body, url).to.include(
+          '<title>UI-Router Lit sample app',
+        );
+        expect(response.headers, url).to.not.have.property('x-robots-tag');
+      });
+    }
+    // A mistyped deep path (never produced by a hash client) is an honest 404.
+    cy.request({
+      url: '/app-hash/no/such/route',
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status).to.eq(404);
+    });
+  });
+
   it('serves the shell at 200 for everything under the naive exhibit', () => {
     // The not-found-naive rung: the classic SPA-host fallback (the soft-404
     // anti-pattern baseline) — no server routing at all.

--- a/apps/sample-app-lit-e2e/src/support/e2e.ts
+++ b/apps/sample-app-lit-e2e/src/support/e2e.ts
@@ -28,10 +28,12 @@ export function visitWithFeatures(
   features: Record<string, string> = {},
 ) {
   const { query, isHashMode } = featureQuery(features);
-  // Hash-mode visits target the bare mount (`/app`, not `/app/`): the worker
-  // 302s the mount root to /welcome, which would rewrite the path under the
-  // hash on every visit; the bare mount serves the shell directly, and
-  // consecutive visits differ only by hash, as hash routing intends.
+  // Hash-mode visits target the bare mount (`/app-hash`, not `/app-hash/`):
+  // the dedicated hash mount serves the shell at 200 there with no redirect
+  // (the flagship mounts 302 their root to /welcome, which would rewrite the
+  // path under the hash on every visit — the reason hash mode gets its own
+  // mount). Consecutive visits then differ only by hash, as hash routing
+  // intends.
   const root = (Cypress.config('baseUrl') ?? '').replace(/\/+$/, '');
   const url = query
     ? isHashMode

--- a/apps/sample-app-lit-vanilla/.env.hash
+++ b/apps/sample-app-lit-vanilla/.env.hash
@@ -1,0 +1,6 @@
+# `vite build --mode hash` layers these over .env: the hash-location sibling
+# shell (docs serves it at /app-hash) boots in hash mode with its own base, so
+# a real visitor gets clean `/app-hash#/route` urls, not the flag-seeded path
+# the e2e used to drive. GA id and trace inherit from .env.
+VITE_SAMPLE_APP_BASE_URL=/app-hash/
+VITE_SAMPLE_APP_LOCATION_PLUGIN=hash

--- a/apps/sample-app-lit-vanilla/package.json
+++ b/apps/sample-app-lit-vanilla/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "build": "vite build",
+    "build:hash": "vite build --mode hash --outDir dist-hash",
     "codecov:bundle": "node ../../scripts/upload-bundle-stats.ts sample-app-lit-vanilla-esm",
     "dev": "vite",
     "format": "oxfmt \"**/*.{js,ts,json,md,html}\"",

--- a/apps/sample-app-lit-vanilla/turbo.json
+++ b/apps/sample-app-lit-vanilla/turbo.json
@@ -8,7 +8,18 @@
         "VITE_SAMPLE_APP_BASE_URL",
         "VITE_SAMPLE_APP_PUSH_STATE"
       ],
-      "dependsOn": ["^build", "^transit"]
+      "dependsOn": ["^build", "^transit"],
+      "outputs": ["dist/**"],
+      "with": ["build:hash"]
+    },
+    "build:hash": {
+      "env": [
+        "VITE_GOOGLE_ANALYTICS_TRACKING_ID",
+        "VITE_SAMPLE_APP_BASE_URL",
+        "VITE_SAMPLE_APP_PUSH_STATE"
+      ],
+      "dependsOn": ["^build", "^transit"],
+      "outputs": ["dist-hash/**"]
     }
   }
 }

--- a/apps/sample-app-routes/src/routes.ts
+++ b/apps/sample-app-routes/src/routes.ts
@@ -69,15 +69,31 @@ const simulatedRoutingDemo: MountConfig = {
   otherwise: { state: 'notFound' },
 };
 
+// The hash-location demo: a hash client keeps the whole route in the fragment,
+// so the server only ever sees the bare mount — and it MUST serve the shell at
+// 200 there. A redirect at the root (the flagship's `/` -> welcome rule) would
+// 302 the mount, and a 302 sends the browser to a new path, stripping the
+// route the hash client entered with; that is exactly why hash mode is not
+// first-class at the flagship mounts. A single url-less-prefix root route
+// (`url: ''`) matches the empty subpath to a shell verdict with no redirect;
+// `strict: false` extends it to the trailing-slash form (`/app-hash/`). Deep
+// paths never occur under a hash client, so they stay honest 404s.
+const hashDemo: MountConfig = {
+  routes: [{ name: 'root', url: '' }],
+  config: { strict: false },
+};
+
 /**
  * Both sample apps run the same route tree, each under its own mount
  * (not-found-static); the demo mounts exhibit the not-found-spa and
  * simulated-routing rungs (not-found-naive lives worker-side — it is the
- * absence of routing config).
+ * absence of routing config), and /app-hash the hash-location shape (shell at
+ * the root, no redirect, so the fragment survives entry).
  */
 export const mounts: Record<string, MountConfig> = {
   '/app': app,
   '/app-mobx': app,
+  '/app-hash': hashDemo,
   '/not-found-spa': notFoundSpaDemo,
   '/simulated-routing': simulatedRoutingDemo,
 };

--- a/apps/sample-app-routes/test/routes.test.ts
+++ b/apps/sample-app-routes/test/routes.test.ts
@@ -92,6 +92,33 @@ for (const mount of ['/app', '/app-mobx']) {
   });
 }
 
+describe('/app-hash verdicts (the hash-location demo)', () => {
+  it('serves the shell at the mount root, with and without the slash', async () => {
+    // A hash client keeps the whole route in the fragment, so the server only
+    // ever sees the bare mount and must serve the shell there with NO redirect
+    // (a 302 would strip the fragment's route on entry — the reason hash mode
+    // is not first-class at the flagship mounts). strict:false pins the
+    // trailing-slash form to the same shell verdict.
+    for (const path of ['', '/']) {
+      assert.deepEqual(
+        await router.resolve(`/app-hash${path}`),
+        { kind: 'shell', mount: '/app-hash' },
+        `/app-hash${path}`,
+      );
+    }
+  });
+
+  it('reports notFound for deep paths (a hash client never produces them)', async () => {
+    for (const path of ['/welcome', '/contacts/3', '/no/such/route']) {
+      assert.deepEqual(
+        await router.resolve(`/app-hash${path}`),
+        { kind: 'notFound', mount: '/app-hash' },
+        `/app-hash${path}`,
+      );
+    }
+  });
+});
+
 describe('/not-found-spa verdicts (the not-found-spa exhibit)', () => {
   it('serves the shell at 404 for every path under the mount', async () => {
     // The otherwise projection: the shell IS the error page, at an honest
@@ -146,6 +173,7 @@ describe('mounts', () => {
     assert.deepEqual(Object.keys(mounts), [
       '/app',
       '/app-mobx',
+      '/app-hash',
       '/not-found-spa',
       '/simulated-routing',
     ]);

--- a/docs/.vitepress/vite.config.ts
+++ b/docs/.vitepress/vite.config.ts
@@ -21,6 +21,9 @@ const TARGET = ['chrome87', 'edge88', 'es2020', 'firefox78', 'safari14.1'];
 const SHELL_PATHS: Record<string, string> = {
   '/app': '/app.html',
   '/app-mobx': '/app-mobx.html',
+  // The hash demo has its own shell (base href /app-hash/, hash location baked
+  // at build), not the vanilla one the exhibits borrow.
+  '/app-hash': '/app-hash.html',
   '/not-found-spa': '/app.html',
   '/simulated-routing': '/app.html',
 };
@@ -89,6 +92,19 @@ export default defineConfig({
           dest: '',
           rename: 'app-mobx.html',
         },
+        // The hash-location sibling shell: the vanilla app's second build
+        // (`vite build --mode hash`), hash location + `/app-hash/` base baked
+        // in. Its bundle is content-hashed against different env, so it
+        // coexists with the vanilla one under /assets.
+        {
+          src: 'node_modules/sample-app-lit-vanilla/dist-hash/assets/*',
+          dest: 'assets',
+        },
+        {
+          src: 'node_modules/sample-app-lit-vanilla/dist-hash/index.html',
+          dest: '',
+          rename: 'app-hash.html',
+        },
         // Per-mount 404 pages: the worker (docs/worker/index.ts) serves
         // <mount>/404.html with status 404 for unmatched paths in a mount.
         {
@@ -98,6 +114,12 @@ export default defineConfig({
         {
           src: 'node_modules/sample-app-lit-mobx/dist/404.html',
           dest: 'app-mobx',
+        },
+        // Hash deep paths (`/app-hash/foo`) never happen under a hash client,
+        // but a mistyped one gets the same honest 404 page as the other mounts.
+        {
+          src: 'node_modules/sample-app-lit-vanilla/dist-hash/404.html',
+          dest: 'app-hash',
         },
         // images/ and static/ come from sample-app-shared and are identical
         // in both apps' dists; copy once so neither can silently clobber.

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -11,16 +11,20 @@
     // Sample-app deep links and the 404-pattern exhibits invoke the worker;
     // other misses serve 404.html. EVERY mount lists its bare path too, not
     // just the `/*` wildcard: a `/*` pattern matches `/app/foo` but NOT the
-    // bare mount root `/app`, and the root is exactly where the redirect
-    // verdict lives (the `/` -> welcome rule). Omit the bare path and
-    // html_handling serves the shell asset (/app.html) at 200 before the
-    // worker runs, silently shadowing the 302. The exhibits also need their
-    // bare paths because no asset exists there — the whole prefix is the demo.
+    // bare mount root `/app`, and the root is exactly where the verdict that
+    // differs from the plain asset lives — the flagship's `/` -> welcome 302,
+    // and /app-hash's shell-at-200 (its own `app-hash.html`, not the vanilla
+    // shell html_handling would serve at `/app-hash`). Omit the bare path and
+    // html_handling answers before the worker runs, shadowing that verdict.
+    // The exhibits also need their bare paths because no asset exists there —
+    // the whole prefix is the demo.
     "run_worker_first": [
       "/app",
       "/app/*",
       "/app-mobx",
       "/app-mobx/*",
+      "/app-hash",
+      "/app-hash/*",
       "/not-found-naive",
       "/not-found-naive/*",
       "/not-found-spa",


### PR DESCRIPTION
Stacked on #346 (`feat/server-routing`). Split out of that branch so the hash-location demo reviews on its own.

## What

The `[hash]` e2e suite regressed when bare `/app` began 302-ing (so the flagship root honestly redirects to `/welcome`): the hash suite entered at the bare mount, and a hash client can't survive a redirect there — the browser GETs the bare mount with the route in the (unsent) fragment, and a 302 moves it off the entry path.

Rather than weaken the flagship verdict, hash mode gets its **own mount**:

- **Flagship keeps its root 302.** Path-location is first-class; hash mode is explicitly not first-class there.
- **`/app-hash` serves the shell at 200 at its root, no redirect** — a `url: ''` root route (`strict: false` for the trailing-slash form). Deep paths never occur under a hash client, so they stay honest 404s.
- **Visible docs demo, not just an e2e seed.** The sibling shell is the vanilla app's `build:hash` (`vite build --mode hash`), with hash location + `/app-hash/` base baked in via `.env.hash`, so a real visitor gets clean `/app-hash#/route` URLs. The two builds run in parallel as sibling turbo tasks (`build` `with` `build:hash`), each with its own outputs + cache entry.
- **e2e:** the hash suite retargets from `/app` to `/app-hash`; `docs_site` gains explicit tests for the flagship-root 302 (the limitation) and the `/app-hash` shell-at-200.

## Verification

- All 5 e2e suites green locally (hash 27/27 against `/app-hash`, docs 14/14 with the 2 new server-verdict tests).
- Typecheck / lint / format clean on the touched packages.
- `with` parallelizes the two builds and still feeds `dist-hash` to the docs copy through `^build`; both builds cache + restore independently.
