### PR TITLE
chore: license housekeeping — ui-router-server MIT + @uirouter/core port notice, repo-level LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,9 @@
+The MIT License
+
+Copyright (c) 2024-present Lit UI-Router Team
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Main Branch CI](https://github.com/simshanith/lit-ui-router/actions/workflows/build-test.yml/badge.svg?branch=main)](https://github.com/simshanith/lit-ui-router/actions/workflows/build-test.yml?query=branch%3Amain)
 [![npm](https://img.shields.io/npm/v/lit-ui-router.svg)](https://www.npmjs.com/package/lit-ui-router)
 [![GitHub Release](https://img.shields.io/github/v/release/simshanith/lit-ui-router?filter=lit-ui-router@*)](https://github.com/simshanith/lit-ui-router/releases/?q=lit-ui-router)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Website](https://img.shields.io/website?url=https%3A%2F%2Flit-ui-router.dev)](https://lit-ui-router.dev)
 [![codecov](https://codecov.io/gh/simshanith/lit-ui-router/branch/main/graph/badge.svg)](https://codecov.io/gh/simshanith/lit-ui-router)
 

--- a/packages/lit-ui-router/README.md
+++ b/packages/lit-ui-router/README.md
@@ -4,6 +4,7 @@
 
 [![npm version](https://img.shields.io/npm/v/lit-ui-router.svg)](https://www.npmjs.com/package/lit-ui-router)
 [![GitHub Release](https://img.shields.io/github/v/release/simshanith/lit-ui-router?filter=lit-ui-router@*)](https://github.com/simshanith/lit-ui-router/releases/?q=lit-ui-router)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 [![Website](https://img.shields.io/website?url=https%3A%2F%2Flit-ui-router.dev)](https://lit-ui-router.dev)
 [![codecov](https://codecov.io/gh/simshanith/lit-ui-router/graph/badge.svg?component=lit-ui-router)](https://app.codecov.io/gh/simshanith/lit-ui-router?components%5B0%5D=lit-ui-router)
 

--- a/packages/ui-router-server/LICENSE
+++ b/packages/ui-router-server/LICENSE
@@ -1,0 +1,37 @@
+The MIT License
+
+Copyright (c) 2026-present Lit UI-Router Team
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+---
+
+Third-party notices
+
+Portions of this software (src/url-matcher.ts: UrlMatcher, Param, and ParamTypes logic) are derived from @uirouter/core (https://github.com/ui-router/core), used under the following license:
+
+The MIT License
+
+Copyright (c) 2013-2015 The AngularUI Team, Karsten Sperling
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/packages/ui-router-server/README.md
+++ b/packages/ui-router-server/README.md
@@ -1,5 +1,7 @@
 # ui-router-server
 
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
+
 Server-side routing for ui-router state trees. Given per-mount routing config and a request URL, it resolves the path against the registered states and returns a plain routing verdict (render, redirect, or miss) — runtime-agnostic, with no fetch/Response or workers types in the core. Adapters turn verdicts into HTTP for Connect/Vite middleware and fetch/Hono handlers. Matcher-only mounts are dependency-free; `simulate` mounts lazily replay the path through a headless `@uirouter/core` router (an optional peer dependency).
 
 **Status: unreleased** — this package has not been published to npm yet.

--- a/packages/ui-router-server/README.md
+++ b/packages/ui-router-server/README.md
@@ -1,0 +1,9 @@
+# ui-router-server
+
+Server-side routing for ui-router state trees. Given per-mount routing config and a request URL, it resolves the path against the registered states and returns a plain routing verdict (render, redirect, or miss) — runtime-agnostic, with no fetch/Response or workers types in the core. Adapters turn verdicts into HTTP for Connect/Vite middleware and fetch/Hono handlers. Matcher-only mounts are dependency-free; `simulate` mounts lazily replay the path through a headless `@uirouter/core` router (an optional peer dependency).
+
+**Status: unreleased** — this package has not been published to npm yet.
+
+## Attribution
+
+URL-matching logic (`src/url-matcher.ts`) is derived from [@uirouter/core](https://github.com/ui-router/core) (MIT) — see [LICENSE](./LICENSE).

--- a/packages/ui-router-server/package.json
+++ b/packages/ui-router-server/package.json
@@ -2,6 +2,7 @@
   "name": "ui-router-server",
   "version": "0.0.0",
   "private": true,
+  "license": "MIT",
   "type": "module",
   "sideEffects": false,
   "exports": {


### PR DESCRIPTION
## The gap

- **ui-router-server had no license metadata** ahead of its first publish: no `license` field in package.json, no LICENSE file, no README.
- **The repo root had no LICENSE file** — each package carries one, but the repository itself declared nothing.

## What this adds

- `packages/ui-router-server/package.json`: `"license": "MIT"` (placed where `lint:package-json` field ordering wants it).
- `packages/ui-router-server/LICENSE`: the project MIT text (mirroring the mobx package's style), plus a clearly separated **Third-party notices** section carrying the full upstream `@uirouter/core` notice verbatim (Copyright (c) 2013-2015 The AngularUI Team, Karsten Sperling) for the `src/url-matcher.ts` UrlMatcher/Param/ParamTypes port.
- `packages/ui-router-server/README.md`: minimal package README (what it is, unreleased status, Attribution section pointing at LICENSE).
- Root `LICENSE`: project MIT, "Copyright (c) 2024-present Lit UI-Router Team" matching `packages/lit-ui-router/LICENSE`.

## Why the LICENSE file is the carrier

MIT requires the copyright notice **and** permission notice be included in all copies or substantial portions of the Software. The build pipeline strips comments from dist output, so the one-line `// Derived from @uirouter/core ...` header in `src/url-matcher.ts` cannot be the only carrier — it doesn't survive into published artifacts. LICENSE is force-included by npm in every pack, making it the reliable vehicle; the src header stays as the in-tree pointer.

## Sweep result

`rg`'d the other packages' src (lit-ui-router, lit-ui-router-mobx, navigation-location-plugin) and the rest of ui-router-server/src for derived/ported/adapted/copied markers: **only `src/url-matcher.ts` carries a derivation marker**. All other `@uirouter/core` mentions are ordinary imports of the declared peer dependency. The root README does not currently mention a license (unchanged here — the badge-per-package pattern and the new root LICENSE cover it; a root README license line could follow separately).

## Gates

- `turbo run format` + `turbo run format:check` — pass
- `turbo run lint --filter=ui-router-server` — pass
- `lint:package-json` — pass (23/23 ok)