### PR TITLE
build(lit-ui-router): source maps for both emit passes + ship-affecting published-diff split

### DIFF
--- a/packages/lit-ui-router/package.json
+++ b/packages/lit-ui-router/package.json
@@ -10,7 +10,9 @@
     "url": "https://github.com/simshanith/lit-ui-router"
   },
   "files": [
-    "dist/**"
+    "dist/**",
+    "src/*.ts",
+    "!src/*.spec.ts"
   ],
   "type": "module",
   "sideEffects": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,9 @@ settings:
 
 catalogs:
   default:
+    '@ampproject/remapping':
+      specifier: ^2.3.0
+      version: 2.3.0
     '@api-viewer/docs':
       specifier: 1.0.0-pre.10
       version: 1.0.0-pre.10
@@ -776,6 +779,9 @@ importers:
 
   tools/oxc-emit:
     dependencies:
+      '@ampproject/remapping':
+        specifier: 'catalog:'
+        version: 2.3.0
       oxc-minify:
         specifier: 'catalog:'
         version: 0.140.0
@@ -876,6 +882,10 @@ packages:
 
   '@altano/repository-tools@2.0.3':
     resolution: {integrity: sha512-cSR/ZYDF6Wp9OeAJMyLYYN1GenAAhV17W+w38ELP+3c5Ltsy9jkkCymi33nz/qnXyef3n6Fbr1h2yt3dvUN5sQ==}
+
+  '@ampproject/remapping@2.3.0':
+    resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
+    engines: {node: '>=6.0.0'}
 
   '@api-viewer/common@1.0.0-pre.10':
     resolution: {integrity: sha512-6quixfdtbQ0oF3QIfm20+Fj+ODusYrssjBNQsCiXj3qwFsRmNVGfwdKvBXuH3y022NYgq0dgwADVPOm8SXLj7A==}
@@ -1634,6 +1644,9 @@ packages:
     peerDependenciesMeta:
       '@types/node':
         optional: true
+
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
   '@jridgewell/resolve-uri@3.1.2':
     resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
@@ -5854,6 +5867,11 @@ snapshots:
 
   '@altano/repository-tools@2.0.3': {}
 
+  '@ampproject/remapping@2.3.0':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
   '@api-viewer/common@1.0.0-pre.10':
     dependencies:
       custom-elements-manifest: 2.1.0
@@ -6639,6 +6657,11 @@ snapshots:
   '@inquirer/type@4.0.7(@types/node@25.0.9)':
     optionalDependencies:
       '@types/node': 25.0.9
+
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
 
   '@jridgewell/resolve-uri@3.1.2': {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,6 +6,7 @@ packages:
   - examples
 
 catalog:
+  '@ampproject/remapping': ^2.3.0
   '@api-viewer/docs': 1.0.0-pre.10
   '@codecov/bundle-analyzer': ^2.0.1
   '@oxc-project/runtime': 0.140.0

--- a/tools/oxc-emit/package.json
+++ b/tools/oxc-emit/package.json
@@ -14,6 +14,7 @@
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
+    "@ampproject/remapping": "catalog:",
     "oxc-minify": "catalog:",
     "oxc-transform": "catalog:"
   },

--- a/tools/oxc-emit/src/emit-dts.ts
+++ b/tools/oxc-emit/src/emit-dts.ts
@@ -1,19 +1,25 @@
 #!/usr/bin/env node
 // Types pass: oxc isolated declarations — syntax-derived d.ts, no typechecking.
 // Conformance is enforced by the packages' isolatedDeclarations typecheck.
-import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
-import { dirname, join, relative } from 'node:path';
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { basename, dirname, join, relative } from 'node:path';
 
 import { isolatedDeclarationSync } from 'oxc-transform';
 
