### PR TITLE
fix(docs): render real routes client-side under the aliased exhibit mounts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 
 # compiled output
 dist
-dist-hash
+dist-*
 tmp
 
 # dependencies

--- a/apps/sample-app-lit-e2e/src/docs/docs_site.cy.js
+++ b/apps/sample-app-lit-e2e/src/docs/docs_site.cy.js
@@ -162,14 +162,31 @@ describe('docs site', () => {
     }
   });
 
-  it('serves the app shell at 404 under the shell-404 exhibit mount', () => {
-    // The /not-found-spa exhibit: every path is an honest 404 whose body IS
-    // the app shell — the other 404 pattern, demonstrated side by side.
-    for (const url of [
-      '/not-found-spa',
-      '/not-found-spa/',
-      '/not-found-spa/any/path',
-    ]) {
+  it('serves the honest-404 SPA exhibit — 200 for real routes, 404-shell for misses', () => {
+    // The /not-found-spa exhibit is the flagship shape plus one difference: a
+    // miss serves the app shell at an honest 404 (the `otherwise` projection —
+    // a status'd shell) instead of the flagship's static 404 page. Real routes
+    // and the root redirect earn a shell-200, exactly like the flagship.
+    cy.request({ url: '/not-found-spa', followRedirect: false }).then(
+      (response) => {
+        expect(response.status, '/not-found-spa').to.eq(302);
+        expect(response.headers.location).to.eq('/not-found-spa/welcome');
+        expect(response.headers['x-robots-tag']).to.eq('noindex');
+      },
+    );
+    // Real routes (static and parameterized) serve the shell at 200.
+    for (const path of ['/welcome', '/contacts/1/edit']) {
+      const url = `/not-found-spa${path}`;
+      cy.request(url).then((response) => {
+        expect(response.status, url).to.eq(200);
+        expect(response.body).to.include('<title>UI-Router Lit sample app');
+        expect(response.headers['x-robots-tag'], url).to.eq('noindex');
+      });
+    }
+    // A genuine miss serves the shell at an honest 404 — the body IS the app
+    // shell (the other 404 pattern, side by side with the flagship's static
+    // page), and a 404 carries no canonical Link.
+    for (const url of ['/not-found-spa/any/path', '/not-found-spa/nope']) {
       cy.request({ url, failOnStatusCode: false }).then((response) => {
         expect(response.status, url).to.eq(404);
         expect(response.body).to.include('<title>UI-Router Lit sample app');
@@ -207,7 +224,36 @@ describe('docs site', () => {
     });
   });
 
-  it('boots the in-app 404 state on a direct exhibit load', () => {
+  it('renders real routes client-side under every aliased exhibit', () => {
+    // The regression this fix addresses. Each exhibit now ships its own build
+    // whose VITE_SAMPLE_APP_BASE_URL matches its prefix, so the client router
+    // strips that prefix and renders the real route — where the shared /app
+    // shell used to resolve every foreign prefix to the in-app 404 (e.g.
+    // "No state matched the URL /simulated-routing/welcome").
+    for (const mount of [
+      '/not-found-spa',
+      '/simulated-routing',
+      '/not-found-naive',
+    ]) {
+      cy.visit(`${mount}/welcome`);
+      cy.contains('Welcome to the sample app!');
+      cy.location('pathname').should('eq', `${mount}/welcome`);
+    }
+  });
+
+  it('shows the soft-404: naive serves 200, the client renders its 404 view', () => {
+    // The naive rung's whole lesson: the server answers 200 for a path that
+    // does not exist (bad for crawlers), yet the client — now correctly based
+    // at /not-found-naive/ — resolves it to the in-app 404 view. Server and
+    // client disagree; that gap IS the anti-pattern.
+    cy.request('/not-found-naive/definitely-not-a-route')
+      .its('status')
+      .should('eq', 200);
+    cy.visit('/not-found-naive/definitely-not-a-route');
+    cy.contains('404 Page Not Found');
+  });
+
+  it('boots the in-app 404 state on a direct miss under the shell-404 exhibit', () => {
     cy.visit('/not-found-spa/definitely-not-a-route', {
       failOnStatusCode: false,
     });

--- a/apps/sample-app-lit-vanilla/.env.not-found-naive
+++ b/apps/sample-app-lit-vanilla/.env.not-found-naive
@@ -1,0 +1,6 @@
+# `vite build --mode not-found-naive --outDir dist-not-found-naive`: the shell
+# the docs worker serves at /not-found-naive (the soft-404 baseline — server
+# answers 200 for every path, no matching). Only the base differs from .env, so
+# the client routes real paths and shows its 404 view on the ones the server lied
+# 200 about — the anti-pattern, made visible.
+VITE_SAMPLE_APP_BASE_URL=/not-found-naive/

--- a/apps/sample-app-lit-vanilla/.env.not-found-spa
+++ b/apps/sample-app-lit-vanilla/.env.not-found-spa
@@ -1,0 +1,5 @@
+# `vite build --mode not-found-spa --outDir dist-not-found-spa`: the shell the
+# docs worker serves at /not-found-spa (the shell-at-404 exhibit). Only the base
+# differs from .env — pushState location, GA id, and trace all inherit — so the
+# client router strips /not-found-spa/ and matches real routes at this prefix.
+VITE_SAMPLE_APP_BASE_URL=/not-found-spa/

--- a/apps/sample-app-lit-vanilla/.env.simulated-routing
+++ b/apps/sample-app-lit-vanilla/.env.simulated-routing
@@ -1,0 +1,5 @@
+# `vite build --mode simulated-routing --outDir dist-simulated-routing`: the
+# shell the docs worker serves at /simulated-routing (verdicts from a headless
+# @uirouter/core replay). Only the base differs from .env, so the client router
+# strips /simulated-routing/ and renders the routes the server just computed.
+VITE_SAMPLE_APP_BASE_URL=/simulated-routing/

--- a/apps/sample-app-lit-vanilla/package.json
+++ b/apps/sample-app-lit-vanilla/package.json
@@ -6,6 +6,9 @@
   "scripts": {
     "build": "vite build",
     "build:hash": "vite build --mode hash --outDir dist-hash",
+    "build:not-found-naive": "vite build --mode not-found-naive --outDir dist-not-found-naive",
+    "build:not-found-spa": "vite build --mode not-found-spa --outDir dist-not-found-spa",
+    "build:simulated-routing": "vite build --mode simulated-routing --outDir dist-simulated-routing",
     "codecov:bundle": "upload-bundle-stats sample-app-lit-vanilla-esm",
     "dev": "vite",
     "format": "oxfmt \"**/*.{js,ts,json,md,html}\"",

--- a/apps/sample-app-lit-vanilla/turbo.json
+++ b/apps/sample-app-lit-vanilla/turbo.json
@@ -10,7 +10,12 @@
       ],
       "dependsOn": ["^build", "^transit"],
       "outputs": ["dist/**"],
-      "with": ["build:hash"]
+      "with": [
+        "build:hash",
+        "build:not-found-naive",
+        "build:not-found-spa",
+        "build:simulated-routing"
+      ]
     },
     "build:hash": {
       "env": [
@@ -20,6 +25,33 @@
       ],
       "dependsOn": ["^build", "^transit"],
       "outputs": ["dist-hash/**"]
+    },
+    "build:not-found-naive": {
+      "env": [
+        "VITE_GOOGLE_ANALYTICS_TRACKING_ID",
+        "VITE_SAMPLE_APP_BASE_URL",
+        "VITE_SAMPLE_APP_PUSH_STATE"
+      ],
+      "dependsOn": ["^build", "^transit"],
+      "outputs": ["dist-not-found-naive/**"]
+    },
+    "build:not-found-spa": {
+      "env": [
+        "VITE_GOOGLE_ANALYTICS_TRACKING_ID",
+        "VITE_SAMPLE_APP_BASE_URL",
+        "VITE_SAMPLE_APP_PUSH_STATE"
+      ],
+      "dependsOn": ["^build", "^transit"],
+      "outputs": ["dist-not-found-spa/**"]
+    },
+    "build:simulated-routing": {
+      "env": [
+        "VITE_GOOGLE_ANALYTICS_TRACKING_ID",
+        "VITE_SAMPLE_APP_BASE_URL",
+        "VITE_SAMPLE_APP_PUSH_STATE"
+      ],
+      "dependsOn": ["^build", "^transit"],
+      "outputs": ["dist-simulated-routing/**"]
     }
   }
 }

--- a/apps/sample-app-routes/src/routes.ts
+++ b/apps/sample-app-routes/src/routes.ts
@@ -43,25 +43,25 @@ export const redirects: RedirectRule[] = [{ pattern: /^\/?$/, to: 'welcome' }];
 // 'simulate' is config, not code.
 const app: MountConfig = { routes, redirects, strategy: 'matcher' };
 
-// The not-found-spa exhibit: the otherwise projection (mirroring the client's
-// otherwise() -> notFound rule) makes every path under this mount serve the
-// app shell at an honest 404 — the client boots at the retained url and
-// renders the rich in-app notFound state. It deliberately carries NO
-// url-bearing routes: the shell bakes <base href="/app/">, so the client
-// router cannot match deep links under this prefix — a shell-200 here would
-// be exactly the soft-404 shape the flagship mounts avoid.
+// The not-found-spa exhibit: an honest-404 SPA. It is the flagship mount plus
+// one difference — the miss. Real routes and the root redirect earn a shell-200
+// (its own base-baked build, VITE_SAMPLE_APP_BASE_URL /not-found-spa/, lets the
+// client match deep links at this prefix), while the `otherwise` projection
+// serves the app shell at an honest 404 for genuine misses; the client boots at
+// the retained url and renders the rich in-app notFound state. The flagship
+// carries no `otherwise`, so its miss is a static 404 page instead (see the
+// fetch adapter's verdict mapping: an `otherwise` state is a status'd shell).
 const notFoundSpaDemo: MountConfig = {
-  routes: [{ name: 'notFound' }],
+  ...app,
   otherwise: { state: 'notFound' },
 };
 
 // The simulated-routing exhibit: full router semantics server-side — the
 // same tables, but every verdict computed by replaying the url through a
 // headless @uirouter/core router (redirect rules, otherwise, and one day
-// hooks/resolves all ride). Deep links serve shell-200 here, but the shell's
-// baked <base href="/app/"> means the client renders its in-app notFound
-// under this prefix — the exhibit teaches SERVER semantics; noindex (worker)
-// quarantines it from crawlers.
+// hooks/resolves all ride). Its own base-baked build (VITE_SAMPLE_APP_BASE_URL
+// /simulated-routing/) lets the client render the very route the server
+// computed; noindex (worker) still quarantines the exhibit from crawlers.
 const simulatedRoutingDemo: MountConfig = {
   routes,
   redirects,

--- a/docs/.vitepress/vite.config.ts
+++ b/docs/.vitepress/vite.config.ts
@@ -2,25 +2,25 @@ import { createServerRouter } from 'ui-router-server';
 import { serverRouterPlugin } from 'ui-router-server/vite';
 import { mounts } from 'sample-app-routes';
 import { defineConfig, Plugin } from 'vite';
-import { viteStaticCopy } from 'vite-plugin-static-copy';
+import { Target, viteStaticCopy } from 'vite-plugin-static-copy';
 
 // Tutorial examples embedded same-origin at /examples/<name>/; built by
 // `examples#build:embeds` (hash routing, so no SPA fallback needed).
 const EMBEDDED_EXAMPLES = ['helloworld', 'hellosolarsystem', 'hellogalaxy'];
 
 // The mount shells as the dev server serves them. Production (docs/worker)
-// serves each at its bare mount via Cloudflare's html_handling; the dev
-// server serves the static-copied files, so the paths carry `.html` and the
-// borrowed exhibits (/not-found-spa, /simulated-routing) point at the vanilla
-// shell — the SHELL_PATHS aliasing the worker does, in the dev host's terms.
+// serves each at its bare mount via Cloudflare's html_handling; the dev server
+// serves the static-copied files, so the paths carry `.html`. Every mount owns
+// its base-baked shell — each exhibit is a dedicated vanilla build whose
+// VITE_SAMPLE_APP_BASE_URL matches its prefix (see the app's .env.<mount>
+// files) — so the client router matches real routes under the exhibit prefixes
+// instead of falling back to the in-app notFound at every foreign prefix.
 const SHELL_PATHS: Record<string, string> = {
   '/app': '/app.html',
   '/app-mobx': '/app-mobx.html',
-  // The hash demo has its own shell (base href /app-hash/, hash location baked
-  // at build), not the vanilla one the exhibits borrow.
   '/app-hash': '/app-hash.html',
-  '/not-found-spa': '/app.html',
-  '/simulated-routing': '/app.html',
+  '/not-found-spa': '/not-found-spa.html',
+  '/simulated-routing': '/simulated-routing.html',
 };
 
 // The dev-server twin of the docs worker: the SAME mounts table, resolved by
@@ -124,6 +124,27 @@ export default defineConfig({
           dest: 'app-hash',
           rename: { stripBase: true },
         },
+        // The aliased-exhibit shells: each is the vanilla app rebuilt with
+        // VITE_SAMPLE_APP_BASE_URL matching its mount prefix (see the app's
+        // .env.<mount> files), so the client routes real paths under that
+        // prefix instead of the in-app notFound. Content-hashed against a
+        // different base string, their bundles coexist with the flagship's
+        // under /assets. No 404.html: misses serve a status'd shell (the
+        // `otherwise` projection), not a static page.
+        ...['not-found-naive', 'not-found-spa', 'simulated-routing'].flatMap(
+          (mount): Target[] => [
+            {
+              src: `node_modules/sample-app-lit-vanilla/dist-${mount}/assets/*`,
+              dest: 'assets',
+              rename: { stripBase: true },
+            },
+            {
+              src: `node_modules/sample-app-lit-vanilla/dist-${mount}/index.html`,
+              dest: '',
+              rename: { name: `${mount}.html`, stripBase: true },
+            },
+          ],
+        ),
         // images/ and static/ come from sample-app-shared and are identical
         // in both apps' dists; copy once so neither can silently clobber.
         {

--- a/docs/guides/server-route-matching.md
+++ b/docs/guides/server-route-matching.md
@@ -203,7 +203,7 @@ Every level from 1 up runs behind lit-ui-router.dev — same worker, same
 | 1     | `/app-hash`          | Hash routing done right: the mount root serves the shell at **200** with no redirect, so the fragment survives entry; deep paths stay 404 |
 | 2     | `/not-found-naive`   | Every path serves the shell at **200**, no route matching — the platform-default fallback, reproduced                                     |
 | 3+4   | `/app`, `/app-mobx`  | Route-aware verdicts: shell, 302, or a **real 404** with a per-mount static 404 page (the flagship)                                       |
-| 4     | `/not-found-spa`     | Route-aware, shell-at-404: the `otherwise` projection; the client renders its in-app 404 at the retained URL                              |
+| 4     | `/not-found-spa`     | Route-aware, shell-at-404: real routes serve **200**; a miss serves the shell at **404** and the client renders its in-app 404 view       |
 | 5     | `/simulated-routing` | Every verdict computed by a **real headless router** replaying the URL                                                                    |
 
 Try them on a URL that matches nothing:
@@ -226,14 +226,17 @@ Two honesty notes about the exhibits. Every **exhibit** response
 (`/not-found-naive`, `/not-found-spa`, `/simulated-routing`) carries
 `X-Robots-Tag: noindex`: the level-2 exhibit deliberately manufactures
 soft-404s, and the site must not be penalized by its own teaching material.
-And those exhibit mounts alias the vanilla sample app's shell (they have no
-build of their own), which works because the built shell's asset URLs are
-absolute — but the shell also bakes `<base href="/app/">`, so the client
-router cannot match deep links under a foreign prefix; they teach **server**
-semantics and stay quarantined from crawlers. `/app-hash` is the exception
-that proves the rule: it has its own `--mode hash` build with
-`<base href="/app-hash/">` baked in, so it is a fully working, indexable hash
-client, not an exhibit.
+And each exhibit mount ships its **own** build — the vanilla sample app rebuilt
+with `VITE_SAMPLE_APP_BASE_URL` set to the mount's prefix (`/not-found-spa/`,
+`/simulated-routing/`, `/not-found-naive/`), the same per-mount `--mode` build
+`/app-hash` uses — so the client router strips that prefix and renders real
+routes under the mount, exactly like the flagship. What makes them exhibits is
+the **server** verdict each demonstrates (the soft-404 lie, shell-at-404, the
+headless replay), not any client limitation; `noindex` simply keeps the
+teaching material out of the search index. `/app-hash` is the same mechanism
+pointed at hash mode: its `--mode hash` build bakes `<base href="/app-hash/">`
+and the hash location plugin, so it is a fully working, indexable hash client
+rather than an exhibit.
 
 ## Path-location clients
 
@@ -774,20 +777,21 @@ client entered with.
 
 ## Shell-at-404: the `otherwise` projection
 
-The `/not-found-spa` exhibit is one config line: `MountConfig.otherwise`
-projects the client's `otherwise()` rule
+The `/not-found-spa` exhibit is the flagship `app` config plus one field:
+`MountConfig.otherwise` projects the client's `otherwise()` rule
 ([`routes.ts`](https://github.com/simshanith/lit-ui-router/blob/main/apps/sample-app-routes/src/routes.ts)):
 
 ```ts
-// The not-found-spa exhibit: the otherwise projection (mirroring the client's
-// otherwise() -> notFound rule) makes every path under this mount serve the
-// app shell at an honest 404 — the client boots at the retained url and
-// renders the rich in-app notFound state. It deliberately carries NO
-// url-bearing routes: the shell bakes <base href="/app/">, so the client
-// router cannot match deep links under this prefix — a shell-200 here would
-// be exactly the soft-404 shape the flagship mounts avoid.
+// The not-found-spa exhibit: an honest-404 SPA. It is the flagship mount plus
+// one difference — the miss. Real routes and the root redirect earn a shell-200
+// (its own base-baked build, VITE_SAMPLE_APP_BASE_URL /not-found-spa/, lets the
+// client match deep links at this prefix), while the `otherwise` projection
+// serves the app shell at an honest 404 for genuine misses; the client boots at
+// the retained url and renders the rich in-app notFound state. The flagship
+// carries no `otherwise`, so its miss is a static 404 page instead (see the
+// fetch adapter's verdict mapping: an `otherwise` state is a status'd shell).
 const notFoundSpaDemo: MountConfig = {
-  routes: [{ name: 'notFound' }],
+  ...app,
   otherwise: { state: 'notFound' },
 };
 ```
@@ -820,10 +824,9 @@ same data, plus the mount table that puts every level side by side:
 // The simulated-routing exhibit: full router semantics server-side — the
 // same tables, but every verdict computed by replaying the url through a
 // headless @uirouter/core router (redirect rules, otherwise, and one day
-// hooks/resolves all ride). Deep links serve shell-200 here, but the shell's
-// baked <base href="/app/"> means the client renders its in-app notFound
-// under this prefix — the exhibit teaches SERVER semantics; noindex (worker)
-// quarantines it from crawlers.
+// hooks/resolves all ride). Its own base-baked build (VITE_SAMPLE_APP_BASE_URL
+// /simulated-routing/) lets the client render the very route the server
+// computed; noindex (worker) still quarantines the exhibit from crawlers.
 const simulatedRoutingDemo: MountConfig = {
   routes,
   redirects,

--- a/docs/sample-app.md
+++ b/docs/sample-app.md
@@ -19,12 +19,13 @@ different server configurations — so each mount is a live point on the
 | <a href="/app-mobx" target="_self">`/app-mobx`</a>                   | 3+4 · flagship | The same app and the same verdicts, with [MobX bindings](./packages/mobx) for state — routing is identical, so this varies the client-state axis, not a routing one.                                                             |
 | <a href="/app-hash" target="_self">`/app-hash`</a>                   | 1 · hash       | [Hash location](./guides/location-plugins#hash-urls) done right: the route lives in the fragment, so the server serves the shell at **200** at the mount root and never redirects it. Needs no routing verdicts — and shows why. |
 | <a href="/not-found-naive" target="_self">`/not-found-naive`</a>     | 2 · exhibit    | The **anti-pattern baseline**: every path answers **200** with the shell, no matching at all — the soft-404 fallback most SPAs ship. `noindex`.                                                                                  |
-| <a href="/not-found-spa" target="_self">`/not-found-spa`</a>         | 4 · exhibit    | **Shell-at-404**: the `otherwise` projection serves the app shell at an honest **404**, and the client renders its in-app 404 view at the retained URL. `noindex`.                                                               |
+| <a href="/not-found-spa" target="_self">`/not-found-spa`</a>         | 4 · exhibit    | **Shell-at-404**: real routes serve the shell at **200**; only a genuine miss serves the app shell at an honest **404**, where the client renders its in-app 404 view at the retained URL. `noindex`.                            |
 | <a href="/simulated-routing" target="_self">`/simulated-routing`</a> | 5 · exhibit    | Every verdict computed by a **real headless `@uirouter/core` router** replaying the URL per request — redirects and `otherwise()` run as real rules. `noindex`.                                                                  |
 
 The three `noindex` **exhibits** exist to teach server semantics side by side;
-they alias the vanilla shell and stay out of the search index. `/app`,
-`/app-mobx`, and `/app-hash` are the real, indexable app.
+each ships its own base-baked build (so the client renders real routes under
+the mount) and stays out of the search index. `/app`, `/app-mobx`, and
+`/app-hash` are the real, indexable app.
 
 ## Two axes, one app
 

--- a/docs/worker/index.ts
+++ b/docs/worker/index.ts
@@ -7,14 +7,12 @@ import { createFetchHandler } from 'ui-router-server/fetch';
 // compile once per isolate.
 const router = createServerRouter({ mounts });
 
-// The 404-pattern exhibit mounts have no shell asset of their own — they serve
-// the vanilla app's (its asset urls are absolute, so the shell works under any
-// prefix). Mounts without an alias serve the shell at their own base, which is
-// the adapter's shellPath default.
-const SHELL_PATHS: Record<string, string> = {
-  '/not-found-spa': '/app',
-  '/simulated-routing': '/app',
-};
+// Every mount serves its own base-baked shell: each aliased exhibit gets a
+// dedicated vanilla build whose VITE_SAMPLE_APP_BASE_URL matches its prefix, so
+// the client router strips that prefix and renders real routes (not the in-app
+// 404 the /app-based shell fell back to at every foreign prefix). Cloudflare's
+// html_handling maps the bare mount to <mount>.html — the adapter's shellPath
+// default (mount -> mount) — so no aliasing table is needed.
 
 // Every exhibit response carries noindex: the naive rung deliberately serves
 // soft-404s, and the site must not be penalized by its own teaching material.
@@ -48,7 +46,7 @@ export default {
       // Construct the shell request from the original so its conditional
       // headers ride along and a repeat load can still 304.
       const shell = await env.ASSETS.fetch(
-        new Request(new URL('/app', request.url), request),
+        new Request(new URL('/not-found-naive', request.url), request),
       );
       return withNoindex(shell);
     }
@@ -56,10 +54,10 @@ export default {
     // The fetch adapter fronts every routed mount: it owns status mapping,
     // mergeSearch on redirect Locations, validator stripping + status relabel
     // on status'd shells, and the canonical Link header. The host supplies the
-    // asset IO (env.ASSETS) and the two policies the adapter can't know: shell
-    // aliasing (SHELL_PATHS) and the real 404 page.
+    // asset IO (env.ASSETS) and the one policy the adapter can't know: the real
+    // 404 page. Shells need no aliasing — each mount owns its base-baked build,
+    // so the adapter's shellPath default (mount -> mount) is correct.
     const handler = createFetchHandler(router, {
-      shellPath: (mount) => SHELL_PATHS[mount] ?? mount,
       // The adapter hands over a shell Request already rewritten to shellPath
       // and (for a status'd shell) stripped of validators — the host's job is
       // the raw asset fetch; the adapter owns the relabel and Link on the way


### PR DESCRIPTION
## Problem

On lit-ui-router.dev the three exhibit mounts rendered the in-app **404 view**
client-side even when the server verdict was correct:

- `/simulated-routing` → server `302 → /simulated-routing/welcome`, but the page
  showed `No state matched the URL /simulated-routing/welcome`.
- `/not-found-naive`, `/not-found-spa` → likewise resolved every path to notFound
  client-side.

**Root cause:** all three aliased the vanilla `/app` shell, whose client base is
baked to `/app/` (`VITE_SAMPLE_APP_BASE_URL`, injected in `router.config.ts`). The
pushState location plugin strips that base off `location.pathname` before matching,
so at any *other* prefix (`/simulated-routing/…`) nothing matched → `otherwise()` →
the in-app 404. The server was honest; the client couldn't route the borrowed shell.

## Fix

Give each exhibit its **own base-baked build** — the same per-mount `--mode` trick
`/app-hash` already uses:

- `apps/sample-app-lit-vanilla/.env.<mount>` sets `VITE_SAMPLE_APP_BASE_URL` to the
  mount prefix (`/not-found-spa/`, `/simulated-routing/`, `/not-found-naive/`);
  pushState + GA + trace inherit from `.env`.
- `build:<mount>` scripts emit `dist-<mount>`; a turbo task per build runs beside
  `build` (via `with`), and `docs` static-copy publishes each as `<mount>.html`.
- The worker's `SHELL_PATHS` aliasing is gone — every mount owns its shell, so the
  adapter's `shellPath` default (`mount → mount`) is correct; the naive handler now
  serves `/not-found-naive`.

`/not-found-spa` also becomes a proper **honest-404 SPA**: it inherits the flagship
`routes` + `redirects` and keeps `otherwise → notFound`, so real routes and the root
redirect earn a **shell-200** and only genuine misses serve the shell at **404**
(the `otherwise` status'd-shell path). Previously the whole mount was always-404.

## Behavior (verified against `wrangler dev` + docs Cypress, 16 passing)

| Mount | index / real routes | miss |
| --- | --- | --- |
| `/not-found-spa` | `302`→welcome, then `200` shell; client renders the route | `404` shell, client 404 view |
| `/simulated-routing` | `302`→welcome, `200` shell; client renders the route | `404` shell |
| `/not-found-naive` | `200` everything; client renders the route | `200` (server lie), client 404 view — the soft-404, now observable |

New/updated e2e in `apps/sample-app-lit-e2e/src/docs/docs_site.cy.js`:
`renders real routes client-side under every aliased exhibit`, the honest-404-SPA
matrix, and the naive soft-404 gap. Docs prose (`sample-app.md`,
`server-route-matching.md`) updated; the stale `<base href="/app/">` limitation note
is removed.

## Cost / note

Three extra vanilla builds ship near-duplicate bundles under `/assets` (they differ
only by the baked base string, so they content-hash apart) — consistent with how
`/app-hash` already duplicates. This resolves the client-render symptom the
**mount-agnostic shell** thread on #313 flagged; it takes the per-mount-build route
rather than that thread's *one-build* runtime-base idea, which stays open there.
