### PR TITLE
chore(ci): post-canary hardening — cache:false on PAT jobs + tag idempotency comment

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -79,6 +79,10 @@ jobs:
         with:
           # task-env handling regressed before in unpinned mise; pin the version
           version: 2026.6.14
+          # no restored tool cache (zizmor cache-poisoning): this job checks out
+          # with a persisted PAT, so a poisoned cache would run adjacent to live
+          # push credentials. Tools install fresh, checksum-verified against mise.lock.
+          cache: false
       - name: Install dependencies
         run: mise run setup
       - name: Setup Git user

--- a/.github/workflows/publish-gh.yml
+++ b/.github/workflows/publish-gh.yml
@@ -63,13 +63,18 @@ jobs:
         with:
           # task-env handling regressed before in unpinned mise; pin the version
           version: 2026.6.14
+          # no restored tool cache (zizmor cache-poisoning): this job checks out
+          # with a persisted PAT, so a poisoned cache would run adjacent to live
+          # push credentials. Tools install fresh, checksum-verified against mise.lock.
+          cache: false
       - name: Install dependencies
         run: mise run setup
       - name: Setup Git user
         run: mise run //tools/release:git_user
       - name: Tag
         run: mise run //tools/release:tag
-        # continue-on-error: Tagging is idempotent - if tag exists, we succeed anyway
+        # continue-on-error: re-tagging an existing version fails here (release-it
+        # errors, not a no-op); continue-on-error lets the run proceed anyway.
         continue-on-error: true
         env:
           PACKAGE: ${{ matrix.package }}

--- a/tools/release/src/steps/release-tag.ts
+++ b/tools/release/src/steps/release-tag.ts
@@ -4,9 +4,9 @@
 // release-it tags locally only (--git.push false): pushing main + tag
 // together is release-it's rollback trap, so the tag ref is pushed
 // separately by release-tag-push.ts. The workflow keeps
-// continue-on-error on this step — tagging is idempotent, an existing
-// tag fails here and that is fine. argv comes from the engine seam
-// (release-it.core.ts).
+// continue-on-error on this step — re-tagging an existing version fails
+// here (release-it errors, not a no-op) and that is fine. argv comes from
+// the engine seam (release-it.core.ts).
 
 import { boolEnv, requireEnv } from '@tools/shared/env.core.ts';
 import { group, runMain } from '@tools/shared/gha.ts';


### PR DESCRIPTION
Post-canary release-pipeline hardening from the #331 review — closes items **1** and **3** of #336, now unblocked since the merged pipeline was proven by the live `lit-ui-router@1.7.1-canary.0` canary.

## 1. `cache: false` on the PAT-bearing jobs

#331 disabled the mise tool cache only on `publish-npm` (OIDC, no persisted credentials). The two jobs that check out with a **persisted `GH_PERSONAL_ACCESS_TOKEN`** — `bump-version` and `publish-gh` — still restored a shared tool cache, so a poisoned cache would execute adjacent to live push credentials. That's the precise cache-poisoning adjacency zizmor's `cache-poisoning` audit is about. Both now install tools fresh, checksum-verified against `mise.lock`, matching `publish-npm`.

## 3. Correct the "Tagging is idempotent" comment drift

The `publish-gh` Tag step is **not** idempotent: re-tagging an existing version makes release-it error — `continue-on-error` is what lets the run proceed, not a no-op. Corrected the workflow prose (`publish-gh.yml`) and the mirrored source comment (`release-tag.ts`) to describe the actual behavior. Comment-only.

## Not in scope (staying on #336)

- **Item 2** (`release_tag` PAT probe): effectively pre-answered by the in-file comment — a `GITHUB_TOKEN` push does not cross-trigger `publish-npm`, so the PAT is required by design. Left as a note on #336, not a code change.
- **Carry-overs**: release-it's first-release `secondLatestTag` bug + the upstream `tagMatch` / plugin silent-empty-fallback filings remain open on #336 for upstreaming — deliberately not closed.

## Verification

- `mise run lint_workflows` (actionlint + zizmor) — **0 findings, 3 honest ignores**; the two new `cache: false` keys add no findings.
- The `release-tag.ts` change is comment-only (no behavior/typecheck impact).
- Note: `bump-version`/`publish-gh` were **not** exercised by the decoupled throwaway-tag canary (which drove `publish-npm` directly), so these two jobs remain design-verified pending a real bump→tag run.