-import { fail, OUT, publishableSources, SRC } from './shared.ts';
+import { fail, OUT, publishableSources, shippedMap, SRC } from './shared.ts';
 
 for (const file of publishableSources()) {
-  const declaration = isolatedDeclarationSync(file, readFileSync(file, 'utf8'));
+  const declaration = isolatedDeclarationSync(
+    file,
+    readFileSync(file, 'utf8'),
+    { sourcemap: true },
+  );
   if (declaration.errors.length) fail(file, declaration.errors);
   const out = join(OUT, relative(SRC, file)).replace(/\.ts$/, '.d.ts');
   mkdirSync(dirname(out), { recursive: true });
-  writeFileSync(out, declaration.code);
-  // Stale tsc-era declaration map, if the checkout carries one.
-  rmSync(`${out}.map`, { force: true });
+  writeFileSync(
+    out,
+    `${declaration.code}//# sourceMappingURL=${basename(out)}.map\n`,
+  );
+  writeFileSync(`${out}.map`, shippedMap(file, out, declaration.map!));
 }

--- a/tools/oxc-emit/src/emit-js.ts
+++ b/tools/oxc-emit/src/emit-js.ts
@@ -1,17 +1,18 @@
 #!/usr/bin/env node
 // JS pass: oxc transform (type-strip + legacy decorators) then codegen-only minify.
 // Comments never ship, so editing them can't trip check:published-diff.
-import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
-import { dirname, join, relative } from 'node:path';
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { basename, dirname, join, relative } from 'node:path';
 
 import { minifySync } from 'oxc-minify';
 import { transformSync } from 'oxc-transform';
 
