### PR TITLE
docs: companion API sidebar — package-name headings, category grouping

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -55,11 +55,11 @@ function makeSidebar() {
         { text: 'Overview', link: '/packages/' },
         {
           text: 'MobX',
+          link: '/packages/mobx',
           collapsed: true,
           items: [
-            { text: 'lit-ui-router-mobx', link: '/packages/mobx' },
             {
-              text: 'API',
+              text: 'lit-ui-router-mobx',
               link: '/api/lit-ui-router-mobx/',
               collapsed: false,
               items: mobxSidebarItems,
@@ -68,14 +68,11 @@ function makeSidebar() {
         },
         {
           text: 'Navigation Location',
+          link: '/packages/navigation-plugin',
           collapsed: true,
           items: [
             {
               text: 'ui-router-navigation-location-plugin',
-              link: '/packages/navigation-plugin',
-            },
-            {
-              text: 'API',
               link: '/api/navigation-location-plugin/',
               collapsed: false,
               items: navigationSidebarItems,

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -7,19 +7,12 @@ import navigationSidebarItemsJson from '../api/navigation-location-plugin/typedo
 
 const typedocSidebarItems =
   typedocSidebarItemsJson as DefaultTheme.SidebarItem[];
-
-// The companion references are small; their kind grouping (Classes,
-// Interfaces, …) adds a sidebar level without earning it. Flatten the groups
-// into a single member list so the API entries sit flat under "API" — the
-// grouped listing still lives on each reference's index page.
-function flattenGroups(
-  items: DefaultTheme.SidebarItem[],
-): DefaultTheme.SidebarItem[] {
-  return items.flatMap((item) => (item.items ? item.items : [item]));
-}
-
-const mobxSidebarItems = flattenGroups(mobxSidebarItemsJson);
-const navigationSidebarItems = flattenGroups(navigationSidebarItemsJson);
+// The companion references carry their kind categories (Classes, Interfaces,
+// …) collapsed, mirroring how the flagship reference groups members — each
+// category heading links to its generated kind-index page.
+const mobxSidebarItems = mobxSidebarItemsJson as DefaultTheme.SidebarItem[];
+const navigationSidebarItems =
+  navigationSidebarItemsJson as DefaultTheme.SidebarItem[];
 
 const baseUrl = 'https://lit-ui-router.dev';
 
@@ -107,7 +100,7 @@ function makeSidebar() {
         {
           text: 'lit-ui-router',
           link: '/api/reference/',
-          collapsed: false,
+          collapsed: true,
           items: typedocSidebarItems,
         },
       ],

--- a/docs/packages/mobx.md
+++ b/docs/packages/mobx.md
@@ -3,7 +3,7 @@ title: MobX Bindings
 description: Observable router state and reaction-based controllers with lit-ui-router-mobx
 ---
 
-# MobX Bindings (lit-ui-router-mobx)
+# lit-ui-router-mobx
 
 <p class="badges">
 <a href="https://www.npmjs.com/package/lit-ui-router-mobx" target="_blank" class="badge"><img alt="NPM Version" src="https://img.shields.io/npm/v/lit-ui-router-mobx" /></a>

--- a/docs/packages/navigation-plugin.md
+++ b/docs/packages/navigation-plugin.md
@@ -3,7 +3,7 @@ title: Navigation API Plugin
 description: Manage URLs with the modern browser Navigation API using ui-router-navigation-location-plugin
 ---
 
-# Navigation API Plugin
+# ui-router-navigation-location-plugin
 
 <p class="badges">
 <a href="https://www.npmjs.com/package/ui-router-navigation-location-plugin" target="_blank" class="badge"><img alt="NPM Version" src="https://img.shields.io/npm/v/ui-router-navigation-location-plugin" /></a>


### PR DESCRIPTION
Stacked on #346 (`feat/server-routing`), following the merge of #353.

Sidebar/API polish for the companion packages:

- **Package-name H1s** — `packages/mobx.md` → `# lit-ui-router-mobx`; `packages/navigation-plugin.md` → `# ui-router-navigation-location-plugin`.
- **Un-flatten companion API** — restore the kind categories (Classes, Interfaces, …) in the sidebar so companion references group by category like the flagship; category headings link to their generated kind-index pages.
- **Companion API node = package name, guide on header** — each companion group header (MobX, Navigation Location) links to its guide; its single child is the package-named API reference (expanded) holding the collapsed categories — mirroring the flagship's package-node-plus-categories shape.
- **Flagship API default-collapsed** — the `lit-ui-router` reference node now starts collapsed.