### PR TITLE
chore(lit-ui-router): drop the closed-issue ref from the $get() lint exception

### DIFF
--- a/packages/lit-ui-router/src/core.ts
+++ b/packages/lit-ui-router/src/core.ts
@@ -252,7 +252,7 @@ export class UIRouterLit extends UIRouter {
     if (this.started) {
       throw new Error('start() called multiple times');
     }
-    // eslint-disable-next-line typescript/no-deprecated -- $get() flushes the param-type queue; #279 tracks the @internal replacement
+    // eslint-disable-next-line typescript/no-deprecated -- $get() flushes the param-type queue; kept deliberately over the @internal flush
     this.urlMatcherFactory.$get();
     this.urlService.listen();
     this.urlService.sync();


### PR DESCRIPTION
#279 closed won't-fix (with #366 unmerged), so the lint exception's "#279 tracks the @internal replacement" pointed at a tracker that no longer tracks anything. The comment now states the decision inline: the deprecated $get() call is kept deliberately over reaching into the @internal flush.

Note: this comment ships in `dist/core.js` under the current single-pass tsc build, so `check:published-diff` will show lit-ui-router owing a release until this rides along with the next publish (or until the two-pass comment-stripping build lands, which makes src comments publish-neutral).