### PR TITLE
docs(sidebar): flatten companion API members under the package node

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -7,12 +7,19 @@ import navigationSidebarItemsJson from '../api/navigation-location-plugin/typedo
 
 const typedocSidebarItems =
   typedocSidebarItemsJson as DefaultTheme.SidebarItem[];
-// The companion references carry their kind categories (Classes, Interfaces,
-// …) collapsed, mirroring how the flagship reference groups members — each
-// category heading links to its generated kind-index page.
-const mobxSidebarItems = mobxSidebarItemsJson as DefaultTheme.SidebarItem[];
-const navigationSidebarItems =
-  navigationSidebarItemsJson as DefaultTheme.SidebarItem[];
+// The companion references are small, and their kind categories (Classes,
+// Interfaces, …) are generic — unlike the flagship's semantic categories
+// (Core, Components, …). Flatten them into a single member list under the
+// package-name API node; the grouped listing still lives on the reference's
+// index page and the kind-index pages stay reachable by URL.
+function flattenGroups(
+  items: DefaultTheme.SidebarItem[],
+): DefaultTheme.SidebarItem[] {
+  return items.flatMap((item) => (item.items ? item.items : [item]));
+}
+
+const mobxSidebarItems = flattenGroups(mobxSidebarItemsJson);
+const navigationSidebarItems = flattenGroups(navigationSidebarItemsJson);
 
 const baseUrl = 'https://lit-ui-router.dev';
 

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -66,7 +66,7 @@ function makeSidebar() {
           collapsed: true,
           items: [
             {
-              text: 'lit-ui-router-mobx',
+              text: 'lit-ui-router-mobx API',
               link: '/api/lit-ui-router-mobx/',
               collapsed: false,
               items: mobxSidebarItems,
@@ -79,7 +79,7 @@ function makeSidebar() {
           collapsed: true,
           items: [
             {
-              text: 'ui-router-navigation-location-plugin',
+              text: 'navigation-location-plugin API',
               link: '/api/navigation-location-plugin/',
               collapsed: false,
               items: navigationSidebarItems,


### PR DESCRIPTION
Stacked on #346 (`feat/server-routing`), after #356.

#356 un-flattened the companion API sidebars into their Classes/Interfaces kind categories to mirror the flagship. But those kind categories are **generic** — unlike the flagship's **semantic** categories (Core, Components, Controllers, …), which carry real grouping information. So the companion members read better as a flat list.

This restores the `flatMap` flatten on the companion references only:

- **`lit-ui-router-mobx`** / **`ui-router-navigation-location-plugin`** API nodes now hold a flat member list (no Classes/Interfaces sub-groups).
- **Flagship keeps its semantic categories** — unchanged.
- The grouped listing still lives on each reference's index page, and the generated kind-index pages (e.g. `/api/lit-ui-router-mobx/classes/`) stay reachable by URL.

Package-name API node + guide-on-header structure from #356 is preserved; only the members flatten.