### PR TITLE
fix(lit-ui-router): flush param types without deprecated urlMatcherFactory.$get()

### DIFF
--- a/packages/lit-ui-router/src/core.ts
+++ b/packages/lit-ui-router/src/core.ts
@@ -252,7 +252,6 @@ export class UIRouterLit extends UIRouter {
     if (this.started) {
       throw new Error('start() called multiple times');
     }
-    // @internal API, acceptable first-party: exactly what the deprecated urlMatcherFactory.$get() did (#279)
     const { paramTypes } = this.urlService.config;
     paramTypes.enqueue = false;
     paramTypes._flushTypeQueue();

--- a/packages/lit-ui-router/src/core.ts
+++ b/packages/lit-ui-router/src/core.ts
@@ -252,8 +252,10 @@ export class UIRouterLit extends UIRouter {
     if (this.started) {
       throw new Error('start() called multiple times');
     }
-    // eslint-disable-next-line typescript/no-deprecated -- $get() flushes the param-type queue; #279 tracks the @internal replacement
-    this.urlMatcherFactory.$get();
+    // @internal API, acceptable first-party: exactly what the deprecated urlMatcherFactory.$get() did (#279)
+    const { paramTypes } = this.urlService.config;
+    paramTypes.enqueue = false;
+    paramTypes._flushTypeQueue();
     this.urlService.listen();
     this.urlService.sync();
     this.started = true;


### PR DESCRIPTION
Closes #279

## What

`UIRouterLit.start()` called the deprecated `urlMatcherFactory.$get()` (with an oxlint `no-deprecated` suppression from #277) solely to flush the queued param types. This replaces it with the equivalent non-deprecated calls and drops the suppression.

## Equivalence evidence

From `@uirouter/core` source (`lib/url/urlMatcherFactory.js`), `$get()` is exactly:

```js
UrlMatcherFactory.prototype.$get = function () {
    var urlConfig = this.router.urlService.config;
    urlConfig.paramTypes.enqueue = false;
    urlConfig.paramTypes._flushTypeQueue();
    return this;
};
```

The replacement performs those same two statements directly on `this.urlService.config.paramTypes` — behavior-identical (the `return this` was unused). `UrlConfig.paramTypes` is marked `@internal` upstream, but as a first-party router integration using it is acceptable (decided on #279). Neither `enqueue` nor `_flushTypeQueue()` carries a `@deprecated` marker, so lint passes with no suppression.

## Verification

`turbo run test lint --filter=lit-ui-router` — 6/6 tasks successful:
- test: 27 files, 489 tests passed (chromium/firefox/safari)
- lint: clean, with the suppression comment removed