-import { fail, OUT, publishableSources, SRC } from './shared.ts';
+import { fail, OUT, publishableSources, shippedMap, SRC } from './shared.ts';
 
 for (const file of publishableSources()) {
   const transformed = transformSync(file, readFileSync(file, 'utf8'), {
     target: 'es2022',
+    sourcemap: true,
     // tsconfig.base parity: experimentalDecorators + useDefineForClassFields:false
     decorator: { legacy: true },
     assumptions: { setPublicClassFields: true },
@@ -22,11 +23,17 @@ for (const file of publishableSources()) {
     compress: false,
     mangle: false,
     codegen: { removeWhitespace: false },
+    sourcemap: true,
   });
   if (printed.errors.length) fail(file, printed.errors);
   const out = join(OUT, relative(SRC, file)).replace(/\.ts$/, '.js');
   mkdirSync(dirname(out), { recursive: true });
-  writeFileSync(out, printed.code);
-  // Stale tsc-era sourcemap for this module, if the checkout carries one.
-  rmSync(`${out}.map`, { force: true });
+  writeFileSync(
+    out,
+    `${printed.code}//# sourceMappingURL=${basename(out)}.map\n`,
+  );
+  writeFileSync(
+    `${out}.map`,
+    shippedMap(file, out, printed.map!, transformed.map),
+  );
 }

--- a/tools/oxc-emit/src/shared.ts
+++ b/tools/oxc-emit/src/shared.ts
@@ -1,4 +1,6 @@
 import { globSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { basename, dirname, relative } from 'node:path';
 
 export const SRC = 'src';
 export const OUT = 'dist';
@@ -14,4 +16,38 @@ export function publishableSources(): string[] {
   return globSync(`${SRC}/**/*.ts`, {
     exclude: [`${SRC}/**/*.spec.ts`, `${SRC}/specs/**`],
   });
+}
+
+// remapping ships CJS function-as-module.exports; typed locally, fetched via require
+interface RawMap {
+  sources?: (string | null)[];
+}
+interface ComposedMap {
+  sources: string[];
+  file: string;
+  toString(): string;
+}
+const remapping = createRequire(import.meta.url)('@ampproject/remapping') as (
+  map: RawMap,
+  loader: (source: string) => RawMap | null,
+  options: { excludeContent: boolean },
+) => ComposedMap;
+
+// Compose an emit stage's map (or chain of two) into the shipped map for `out`:
+// single relative src source, no sourcesContent — the shipped src/ files are the referents.
+export function shippedMap(
+  file: string,
+  out: string,
+  finalMap: RawMap,
+  priorMap?: RawMap,
+): string {
+  const map = remapping(
+    finalMap,
+    (source) => (priorMap && source === file ? priorMap : null),
+    { excludeContent: true },
+  );
+  // exactly one original source; remapping's own resolution double-prefixes relative paths
+  map.sources = [relative(dirname(out), file)];
+  map.file = basename(out);
+  return map.toString();
 }

--- a/tools/release/src/checks/check-published-diff.core.ts
+++ b/tools/release/src/checks/check-published-diff.core.ts
@@ -31,6 +31,23 @@ export function changedFiles(diffOutput: string): string[] {
   return [...files].sort();
 }
 
+/** Ship-affecting drift owes a release; src/map paths never do — atomic packs make a masking src-only diff impossible. */
+export function isShipAffecting(file: string): boolean {
+  return !(file.startsWith('src/') || /^dist\/.*\.map$/.test(file));
+}
+
+/** Split a diff's file list into ship-affecting and ship-inert. */
+export function classifyFiles(files: string[]): {
+  shipAffecting: string[];
+  shipInert: string[];
+} {
+  const shipAffecting: string[] = [];
+  const shipInert: string[] = [];
+  for (const file of files)
+    (isShipAffecting(file) ? shipAffecting : shipInert).push(file);
+  return { shipAffecting, shipInert };
+}
+
 // One package's comparison against its published `latest`.
 export type DiffResult = {
   name: string;
@@ -39,9 +56,12 @@ export type DiffResult = {
   latest?: string;
   /** Version in the working tree's manifest. */
   localVersion?: string;
-  status: 'clean' | 'drift' | 'unpublished';
-  /** Tarball paths that differ; only meaningful for `drift`. */
+  /** `ship-inert` = only src/maps differ; release not owed. */
+  status: 'clean' | 'drift' | 'ship-inert' | 'unpublished';
+  /** Ship-affecting tarball paths; only meaningful for `drift`. */
   files?: string[];
+  /** Ship-inert paths (src/**, dist maps); listed, never owing. */
+  shipInertFiles?: string[];
 };
 
 export type ReportOptions = {
@@ -64,7 +84,8 @@ export function formatReport(
   const drifted = results.filter((result) => result.status === 'drift');
   const lines: string[] = [];
   for (const result of results) {
-    const { name, latest, localVersion, status, files } = result;
+    const { name, latest, localVersion, status, files, shipInertFiles } =
+      result;
     if (status === 'unpublished') {
       lines.push(`  ${name}: never published — skipped`);
       continue;
@@ -75,20 +96,33 @@ export function formatReport(
         : '';
     if (status === 'clean') {
       lines.push(`  ${name}: clean vs ${latest}${ahead}`);
+    } else if (status === 'ship-inert') {
+      const count = shipInertFiles?.length ?? 0;
+      lines.push(
+        `  ${name}: src/map drift vs ${latest}${ahead} — ${count} ship-inert file(s):`,
+      );
+      for (const file of shipInertFiles ?? []) lines.push(`      ◦ ${file}`);
     } else {
       const count = files?.length ?? 0;
       lines.push(
-        `  ${name}: SHIPS CHANGES vs ${latest}${ahead} — ${count} file(s):`,
+        `  ${name}: SHIPS CHANGES vs ${latest}${ahead} — ${count} ship-affecting file(s):`,
       );
       for (const file of files ?? []) lines.push(`      • ${file}`);
+      for (const file of shipInertFiles ?? [])
+        lines.push(`      ◦ ${file} (ship-inert)`);
     }
   }
 
+  const shipInertOnly = results.filter(
+    (result) => result.status === 'ship-inert',
+  );
   const ok = !options.strict || drifted.length === 0;
+  const shipInertNote =
+    shipInertOnly.length > 0 ? ` (${shipInertOnly.length} ship-inert)` : '';
   const headline = ok
     ? drifted.length === 0
-      ? `✓ published-diff check passed — ${results.length} packages match their published tarballs.`
-      : `published-diff report — ${drifted.length} of ${results.length} packages would ship changes if released:`
-    : `✗ published-diff check failed — ${drifted.length} of ${results.length} packages drift from their published tarballs:`;
+      ? `✓ published-diff check passed — ${results.length} packages, no ship-affecting drift${shipInertNote}.`
+      : `published-diff report — ${drifted.length} of ${results.length} packages would ship changes if released${shipInertNote}:`
+    : `✗ published-diff check failed — ${drifted.length} of ${results.length} packages drift from their published tarballs${shipInertNote}:`;
   return { ok, text: [headline, ...lines].join('\n') };
 }

--- a/tools/release/src/checks/check-published-diff.test.ts
+++ b/tools/release/src/checks/check-published-diff.test.ts
@@ -3,6 +3,7 @@ import { describe, it } from 'node:test';
 
 import {
   changedFiles,
+  classifyFiles,
   formatReport,
   isCleanDiff,
 } from './check-published-diff.core.ts';
@@ -50,6 +51,34 @@ describe('changedFiles', () => {
   });
 });
 
+describe('classifyFiles', () => {
+  it('routes src and dist maps to ship-inert, everything else to ship-affecting', () => {
+    assert.deepEqual(
+      classifyFiles([
+        'dist/core.js',
+        'dist/core.js.map',
+        'dist/core.d.ts',
+        'dist/core.d.ts.map',
+        'src/core.ts',
+        'package.json',
+      ]),
+      {
+        shipAffecting: ['dist/core.js', 'dist/core.d.ts', 'package.json'],
+        shipInert: ['dist/core.js.map', 'dist/core.d.ts.map', 'src/core.ts'],
+      },
+    );
+  });
+
+  it('never treats a map-named source file as ship-inert', () => {
+    // A real code change always also changes emitted js/d.ts, so ship-inert
+    // entries alone can't mask ship-affecting drift.
+    assert.deepEqual(classifyFiles(['dist/sourcemap-utils.js']), {
+      shipAffecting: ['dist/sourcemap-utils.js'],
+      shipInert: [],
+    });
+  });
+});
+
 describe('formatReport', () => {
   const clean = {
     name: 'lit-ui-router',
@@ -67,18 +96,53 @@ describe('formatReport', () => {
     files: ['dist/router-store.js', 'package.json'],
   };
 
+  const shipInert = {
+    name: 'lit-ui-router',
+    dir: 'packages/lit-ui-router',
+    latest: '1.7.1',
+    localVersion: '1.7.1',
+    status: 'ship-inert' as const,
+    files: [],
+    shipInertFiles: ['dist/core.js.map', 'src/core.ts'],
+  };
+
   it('passes when every package matches its published tarball', () => {
     const { ok, text } = formatReport([clean]);
     assert.equal(ok, true);
-    assert.match(text, /✓ published-diff check passed — 1 packages match/);
+    assert.match(
+      text,
+      /✓ published-diff check passed — 1 packages, no ship-affecting drift/,
+    );
     assert.match(text, /lit-ui-router: clean vs 1\.7\.0/);
+  });
+
+  it('passes with ship-inert drift only — even strict', () => {
+    const { ok, text } = formatReport([shipInert], { strict: true });
+    assert.equal(ok, true);
+    assert.match(text, /\(1 ship-inert\)/);
+    assert.match(text, /src\/map drift vs 1\.7\.1 — 2 ship-inert file\(s\)/);
+    assert.match(text, /◦ src\/core\.ts/);
+  });
+
+  it('lists ship-inert files under a drifting package without counting them', () => {
+    const { text } = formatReport([
+      { ...drift, shipInertFiles: ['src/router-store.ts'] },
+    ]);
+    assert.match(
+      text,
+      /SHIPS CHANGES vs 0\.3\.2 — 2 ship-affecting file\(s\):/,
+    );
+    assert.match(text, /◦ src\/router-store\.ts \(ship-inert\)/);
   });
 
   it('reports drift without failing by default', () => {
     const { ok, text } = formatReport([clean, drift]);
     assert.equal(ok, true);
     assert.match(text, /1 of 2 packages would ship changes/);
-    assert.match(text, /SHIPS CHANGES vs 0\.3\.2 — 2 file\(s\):/);
+    assert.match(
+      text,
+      /SHIPS CHANGES vs 0\.3\.2 — 2 ship-affecting file\(s\):/,
+    );
     assert.match(text, /• dist\/router-store\.js/);
   });
 

--- a/tools/release/src/checks/check-published-diff.ts
+++ b/tools/release/src/checks/check-published-diff.ts
@@ -36,6 +36,7 @@ import { promisify } from 'node:util';
 import { STRIPPED_MANIFEST_FIELDS } from './check-pack.core.ts';
 import {
   changedFiles,
+  classifyFiles,
   type DiffResult,
   formatReport,
   isCleanDiff,
@@ -119,18 +120,20 @@ async function main() {
       continue;
     }
     const diff = await diffAgainstPublished(packageDir, `${name}@${latest}`);
-    results.push(
-      isCleanDiff(diff)
-        ? { name, dir, latest, localVersion, status: 'clean' }
-        : {
-            name,
-            dir,
-            latest,
-            localVersion,
-            status: 'drift',
-            files: changedFiles(diff),
-          },
-    );
+    if (isCleanDiff(diff)) {
+      results.push({ name, dir, latest, localVersion, status: 'clean' });
+      continue;
+    }
+    const { shipAffecting, shipInert } = classifyFiles(changedFiles(diff));
+    results.push({
+      name,
+      dir,
+      latest,
+      localVersion,
+      status: shipAffecting.length > 0 ? 'drift' : 'ship-inert',
+      files: shipAffecting,
+      shipInertFiles: shipInert,
+    });
   }
 
   const { ok, text } = formatReport(results, { strict });


### PR DESCRIPTION
Stacked on #369 — **review vehicle only**: on approval this folds into #369 (cherry-pick + close unmerged) so maps ship with the pass-split conversion as one 1.7.1 story.

Adds working source maps to both emit passes and teaches `check:published-diff` that map/src drift is ship-inert — reported, never owing a release.

## Maps from both passes (`@tools/oxc-emit`)
- **JS**: `sourcemap: true` through both stages, composed via `@ampproject/remapping` (`excludeContent: true`) into one `dist/*.js.map` — mappings survive the comment-stripping minify stage and land on real src lines.
- **d.ts**: `isolatedDeclarationSync(..., { sourcemap: true })` → `dist/*.d.ts.map`. Net-new capability: the old tsc build never shipped `declarationMap`, so consumer go-to-definition now lands on actual sources for the first time.
- `shippedMap()` handles two interop wrinkles: remapping's CJS export typed via a local call surface under nodenext (`createRequire`), and `sources` set deterministically to `../src/<name>.ts` (remapping double-prefixes relative paths in the single-module compose).

## Shipped sources as referents
`files: ["dist/**", "src/*.ts", "!src/*.spec.ts"]` — 12 source files ship (specs verified absent from the pack), no `sourcesContent` anywhere. Maps stay lean; comments live only in `src/**`.

## `check:published-diff`: ship-affecting vs ship-inert
Drift now classifies into **ship-affecting** (`dist` js/d.ts + manifest — drives the release-owed verdict) vs **ship-inert** (`src/**`, `dist/**/*.map` — printed with hollow `◦` bullets, excluded from the headline count). Atomic packs make wrong-line mapping impossible, so ship-inert drift can't hurt consumers and shouldn't force a publish. Against published 1.7.0: **27 ship-affecting files, 37 ship-inert**.

## Verification
Full `turbo run ci` green (94 tasks); tools/release 102/102 incl. three new split suites; spot traces: `dist/core.js 62:20 → ../src/core.ts 253:22` (the `start()` re-entry throw) and `dist/core.d.ts 64 → litViewsBuilder`. New catalog dep `@ampproject/remapping` is tool-only — nothing new at runtime.

