### PR TITLE
fix(ui-router-server): order route matches by segment specificity (#360)

### DIFF
--- a/packages/ui-router-server/src/redirects.ts
+++ b/packages/ui-router-server/src/redirects.ts
@@ -10,8 +10,8 @@
 
 import type { RawParams } from '@uirouter/core';
 
-import { urlMatcherFactory } from './url-matcher.ts';
-import type { UrlMatcher, UrlMatcherCompilerConfig } from './url-matcher.ts';
+import { UrlMatcher, urlMatcherFactory } from './url-matcher.ts';
+import type { UrlMatcherCompilerConfig } from './url-matcher.ts';
 
 /** A state's contribution to the url-addressable route set. */
 export interface RouteDeclaration {
@@ -129,26 +129,28 @@ export interface RouteMatch {
 
 /**
  * Match identity, not just truth: which route's pattern the pathname
- * matched, with the extracted params. Among multiple matches the one with
- * the fewest params wins (static segments beat placeholders, as in the
- * router's own rule ordering); ties go to declaration order. That heuristic
- * approximates core's segment-by-segment static-specificity sort and can
- * diverge from it on pathological overlaps (equal param counts, mixed
- * static/dynamic positions).
+ * matched, with the extracted params. Among multiple matches the most
+ * specific one wins by core's segment-by-segment static-specificity sort
+ * ([[UrlMatcher.compare]]): static segments beat placeholders position by
+ * position, so `/users/new` outranks `/users/:id` and `/a/:y` outranks
+ * `/:x/b` regardless of equal param counts. Ties (equal specificity) go to
+ * declaration order. This mirrors the client router's own rule ordering, so
+ * a compiled server redirect agrees with what the client would resolve.
  */
 export function matchRoute(
   routes: CompiledRoute[],
   pathname: string,
 ): RouteMatch | null {
   let best: RouteMatch | null = null;
+  let bestMatcher: UrlMatcher | null = null;
   for (const { name, matcher } of routes) {
     const params = matcher.exec(pathname);
-    if (
-      params !== null &&
-      (best === null ||
-        Object.keys(params).length < Object.keys(best.params).length)
-    ) {
+    if (params === null) continue;
+    // Strictly-more-specific replaces; equal specificity keeps the earlier
+    // declaration (compare < 0 only when the new matcher outranks the best).
+    if (bestMatcher === null || UrlMatcher.compare(matcher, bestMatcher) < 0) {
       best = { state: name, params };
+      bestMatcher = matcher;
     }
   }
   return best;

--- a/packages/ui-router-server/src/redirects.ts
+++ b/packages/ui-router-server/src/redirects.ts
@@ -128,14 +128,9 @@ export interface RouteMatch {
 }
 
 /**
- * Match identity, not just truth: which route's pattern the pathname
- * matched, with the extracted params. Among multiple matches the most
- * specific one wins by core's segment-by-segment static-specificity sort
- * ([[UrlMatcher.compare]]): static segments beat placeholders position by
- * position, so `/users/new` outranks `/users/:id` and `/a/:y` outranks
- * `/:x/b` regardless of equal param counts. Ties (equal specificity) go to
- * declaration order. This mirrors the client router's own rule ordering, so
- * a compiled server redirect agrees with what the client would resolve.
+ * Returns which route's pattern the pathname matched, with the extracted
+ * params. The most specific match wins ([[UrlMatcher.compare]]); ties go
+ * to declaration order.
  */
 export function matchRoute(
   routes: CompiledRoute[],
@@ -146,8 +141,7 @@ export function matchRoute(
   for (const { name, matcher } of routes) {
     const params = matcher.exec(pathname);
     if (params === null) continue;
-    // Strictly-more-specific replaces; equal specificity keeps the earlier
-    // declaration (compare < 0 only when the new matcher outranks the best).
+    // Strict < keeps the earlier declaration on ties.
     if (bestMatcher === null || UrlMatcher.compare(matcher, bestMatcher) < 0) {
       best = { state: name, params };
       bestMatcher = matcher;

--- a/packages/ui-router-server/src/url-matcher.ts
+++ b/packages/ui-router-server/src/url-matcher.ts
@@ -472,11 +472,16 @@ export class UrlMatcher {
     return 0;
   }
 
+  #weights?: number[];
+
   // Path tokens as core's sort weights (UrlMatcher.compare): interleave the
   // static segments with the path params in order, split each static segment
   // on '/' keeping the delimiters, then weight slash → 1, static text → 2,
-  // param → 3. Search params never affect path specificity.
+  // param → 3. Search params never affect path specificity. Memoized, as
+  // core caches on _cache.weights — matchRoute compares the running best
+  // against every later candidate.
   #segmentWeights(): number[] {
+    if (this.#weights) return this.#weights;
     const weights: number[] = [];
     this.#segments.forEach((segment, index) => {
       for (const piece of segment.split(/(\/)/)) {
@@ -485,7 +490,7 @@ export class UrlMatcher {
       }
       if (this.#pathParams[index]) weights.push(3);
     });
-    return weights;
+    return (this.#weights = weights);
   }
 
   /**

--- a/packages/ui-router-server/src/url-matcher.ts
+++ b/packages/ui-router-server/src/url-matcher.ts
@@ -449,17 +449,10 @@ export class UrlMatcher {
   }
 
   /**
-   * Core's UrlMatcher.compare: sorts two matchers by static specificity so
-   * the more specific pattern wins. Each is flattened to path tokens (slash
-   * literals, static text, path params) and compared position-by-position;
-   * slash (1) sorts before static text (2) before a param (3), and a shorter
-   * pattern (0-padded) sorts before a longer one where they first differ. A
-   * negative result means `a` is more specific (higher priority) than `b`.
-   *
-   * Ported from core so the dep-free redirects tier picks the same route the
-   * client's own router would — not a fewest-params approximation. Single-
-   * matcher only: matchers here never `append`, so there is no parent path
-   * to concatenate.
+   * Sorts two matchers by static specificity, as core's UrlMatcher.compare:
+   * path tokens compared position-by-position, slash before static text
+   * before a param. Negative means `a` is more specific than `b`.
+   * Single-matcher only: matchers here never `append`.
    */
   static compare(a: UrlMatcher, b: UrlMatcher): number {
     const weightsA = a.#segmentWeights();
@@ -474,12 +467,8 @@ export class UrlMatcher {
 
   #weights?: number[];
 
-  // Path tokens as core's sort weights (UrlMatcher.compare): interleave the
-  // static segments with the path params in order, split each static segment
-  // on '/' keeping the delimiters, then weight slash → 1, static text → 2,
-  // param → 3. Search params never affect path specificity. Memoized, as
-  // core caches on _cache.weights — matchRoute compares the running best
-  // against every later candidate.
+  // Core's sort weights: slash → 1, static text → 2, param → 3; search
+  // params carry no weight. Memoized, as in core.
   #segmentWeights(): number[] {
     if (this.#weights) return this.#weights;
     const weights: number[] = [];

--- a/packages/ui-router-server/src/url-matcher.ts
+++ b/packages/ui-router-server/src/url-matcher.ts
@@ -449,6 +449,46 @@ export class UrlMatcher {
   }
 
   /**
+   * Core's UrlMatcher.compare: sorts two matchers by static specificity so
+   * the more specific pattern wins. Each is flattened to path tokens (slash
+   * literals, static text, path params) and compared position-by-position;
+   * slash (1) sorts before static text (2) before a param (3), and a shorter
+   * pattern (0-padded) sorts before a longer one where they first differ. A
+   * negative result means `a` is more specific (higher priority) than `b`.
+   *
+   * Ported from core so the dep-free redirects tier picks the same route the
+   * client's own router would — not a fewest-params approximation. Single-
+   * matcher only: matchers here never `append`, so there is no parent path
+   * to concatenate.
+   */
+  static compare(a: UrlMatcher, b: UrlMatcher): number {
+    const weightsA = a.#segmentWeights();
+    const weightsB = b.#segmentWeights();
+    const length = Math.max(weightsA.length, weightsB.length);
+    for (let i = 0; i < length; i++) {
+      const cmp = (weightsA[i] ?? 0) - (weightsB[i] ?? 0);
+      if (cmp !== 0) return cmp;
+    }
+    return 0;
+  }
+
+  // Path tokens as core's sort weights (UrlMatcher.compare): interleave the
+  // static segments with the path params in order, split each static segment
+  // on '/' keeping the delimiters, then weight slash → 1, static text → 2,
+  // param → 3. Search params never affect path specificity.
+  #segmentWeights(): number[] {
+    const weights: number[] = [];
+    this.#segments.forEach((segment, index) => {
+      for (const piece of segment.split(/(\/)/)) {
+        if (piece === '') continue;
+        weights.push(piece === '/' ? 1 : 2);
+      }
+      if (this.#pathParams[index]) weights.push(3);
+    });
+    return weights;
+  }
+
+  /**
    * Tests a url path against this matcher.
    *
    * Returns the captured parameter values when the path matches the pattern,

--- a/packages/ui-router-server/test/redirects.test.ts
+++ b/packages/ui-router-server/test/redirects.test.ts
@@ -82,7 +82,7 @@ describe('matchRoute', () => {
     });
   });
 
-  it('prefers the match with the fewest params (static beats placeholder)', () => {
+  it('prefers the more specific match (static beats placeholder)', () => {
     assert.deepEqual(matchRoute(compiled, '/contacts/new'), {
       state: 'contacts.new',
       params: {},
@@ -92,6 +92,29 @@ describe('matchRoute', () => {
   it('returns null when nothing matches', () => {
     assert.equal(matchRoute(compiled, '/nope'), null);
     assert.equal(matchRoute(compiled, ''), null);
+  });
+
+  // Regression for #360: a static segment in an earlier position outranks a
+  // param in that position even when both patterns carry the same number of
+  // params. The old fewest-params heuristic tied here and fell to declaration
+  // order, letting the first-declared '/:x/b' win over the correct '/a/:y'.
+  it('orders by segment specificity, not param count or declaration order', () => {
+    const routes = compileRoutes([
+      { name: 'dynamicFirst', url: '/:x/b' },
+      { name: 'staticFirst', url: '/a/:y' },
+    ]);
+    assert.deepEqual(matchRoute(routes, '/a/b'), {
+      state: 'staticFirst',
+      params: { y: 'b' },
+    });
+  });
+
+  it('keeps declaration order only when specificity is genuinely equal', () => {
+    const routes = compileRoutes([
+      { name: 'first', url: '/:a/:b' },
+      { name: 'second', url: '/:c/:d' },
+    ]);
+    assert.equal(matchRoute(routes, '/x/y')?.state, 'first');
   });
 });
 
@@ -138,6 +161,27 @@ describe('evaluateRedirects', () => {
 
   it('follows redirect chains', () => {
     assert.equal(evaluateRedirects(table, '/chain'), '/home');
+  });
+
+  // #360: with two equal-param routes overlapping on one pathname, only the
+  // more specific one carries a redirectTo. The old fewest-params heuristic
+  // could select the wrong route (declaration order) and emit its redirect;
+  // the specificity sort selects the same route the client would resolve.
+  it('emits the redirect of the segment-specific route, not the first-declared', () => {
+    const overlapping: RedirectTable = {
+      routes: [
+        // Declared first, but less specific at '/legacy/settings'.
+        { name: 'section', url: '/legacy/:page', redirectTo: 'home' },
+        { name: 'home', url: '/home' },
+        // More specific: static 'settings' beats the ':page' placeholder.
+        { name: 'settings', url: '/legacy/settings' },
+      ],
+    };
+    // '/legacy/settings' matches both; the specific 'settings' route has no
+    // redirect, so the path is served as-is (null), not redirected to /home.
+    assert.equal(evaluateRedirects(overlapping, '/legacy/settings'), null);
+    // A non-overlapping page still redirects through 'section'.
+    assert.equal(evaluateRedirects(overlapping, '/legacy/other'), '/home');
   });
 
   it('returns null for plain and unknown paths', () => {

--- a/packages/ui-router-server/test/redirects.test.ts
+++ b/packages/ui-router-server/test/redirects.test.ts
@@ -94,10 +94,7 @@ describe('matchRoute', () => {
     assert.equal(matchRoute(compiled, ''), null);
   });
 
-  // Regression for #360: a static segment in an earlier position outranks a
-  // param in that position even when both patterns carry the same number of
-  // params. The old fewest-params heuristic tied here and fell to declaration
-  // order, letting the first-declared '/:x/b' win over the correct '/a/:y'.
+  // Both patterns carry one param; the static-first pattern must win.
   it('orders by segment specificity, not param count or declaration order', () => {
     const routes = compileRoutes([
       { name: 'dynamicFirst', url: '/:x/b' },
@@ -163,10 +160,6 @@ describe('evaluateRedirects', () => {
     assert.equal(evaluateRedirects(table, '/chain'), '/home');
   });
 
-  // #360: with two equal-param routes overlapping on one pathname, only the
-  // more specific one carries a redirectTo. The old fewest-params heuristic
-  // could select the wrong route (declaration order) and emit its redirect;
-  // the specificity sort selects the same route the client would resolve.
   it('emits the redirect of the segment-specific route, not the first-declared', () => {
     const overlapping: RedirectTable = {
       routes: [
@@ -177,8 +170,7 @@ describe('evaluateRedirects', () => {
         { name: 'settings', url: '/legacy/settings' },
       ],
     };
-    // '/legacy/settings' matches both; the specific 'settings' route has no
-    // redirect, so the path is served as-is (null), not redirected to /home.
+    // Both routes match; the specific one has no redirect, so serve as-is.
     assert.equal(evaluateRedirects(overlapping, '/legacy/settings'), null);
     // A non-overlapping page still redirects through 'section'.
     assert.equal(evaluateRedirects(overlapping, '/legacy/other'), '/home');

--- a/packages/ui-router-server/test/url-matcher.differential.test.ts
+++ b/packages/ui-router-server/test/url-matcher.differential.test.ts
@@ -521,6 +521,9 @@ const specificityPatterns = [
   '/a',
   '/a/b/:z',
   '/a/:m/c',
+  // Search params carry no path weight: '/users/new?q' ties '/users/new'.
+  '/users/new?q',
+  '/users/:id?sort&page',
 ];
 
 describe(`differential: UrlMatcher.compare vs @uirouter/core (${specificityPatterns.length} patterns, all pairs)`, () => {

--- a/packages/ui-router-server/test/url-matcher.differential.test.ts
+++ b/packages/ui-router-server/test/url-matcher.differential.test.ts
@@ -501,11 +501,7 @@ const formatCases: FormatCase[] = [
   },
 ];
 
-// Specificity ordering (#360): the standalone UrlMatcher.compare must agree
-// with core's on every pair of overlapping patterns — the tie-break the
-// redirects tier relies on to pick the same route the client router would.
-// Signs, not magnitudes, must match (core and the port build different
-// internal token arrays); normalize to -1 / 0 / 1.
+// Only signs must match: core and the port build different token arrays.
 const sign = (n: number) => (n < 0 ? -1 : n > 0 ? 1 : 0);
 
 const specificityPatterns = [

--- a/packages/ui-router-server/test/url-matcher.differential.test.ts
+++ b/packages/ui-router-server/test/url-matcher.differential.test.ts
@@ -1,7 +1,11 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
-import { services, UIRouter, UrlMatcher as CoreUrlMatcher } from '@uirouter/core';
+import {
+  services,
+  UIRouter,
+  UrlMatcher as CoreUrlMatcher,
+} from '@uirouter/core';
 import type { RawParams } from '@uirouter/core';
 
 import { UrlMatcher, urlMatcherFactory } from '../src/url-matcher.ts';

--- a/packages/ui-router-server/test/url-matcher.differential.test.ts
+++ b/packages/ui-router-server/test/url-matcher.differential.test.ts
@@ -1,10 +1,10 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
-import { services, UIRouter } from '@uirouter/core';
+import { services, UIRouter, UrlMatcher as CoreUrlMatcher } from '@uirouter/core';
 import type { RawParams } from '@uirouter/core';
 
-import { urlMatcherFactory } from '../src/url-matcher.ts';
+import { UrlMatcher, urlMatcherFactory } from '../src/url-matcher.ts';
 import type { UrlMatcherCompileOptions } from '../src/url-matcher.ts';
 
 // The divergence guard for the standalone extraction: every pattern/url pair
@@ -496,6 +496,42 @@ const formatCases: FormatCase[] = [
     ],
   },
 ];
+
+// Specificity ordering (#360): the standalone UrlMatcher.compare must agree
+// with core's on every pair of overlapping patterns — the tie-break the
+// redirects tier relies on to pick the same route the client router would.
+// Signs, not magnitudes, must match (core and the port build different
+// internal token arrays); normalize to -1 / 0 / 1.
+const sign = (n: number) => (n < 0 ? -1 : n > 0 ? 1 : 0);
+
+const specificityPatterns = [
+  '/a/:y',
+  '/:x/b',
+  '/users/new',
+  '/users/:id',
+  '/users/:id/edit',
+  '/:a/:b',
+  '/files/:path',
+  '/files/shared',
+  '/',
+  '/a',
+  '/a/b/:z',
+  '/a/:m/c',
+];
+
+describe(`differential: UrlMatcher.compare vs @uirouter/core (${specificityPatterns.length} patterns, all pairs)`, () => {
+  for (const left of specificityPatterns) {
+    for (const right of specificityPatterns) {
+      it(`compare('${left}', '${right}')`, () => {
+        const expected = sign(
+          CoreUrlMatcher.compare(coreCompile(left), coreCompile(right)),
+        );
+        const actual = sign(UrlMatcher.compare(compile(left), compile(right)));
+        assert.equal(actual, expected);
+      });
+    }
+  }
+});
 
 const formatComparisons = formatCases.reduce(
   (sum, c) => sum + c.values.length,


### PR DESCRIPTION
## Problem

`matchRoute` in the `./redirects` tier picked *which* route a pathname matched using a **fewest-params + declaration-order** heuristic, not core's real segment-by-segment static-specificity sort. On overlapping patterns with **equal param counts** and mixed static/dynamic positions the wrong route could win — and when that route carried a `redirectTo`, `compileRedirects` emitted an **incorrect server redirect** disagreeing with what the client's own router would resolve. This is exactly the server/client-honesty guarantee the package sells.

Flagged by a `codex` P2 review on #346; the divergence was self-documented in the docstring but untracked until #360.

## Fix

Port core's `UrlMatcher.compare` into the matcher tier (`url-matcher.ts`):

- Each matcher is flattened to path tokens — slash literals, static text, path params — and compared position-by-position.
- Weights: slash `1` < static text `2` < param `3`; the shorter pattern (0-padded) sorts first where they diverge. A negative result means the first matcher is more specific.
- `matchRoute` now replaces the running best only on a strictly-more-specific match (`compare < 0`), so **genuinely equal** specificity still falls to declaration order.

### Dep-free boundary preserved

No runtime `@uirouter/core` import is added — the port lives in the already-dep-free `url-matcher.ts` and reuses its private segment/param data. The treeshake probe (`treeshake.test.ts`) still passes, confirming the matcher/redirects tiers bundle core-free. (Inline docstrings say "core", not the literal `@uirouter/core` token, per the tier's existing convention — that token is what the treeshake assertion greps for.)

## Tests

- **Differential vs core** (`url-matcher.differential.test.ts`): all pairs of 12 overlapping patterns cross-checked against core's own `UrlMatcher.compare` (sign-normalized) — 144 comparisons, all agree.
- **`matchRoute` regression** (`redirects.test.ts`): `/a/:y` vs `/:x/b` on `/a/b` now picks the static-first `/a/:y` where the old heuristic tied and let the first-declared `/:x/b` win; plus a genuinely-equal case that still honors declaration order.
- **Redirect-surface regression**: an equal-param overlap where only the specific route lacks a `redirectTo` — the path is now served as-is instead of wrongly redirected.

Full suite: **359 tests, 0 fail**; all lint tasks green.

Closes #360