### PR TITLE
refactor(ui-router-server): functional matcher core — compiled data + per-operation functions

### DIFF
--- a/packages/ui-router-server/src/redirects.ts
+++ b/packages/ui-router-server/src/redirects.ts
@@ -10,8 +10,11 @@
 
 import type { RawParams } from '@uirouter/core';
 
-import { UrlMatcher, urlMatcherFactory } from './url-matcher.ts';
-import type { UrlMatcherCompilerConfig } from './url-matcher.ts';
+import { compare, exec, format, urlMatcherFactory } from './url-matcher.ts';
+import type {
+  CompiledMatcher,
+  UrlMatcherCompilerConfig,
+} from './url-matcher.ts';
 
 /** A state's contribution to the url-addressable route set. */
 export interface RouteDeclaration {
@@ -63,7 +66,7 @@ export interface CompiledRoute {
   name: string;
   /** The full pattern: this state's url appended to its ancestors'. */
   pattern: string;
-  matcher: UrlMatcher;
+  matcher: CompiledMatcher;
   redirectTo?: string | RedirectTarget;
 }
 
@@ -129,20 +132,20 @@ export interface RouteMatch {
 
 /**
  * Returns which route's pattern the pathname matched, with the extracted
- * params. The most specific match wins ([[UrlMatcher.compare]]); ties go
- * to declaration order.
+ * params. The most specific match wins ([[compare]]); ties go to
+ * declaration order.
  */
 export function matchRoute(
   routes: CompiledRoute[],
   pathname: string,
 ): RouteMatch | null {
   let best: RouteMatch | null = null;
-  let bestMatcher: UrlMatcher | null = null;
+  let bestMatcher: CompiledMatcher | null = null;
   for (const { name, matcher } of routes) {
-    const params = matcher.exec(pathname);
+    const params = exec(matcher, pathname);
     if (params === null) continue;
     // Strict < keeps the earlier declaration on ties.
-    if (bestMatcher === null || UrlMatcher.compare(matcher, bestMatcher) < 0) {
+    if (bestMatcher === null || compare(matcher, bestMatcher) < 0) {
       best = { state: name, params };
       bestMatcher = matcher;
     }
@@ -213,7 +216,7 @@ export function compileRedirects(
       carried = next.params ?? carried;
       state = byName.get(next.state)!;
     }
-    const path = state.matcher.format(carried);
+    const path = format(state.matcher, carried);
     // Invalid target params, or a redirect landing where it started: no-op.
     return path === null || path === pathname ? null : path;
   };
@@ -225,7 +228,7 @@ export function compileRedirects(
           return follow(rule.to.state, rule.to.params ?? {}, pathname);
         continue;
       }
-      const params = rule.matcher!.exec(pathname);
+      const params = exec(rule.matcher!, pathname);
       if (params !== null)
         return follow(
           rule.to.state,

--- a/packages/ui-router-server/src/url-matcher.ts
+++ b/packages/ui-router-server/src/url-matcher.ts
@@ -383,10 +383,11 @@ interface ResolvedConfig extends Required<UrlMatcherCompilerConfig> {
  * `compile` and consumed by [[exec]], [[format]], and [[compare]].
  * Frozen — treat as immutable: [[compare]] memoizes per object identity,
  * and the functions/regexps inside make it not structuredClone-able.
- * To associate data with a matcher, use your own identity-keyed WeakMap
- * (frozen objects are fine as keys).
+ * Two data channels: `meta` rides compile-time data on the matcher, and a
+ * consumer-owned identity-keyed WeakMap (frozen keys are fine) covers
+ * external or mutable association.
  */
-export interface CompiledMatcher {
+export interface CompiledMatcher<M = undefined> {
   /** The pattern that was compiled. */
   readonly pattern: string;
   /** The whole-path regexp the pattern compiled to. */
@@ -397,14 +398,17 @@ export interface CompiledMatcher {
   readonly searchParams: readonly CompiledParam[];
   /** Whether [[exec]] percent-decodes captured values (the factory's decodeParams). */
   readonly decodeParams: boolean;
+  /** Compile-time data riding the matcher (e.g. a build-time route id); the reference is frozen in, the object stays consumer-owned. */
+  readonly meta: M;
 }
 
 const nameValidator = /^\w+([-.]+\w+)*(?:\[\])?$/;
 
-const compileMatcher = (
+const compileMatcher = <M>(
   pattern: string,
   config: ResolvedConfig,
-): CompiledMatcher => {
+  meta: M,
+): CompiledMatcher<M> => {
   // Placeholder syntax (regexps identical to @uirouter/core): ':name',
   // '*name' (catch-all), '{name}', '{name:regexp-or-type}' with balanced or
   // escaped inner braces; search params additionally allow '.' and '-' in
@@ -476,15 +480,16 @@ const compileMatcher = (
     pathParams: freeze(params.filter((param) => !param.isSearch)),
     searchParams: freeze(params.filter((param) => param.isSearch)),
     decodeParams: config.decodeParams,
+    meta,
   });
 };
 
 // Core's sort weights: slash → 1, static text → 2, param → 3; search
 // params carry no weight. Memoized as in core; the WeakMap keeps the
 // cache off the matcher's inert data.
-const weightsCache = new WeakMap<CompiledMatcher, number[]>();
+const weightsCache = new WeakMap<CompiledMatcher<unknown>, number[]>();
 
-const segmentWeights = (matcher: CompiledMatcher): number[] => {
+const segmentWeights = (matcher: CompiledMatcher<unknown>): number[] => {
   const cached = weightsCache.get(matcher);
   if (cached) return cached;
   const weights: number[] = [];
@@ -505,7 +510,10 @@ const segmentWeights = (matcher: CompiledMatcher): number[] => {
  * before static text before a param. Negative means `a` is more specific
  * than `b`. Single-matcher only: matchers here never `append`.
  */
-export function compare(a: CompiledMatcher, b: CompiledMatcher): number {
+export function compare(
+  a: CompiledMatcher<unknown>,
+  b: CompiledMatcher<unknown>,
+): number {
   const weightsA = segmentWeights(a);
   const weightsB = segmentWeights(b);
   const length = Math.max(weightsA.length, weightsB.length);
@@ -523,7 +531,10 @@ export function compare(a: CompiledMatcher, b: CompiledMatcher): number {
  * or null when it does not. Search params always appear in the result,
  * resolved to their static defaults (undefined when none is declared).
  */
-export function exec(matcher: CompiledMatcher, path: string): RawParams | null {
+export function exec(
+  matcher: CompiledMatcher<unknown>,
+  path: string,
+): RawParams | null {
   const match = matcher.regexp.exec(path);
   if (!match) return null;
   // A custom inline regexp with its own capture group would misalign values.
@@ -561,7 +572,7 @@ export function exec(matcher: CompiledMatcher, path: string): RawParams | null {
  * Returns null when any value fails its param's validation.
  */
 export function format(
-  matcher: CompiledMatcher,
+  matcher: CompiledMatcher<unknown>,
   values: RawParams = {},
 ): string | null {
   const details = (param: CompiledParam) => {
@@ -632,10 +643,11 @@ export function format(
  * percent-decoding on, and a default squash policy of false.
  */
 export function urlMatcherFactory(config: UrlMatcherCompilerConfig = {}): {
-  compile: (
+  compile: <M = undefined>(
     pattern: string,
     options?: UrlMatcherCompileOptions,
-  ) => CompiledMatcher;
+    meta?: M,
+  ) => CompiledMatcher<M>;
 } {
   const {
     strict = true,
@@ -646,13 +658,22 @@ export function urlMatcherFactory(config: UrlMatcherCompilerConfig = {}): {
   // Same validation as ui-router's UrlConfig.defaultSquashPolicy().
   getSquashPolicy(defaultSquashPolicy, true, false);
   return {
-    compile: (pattern, options = {}) =>
-      compileMatcher(pattern, {
-        strict: options.strict ?? strict,
-        caseInsensitive: options.caseInsensitive ?? caseInsensitive,
-        decodeParams,
-        defaultSquashPolicy,
-        params: options.params ?? {},
-      }),
+    compile: <M = undefined>(
+      pattern: string,
+      options: UrlMatcherCompileOptions = {},
+      meta?: M,
+    ) =>
+      compileMatcher(
+        pattern,
+        {
+          strict: options.strict ?? strict,
+          caseInsensitive: options.caseInsensitive ?? caseInsensitive,
+          decodeParams,
+          defaultSquashPolicy,
+          params: options.params ?? {},
+        },
+        // Omitted meta is the declared default: `compile(p)` → meta undefined.
+        meta as M,
+      ),
   };
 }

--- a/packages/ui-router-server/src/url-matcher.ts
+++ b/packages/ui-router-server/src/url-matcher.ts
@@ -195,7 +195,8 @@ const getSquashPolicy = (
   );
 };
 
-interface Replace {
+/** An input rewrite applied before typing (absent/empty/squash handling). */
+export interface Replace {
   from: unknown;
   to: unknown;
 }
@@ -215,101 +216,104 @@ const getReplace = (
   return [...defaults, ...fromSquash];
 };
 
-class Param {
+/** A compiled parameter: inert data for one placeholder of a pattern. */
+export interface CompiledParam {
   readonly id: string;
   readonly type: ParamType;
   readonly isSearch: boolean;
   readonly isOptional: boolean;
   readonly squash: boolean | string;
-  readonly replace: Replace[];
-  readonly #defaultValue: unknown;
-
-  constructor(
-    id: string,
-    urlType: ParamType | null,
-    isSearch: boolean,
-    config: ResolvedConfig,
-    pattern: string,
-  ) {
-    const declared = unwrapShorthand(config.params[id]);
-    const where = `param '${id}' in pattern '${pattern}'`;
-    if (
-      id.endsWith('[]') ||
-      (Object.hasOwn(declared, 'array') && declared.array)
-    )
-      throw new Error(
-        `Array parameters are not supported by the standalone matcher (${where})`,
-      );
-    if (Object.hasOwn(declared, 'replace'))
-      throw new Error(
-        `'replace' is not supported by the standalone matcher (${where})`,
-      );
-    if (typeof declared.value === 'function')
-      throw new Error(
-        `Function (injected) defaults are not supported by the standalone matcher (${where}); use a static value`,
-      );
-
-    this.id = id;
-    this.type = resolveType(declared.type, urlType, isSearch, id);
-    this.isSearch = isSearch;
-    this.isOptional = declared.value !== undefined || isSearch;
-    this.squash = getSquashPolicy(
-      declared.squash,
-      this.isOptional,
-      config.defaultSquashPolicy,
-    );
-    this.replace = getReplace(this.isOptional, this.squash);
-    this.#defaultValue = declared.value;
-  }
-
-  /** The typed value for a decoded input, or the static default when absent. */
-  value(input: unknown): unknown {
-    for (const { from, to } of this.replace) {
-      if (from === input) {
-        input = to;
-        break;
-      }
-    }
-    if (input === undefined) {
-      // Static value, applied directly: upstream invokes even non-function
-      // defaults through services.$injector and throws when none exists.
-      const value = this.#defaultValue;
-      if (value !== null && value !== undefined && !this.type.is(value))
-        throw new Error(
-          `Default value (${JSON.stringify(value)}) for parameter '${this.id}' is not an instance of ParamType (${this.type.name})`,
-        );
-      return value;
-    }
-    return this.type.is(input) ? input : this.type.decode(input as string);
-  }
-
-  /** True when the typed value equals this param's default (core's Param.isDefaultValue). */
-  isDefaultValue(input: unknown): boolean {
-    if (!this.isOptional) return false;
-    const defaultValue = this.value(undefined);
-    // Search params are auto-array-wrapped upstream, where an absent value
-    // compares as the empty array: equal only to another absent value.
-    if (this.isSearch && (defaultValue === undefined || input === undefined))
-      return defaultValue === undefined && input === undefined;
-    return typeEquals(this.type, defaultValue, input);
-  }
-
-  /** Whether a typed value can appear in a built url (core's Param.validates). */
-  validates(input: unknown): boolean {
-    // No value, but the param is optional.
-    if ((input === undefined || input === null) && this.isOptional) return true;
-    const normalized: unknown = this.type.is(input)
-      ? input
-      : this.type.decode(input as string);
-    if (!this.type.is(normalized)) return false;
-    // Of the right type, but its encoded form escapes the type's pattern.
-    const encoded = typeEncode(this.type, normalized);
-    return !(typeof encoded === 'string' && !this.type.pattern.exec(encoded));
-  }
+  readonly replace: readonly Replace[];
+  /** The static default value, applied directly (see the module docblock). */
+  readonly defaultValue: unknown;
 }
 
+const makeParam = (
+  id: string,
+  urlType: ParamType | null,
+  isSearch: boolean,
+  config: ResolvedConfig,
+  pattern: string,
+): CompiledParam => {
+  const declared = unwrapShorthand(config.params[id]);
+  const where = `param '${id}' in pattern '${pattern}'`;
+  if (id.endsWith('[]') || (Object.hasOwn(declared, 'array') && declared.array))
+    throw new Error(
+      `Array parameters are not supported by the standalone matcher (${where})`,
+    );
+  if (Object.hasOwn(declared, 'replace'))
+    throw new Error(
+      `'replace' is not supported by the standalone matcher (${where})`,
+    );
+  if (typeof declared.value === 'function')
+    throw new Error(
+      `Function (injected) defaults are not supported by the standalone matcher (${where}); use a static value`,
+    );
+
+  const isOptional = declared.value !== undefined || isSearch;
+  const squash = getSquashPolicy(
+    declared.squash,
+    isOptional,
+    config.defaultSquashPolicy,
+  );
+  return {
+    id,
+    type: resolveType(declared.type, urlType, isSearch, id),
+    isSearch,
+    isOptional,
+    squash,
+    replace: getReplace(isOptional, squash),
+    defaultValue: declared.value,
+  };
+};
+
+/** The typed value for a decoded input, or the static default when absent (core's Param.value). */
+const paramValue = (param: CompiledParam, input: unknown): unknown => {
+  for (const { from, to } of param.replace) {
+    if (from === input) {
+      input = to;
+      break;
+    }
+  }
+  if (input === undefined) {
+    // Static value, applied directly: upstream invokes even non-function
+    // defaults through services.$injector and throws when none exists.
+    const value = param.defaultValue;
+    if (value !== null && value !== undefined && !param.type.is(value))
+      throw new Error(
+        `Default value (${JSON.stringify(value)}) for parameter '${param.id}' is not an instance of ParamType (${param.type.name})`,
+      );
+    return value;
+  }
+  return param.type.is(input) ? input : param.type.decode(input as string);
+};
+
+/** True when the typed value equals the param's default (core's Param.isDefaultValue). */
+const paramIsDefault = (param: CompiledParam, input: unknown): boolean => {
+  if (!param.isOptional) return false;
+  const defaultValue = paramValue(param, undefined);
+  // Search params are auto-array-wrapped upstream, where an absent value
+  // compares as the empty array: equal only to another absent value.
+  if (param.isSearch && (defaultValue === undefined || input === undefined))
+    return defaultValue === undefined && input === undefined;
+  return typeEquals(param.type, defaultValue, input);
+};
+
+/** Whether a typed value can appear in a built url (core's Param.validates). */
+const paramValidates = (param: CompiledParam, input: unknown): boolean => {
+  // No value, but the param is optional.
+  if ((input === undefined || input === null) && param.isOptional) return true;
+  const normalized: unknown = param.type.is(input)
+    ? input
+    : param.type.decode(input as string);
+  if (!param.type.is(normalized)) return false;
+  // Of the right type, but its encoded form escapes the type's pattern.
+  const encoded = typeEncode(param.type, normalized);
+  return !(typeof encoded === 'string' && !param.type.pattern.exec(encoded));
+};
+
 /** Escapes a static segment; with a param, appends its capture group per squash policy. */
-const quoteRegExp = (segment: string, param?: Param): string => {
+const quoteRegExp = (segment: string, param?: CompiledParam): string => {
   let result = segment.replace(/[\\[\]^$*+?.()|{}]/g, '\\$&');
   if (!param) return result;
   let surround: [string, string];
@@ -350,244 +354,257 @@ interface ResolvedConfig extends Required<UrlMatcherCompilerConfig> {
   params: Record<string, unknown>;
 }
 
-export class UrlMatcher {
-  static readonly nameValidator: RegExp = /^\w+([-.]+\w+)*(?:\[\])?$/;
+const nameValidator = /^\w+([-.]+\w+)*(?:\[\])?$/;
 
+/**
+ * A compiled url pattern: inert data produced by [[urlMatcherFactory]]'s
+ * `compile` and consumed by the free functions [[exec]], [[format]], and
+ * [[compare]] — import only the operations you use.
+ */
+export interface CompiledMatcher {
   /** The pattern that was compiled. */
   readonly pattern: string;
-  readonly #regexp: RegExp;
-  readonly #pathParams: Param[];
-  readonly #searchParams: Param[];
-  readonly #decodeParams: boolean;
+  /** The whole-path regexp the pattern compiled to. */
+  readonly regexp: RegExp;
   /** The raw static segments between path params (length: path params + 1). */
-  readonly #segments: string[];
+  readonly segments: readonly string[];
+  readonly pathParams: readonly CompiledParam[];
+  readonly searchParams: readonly CompiledParam[];
+  /** Whether [[exec]] percent-decodes captured values (the factory's decodeParams). */
+  readonly decodeParams: boolean;
+}
 
-  constructor(pattern: string, config: ResolvedConfig) {
-    this.pattern = pattern;
-    this.#decodeParams = config.decodeParams;
+const compileMatcher = (
+  pattern: string,
+  config: ResolvedConfig,
+): CompiledMatcher => {
+  // Placeholder syntax (regexps identical to @uirouter/core): ':name',
+  // '*name' (catch-all), '{name}', '{name:regexp-or-type}' with balanced or
+  // escaped inner braces; search params additionally allow '.' and '-' in
+  // names. The (?=(\s*))\4 backreference makes the regexp-body atom atomic.
+  const placeholder =
+    /([:*])([\w[\]]+)|\{([\w[\]]+)(?::(?=(\s*))\4((?:[^{}\\]|\\.|\{(?:[^{}\\]|\\.)*\})+))?\}/g;
+  const searchPlaceholder =
+    /([:]?)([\w[\].-]+)|\{([\w[\].-]+)(?::(?=(\s*))\4((?:[^{}\\]|\\.|\{(?:[^{}\\]|\\.)*\})+))?\}/g;
 
-    // Placeholder syntax (regexps identical to @uirouter/core): ':name',
-    // '*name' (catch-all), '{name}', '{name:regexp-or-type}' with balanced or
-    // escaped inner braces; search params additionally allow '.' and '-' in
-    // names. The (?=(\s*))\4 backreference makes the regexp-body atom atomic.
-    const placeholder =
-      /([:*])([\w[\]]+)|\{([\w[\]]+)(?::(?=(\s*))\4((?:[^{}\\]|\\.|\{(?:[^{}\\]|\\.)*\})+))?\}/g;
-    const searchPlaceholder =
-      /([:]?)([\w[\].-]+)|\{([\w[\].-]+)(?::(?=(\s*))\4((?:[^{}\\]|\\.|\{(?:[^{}\\]|\\.)*\})+))?\}/g;
+  const params: CompiledParam[] = [];
+  const compiled: string[] = [];
+  const segments: string[] = [];
 
-    const params: Param[] = [];
-    const compiled: string[] = [];
-    const segments: string[] = [];
-
-    const makeParam = (m: RegExpExecArray, isSearch: boolean): Param => {
-      const id = m[2] || m[3];
-      // Inline regexp or type name from '{name:...}'; '*name' matches everything.
-      const inline = isSearch
-        ? m[5]
-        : m[5] || (m[1] === '*' ? '[\\s\\S]*' : null);
-      if (!UrlMatcher.nameValidator.test(id))
+  const paramFromMatch = (
+    m: RegExpExecArray,
+    isSearch: boolean,
+  ): CompiledParam => {
+    const id = m[2] || m[3];
+    // Inline regexp or type name from '{name:...}'; '*name' matches everything.
+    const inline = isSearch
+      ? m[5]
+      : m[5] || (m[1] === '*' ? '[\\s\\S]*' : null);
+    if (!nameValidator.test(id))
+      throw new Error(`Invalid parameter name '${id}' in pattern '${pattern}'`);
+    if (params.some((p) => p.id === id))
+      throw new Error(
+        `Duplicate parameter name '${id}' in pattern '${pattern}'`,
+      );
+    let urlType: ParamType | null = null;
+    if (inline) {
+      if (unsupportedTypes.has(inline))
         throw new Error(
-          `Invalid parameter name '${id}' in pattern '${pattern}'`,
+          `Param type '${inline}' is not supported by the standalone matcher`,
         );
-      if (params.some((p) => p.id === id))
-        throw new Error(
-          `Duplicate parameter name '${id}' in pattern '${pattern}'`,
-        );
-      let urlType: ParamType | null = null;
-      if (inline) {
-        if (unsupportedTypes.has(inline))
-          throw new Error(
-            `Param type '${inline}' is not supported by the standalone matcher`,
-          );
-        urlType = builtinTypes[inline] ?? {
-          ...builtinTypes[isSearch ? 'query' : 'path'],
-          pattern: new RegExp(inline, config.caseInsensitive ? 'i' : undefined),
-        };
-      }
-      return new Param(id, urlType, isSearch, config, pattern);
-    };
-
-    // Split the path part into static segments separated by param placeholders.
-    let last = 0;
-    let match: RegExpExecArray | null;
-    while ((match = placeholder.exec(pattern)) !== null) {
-      const segment = pattern.substring(last, match.index);
-      if (segment.includes('?')) break; // we're into the search part
-      const param = makeParam(match, false);
-      params.push(param);
-      compiled.push(quoteRegExp(segment, param));
-      segments.push(segment);
-      last = placeholder.lastIndex;
+      urlType = builtinTypes[inline] ?? {
+        ...builtinTypes[isSearch ? 'query' : 'path'],
+        pattern: new RegExp(inline, config.caseInsensitive ? 'i' : undefined),
+      };
     }
-    let segment = pattern.substring(last);
+    return makeParam(id, urlType, isSearch, config, pattern);
+  };
 
-    // Search params live after '?'; they parse (and must be valid) but never
-    // affect whether a path matches.
-    const searchIndex = segment.indexOf('?');
-    if (searchIndex >= 0) {
-      const search = segment.substring(searchIndex + 1);
-      segment = segment.substring(0, searchIndex);
-      while ((match = searchPlaceholder.exec(search)) !== null) {
-        params.push(makeParam(match, true));
-      }
-    }
-    compiled.push(quoteRegExp(segment));
+  // Split the path part into static segments separated by param placeholders.
+  let last = 0;
+  let match: RegExpExecArray | null;
+  while ((match = placeholder.exec(pattern)) !== null) {
+    const segment = pattern.substring(last, match.index);
+    if (segment.includes('?')) break; // we're into the search part
+    const param = paramFromMatch(match, false);
+    params.push(param);
+    compiled.push(quoteRegExp(segment, param));
     segments.push(segment);
+    last = placeholder.lastIndex;
+  }
+  let segment = pattern.substring(last);
 
-    this.#segments = segments;
-    this.#pathParams = params.filter((param) => !param.isSearch);
-    this.#searchParams = params.filter((param) => param.isSearch);
-    this.#regexp = new RegExp(
+  // Search params live after '?'; they parse (and must be valid) but never
+  // affect whether a path matches.
+  const searchIndex = segment.indexOf('?');
+  if (searchIndex >= 0) {
+    const search = segment.substring(searchIndex + 1);
+    segment = segment.substring(0, searchIndex);
+    while ((match = searchPlaceholder.exec(search)) !== null) {
+      params.push(paramFromMatch(match, true));
+    }
+  }
+  compiled.push(quoteRegExp(segment));
+  segments.push(segment);
+
+  return {
+    pattern,
+    regexp: new RegExp(
       `^${compiled.join('')}${config.strict ? '' : '/?'}$`,
       config.caseInsensitive ? 'i' : undefined,
-    );
-  }
+    ),
+    segments,
+    pathParams: params.filter((param) => !param.isSearch),
+    searchParams: params.filter((param) => param.isSearch),
+    decodeParams: config.decodeParams,
+  };
+};
 
-  /** Returns the input pattern string */
-  toString(): string {
-    return this.pattern;
-  }
+// Core's sort weights: slash → 1, static text → 2, param → 3; search
+// params carry no weight. Memoized as in core, but off the data: a WeakMap
+// keyed on the compiled matcher keeps the cache out of its inert surface.
+const weightsCache = new WeakMap<CompiledMatcher, number[]>();
 
-  /**
-   * Sorts two matchers by static specificity, as core's UrlMatcher.compare:
-   * path tokens compared position-by-position, slash before static text
-   * before a param. Negative means `a` is more specific than `b`.
-   * Single-matcher only: matchers here never `append`.
-   */
-  static compare(a: UrlMatcher, b: UrlMatcher): number {
-    const weightsA = a.#segmentWeights();
-    const weightsB = b.#segmentWeights();
-    const length = Math.max(weightsA.length, weightsB.length);
-    for (let i = 0; i < length; i++) {
-      const cmp = (weightsA[i] ?? 0) - (weightsB[i] ?? 0);
-      if (cmp !== 0) return cmp;
+const segmentWeights = (matcher: CompiledMatcher): number[] => {
+  const cached = weightsCache.get(matcher);
+  if (cached) return cached;
+  const weights: number[] = [];
+  matcher.segments.forEach((segment, index) => {
+    for (const piece of segment.split(/(\/)/)) {
+      if (piece === '') continue;
+      weights.push(piece === '/' ? 1 : 2);
     }
-    return 0;
+    if (matcher.pathParams[index]) weights.push(3);
+  });
+  weightsCache.set(matcher, weights);
+  return weights;
+};
+
+/**
+ * Sorts two compiled matchers by static specificity, as core's
+ * UrlMatcher.compare: path tokens compared position-by-position, slash
+ * before static text before a param. Negative means `a` is more specific
+ * than `b`. Single-matcher only: matchers here never `append`.
+ */
+export function compare(a: CompiledMatcher, b: CompiledMatcher): number {
+  const weightsA = segmentWeights(a);
+  const weightsB = segmentWeights(b);
+  const length = Math.max(weightsA.length, weightsB.length);
+  for (let i = 0; i < length; i++) {
+    const cmp = (weightsA[i] ?? 0) - (weightsB[i] ?? 0);
+    if (cmp !== 0) return cmp;
   }
+  return 0;
+}
 
-  #weights?: number[];
+/**
+ * Tests a url path against a compiled matcher.
+ *
+ * Returns the captured parameter values when the path matches the pattern,
+ * or null when it does not. Search params always appear in the result,
+ * resolved to their static defaults (undefined when none is declared).
+ */
+export function exec(matcher: CompiledMatcher, path: string): RawParams | null {
+  const match = matcher.regexp.exec(path);
+  if (!match) return null;
+  // A custom inline regexp with its own capture group would misalign values.
+  if (match.length - 1 !== matcher.pathParams.length)
+    throw new Error(`Unbalanced capture group in route '${matcher.pattern}'`);
 
-  // Core's sort weights: slash → 1, static text → 2, param → 3; search
-  // params carry no weight. Memoized, as in core.
-  #segmentWeights(): number[] {
-    if (this.#weights) return this.#weights;
-    const weights: number[] = [];
-    this.#segments.forEach((segment, index) => {
-      for (const piece of segment.split(/(\/)/)) {
-        if (piece === '') continue;
-        weights.push(piece === '/' ? 1 : 2);
-      }
-      if (this.#pathParams[index]) weights.push(3);
-    });
-    return (this.#weights = weights);
-  }
-
-  /**
-   * Tests a url path against this matcher.
-   *
-   * Returns the captured parameter values when the path matches the pattern,
-   * or null when it does not. Search params always appear in the result,
-   * resolved to their static defaults (undefined when none is declared).
-   */
-  exec(path: string): RawParams | null {
-    const match = this.#regexp.exec(path);
-    if (!match) return null;
-    // A custom inline regexp with its own capture group would misalign values.
-    if (match.length - 1 !== this.#pathParams.length)
-      throw new Error(`Unbalanced capture group in route '${this.pattern}'`);
-
-    const values: RawParams = {};
-    this.#pathParams.forEach((param, index) => {
-      let value: unknown = match[index + 1];
-      for (const { from, to } of param.replace) {
-        if (from === value) value = to;
-      }
-      if (value !== undefined) {
-        const raw =
-          this.#decodeParams && !param.type.raw
-            ? decodeURIComponent(value as string)
-            : (value as string);
-        value = param.type.decode(raw);
-      }
-      values[param.id] = param.value(value);
-    });
-    for (const param of this.#searchParams) {
-      values[param.id] = param.value(undefined);
+  const values: RawParams = {};
+  matcher.pathParams.forEach((param, index) => {
+    let value: unknown = match[index + 1];
+    for (const { from, to } of param.replace) {
+      if (from === value) value = to;
     }
-    return values;
+    if (value !== undefined) {
+      const raw =
+        matcher.decodeParams && !param.type.raw
+          ? decodeURIComponent(value as string)
+          : (value as string);
+      value = param.type.decode(raw);
+    }
+    values[param.id] = paramValue(param, value);
+  });
+  for (const param of matcher.searchParams) {
+    values[param.id] = paramValue(param, undefined);
   }
+  return values;
+}
 
-  /**
-   * Builds a url from this matcher by substituting parameter values — the
-   * inverse of [[exec]], mirroring core's UrlMatcher.format for the
-   * supported subset (no parent-matcher composition: matchers here never
-   * append). Default values honor the squash policy, search params render
-   * as a query string, and `values['#']` appends a hash fragment.
-   *
-   * Returns null when any value fails its param's validation.
-   */
-  format(values: RawParams = {}): string | null {
-    const details = (param: Param) => {
-      const value = param.value(values[param.id]);
-      const isValid = param.validates(value);
-      const isDefaultValue = param.isDefaultValue(value);
-      // Squashing only ever applies to a param sitting at its default.
-      const squash = isDefaultValue ? param.squash : false;
-      // Auto-array wrapping again: an absent search value encodes to
-      // undefined (the empty array unwraps), skipping the scalar encoder.
-      const encoded =
-        param.isSearch && value === undefined
-          ? undefined
-          : typeEncode(param.type, value);
-      return { param, isValid, isDefaultValue, squash, encoded };
-    };
-    const path = this.#pathParams.map(details);
-    const search = this.#searchParams.map(details);
-    if ([...path, ...search].some((d) => !d.isValid)) return null;
+/**
+ * Builds a url from a compiled matcher by substituting parameter values —
+ * the inverse of [[exec]], mirroring core's UrlMatcher.format for the
+ * supported subset (no parent-matcher composition: matchers here never
+ * append). Default values honor the squash policy, search params render
+ * as a query string, and `values['#']` appends a hash fragment.
+ *
+ * Returns null when any value fails its param's validation.
+ */
+export function format(
+  matcher: CompiledMatcher,
+  values: RawParams = {},
+): string | null {
+  const details = (param: CompiledParam) => {
+    const value = paramValue(param, values[param.id]);
+    const isValid = paramValidates(param, value);
+    const isDefaultValue = paramIsDefault(param, value);
+    // Squashing only ever applies to a param sitting at its default.
+    const squash = isDefaultValue ? param.squash : false;
+    // Auto-array wrapping again: an absent search value encodes to
+    // undefined (the empty array unwraps), skipping the scalar encoder.
+    const encoded =
+      param.isSearch && value === undefined
+        ? undefined
+        : typeEncode(param.type, value);
+    return { param, isValid, isDefaultValue, squash, encoded };
+  };
+  const path = matcher.pathParams.map(details);
+  const search = matcher.searchParams.map(details);
+  if ([...path, ...search].some((d) => !d.isValid)) return null;
 
-    let result = '';
-    this.#segments.forEach((segment, index) => {
-      result += segment;
-      const detail = path[index];
-      if (!detail) return; // the final segment has no param after it
-      const { squash, encoded, param } = detail;
-      if (squash === true) {
-        if (result.endsWith('/')) result = result.slice(0, -1);
-        return;
-      }
-      if (typeof squash === 'string') {
-        result += squash;
-        return;
-      }
-      if (encoded === null || encoded === undefined) return;
-      result += param.type.raw
-        ? String(encoded)
-        : encodeURIComponent(encoded as string);
-    });
+  let result = '';
+  matcher.segments.forEach((segment, index) => {
+    result += segment;
+    const detail = path[index];
+    if (!detail) return; // the final segment has no param after it
+    const { squash, encoded, param } = detail;
+    if (squash === true) {
+      if (result.endsWith('/')) result = result.slice(0, -1);
+      return;
+    }
+    if (typeof squash === 'string') {
+      result += squash;
+      return;
+    }
+    if (encoded === null || encoded === undefined) return;
+    result += param.type.raw
+      ? String(encoded)
+      : encodeURIComponent(encoded as string);
+  });
 
-    const query = search
-      .map(({ param, squash, encoded, isDefaultValue }) => {
-        if (
-          encoded === null ||
-          encoded === undefined ||
-          (isDefaultValue && squash !== false)
+  const query = search
+    .map(({ param, squash, encoded, isDefaultValue }) => {
+      if (
+        encoded === null ||
+        encoded === undefined ||
+        (isDefaultValue && squash !== false)
+      )
+        return null;
+      const vals = Array.isArray(encoded) ? encoded : [encoded];
+      if (vals.length === 0) return null;
+      return vals
+        .map(
+          (val) =>
+            `${param.id}=${param.type.raw ? val : encodeURIComponent(val)}`,
         )
-          return null;
-        const vals = Array.isArray(encoded) ? encoded : [encoded];
-        if (vals.length === 0) return null;
-        return vals
-          .map(
-            (val) =>
-              `${param.id}=${param.type.raw ? val : encodeURIComponent(val)}`,
-          )
-          .join('&');
-      })
-      .filter((pair) => pair !== null)
-      .join('&');
+        .join('&');
+    })
+    .filter((pair) => pair !== null)
+    .join('&');
 
-    const fragment = values['#'] ? `#${String(values['#'])}` : '';
-    return result + (query ? `?${query}` : '') + fragment;
-  }
+  const fragment = values['#'] ? `#${String(values['#'])}` : '';
+  return result + (query ? `?${query}` : '') + fragment;
 }
 
 /**
@@ -596,7 +613,10 @@ export class UrlMatcher {
  * percent-decoding on, and a default squash policy of false.
  */
 export function urlMatcherFactory(config: UrlMatcherCompilerConfig = {}): {
-  compile: (pattern: string, options?: UrlMatcherCompileOptions) => UrlMatcher;
+  compile: (
+    pattern: string,
+    options?: UrlMatcherCompileOptions,
+  ) => CompiledMatcher;
 } {
   const {
     strict = true,
@@ -608,7 +628,7 @@ export function urlMatcherFactory(config: UrlMatcherCompilerConfig = {}): {
   getSquashPolicy(defaultSquashPolicy, true, false);
   return {
     compile: (pattern, options = {}) =>
-      new UrlMatcher(pattern, {
+      compileMatcher(pattern, {
         strict: options.strict ?? strict,
         caseInsensitive: options.caseInsensitive ?? caseInsensitive,
         decodeParams,

--- a/packages/ui-router-server/src/url-matcher.ts
+++ b/packages/ui-router-server/src/url-matcher.ts
@@ -280,15 +280,15 @@ const compileParam = (
     isOptional,
     config.defaultSquashPolicy,
   );
-  return {
+  return freeze<CompiledParam>({
     id,
     type: resolveType(declared.type, urlType, isSearch, id),
     isSearch,
     isOptional,
     squash,
-    replace: getReplace(isOptional, squash),
+    replace: freeze(getReplace(isOptional, squash)),
     defaultValue: declared.value,
-  };
+  });
 };
 
 /** The typed value for a decoded input, or the static default when absent (core's Param.value). */
@@ -383,6 +383,8 @@ interface ResolvedConfig extends Required<UrlMatcherCompilerConfig> {
  * `compile` and consumed by [[exec]], [[format]], and [[compare]].
  * Frozen — treat as immutable: [[compare]] memoizes per object identity,
  * and the functions/regexps inside make it not structuredClone-able.
+ * To associate data with a matcher, use your own identity-keyed WeakMap
+ * (frozen objects are fine as keys).
  */
 export interface CompiledMatcher {
   /** The pattern that was compiled. */

--- a/packages/ui-router-server/src/url-matcher.ts
+++ b/packages/ui-router-server/src/url-matcher.ts
@@ -41,14 +41,16 @@ import type {
  */
 export interface ParamType
   extends
-    Pick<ParamTypeDefinition, 'is' | 'decode' | 'raw'>,
-    Required<Pick<ParamTypeDefinition, 'pattern'>> {
-  name: string;
+    Readonly<Pick<ParamTypeDefinition, 'is' | 'decode' | 'raw'>>,
+    Readonly<Required<Pick<ParamTypeDefinition, 'pattern'>>> {
+  readonly name: string;
   /** Relaxation vs core: may return null/undefined, which format() renders as an absent value (core's built-ins do the same at runtime). */
-  encode?: (val: unknown) => string | string[] | null | undefined;
+  readonly encode?: (val: unknown) => string | string[] | null | undefined;
   /** Relaxation vs core: optional here (core's class always carries one). */
-  equals?: ParamTypeDefinition['equals'];
+  readonly equals?: ParamTypeDefinition['equals'];
 }
+
+const { freeze } = Object;
 
 // Core's makeDefaultType encode: stringly, null/undefined passed through.
 const valToString = (val: unknown): string | null | undefined =>
@@ -79,12 +81,15 @@ const dateCapture = /([0-9]{4})-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])/;
 const isDate = (val: unknown): val is Date =>
   val instanceof Date && !Number.isNaN(val.valueOf());
 
-/** The ui-router built-in types, minus json/hash/any (rejected at compile). */
+/**
+ * The ui-router built-in types, minus json/hash/any (rejected at compile).
+ * Frozen: every compiled matcher shares these singletons.
+ */
 const builtinTypes: Record<string, ParamType> = {
-  string: { ...stringBase, name: 'string', pattern: /.*/ },
-  path: { ...stringBase, name: 'path', pattern: /[^/]*/ },
-  query: { ...stringBase, name: 'query', pattern: /.*/ },
-  int: {
+  string: freeze({ ...stringBase, name: 'string', pattern: /.*/ }),
+  path: freeze({ ...stringBase, name: 'path', pattern: /[^/]*/ }),
+  query: freeze({ ...stringBase, name: 'query', pattern: /.*/ }),
+  int: freeze({
     name: 'int',
     pattern: /-?\d+/,
     // Only a number can strict-equal parseInt of its own string form.
@@ -92,16 +97,16 @@ const builtinTypes: Record<string, ParamType> = {
       typeof val === 'number' && decodeInt(val.toString()) === val,
     decode: decodeInt,
     encode: valToString,
-  },
-  bool: {
+  }),
+  bool: freeze({
     name: 'bool',
     pattern: /0|1/,
     is: (val: unknown) => typeof val === 'boolean',
     decode: (val: string) => decodeInt(val) !== 0,
     // Truthiness, as upstream ((val && 1) || 0) — undefined encodes to '0'.
     encode: (val: unknown) => (val ? '1' : '0'),
-  },
-  date: {
+  }),
+  date: freeze({
     name: 'date',
     pattern: /[0-9]{4}-(?:0[1-9]|1[0-2])-(?:0[1-9]|[1-2][0-9]|3[0-1])/,
     is: isDate,
@@ -122,7 +127,7 @@ const builtinTypes: Record<string, ParamType> = {
       (['getFullYear', 'getMonth', 'getDate'] as const).every(
         (fn) => (l as Date)[fn]() === (r as Date)[fn](),
       ),
-  },
+  }),
 };
 
 // Upstream registers these, but they only mean something with url building
@@ -376,6 +381,8 @@ interface ResolvedConfig extends Required<UrlMatcherCompilerConfig> {
 /**
  * A compiled url pattern: inert data produced by [[urlMatcherFactory]]'s
  * `compile` and consumed by [[exec]], [[format]], and [[compare]].
+ * Frozen — treat as immutable: [[compare]] memoizes per object identity,
+ * and the functions/regexps inside make it not structuredClone-able.
  */
 export interface CompiledMatcher {
   /** The pattern that was compiled. */
@@ -457,17 +464,17 @@ const compileMatcher = (
   compiled.push(quoteRegExp(segment));
   segments.push(segment);
 
-  return {
+  return freeze({
     pattern,
     regexp: new RegExp(
       `^${compiled.join('')}${config.strict ? '' : '/?'}$`,
       config.caseInsensitive ? 'i' : undefined,
     ),
-    segments,
-    pathParams: params.filter((param) => !param.isSearch),
-    searchParams: params.filter((param) => param.isSearch),
+    segments: freeze(segments),
+    pathParams: freeze(params.filter((param) => !param.isSearch)),
+    searchParams: freeze(params.filter((param) => param.isSearch)),
     decodeParams: config.decodeParams,
-  };
+  });
 };
 
 // Core's sort weights: slash → 1, static text → 2, param → 3; search

--- a/packages/ui-router-server/src/url-matcher.ts
+++ b/packages/ui-router-server/src/url-matcher.ts
@@ -181,6 +181,25 @@ const resolveType = (
   return named;
 };
 
+// An inline '{name:...}' body: a built-in type name, or a raw regexp that
+// adopts the positional default type's semantics.
+const resolveInlineType = (
+  inline: string,
+  isSearch: boolean,
+  caseInsensitive: boolean,
+): ParamType => {
+  if (unsupportedTypes.has(inline))
+    throw new Error(
+      `Param type '${inline}' is not supported by the standalone matcher`,
+    );
+  return (
+    builtinTypes[inline] ?? {
+      ...builtinTypes[isSearch ? 'query' : 'path'],
+      pattern: new RegExp(inline, caseInsensitive ? 'i' : undefined),
+    }
+  );
+};
+
 /** false, true, or the placeholder string: the param's url squash policy. */
 const getSquashPolicy = (
   declared: unknown,
@@ -228,7 +247,7 @@ export interface CompiledParam {
   readonly defaultValue: unknown;
 }
 
-const makeParam = (
+const compileParam = (
   id: string,
   urlType: ParamType | null,
   isSearch: boolean,
@@ -354,12 +373,9 @@ interface ResolvedConfig extends Required<UrlMatcherCompilerConfig> {
   params: Record<string, unknown>;
 }
 
-const nameValidator = /^\w+([-.]+\w+)*(?:\[\])?$/;
-
 /**
  * A compiled url pattern: inert data produced by [[urlMatcherFactory]]'s
- * `compile` and consumed by the free functions [[exec]], [[format]], and
- * [[compare]] — import only the operations you use.
+ * `compile` and consumed by [[exec]], [[format]], and [[compare]].
  */
 export interface CompiledMatcher {
   /** The pattern that was compiled. */
@@ -373,6 +389,8 @@ export interface CompiledMatcher {
   /** Whether [[exec]] percent-decodes captured values (the factory's decodeParams). */
   readonly decodeParams: boolean;
 }
+
+const nameValidator = /^\w+([-.]+\w+)*(?:\[\])?$/;
 
 const compileMatcher = (
   pattern: string,
@@ -406,18 +424,10 @@ const compileMatcher = (
       throw new Error(
         `Duplicate parameter name '${id}' in pattern '${pattern}'`,
       );
-    let urlType: ParamType | null = null;
-    if (inline) {
-      if (unsupportedTypes.has(inline))
-        throw new Error(
-          `Param type '${inline}' is not supported by the standalone matcher`,
-        );
-      urlType = builtinTypes[inline] ?? {
-        ...builtinTypes[isSearch ? 'query' : 'path'],
-        pattern: new RegExp(inline, config.caseInsensitive ? 'i' : undefined),
-      };
-    }
-    return makeParam(id, urlType, isSearch, config, pattern);
+    const urlType = inline
+      ? resolveInlineType(inline, isSearch, config.caseInsensitive)
+      : null;
+    return compileParam(id, urlType, isSearch, config, pattern);
   };
 
   // Split the path part into static segments separated by param placeholders.
@@ -461,8 +471,8 @@ const compileMatcher = (
 };
 
 // Core's sort weights: slash → 1, static text → 2, param → 3; search
-// params carry no weight. Memoized as in core, but off the data: a WeakMap
-// keyed on the compiled matcher keeps the cache out of its inert surface.
+// params carry no weight. Memoized as in core; the WeakMap keeps the
+// cache off the matcher's inert data.
 const weightsCache = new WeakMap<CompiledMatcher, number[]>();
 
 const segmentWeights = (matcher: CompiledMatcher): number[] => {

--- a/packages/ui-router-server/src/url-matcher.ts
+++ b/packages/ui-router-server/src/url-matcher.ts
@@ -356,12 +356,14 @@ const quoteRegExp = (segment: string, param?: CompiledParam): string => {
   return result + surround[0] + param.type.pattern.source + surround[1];
 };
 
-export interface UrlMatcherCompileOptions extends Pick<
+export interface UrlMatcherCompileOptions<M = undefined> extends Pick<
   UrlMatcherCompileConfig,
   'strict' | 'caseInsensitive'
 > {
   /** Relaxation vs core: `state.params` flattened to `params` (no StateDeclaration here) — a [[ParamDeclaration]] or a shorthand static default per name. */
   params?: Record<string, unknown>;
+  /** Passenger field: rides the compiled matcher as [[CompiledMatcher.meta]], untouched by compilation. */
+  meta?: M;
 }
 
 export interface UrlMatcherCompilerConfig extends Pick<
@@ -383,9 +385,9 @@ interface ResolvedConfig extends Required<UrlMatcherCompilerConfig> {
  * `compile` and consumed by [[exec]], [[format]], and [[compare]].
  * Frozen — treat as immutable: [[compare]] memoizes per object identity,
  * and the functions/regexps inside make it not structuredClone-able.
- * Two data channels: `meta` rides compile-time data on the matcher, and a
- * consumer-owned identity-keyed WeakMap (frozen keys are fine) covers
- * external or mutable association.
+ * Two data channels: compile's `options.meta` rides compile-time data on
+ * the matcher, and a consumer-owned identity-keyed WeakMap (frozen keys
+ * are fine) covers external or mutable association.
  */
 export interface CompiledMatcher<M = undefined> {
   /** The pattern that was compiled. */
@@ -645,8 +647,7 @@ export function format(
 export function urlMatcherFactory(config: UrlMatcherCompilerConfig = {}): {
   compile: <M = undefined>(
     pattern: string,
-    options?: UrlMatcherCompileOptions,
-    meta?: M,
+    options?: UrlMatcherCompileOptions<M>,
   ) => CompiledMatcher<M>;
 } {
   const {
@@ -660,8 +661,7 @@ export function urlMatcherFactory(config: UrlMatcherCompilerConfig = {}): {
   return {
     compile: <M = undefined>(
       pattern: string,
-      options: UrlMatcherCompileOptions = {},
-      meta?: M,
+      options: UrlMatcherCompileOptions<M> = {},
     ) =>
       compileMatcher(
         pattern,
@@ -673,7 +673,7 @@ export function urlMatcherFactory(config: UrlMatcherCompilerConfig = {}): {
           params: options.params ?? {},
         },
         // Omitted meta is the declared default: `compile(p)` → meta undefined.
-        meta as M,
+        options.meta as M,
       ),
   };
 }

--- a/packages/ui-router-server/test/redirects.test.ts
+++ b/packages/ui-router-server/test/redirects.test.ts
@@ -11,6 +11,7 @@ import {
 } from '../src/redirects.ts';
 import type { RedirectTable } from '../src/redirects.ts';
 import { createHeadlessRouter, onceSettled } from '../src/simulate.ts';
+import { exec } from '../src/url-matcher.ts';
 
 describe('compileRoutes', () => {
   it('appends nested urls along dotted names and merges params rootward', () => {
@@ -23,7 +24,7 @@ describe('compileRoutes', () => {
       compiled.map((route) => route.pattern),
       ['/contacts', '/contacts/:contactId', '/contacts/:contactId/edit'],
     );
-    assert.deepEqual(compiled[1].matcher.exec('/contacts/3'), {
+    assert.deepEqual(exec(compiled[1].matcher, '/contacts/3'), {
       contactId: '3',
     });
   });

--- a/packages/ui-router-server/test/url-matcher.differential.test.ts
+++ b/packages/ui-router-server/test/url-matcher.differential.test.ts
@@ -8,7 +8,12 @@ import {
 } from '@uirouter/core';
 import type { RawParams } from '@uirouter/core';
 
-import { UrlMatcher, urlMatcherFactory } from '../src/url-matcher.ts';
+import {
+  compare,
+  exec,
+  format,
+  urlMatcherFactory,
+} from '../src/url-matcher.ts';
 import type { UrlMatcherCompileOptions } from '../src/url-matcher.ts';
 
 // The divergence guard for the standalone extraction: every pattern/url pair
@@ -258,7 +263,7 @@ describe(`differential: standalone matcher vs @uirouter/core (${allCases.length}
       const actualMatcher = compile(pattern, options);
       for (const url of urls) {
         const expected: unknown = expectedMatcher.exec(url);
-        const actual: unknown = actualMatcher.exec(url);
+        const actual: unknown = exec(actualMatcher, url);
         assert.deepStrictEqual(actual, expected, `'${pattern}' × '${url}'`);
       }
     });
@@ -309,7 +314,7 @@ describe('differential: rejected by both implementations', () => {
         `core accepted: ${label}`,
       );
       assert.throws(
-        () => compile(pattern, options).exec(url ?? '/'),
+        () => exec(compile(pattern, options), url ?? '/'),
         `standalone accepted: ${label}`,
       );
     });
@@ -522,14 +527,14 @@ const specificityPatterns = [
   '/users/:id?sort&page',
 ];
 
-describe(`differential: UrlMatcher.compare vs @uirouter/core (${specificityPatterns.length} patterns, all pairs)`, () => {
+describe(`differential: compare vs @uirouter/core (${specificityPatterns.length} patterns, all pairs)`, () => {
   for (const left of specificityPatterns) {
     for (const right of specificityPatterns) {
       it(`compare('${left}', '${right}')`, () => {
         const expected = sign(
           CoreUrlMatcher.compare(coreCompile(left), coreCompile(right)),
         );
-        const actual = sign(UrlMatcher.compare(compile(left), compile(right)));
+        const actual = sign(compare(compile(left), compile(right)));
         assert.equal(actual, expected);
       });
     }
@@ -549,7 +554,7 @@ describe(`differential: format() vs @uirouter/core (${formatCases.length} patter
       const actualMatcher = compile(pattern, options);
       for (const value of values) {
         const expected: unknown = expectedMatcher.format(value);
-        const actual: unknown = actualMatcher.format(value);
+        const actual: unknown = format(actualMatcher, value);
         assert.deepStrictEqual(
           actual,
           expected,

--- a/packages/ui-router-server/test/url-matcher.test.ts
+++ b/packages/ui-router-server/test/url-matcher.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
-import { urlMatcherFactory } from '../src/url-matcher.ts';
+import { exec, format, urlMatcherFactory } from '../src/url-matcher.ts';
 
 // Behavior specs for the standalone matcher on its own. Fidelity against
 // @uirouter/core is asserted separately, case by case, by the differential
@@ -11,27 +11,27 @@ const { compile } = urlMatcherFactory();
 describe('factory defaults', () => {
   it('is strict about trailing slashes', () => {
     const matcher = compile('/welcome');
-    assert.deepEqual(matcher.exec('/welcome'), {});
-    assert.equal(matcher.exec('/welcome/'), null);
+    assert.deepEqual(exec(matcher, '/welcome'), {});
+    assert.equal(exec(matcher, '/welcome/'), null);
   });
 
   it('is case-sensitive', () => {
-    assert.equal(compile('/welcome').exec('/Welcome'), null);
+    assert.equal(exec(compile('/welcome'), '/Welcome'), null);
   });
 
   it('does not squash defaulted params', () => {
     const matcher = compile('/x/:id', { params: { id: 'fallback' } });
-    assert.equal(matcher.exec('/x'), null);
-    assert.deepEqual(matcher.exec('/x/'), { id: 'fallback' });
+    assert.equal(exec(matcher, '/x'), null);
+    assert.deepEqual(exec(matcher, '/x/'), { id: 'fallback' });
   });
 
   it('overrides per compile', () => {
     assert.deepEqual(
-      compile('/welcome', { strict: false }).exec('/welcome/'),
+      exec(compile('/welcome', { strict: false }), '/welcome/'),
       {},
     );
     assert.deepEqual(
-      compile('/welcome', { caseInsensitive: true }).exec('/WELCOME'),
+      exec(compile('/welcome', { caseInsensitive: true }), '/WELCOME'),
       {},
     );
   });
@@ -43,26 +43,26 @@ describe('static param defaults without any $injector', () => {
   // when no framework installed one. The extraction applies them directly.
   it('matches query-suffixed patterns without throwing', () => {
     const matcher = compile('/welcome?flag');
-    assert.deepEqual(matcher.exec('/welcome'), { flag: undefined });
-    assert.equal(matcher.exec('/nope'), null);
+    assert.deepEqual(exec(matcher, '/welcome'), { flag: undefined });
+    assert.equal(exec(matcher, '/nope'), null);
   });
 
   it('applies defaulted params without throwing', () => {
     const matcher = compile('/x/:id', {
       params: { id: { value: 'fallback', squash: true } },
     });
-    assert.deepEqual(matcher.exec('/x'), { id: 'fallback' });
-    assert.deepEqual(matcher.exec('/x/'), { id: 'fallback' });
-    assert.deepEqual(matcher.exec('/x/7'), { id: '7' });
-    assert.equal(matcher.exec('/y'), null);
+    assert.deepEqual(exec(matcher, '/x'), { id: 'fallback' });
+    assert.deepEqual(exec(matcher, '/x/'), { id: 'fallback' });
+    assert.deepEqual(exec(matcher, '/x/7'), { id: '7' });
+    assert.equal(exec(matcher, '/y'), null);
   });
 
   it('applies typed defaults', () => {
     const matcher = compile('/page/{num:int}', {
       params: { num: { value: 1, squash: true } },
     });
-    assert.deepEqual(matcher.exec('/page'), { num: 1 });
-    assert.deepEqual(matcher.exec('/page/3'), { num: 3 });
+    assert.deepEqual(exec(matcher, '/page'), { num: 1 });
+    assert.deepEqual(exec(matcher, '/page/3'), { num: 3 });
   });
 });
 
@@ -130,7 +130,7 @@ describe('compile errors shared with upstream', () => {
 
   it('throws on inline regexps containing capture groups', () => {
     assert.throws(
-      () => compile('/u/{id:(a|b)}').exec('/u/a'),
+      () => exec(compile('/u/{id:(a|b)}'), '/u/a'),
       /Unbalanced capture group/,
     );
   });
@@ -146,8 +146,8 @@ describe('custom ParamType objects', () => {
       decode: (val: string) => val.toUpperCase(),
     };
     const matcher = compile('/tag/:tag', { params: { tag: { type: upper } } });
-    assert.deepEqual(matcher.exec('/tag/ABC'), { tag: 'ABC' });
-    assert.equal(matcher.exec('/tag/abc'), null);
+    assert.deepEqual(exec(matcher, '/tag/ABC'), { tag: 'ABC' });
+    assert.equal(exec(matcher, '/tag/abc'), null);
   });
 });
 
@@ -155,49 +155,48 @@ describe('format', () => {
   it('builds a url from param values, percent-encoding them', () => {
     const matcher = compile('/user/:id?q');
     assert.equal(
-      matcher.format({ id: 'b ob', q: 'a&b' }),
+      format(matcher, { id: 'b ob', q: 'a&b' }),
       '/user/b%20ob?q=a%26b',
     );
-    assert.equal(matcher.format({ id: 'bob' }), '/user/bob');
+    assert.equal(format(matcher, { id: 'bob' }), '/user/bob');
   });
 
   it('returns null when a value fails its type', () => {
     const matcher = compile('/user/{id:int}');
-    assert.equal(matcher.format({ id: 'abc' }), null);
-    assert.equal(matcher.format({}), null);
-    assert.equal(matcher.format({ id: 42 }), '/user/42');
+    assert.equal(format(matcher, { id: 'abc' }), null);
+    assert.equal(format(matcher, {}), null);
+    assert.equal(format(matcher, { id: 42 }), '/user/42');
   });
 
   it('squashes defaulted params per policy', () => {
     const params = (squash: boolean | string) => ({
       params: { id: { value: 'fallback', squash } },
     });
-    assert.equal(compile('/x/:id', params(true)).format({}), '/x');
-    assert.equal(compile('/x/:id', params(false)).format({}), '/x/fallback');
-    assert.equal(compile('/x/:id', params('~')).format({}), '/x/~');
-    assert.equal(compile('/x/:id', params(true)).format({ id: '7' }), '/x/7');
+    assert.equal(format(compile('/x/:id', params(true)), {}), '/x');
+    assert.equal(format(compile('/x/:id', params(false)), {}), '/x/fallback');
+    assert.equal(format(compile('/x/:id', params('~')), {}), '/x/~');
+    assert.equal(format(compile('/x/:id', params(true)), { id: '7' }), '/x/7');
   });
 
   it('omits absent search params and appends a hash fragment', () => {
     const matcher = compile('/search?q&r');
-    assert.equal(matcher.format({}), '/search');
-    assert.equal(matcher.format({ q: 'a' }), '/search?q=a');
-    assert.equal(matcher.format({ q: 'a', '#': 'frag' }), '/search?q=a#frag');
+    assert.equal(format(matcher, {}), '/search');
+    assert.equal(format(matcher, { q: 'a' }), '/search?q=a');
+    assert.equal(format(matcher, { q: 'a', '#': 'frag' }), '/search?q=a#frag');
   });
 
   it('round-trips exec', () => {
     const matcher = compile('/mymessages/:folderId/{messageId:int}');
     const params = { folderId: 'inbox', messageId: 5 };
-    const url = matcher.format(params);
+    const url = format(matcher, params);
     assert.equal(url, '/mymessages/inbox/5');
-    assert.deepEqual(matcher.exec(url as string), params);
+    assert.deepEqual(exec(matcher, url as string), params);
   });
 });
 
-describe('UrlMatcher surface', () => {
+describe('compiled matcher surface', () => {
   it('exposes the source pattern', () => {
     const matcher = compile('/user/:id');
     assert.equal(matcher.pattern, '/user/:id');
-    assert.equal(String(matcher), '/user/:id');
   });
 });

--- a/packages/ui-router-server/test/url-matcher.test.ts
+++ b/packages/ui-router-server/test/url-matcher.test.ts
@@ -199,4 +199,34 @@ describe('compiled matcher surface', () => {
     const matcher = compile('/user/:id');
     assert.equal(matcher.pattern, '/user/:id');
   });
+
+  it('freezes the compiled matcher and its arrays', () => {
+    const matcher = compile('/user/:id?q');
+    assert.ok(Object.isFrozen(matcher));
+    assert.ok(Object.isFrozen(matcher.segments));
+    assert.ok(Object.isFrozen(matcher.pathParams));
+    assert.ok(Object.isFrozen(matcher.searchParams));
+  });
+
+  it('rejects mutation of a builtin param type (shared singleton)', () => {
+    const matcher = compile('/page/{num:int}');
+    const { type } = matcher.pathParams[0];
+    assert.throws(() => {
+      // @ts-expect-error -- readonly; the throw is the point
+      type.decode = () => 'poisoned';
+    }, TypeError);
+  });
+
+  it('cannot poison a matcher compiled after a mutation attempt', () => {
+    const first = compile('/a/{num:int}');
+    try {
+      // @ts-expect-error -- readonly; sloppy-mode callers no-op instead
+      first.pathParams[0].type.decode = () => 'poisoned';
+    } catch {
+      // strict mode: the assignment throws; either way the singleton is intact
+    }
+    const second = compile('/b/{num:int}');
+    assert.deepEqual(exec(second, '/b/7'), { num: 7 });
+    assert.deepEqual(exec(first, '/a/7'), { num: 7 });
+  });
 });

--- a/packages/ui-router-server/test/url-matcher.test.ts
+++ b/packages/ui-router-server/test/url-matcher.test.ts
@@ -208,6 +208,18 @@ describe('compiled matcher surface', () => {
     assert.ok(Object.isFrozen(matcher.searchParams));
   });
 
+  it('freezes each compiled param (deep, including replace)', () => {
+    const matcher = compile('/x/:id', { params: { id: 'fallback' } });
+    const param = matcher.pathParams[0];
+    assert.ok(Object.isFrozen(param));
+    assert.ok(Object.isFrozen(param.replace));
+    assert.throws(() => {
+      // @ts-expect-error -- readonly; the throw is the point
+      param.squash = true;
+    }, TypeError);
+    assert.deepEqual(exec(matcher, '/x/'), { id: 'fallback' });
+  });
+
   it('rejects mutation of a builtin param type (shared singleton)', () => {
     const matcher = compile('/page/{num:int}');
     const { type } = matcher.pathParams[0];

--- a/packages/ui-router-server/test/url-matcher.test.ts
+++ b/packages/ui-router-server/test/url-matcher.test.ts
@@ -214,8 +214,7 @@ describe('compiled matcher surface', () => {
   });
 
   it('carries typed compile-time meta on the matcher', () => {
-    const matcher = compile('/user/:id', {}, { routeId: 'users.detail' });
-    // Inferred as CompiledMatcher<{ routeId: string }> — .routeId typechecks.
+    const matcher = compile('/user/:id', { meta: { routeId: 'users.detail' } });
     assert.equal(matcher.meta.routeId, 'users.detail');
     // The reference is frozen in; the meta object stays consumer-owned.
     assert.ok(!Object.isFrozen(matcher.meta));
@@ -223,13 +222,22 @@ describe('compiled matcher surface', () => {
     assert.equal(matcher.meta.routeId, 'renamed');
   });
 
+  it('infers the meta type from the options bag', () => {
+    const matcher = compile('/user/:id', { strict: false, meta: { n: 1 } });
+    // CompiledMatcher<{ n: number }>: .n typechecks, arithmetic proves number.
+    assert.equal(matcher.meta.n + 1, 2);
+    // Sibling options still apply alongside meta.
+    assert.deepEqual(exec(matcher, '/user/7/'), { id: '7' });
+  });
+
   it('defaults meta to undefined when not passed', () => {
     assert.equal(compile('/user/:id').meta, undefined);
+    assert.equal(compile('/user/:id', { strict: true }).meta, undefined);
   });
 
   it('operations ignore meta entirely', () => {
     const plain = compile('/user/:id');
-    const tagged = compile('/user/:id', {}, { routeId: 'x' });
+    const tagged = compile('/user/:id', { meta: { routeId: 'x' } });
     assert.deepEqual(exec(tagged, '/user/7'), exec(plain, '/user/7'));
     assert.equal(format(tagged, { id: '7' }), format(plain, { id: '7' }));
     assert.equal(compare(tagged, plain), 0);

--- a/packages/ui-router-server/test/url-matcher.test.ts
+++ b/packages/ui-router-server/test/url-matcher.test.ts
@@ -1,7 +1,12 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
-import { exec, format, urlMatcherFactory } from '../src/url-matcher.ts';
+import {
+  compare,
+  exec,
+  format,
+  urlMatcherFactory,
+} from '../src/url-matcher.ts';
 
 // Behavior specs for the standalone matcher on its own. Fidelity against
 // @uirouter/core is asserted separately, case by case, by the differential
@@ -206,6 +211,30 @@ describe('compiled matcher surface', () => {
     assert.ok(Object.isFrozen(matcher.segments));
     assert.ok(Object.isFrozen(matcher.pathParams));
     assert.ok(Object.isFrozen(matcher.searchParams));
+  });
+
+  it('carries typed compile-time meta on the matcher', () => {
+    const matcher = compile('/user/:id', {}, { routeId: 'users.detail' });
+    // Inferred as CompiledMatcher<{ routeId: string }> — .routeId typechecks.
+    assert.equal(matcher.meta.routeId, 'users.detail');
+    // The reference is frozen in; the meta object stays consumer-owned.
+    assert.ok(!Object.isFrozen(matcher.meta));
+    matcher.meta.routeId = 'renamed';
+    assert.equal(matcher.meta.routeId, 'renamed');
+  });
+
+  it('defaults meta to undefined when not passed', () => {
+    assert.equal(compile('/user/:id').meta, undefined);
+  });
+
+  it('operations ignore meta entirely', () => {
+    const plain = compile('/user/:id');
+    const tagged = compile('/user/:id', {}, { routeId: 'x' });
+    assert.deepEqual(exec(tagged, '/user/7'), exec(plain, '/user/7'));
+    assert.equal(format(tagged, { id: '7' }), format(plain, { id: '7' }));
+    assert.equal(compare(tagged, plain), 0);
+    // Twice: the second compare hits the WeakMap memo, same verdict.
+    assert.equal(compare(tagged, plain), 0);
   });
 
   it('freezes each compiled param (deep, including replace)', () => {


### PR DESCRIPTION
## Why now

`ui-router-server` is private, 0.0.0, zero consumers — the window to break the matcher API freely closes at first publish. The `UrlMatcher` class was one atom: bundlers never tree-shake class members, so importing any operation shipped `exec` + `format` + `compare` (plus the format-only encode/squash machinery) to every consumer. After this surgery, consumers pay only for the functions they import.

## API mapping

| old (class) | new (functional) |
| --- | --- |
| `urlMatcherFactory(config).compile(pattern, opts)` → `UrlMatcher` | unchanged signature, returns `CompiledMatcher` (inert data: `pattern`, `regexp`, `segments`, `pathParams`, `searchParams`, `decodeParams`) |
| `matcher.exec(path)` | `exec(matcher, path)` |
| `matcher.format(values)` | `format(matcher, values)` |
| `UrlMatcher.compare(a, b)` | `compare(a, b)` |
| `matcher.pattern` / `matcher.toString()` | `matcher.pattern` (toString dropped — it was the same string) |
| `UrlMatcher.nameValidator` (static) | internal module constant |

Internal `Param` follows the same shape: exported `CompiledParam` data + private `paramValue`/`paramValidates`/`paramIsDefault` helpers. The `#segmentWeights()` memo (hot in `matchRoute` loops) moves to a `WeakMap` keyed on the compiled matcher, so the memo stays out of the inert data surface — a step toward the roadmap's codegen recipe, though the compiled regexp and `ParamType` functions keep it serializable-ish, not serializable. `./matcher` now exports the factory, the three free functions, and the types. Config/type registration (`params`, custom `ParamType` objects, squash policies) is untouched.

## Measured per-operation savings (esbuild `--bundle --minify --format=esm`)

| bundle | before (class) | after (functional) |
| --- | --- | --- |
| full matcher entry | 6,822 B min / 2,923 gzip | 6,625 B min / 2,887 gzip |
| exec-only consumer (compile + `exec`, no format/compare) | 6,844 B min / 2,942 gzip (whole atom) | 5,079 B min / 2,276 gzip |

An exec-only consumer sheds **26% min / 23% gzip** — the format encode/squash pipeline and compare no longer ride along.

## Semantics preservation

The differential suites (standalone vs `@uirouter/core`, ~1,200 comparisons across exec/format/compare/rejections) pass with **assertions unchanged** — only call sites moved to the new API (`matcher.exec(url)` → `exec(matcher, url)`). Full `turbo run ci` is green (90/90 tasks), including the docs worker and sample-app-routes contract tests; neither touches the matcher API directly (both consume `createServerRouter`). The treeshake probe (core-free tiers, lazy simulate boundary) passes unchanged.

## Coordination with #373

This branch is off main and does not include the bundle-invariants seam (`test/bundle.ts`) from #373 (chore/ui-router-server-bundle-gate, in flight). Whichever lands second rebases mechanically: #373's probes would need their matcher-entry expectations refreshed against the functional surface (numbers above), and nothing here conflicts semantically.
