### PR TITLE
ci(release): published-diff check runs + README badges, dependency-edged turbo inputs

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -35,17 +35,16 @@ on:
 env:
   HUSKY: 0
 
-permissions:
-  id-token: write # Required for OIDC trusted publishing to NPM
-  contents: write # Required for creating GitHub releases
-  attestations: write # Required for build provenance attestation
-  artifact-metadata: write
-
 jobs:
   publish_npm:
     runs-on: ubuntu-latest
     # Protected environment adds approval gate before publishing
     environment: publish
+    permissions:
+      id-token: write # Required for OIDC trusted publishing to NPM
+      contents: write # Required for creating GitHub releases
+      attestations: write # Required for build provenance attestation
+      artifact-metadata: write
     steps:
       - name: 'Checkout code'
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -110,3 +109,16 @@ jobs:
           DRY_RUN: ${{ inputs.dryRun }}
           # scoped here: only release-it's GitHub release needs it (npm auth is OIDC)
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  published_diff:
+    # Refresh the per-package published-diff check runs now that `latest` has
+    # moved; deliberately unscoped — a full run avoids badge gaps on the fresh
+    # bump-commit head. A failure here should be visible; workflow_dispatch on
+    # Published Diff is the re-nudge.
+    needs: publish_npm
+    permissions:
+      checks: write
+      contents: read
+    uses: ./.github/workflows/published-diff.yml
+    secrets:
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}

--- a/.github/workflows/published-diff.yml
+++ b/.github/workflows/published-diff.yml
@@ -8,11 +8,15 @@ on:
   push:
     branches:
       - main
-  # release-it pushes the bump commit before npm `latest` moves, so the
-  # push-triggered run sees stale drift; this re-run flips the badge green.
-  workflow_run:
-    workflows: [Publish to NPM]
-    types: [completed]
+  # Called by publish-npm.yml after a successful publish: release-it pushes
+  # the bump commit before npm `latest` moves, so the push-triggered run sees
+  # stale drift; the post-publish call flips the badge green. Calls always
+  # run the full package set.
+  workflow_call:
+    secrets:
+      TURBO_TOKEN:
+        # Remote turbo cache; absent = local cache only.
+        required: false
   workflow_dispatch:
     inputs:
       packages:
@@ -41,9 +45,9 @@ jobs:
       - name: 'Checkout code'
         uses: actions/checkout@v7
         with:
-          # Always main's head: workflow_run contexts point at the triggering
-          # ref, and the badges query main (filter=latest supersedes stale
-          # same-name runs there).
+          # Always main's head: workflow_call inherits the caller's context
+          # (a tag ref from publish-npm), and the badges query main —
+          # filter=latest supersedes stale same-name runs there.
           ref: main
           persist-credentials: false
       - name: Setup mise
@@ -59,6 +63,7 @@ jobs:
         # declared output, so cache replay materializes it too).
         run: pnpm check:published-diff
         env:
+          # Empty on push and workflow_call runs = full set.
           PUBLISHED_DIFF_PACKAGES: ${{ inputs.packages }}
           TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
           TURBO_API: ${{ vars.TURBO_API }}

--- a/.github/workflows/published-diff.yml
+++ b/.github/workflows/published-diff.yml
@@ -1,0 +1,66 @@
+# Published-diff check runs on main's head — one per package, named
+# "published-diff (<pkg>)"; the README badges read them via shields'
+# check-runs endpoint. action_required renders orange = a release is owed,
+# never a CI failure, so this job succeeds whether or not drift exists.
+name: Published Diff
+
+on:
+  push:
+    branches:
+      - main
+  # release-it pushes the bump commit before npm `latest` moves, so the
+  # push-triggered run sees stale drift; this re-run flips the badge green.
+  workflow_run:
+    workflows: [Publish to NPM]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      packages:
+        description: 'Comma-separated published package names to re-check (re-nudge tool: a scoped run creates check runs only for these, so on a head with no prior full run the other badges show nothing until the next push/full run). Empty = all.'
+        required: false
+        default: ''
+        type: string
+
+# Standard husky CI setup: skip the prepare-script git-hook install on CI installs.
+env:
+  HUSKY: 0
+
+# One run at a time, newest wins; every run targets main's current head.
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  published_diff:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      checks: write
+      contents: read
+    steps:
+      - name: 'Checkout code'
+        uses: actions/checkout@v7
+        with:
+          # Always main's head: workflow_run contexts point at the triggering
+          # ref, and the badges query main (filter=latest supersedes stale
+          # same-name runs there).
+          ref: main
+          persist-credentials: false
+      - name: Setup mise
+        uses: jdx/mise-action@v4
+      - name: Install dependencies
+        run: mise run setup
+        env:
+          # Nothing here runs Cypress; skip the binary download.
+          CYPRESS_INSTALL_BINARY: '0'
+      - name: Published diff summary
+        run: mise run //tools/release:published_diff_json
+        env:
+          PUBLISHED_DIFF_PACKAGES: ${{ inputs.packages }}
+          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+          TURBO_API: ${{ vars.TURBO_API }}
+          TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+      - name: Publish check runs
+        run: mise run //tools/release:publish_check_runs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/published-diff.yml
+++ b/.github/workflows/published-diff.yml
@@ -53,8 +53,11 @@ jobs:
         env:
           # Nothing here runs Cypress; skip the binary download.
           CYPRESS_INSTALL_BINARY: '0'
-      - name: Published diff summary
-        run: mise run //tools/release:published_diff_json
+      - name: Published diff
+        # Root two-invocation script; the check always writes its summary to
+        # tools/release/.cache/published-diff-summary.json (the turbo task's
+        # declared output, so cache replay materializes it too).
+        run: pnpm check:published-diff
         env:
           PUBLISHED_DIFF_PACKAGES: ${{ inputs.packages }}
           TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}

--- a/.github/workflows/published-diff.yml
+++ b/.github/workflows/published-diff.yml
@@ -58,10 +58,7 @@ jobs:
           # Nothing here runs Cypress; skip the binary download.
           CYPRESS_INSTALL_BINARY: '0'
       - name: Published diff
-        # Root two-invocation script; the check always writes its summary to
-        # tools/release/.cache/published-diff-summary.json (the turbo task's
-        # declared output, so cache replay materializes it too).
-        run: pnpm check:published-diff
+        run: mise run //tools/release:published_diff
         env:
           # Empty on push and workflow_call runs = full set.
           PUBLISHED_DIFF_PACKAGES: ${{ inputs.packages }}

--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -7,6 +7,9 @@ on:
   # pull_request_target runs the main-branch workflow with repo secrets;
   # checking out PR code here is forbidden - validate event payload only.
   pull_request_target:
+    # main-targeting PRs only: a stale branch's old workflow file never runs
+    branches:
+      - main
     types:
       - opened
       - edited
@@ -26,6 +29,8 @@ concurrency:
 
 jobs:
   lint_pr_title:
+    # never run in forks' stale copies of this workflow
+    if: ${{ github.repository == 'simshanith/lit-ui-router' }}
     runs-on: ubuntu-latest
     steps:
       - uses: amannn/action-semantic-pull-request@v6

--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,9 @@ certs/
 .turbo
 .claude
 
+# package-local resolved-state caches (e.g. tools/release/.cache)
+.cache/
+
 lit-ui-router-*.tgz
 **/specs/__screenshots__
 coverage

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![Website](https://img.shields.io/website?url=https%3A%2F%2Flit-ui-router.dev)](https://lit-ui-router.dev)
 [![codecov](https://codecov.io/gh/simshanith/lit-ui-router/branch/main/graph/badge.svg)](https://codecov.io/gh/simshanith/lit-ui-router)
 
-Published-diff status (orange = unreleased changes on `main`, a release is owed):
+Published diff status (orange = unreleased ship-affecting changes on `main`)
 
 [![lit-ui-router published diff](https://img.shields.io/github/check-runs/simshanith/lit-ui-router/main?nameFilter=published-diff%20%28lit-ui-router%29&label=lit-ui-router)](https://github.com/simshanith/lit-ui-router/commit/main/checks)
 [![lit-ui-router-mobx published diff](https://img.shields.io/github/check-runs/simshanith/lit-ui-router/main?nameFilter=published-diff%20%28lit-ui-router-mobx%29&label=lit-ui-router-mobx)](https://github.com/simshanith/lit-ui-router/commit/main/checks)

--- a/README.md
+++ b/README.md
@@ -9,6 +9,12 @@
 [![Website](https://img.shields.io/website?url=https%3A%2F%2Flit-ui-router.dev)](https://lit-ui-router.dev)
 [![codecov](https://codecov.io/gh/simshanith/lit-ui-router/branch/main/graph/badge.svg)](https://codecov.io/gh/simshanith/lit-ui-router)
 
+Published-diff status (orange = unreleased changes on `main`, a release is owed):
+
+[![lit-ui-router published diff](https://img.shields.io/github/check-runs/simshanith/lit-ui-router/main?nameFilter=published-diff%20%28lit-ui-router%29&label=lit-ui-router)](https://github.com/simshanith/lit-ui-router/commit/main/checks)
+[![lit-ui-router-mobx published diff](https://img.shields.io/github/check-runs/simshanith/lit-ui-router/main?nameFilter=published-diff%20%28lit-ui-router-mobx%29&label=lit-ui-router-mobx)](https://github.com/simshanith/lit-ui-router/commit/main/checks)
+[![ui-router-navigation-location-plugin published diff](https://img.shields.io/github/check-runs/simshanith/lit-ui-router/main?nameFilter=published-diff%20%28ui-router-navigation-location-plugin%29&label=ui-router-navigation-location-plugin)](https://github.com/simshanith/lit-ui-router/commit/main/checks)
+
 ### lit-ui-router: State based routing for Lit (v2+)
 
 ---

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -810,9 +810,18 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.13.3
+      lit-ui-router:
+        specifier: workspace:*
+        version: link:../../packages/lit-ui-router
+      lit-ui-router-mobx:
+        specifier: workspace:*
+        version: link:../../packages/lit-ui-router-mobx
       typescript:
         specifier: 'catalog:'
         version: 7.0.2
+      ui-router-navigation-location-plugin:
+        specifier: workspace:*
+        version: link:../../packages/navigation-location-plugin
 
   tools/shared:
     devDependencies:

--- a/tools/release/mise.toml
+++ b/tools/release/mise.toml
@@ -55,7 +55,13 @@ run = "node src/steps/release-publish.ts"
 
 [tasks.published_diff]
 description = "Resolve published versions, then run the published-diff check (two turbo invocations: turbo hashes inputs at run startup, so resolve must write before the check's hash computes)"
-run = ["turbo run resolve:published", "turbo run check:published-diff"]
+usage = '''
+flag "--packages <names>" env="PUBLISHED_DIFF_PACKAGES" help="Comma-separated published package names to scope the check; empty = all"
+'''
+run = [
+  "turbo run resolve:published",
+  'PUBLISHED_DIFF_PACKAGES="${usage_packages:-}" turbo run check:published-diff',
+]
 
 [tasks.publish_check_runs]
 # env: GH_TOKEN, GITHUB_REPOSITORY. Reads .cache/published-diff-summary.json

--- a/tools/release/mise.toml
+++ b/tools/release/mise.toml
@@ -53,6 +53,23 @@ run = "node src/steps/release-tag-push.ts"
 description = "Publish the packed tarball to npm and cut the GitHub release"
 run = "node src/steps/release-publish.ts"
 
+[tasks.published_diff_json]
+# env: PUBLISHED_DIFF_PACKAGES (optional scope), TURBO_TOKEN/TURBO_API/
+# TURBO_TEAM (remote cache). Root two-invocation pattern; the check runs
+# directly (not via its turbo task) so --json always materializes — a turbo
+# cache replay would skip the undeclared side-effect file.
+description = "Resolve published versions and write the per-package published-diff summary JSON"
+run = [
+  "turbo run resolve:published",
+  "node src/checks/check-published-diff.ts --json ../../node_modules/.cache/release/published-diff-summary.json",
+]
+
+[tasks.publish_check_runs]
+# env: GH_TOKEN, GITHUB_REPOSITORY. One check run per summarized package on
+# the current HEAD.
+description = "Create per-package published-diff check runs from the summary JSON"
+run = "node src/checks/publish-check-runs.ts ../../node_modules/.cache/release/published-diff-summary.json"
+
 [tasks.bump]
 # env: PACKAGE, INCREMENT, OTHER_INCREMENT, PR_BASE, BRANCH_PREFIX_INPUT,
 # DRY_RUN, GH_TOKEN (gh pr create; the branch push rides checkout's PAT).

--- a/tools/release/mise.toml
+++ b/tools/release/mise.toml
@@ -53,22 +53,12 @@ run = "node src/steps/release-tag-push.ts"
 description = "Publish the packed tarball to npm and cut the GitHub release"
 run = "node src/steps/release-publish.ts"
 
-[tasks.published_diff_json]
-# env: PUBLISHED_DIFF_PACKAGES (optional scope), TURBO_TOKEN/TURBO_API/
-# TURBO_TEAM (remote cache). Root two-invocation pattern; the check runs
-# directly (not via its turbo task) so --json always materializes — a turbo
-# cache replay would skip the undeclared side-effect file.
-description = "Resolve published versions and write the per-package published-diff summary JSON"
-run = [
-  "turbo run resolve:published",
-  "node src/checks/check-published-diff.ts --json ../../node_modules/.cache/release/published-diff-summary.json",
-]
-
 [tasks.publish_check_runs]
-# env: GH_TOKEN, GITHUB_REPOSITORY. One check run per summarized package on
-# the current HEAD.
+# env: GH_TOKEN, GITHUB_REPOSITORY. Reads .cache/published-diff-summary.json
+# (the check:published-diff task's output); one check run per package on the
+# current HEAD.
 description = "Create per-package published-diff check runs from the summary JSON"
-run = "node src/checks/publish-check-runs.ts ../../node_modules/.cache/release/published-diff-summary.json"
+run = "node src/checks/publish-check-runs.ts"
 
 [tasks.bump]
 # env: PACKAGE, INCREMENT, OTHER_INCREMENT, PR_BASE, BRANCH_PREFIX_INPUT,

--- a/tools/release/mise.toml
+++ b/tools/release/mise.toml
@@ -54,10 +54,7 @@ description = "Publish the packed tarball to npm and cut the GitHub release"
 run = "node src/steps/release-publish.ts"
 
 [tasks.published_diff]
-# env: PUBLISHED_DIFF_PACKAGES (optional scope), TURBO_TOKEN/TURBO_API/
-# TURBO_TEAM (remote cache). Pure convention wrapper over the root script's
-# two-invocation turbo contract — no extra plumbing.
-description = "Resolve published versions, then run the cached published-diff check"
+description = "Resolve published versions, then run the published-diff check (two turbo invocations: turbo hashes inputs at run startup, so resolve must write before the check's hash computes)"
 run = ["turbo run resolve:published", "turbo run check:published-diff"]
 
 [tasks.publish_check_runs]

--- a/tools/release/mise.toml
+++ b/tools/release/mise.toml
@@ -53,6 +53,13 @@ run = "node src/steps/release-tag-push.ts"
 description = "Publish the packed tarball to npm and cut the GitHub release"
 run = "node src/steps/release-publish.ts"
 
+[tasks.published_diff]
+# env: PUBLISHED_DIFF_PACKAGES (optional scope), TURBO_TOKEN/TURBO_API/
+# TURBO_TEAM (remote cache). Pure convention wrapper over the root script's
+# two-invocation turbo contract — no extra plumbing.
+description = "Resolve published versions, then run the cached published-diff check"
+run = ["turbo run resolve:published", "turbo run check:published-diff"]
+
 [tasks.publish_check_runs]
 # env: GH_TOKEN, GITHUB_REPOSITORY. Reads .cache/published-diff-summary.json
 # (the check:published-diff task's output); one check run per package on the

--- a/tools/release/package.json
+++ b/tools/release/package.json
@@ -17,6 +17,9 @@
   "devDependencies": {
     "@tools/shared": "workspace:*",
     "@types/node": "catalog:",
-    "typescript": "catalog:"
+    "lit-ui-router": "workspace:*",
+    "lit-ui-router-mobx": "workspace:*",
+    "typescript": "catalog:",
+    "ui-router-navigation-location-plugin": "workspace:*"
   }
 }

--- a/tools/release/src/checks/cache-paths.ts
+++ b/tools/release/src/checks/cache-paths.ts
@@ -1,0 +1,23 @@
+// Package-local cache dir for resolved release state — gitignored via the
+// root `.cache/` convention. Package-relative paths let turbo declare the
+// summary as the check task's output, so cache replay materializes it.
+
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// This file lives in <package>/src/checks.
+export const cacheDir = join(
+  dirname(fileURLToPath(import.meta.url)),
+  '..',
+  '..',
+  '.cache',
+);
+
+/** Written by resolve-published.ts, hashed as check:published-diff's input. */
+export const publishedVersionsPath = join(cacheDir, 'published-versions.json');
+
+/** Written unconditionally by check-published-diff.ts; the turbo task's output. */
+export const publishedDiffSummaryPath = join(
+  cacheDir,
+  'published-diff-summary.json',
+);

--- a/tools/release/src/checks/check-pack.ts
+++ b/tools/release/src/checks/check-pack.ts
@@ -22,6 +22,7 @@ import {
   type PackResult,
 } from './check-pack.core.ts';
 import { pnpmPack } from './pack.ts';
+import { assertSelfDeclaredDeps } from './self-deps.ts';
 import type { PackageManifest } from '@tools/shared/types.ts';
 import { loadWorkspace, workspaceRoot } from '@tools/shared/workspace.ts';
 
@@ -58,6 +59,7 @@ async function main() {
       member.manifest &&
       member.manifest.private !== true,
   );
+  await assertSelfDeclaredDeps(publishable.map(({ name }) => name));
   const results: PackResult[] = [];
   for (const { name, dir } of publishable) {
     const manifest = await packedManifest(join(workspaceRoot, dir));

--- a/tools/release/src/checks/check-published-diff.core.ts
+++ b/tools/release/src/checks/check-published-diff.core.ts
@@ -64,6 +64,25 @@ export type DiffResult = {
   shipInertFiles?: string[];
 };
 
+/** Filter publishable names to a comma-separated scope; empty/unset = all, unknown names throw. */
+export function scopePackages(
+  publishable: string[],
+  scope: string | undefined,
+): string[] {
+  const requested = (scope ?? '')
+    .split(',')
+    .map((name) => name.trim())
+    .filter(Boolean);
+  if (requested.length === 0) return publishable;
+  const unknown = requested.filter((name) => !publishable.includes(name));
+  if (unknown.length > 0) {
+    throw new Error(
+      `PUBLISHED_DIFF_PACKAGES names no publishable member: ${unknown.join(', ')} — publishable: ${publishable.join(', ')}`,
+    );
+  }
+  return publishable.filter((name) => requested.includes(name));
+}
+
 /** Per-package machine verdict; `version` is the published latest (null when unpublished). */
 export type PackageSummary = {
   name: string;
@@ -72,20 +91,26 @@ export type PackageSummary = {
   shipAffecting: number;
   shipInert: number;
   clean: boolean;
+  shipAffectingFiles: string[];
+  shipInertFiles: string[];
 };
 
 /** Shape results for the --json output; `clean` = no ship-affecting drift. */
 export function summarizeResults(results: DiffResult[]): PackageSummary[] {
-  return results.map(
-    ({ name, dir, latest, status, files, shipInertFiles }) => ({
+  return results.map(({ name, dir, latest, status, files, shipInertFiles }) => {
+    const shipAffectingFiles = status === 'drift' ? (files ?? []) : [];
+    const inert = shipInertFiles ?? [];
+    return {
       name,
       dir,
       version: latest ?? null,
-      shipAffecting: status === 'drift' ? (files?.length ?? 0) : 0,
-      shipInert: shipInertFiles?.length ?? 0,
+      shipAffecting: shipAffectingFiles.length,
+      shipInert: inert.length,
       clean: status !== 'drift',
-    }),
-  );
+      shipAffectingFiles,
+      shipInertFiles: inert,
+    };
+  });
 }
 
 /** Canonical --json bytes: 2-space indent, trailing newline. */

--- a/tools/release/src/checks/check-published-diff.core.ts
+++ b/tools/release/src/checks/check-published-diff.core.ts
@@ -64,6 +64,35 @@ export type DiffResult = {
   shipInertFiles?: string[];
 };
 
+/** Per-package machine verdict; `version` is the published latest (null when unpublished). */
+export type PackageSummary = {
+  name: string;
+  dir: string;
+  version: string | null;
+  shipAffecting: number;
+  shipInert: number;
+  clean: boolean;
+};
+
+/** Shape results for the --json output; `clean` = no ship-affecting drift. */
+export function summarizeResults(results: DiffResult[]): PackageSummary[] {
+  return results.map(
+    ({ name, dir, latest, status, files, shipInertFiles }) => ({
+      name,
+      dir,
+      version: latest ?? null,
+      shipAffecting: status === 'drift' ? (files?.length ?? 0) : 0,
+      shipInert: shipInertFiles?.length ?? 0,
+      clean: status !== 'drift',
+    }),
+  );
+}
+
+/** Canonical --json bytes: 2-space indent, trailing newline. */
+export function renderSummary(summaries: PackageSummary[]): string {
+  return `${JSON.stringify(summaries, null, 2)}\n`;
+}
+
 export type ReportOptions = {
   /** When true, drift fails the report instead of merely being listed. */
   strict?: boolean;

--- a/tools/release/src/checks/check-published-diff.test.ts
+++ b/tools/release/src/checks/check-published-diff.test.ts
@@ -6,6 +6,8 @@ import {
   classifyFiles,
   formatReport,
   isCleanDiff,
+  renderSummary,
+  summarizeResults,
 } from './check-published-diff.core.ts';
 
 // Shape of real `npm diff --diff=<spec> --diff=<tarball>` output: both sides
@@ -180,5 +182,105 @@ describe('formatReport', () => {
     const { ok, text } = formatReport([]);
     assert.equal(ok, false);
     assert.match(text, /no publishable workspace packages/);
+  });
+});
+
+describe('summarizeResults', () => {
+  it('maps every status to counts, published version, and a clean flag', () => {
+    assert.deepEqual(
+      summarizeResults([
+        {
+          name: 'lit-ui-router',
+          dir: 'packages/lit-ui-router',
+          latest: '1.7.0',
+          localVersion: '1.7.0',
+          status: 'clean',
+        },
+        {
+          name: 'lit-ui-router-mobx',
+          dir: 'packages/lit-ui-router-mobx',
+          latest: '0.3.2',
+          localVersion: '0.3.2',
+          status: 'drift',
+          files: ['dist/router-store.js', 'package.json'],
+          shipInertFiles: ['src/router-store.ts'],
+        },
+        {
+          name: 'ui-router-navigation-location-plugin',
+          dir: 'packages/navigation-location-plugin',
+          latest: '0.2.1',
+          localVersion: '0.2.1',
+          status: 'ship-inert',
+          files: [],
+          shipInertFiles: ['dist/core.js.map', 'src/core.ts'],
+        },
+        {
+          name: 'ui-router-server',
+          dir: 'packages/ui-router-server',
+          localVersion: '0.0.0',
+          status: 'unpublished',
+        },
+      ]),
+      [
+        {
+          name: 'lit-ui-router',
+          dir: 'packages/lit-ui-router',
+          version: '1.7.0',
+          shipAffecting: 0,
+          shipInert: 0,
+          clean: true,
+        },
+        {
+          name: 'lit-ui-router-mobx',
+          dir: 'packages/lit-ui-router-mobx',
+          version: '0.3.2',
+          shipAffecting: 2,
+          shipInert: 1,
+          clean: false,
+        },
+        {
+          name: 'ui-router-navigation-location-plugin',
+          dir: 'packages/navigation-location-plugin',
+          version: '0.2.1',
+          shipAffecting: 0,
+          shipInert: 2,
+          clean: true,
+        },
+        {
+          name: 'ui-router-server',
+          dir: 'packages/ui-router-server',
+          version: null,
+          shipAffecting: 0,
+          shipInert: 0,
+          clean: true,
+        },
+      ],
+    );
+  });
+});
+
+describe('renderSummary', () => {
+  it('renders canonical bytes: 2-space indent, trailing newline', () => {
+    const rendered = renderSummary([
+      {
+        name: 'lit-ui-router',
+        dir: 'packages/lit-ui-router',
+        version: '1.7.0',
+        shipAffecting: 0,
+        shipInert: 0,
+        clean: true,
+      },
+    ]);
+    assert.equal(rendered.endsWith('\n'), true);
+    assert.deepEqual(JSON.parse(rendered), [
+      {
+        name: 'lit-ui-router',
+        dir: 'packages/lit-ui-router',
+        version: '1.7.0',
+        shipAffecting: 0,
+        shipInert: 0,
+        clean: true,
+      },
+    ]);
   });
 });

--- a/tools/release/src/checks/check-published-diff.test.ts
+++ b/tools/release/src/checks/check-published-diff.test.ts
@@ -7,6 +7,7 @@ import {
   formatReport,
   isCleanDiff,
   renderSummary,
+  scopePackages,
   summarizeResults,
 } from './check-published-diff.core.ts';
 
@@ -185,6 +186,29 @@ describe('formatReport', () => {
   });
 });
 
+describe('scopePackages', () => {
+  const publishable = ['lit-ui-router', 'lit-ui-router-mobx'];
+
+  it('returns all publishable names when the scope is empty or unset', () => {
+    assert.deepEqual(scopePackages(publishable, undefined), publishable);
+    assert.deepEqual(scopePackages(publishable, ''), publishable);
+    assert.deepEqual(scopePackages(publishable, ' , '), publishable);
+  });
+
+  it('filters to the comma-separated scope, whitespace-tolerant', () => {
+    assert.deepEqual(scopePackages(publishable, ' lit-ui-router-mobx '), [
+      'lit-ui-router-mobx',
+    ]);
+  });
+
+  it('throws loudly on names matching no publishable member', () => {
+    assert.throws(
+      () => scopePackages(publishable, 'lit-ui-router,typo-pkg'),
+      /PUBLISHED_DIFF_PACKAGES names no publishable member: typo-pkg/,
+    );
+  });
+});
+
 describe('summarizeResults', () => {
   it('maps every status to counts, published version, and a clean flag', () => {
     assert.deepEqual(
@@ -229,6 +253,8 @@ describe('summarizeResults', () => {
           shipAffecting: 0,
           shipInert: 0,
           clean: true,
+          shipAffectingFiles: [],
+          shipInertFiles: [],
         },
         {
           name: 'lit-ui-router-mobx',
@@ -237,6 +263,8 @@ describe('summarizeResults', () => {
           shipAffecting: 2,
           shipInert: 1,
           clean: false,
+          shipAffectingFiles: ['dist/router-store.js', 'package.json'],
+          shipInertFiles: ['src/router-store.ts'],
         },
         {
           name: 'ui-router-navigation-location-plugin',
@@ -245,6 +273,8 @@ describe('summarizeResults', () => {
           shipAffecting: 0,
           shipInert: 2,
           clean: true,
+          shipAffectingFiles: [],
+          shipInertFiles: ['dist/core.js.map', 'src/core.ts'],
         },
         {
           name: 'ui-router-server',
@@ -253,6 +283,8 @@ describe('summarizeResults', () => {
           shipAffecting: 0,
           shipInert: 0,
           clean: true,
+          shipAffectingFiles: [],
+          shipInertFiles: [],
         },
       ],
     );
@@ -269,6 +301,8 @@ describe('renderSummary', () => {
         shipAffecting: 0,
         shipInert: 0,
         clean: true,
+        shipAffectingFiles: [],
+        shipInertFiles: [],
       },
     ]);
     assert.equal(rendered.endsWith('\n'), true);
@@ -280,6 +314,8 @@ describe('renderSummary', () => {
         shipAffecting: 0,
         shipInert: 0,
         clean: true,
+        shipAffectingFiles: [],
+        shipInertFiles: [],
       },
     ]);
   });

--- a/tools/release/src/checks/check-published-diff.ts
+++ b/tools/release/src/checks/check-published-diff.ts
@@ -42,6 +42,7 @@ import {
   formatReport,
   isCleanDiff,
   renderSummary,
+  scopePackages,
   summarizeResults,
 } from './check-published-diff.core.ts';
 import { pnpmPack } from './pack.ts';
@@ -101,18 +102,24 @@ async function main() {
   );
   await assertSelfDeclaredDeps(publishable.map(({ name }) => name));
 
-  if (!skipBuild && publishable.length > 0) {
+  // PUBLISHED_DIFF_PACKAGES scopes dispatch re-runs; empty/unset = all.
+  const scoped = scopePackages(
+    publishable.map(({ name }) => name),
+    process.env.PUBLISHED_DIFF_PACKAGES,
+  );
+  const targets = publishable.filter(({ name }) => scoped.includes(name));
+
+  if (!skipBuild && targets.length > 0) {
     // Bare turbo (mise-provisioned), never through pnpm run — pnpm's relative
     // .bin PATH breaks turbo's child process spawning.
-    await run(
-      'turbo',
-      ['run', ...publishable.map(({ name }) => `${name}#build`)],
-      { cwd: workspaceRoot, maxBuffer: MAX_BUFFER },
-    );
+    await run('turbo', ['run', ...targets.map(({ name }) => `${name}#build`)], {
+      cwd: workspaceRoot,
+      maxBuffer: MAX_BUFFER,
+    });
   }
 
   const results: DiffResult[] = [];
-  for (const { name, dir } of publishable) {
+  for (const { name, dir } of targets) {
     const packageDir = join(workspaceRoot, dir);
     const localVersion = (
       JSON.parse(await readFile(join(packageDir, 'package.json'), 'utf8')) as {

--- a/tools/release/src/checks/check-published-diff.ts
+++ b/tools/release/src/checks/check-published-diff.ts
@@ -17,7 +17,8 @@
 //
 // Run `turbo run build` first so dist is current; `--strict` turns drift into
 // a failing exit (default is an informational report — drift usually means "a
-// release is owed", not "the tree is broken").
+// release is owed", not "the tree is broken"). `--json <path>` additionally
+// writes the per-package machine verdict (see summarizeResults).
 //
 // Registry state arrives through published-versions.json, written by
 // resolve-published.ts just before this runs (the root script chains them) —
@@ -40,9 +41,12 @@ import {
   type DiffResult,
   formatReport,
   isCleanDiff,
+  renderSummary,
+  summarizeResults,
 } from './check-published-diff.core.ts';
 import { pnpmPack } from './pack.ts';
 import { readPublishedVersions } from './published-versions.ts';
+import { assertSelfDeclaredDeps } from './self-deps.ts';
 import { loadWorkspace, workspaceRoot } from '@tools/shared/workspace.ts';
 
 const run = promisify(execFile);
@@ -81,6 +85,11 @@ async function diffAgainstPublished(
 async function main() {
   const strict = process.argv.includes('--strict');
   const skipBuild = process.argv.includes('--no-build');
+  const jsonFlag = process.argv.indexOf('--json');
+  const jsonPath = jsonFlag === -1 ? undefined : process.argv[jsonFlag + 1];
+  if (jsonFlag !== -1 && (!jsonPath || jsonPath.startsWith('--'))) {
+    throw new Error('--json requires a file path argument');
+  }
 
   const published = await readPublishedVersions();
   const { members } = await loadWorkspace(workspaceRoot);
@@ -90,6 +99,7 @@ async function main() {
       member.manifest &&
       member.manifest.private !== true,
   );
+  await assertSelfDeclaredDeps(publishable.map(({ name }) => name));
 
   if (!skipBuild && publishable.length > 0) {
     // Bare turbo (mise-provisioned), never through pnpm run — pnpm's relative
@@ -135,6 +145,9 @@ async function main() {
       shipInertFiles: shipInert,
     });
   }
+
+  if (jsonPath)
+    await writeFile(jsonPath, renderSummary(summarizeResults(results)));
 
   const { ok, text } = formatReport(results, { strict });
   (ok ? console.log : console.error)(text);

--- a/tools/release/src/checks/check-published-diff.ts
+++ b/tools/release/src/checks/check-published-diff.ts
@@ -17,8 +17,10 @@
 //
 // Run `turbo run build` first so dist is current; `--strict` turns drift into
 // a failing exit (default is an informational report — drift usually means "a
-// release is owed", not "the tree is broken"). `--json <path>` additionally
-// writes the per-package machine verdict (see summarizeResults).
+// release is owed", not "the tree is broken"). The per-package machine
+// verdict (see summarizeResults) always lands at .cache/
+// published-diff-summary.json — the turbo task's output; `--json <path>`
+// overrides the destination ad hoc.
 //
 // Registry state arrives through published-versions.json, written by
 // resolve-published.ts just before this runs (the root script chains them) —
@@ -29,11 +31,12 @@
 // unit-tested ./check-published-diff.core.ts.
 
 import { execFile } from 'node:child_process';
-import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 import { promisify } from 'node:util';
 
+import { publishedDiffSummaryPath } from './cache-paths.ts';
 import { STRIPPED_MANIFEST_FIELDS } from './check-pack.core.ts';
 import {
   changedFiles,
@@ -86,11 +89,14 @@ async function diffAgainstPublished(
 async function main() {
   const strict = process.argv.includes('--strict');
   const skipBuild = process.argv.includes('--no-build');
+  // The summary always lands at the canonical .cache path (the turbo task's
+  // declared output); --json is an ad-hoc override only.
   const jsonFlag = process.argv.indexOf('--json');
-  const jsonPath = jsonFlag === -1 ? undefined : process.argv[jsonFlag + 1];
-  if (jsonFlag !== -1 && (!jsonPath || jsonPath.startsWith('--'))) {
+  const jsonOverride = jsonFlag === -1 ? undefined : process.argv[jsonFlag + 1];
+  if (jsonFlag !== -1 && (!jsonOverride || jsonOverride.startsWith('--'))) {
     throw new Error('--json requires a file path argument');
   }
+  const jsonPath = jsonOverride ?? publishedDiffSummaryPath;
 
   const published = await readPublishedVersions();
   const { members } = await loadWorkspace(workspaceRoot);
@@ -153,8 +159,8 @@ async function main() {
     });
   }
 
-  if (jsonPath)
-    await writeFile(jsonPath, renderSummary(summarizeResults(results)));
+  await mkdir(dirname(jsonPath), { recursive: true });
+  await writeFile(jsonPath, renderSummary(summarizeResults(results)));
 
   const { ok, text } = formatReport(results, { strict });
   (ok ? console.log : console.error)(text);

--- a/tools/release/src/checks/publish-check-runs.core.ts
+++ b/tools/release/src/checks/publish-check-runs.core.ts
@@ -1,0 +1,94 @@
+// Pure shaping for the published-diff check runs: --json summaries in,
+// Checks API payloads and gh argv out. The README badges read these runs by
+// exact name via shields' check-runs endpoint, so `checkRunName` is the one
+// place that composes it. action_required renders orange there — "a release
+// is owed", never a CI failure; `failure` is deliberately unused. The IO
+// (git rev-parse, gh api) lives in ./publish-check-runs.ts.
+
+import type { PackageSummary } from './check-published-diff.core.ts';
+
+export type CheckRunPayload = {
+  name: string;
+  conclusion: 'success' | 'action_required';
+  title: string;
+  summary: string;
+};
+
+/** The exact run name the README badge nameFilter must match. */
+export function checkRunName(packageName: string): string {
+  return `published-diff (${packageName})`;
+}
+
+/** Collapsed ship-inert listing appended to either verdict's summary. */
+function inertDetails({ shipInert, shipInertFiles }: PackageSummary): string[] {
+  if (shipInert === 0) return [];
+  return [
+    '',
+    '<details>',
+    `<summary>${shipInert} ship-inert file(s) — src/maps, never owe a release</summary>`,
+    '',
+    ...shipInertFiles.map((file) => `- \`${file}\``),
+    '',
+    '</details>',
+  ];
+}
+
+/** One package's summary → its Checks API payload. */
+export function toCheckRun(summary: PackageSummary): CheckRunPayload {
+  const name = checkRunName(summary.name);
+  if (summary.version === null) {
+    return {
+      name,
+      conclusion: 'success',
+      title: 'never published — nothing to diff',
+      summary: `${summary.name} has no published \`latest\` to compare against.`,
+    };
+  }
+  const spec = `${summary.name}@${summary.version}`;
+  if (summary.shipAffecting > 0) {
+    return {
+      name,
+      conclusion: 'action_required',
+      title: `unreleased changes vs ${summary.version} (${summary.shipAffecting} shipped files differ)`,
+      summary: [
+        `A publish from main would ship ${summary.shipAffecting} file(s) that differ from ${spec}:`,
+        '',
+        ...summary.shipAffectingFiles.map((file) => `- \`${file}\``),
+        ...inertDetails(summary),
+      ].join('\n'),
+    };
+  }
+  return {
+    name,
+    conclusion: 'success',
+    title: `up to date with ${summary.version}`,
+    summary: [
+      `Packed bytes match ${spec} — no ship-affecting drift.`,
+      ...inertDetails(summary),
+    ].join('\n'),
+  };
+}
+
+/** argv for `gh api` creating one check run on `headSha`. */
+export function checkRunApiArgs(
+  repo: string,
+  headSha: string,
+  payload: CheckRunPayload,
+): string[] {
+  return [
+    'api',
+    `repos/${repo}/check-runs`,
+    '-f',
+    `name=${payload.name}`,
+    '-f',
+    `head_sha=${headSha}`,
+    '-f',
+    'status=completed',
+    '-f',
+    `conclusion=${payload.conclusion}`,
+    '-f',
+    `output[title]=${payload.title}`,
+    '-f',
+    `output[summary]=${payload.summary}`,
+  ];
+}

--- a/tools/release/src/checks/publish-check-runs.test.ts
+++ b/tools/release/src/checks/publish-check-runs.test.ts
@@ -1,0 +1,104 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import type { PackageSummary } from './check-published-diff.core.ts';
+import {
+  checkRunApiArgs,
+  checkRunName,
+  toCheckRun,
+} from './publish-check-runs.core.ts';
+
+const clean: PackageSummary = {
+  name: 'lit-ui-router-mobx',
+  dir: 'packages/lit-ui-router-mobx',
+  version: '0.3.3',
+  shipAffecting: 0,
+  shipInert: 0,
+  clean: true,
+  shipAffectingFiles: [],
+  shipInertFiles: [],
+};
+
+const drifting: PackageSummary = {
+  name: 'lit-ui-router',
+  dir: 'packages/lit-ui-router',
+  version: '1.7.0',
+  shipAffecting: 2,
+  shipInert: 1,
+  clean: false,
+  shipAffectingFiles: ['dist/core.js', 'package.json'],
+  shipInertFiles: ['src/core.ts'],
+};
+
+describe('checkRunName', () => {
+  it('composes the exact name the README badge nameFilter matches', () => {
+    assert.equal(
+      checkRunName('lit-ui-router'),
+      'published-diff (lit-ui-router)',
+    );
+  });
+});
+
+describe('toCheckRun', () => {
+  it('maps a clean package to success with the published baseline named', () => {
+    const payload = toCheckRun(clean);
+    assert.equal(payload.conclusion, 'success');
+    assert.equal(payload.title, 'up to date with 0.3.3');
+    assert.match(payload.summary, /match lit-ui-router-mobx@0\.3\.3/);
+    assert.doesNotMatch(payload.summary, /<details>/);
+  });
+
+  it('maps drift to action_required, never failure, with unit and baseline in the title', () => {
+    const payload = toCheckRun(drifting);
+    assert.equal(payload.conclusion, 'action_required');
+    assert.equal(
+      payload.title,
+      'unreleased changes vs 1.7.0 (2 shipped files differ)',
+    );
+  });
+
+  it('lists ship-affecting files expanded and ship-inert collapsed', () => {
+    const { summary } = toCheckRun(drifting);
+    const details = summary.indexOf('<details>');
+    assert.notEqual(details, -1);
+    assert.equal(summary.indexOf('- `dist/core.js`') < details, true);
+    assert.equal(summary.indexOf('- `package.json`') < details, true);
+    assert.equal(summary.indexOf('- `src/core.ts`') > details, true);
+    assert.match(summary, /<summary>1 ship-inert file\(s\)/);
+  });
+
+  it('treats an unpublished package as success with nothing to diff', () => {
+    const payload = toCheckRun({ ...clean, version: null });
+    assert.equal(payload.conclusion, 'success');
+    assert.match(payload.title, /never published/);
+  });
+});
+
+describe('checkRunApiArgs', () => {
+  it('builds the gh api argv for one check run on the given head', () => {
+    assert.deepEqual(
+      checkRunApiArgs('simshanith/lit-ui-router', 'abc123', {
+        name: 'published-diff (lit-ui-router)',
+        conclusion: 'action_required',
+        title: 'unreleased changes vs 1.7.0 (2 shipped files differ)',
+        summary: 'body',
+      }),
+      [
+        'api',
+        'repos/simshanith/lit-ui-router/check-runs',
+        '-f',
+        'name=published-diff (lit-ui-router)',
+        '-f',
+        'head_sha=abc123',
+        '-f',
+        'status=completed',
+        '-f',
+        'conclusion=action_required',
+        '-f',
+        'output[title]=unreleased changes vs 1.7.0 (2 shipped files differ)',
+        '-f',
+        'output[summary]=body',
+      ],
+    );
+  });
+});

--- a/tools/release/src/checks/publish-check-runs.ts
+++ b/tools/release/src/checks/publish-check-runs.ts
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+// Create one published-diff check run per package on the current HEAD, from
+// the summary check-published-diff.ts --json wrote. Shells out to gh itself
+// (argv arrays via the shared Exec seam, no workflow-side jq) so the
+// workflow stays a one-line mise step. `--dry-run` prints the payloads
+// instead of calling gh. Shaping is pure and unit-tested in
+// ./publish-check-runs.core.ts.
+
+import { readFile } from 'node:fs/promises';
+
+import type { PackageSummary } from './check-published-diff.core.ts';
+import { checkRunApiArgs, toCheckRun } from './publish-check-runs.core.ts';
+import { defaultExec } from '@tools/shared/exec.ts';
+import { ensureGh } from '@tools/shared/gh.ts';
+
+async function main() {
+  const dryRun = process.argv.includes('--dry-run');
+  const summaryPath = process.argv
+    .slice(2)
+    .find((arg) => !arg.startsWith('--'));
+  if (!summaryPath) {
+    throw new Error('usage: publish-check-runs.ts <summary.json> [--dry-run]');
+  }
+  const parsed: unknown = JSON.parse(await readFile(summaryPath, 'utf8'));
+  if (!Array.isArray(parsed)) {
+    throw new Error(`${summaryPath} must contain a JSON array of summaries`);
+  }
+  const summaries = parsed as PackageSummary[];
+
+  const payloads = summaries.map(toCheckRun);
+  if (dryRun) {
+    console.log(JSON.stringify(payloads, null, 2));
+    return;
+  }
+
+  const repo = process.env.GITHUB_REPOSITORY;
+  if (!repo) {
+    throw new Error('GITHUB_REPOSITORY must be set (or pass --dry-run)');
+  }
+  const { stdout } = await defaultExec('git', ['rev-parse', 'HEAD']);
+  const headSha = stdout.trim();
+  await ensureGh();
+  for (const payload of payloads) {
+    await defaultExec('gh', checkRunApiArgs(repo, headSha, payload));
+    console.log(
+      `created check run "${payload.name}" (${payload.conclusion}) on ${headSha}`,
+    );
+  }
+}
+
+main().catch((error: unknown) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/tools/release/src/checks/publish-check-runs.ts
+++ b/tools/release/src/checks/publish-check-runs.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 // Create one published-diff check run per package on the current HEAD, from
-// the summary check-published-diff.ts --json wrote. Shells out to gh itself
+// the summary check-published-diff.ts always writes. Shells out to gh itself
 // (argv arrays via the shared Exec seam, no workflow-side jq) so the
 // workflow stays a one-line mise step. `--dry-run` prints the payloads
 // instead of calling gh. Shaping is pure and unit-tested in
@@ -8,6 +8,7 @@
 
 import { readFile } from 'node:fs/promises';
 
+import { publishedDiffSummaryPath } from './cache-paths.ts';
 import type { PackageSummary } from './check-published-diff.core.ts';
 import { checkRunApiArgs, toCheckRun } from './publish-check-runs.core.ts';
 import { defaultExec } from '@tools/shared/exec.ts';
@@ -15,12 +16,10 @@ import { ensureGh } from '@tools/shared/gh.ts';
 
 async function main() {
   const dryRun = process.argv.includes('--dry-run');
-  const summaryPath = process.argv
-    .slice(2)
-    .find((arg) => !arg.startsWith('--'));
-  if (!summaryPath) {
-    throw new Error('usage: publish-check-runs.ts <summary.json> [--dry-run]');
-  }
+  // Reads the check's canonical output; a positional path overrides ad hoc.
+  const summaryPath =
+    process.argv.slice(2).find((arg) => !arg.startsWith('--')) ??
+    publishedDiffSummaryPath;
   const parsed: unknown = JSON.parse(await readFile(summaryPath, 'utf8'));
   if (!Array.isArray(parsed)) {
     throw new Error(`${summaryPath} must contain a JSON array of summaries`);

--- a/tools/release/src/checks/published-versions.ts
+++ b/tools/release/src/checks/published-versions.ts
@@ -1,28 +1,17 @@
 // Shared IO for the published-versions manifest: the one path both the
 // resolver (writer) and the diff check (reader) agree on. It is resolved
-// registry state, not source, so it lives in the ecosystem-conventional
-// node_modules/.cache — already ignored, out of the package's source
-// listing, no gitignore entry needed. Turbo still hashes it: explicitly
-// listed inputs under node_modules are hashed (probed on turbo 2.10.4).
+// registry state, not source, so it lives in the gitignored package-local
+// .cache; explicitly listed gitignored inputs are still hashed by turbo.
 
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
-import { dirname, join } from 'node:path';
+import { dirname } from 'node:path';
 
+import { publishedVersionsPath } from './cache-paths.ts';
 import {
   parseManifest,
   renderManifest,
   type PublishedVersions,
 } from './published-versions.core.ts';
-import { workspaceRoot } from '@tools/shared/workspace.ts';
-
-/** Where resolve-published.ts writes and check-published-diff.ts reads. */
-export const publishedVersionsPath = join(
-  workspaceRoot,
-  'node_modules',
-  '.cache',
-  'release',
-  'published-versions.json',
-);
 
 /** Write the canonical manifest, creating the cache directory as needed. */
 export async function writePublishedVersions(
@@ -39,7 +28,7 @@ export async function readPublishedVersions(): Promise<PublishedVersions> {
     text = await readFile(publishedVersionsPath, 'utf8');
   } catch {
     throw new Error(
-      'node_modules/.cache/release/published-versions.json missing — run the resolve:published task first (the root check:published-diff script chains it).',
+      'tools/release/.cache/published-versions.json missing — run the resolve:published task first (the root check:published-diff script chains it).',
     );
   }
   return parseManifest(text);

--- a/tools/release/src/checks/self-deps.core.ts
+++ b/tools/release/src/checks/self-deps.core.ts
@@ -1,0 +1,29 @@
+// Pure logic for the static-edges-vs-dynamic-discovery guard: the check:*
+// turbo tasks hash the packed packages through ^build, which only covers
+// packages declared in @tools/release's own manifest — an undeclared
+// publishable package would get stale cached verdicts. The IO (reading this
+// package's manifest) lives in ./self-deps.ts.
+
+import { DEP_FIELDS } from './types.ts';
+import type { PackageManifest } from '@tools/shared/types.ts';
+
+/** Publishable member names absent from every dependency field of `manifest`. */
+export function undeclaredMembers(
+  publishable: string[],
+  manifest: PackageManifest,
+): string[] {
+  const declared = new Set(
+    DEP_FIELDS.flatMap((field) => Object.keys(manifest[field] ?? {})),
+  );
+  return publishable.filter((name) => !declared.has(name)).sort();
+}
+
+/** Error text telling the maintainer exactly which devDeps to add. */
+export function formatUndeclared(missing: string[]): string {
+  return (
+    `publishable package(s) not declared in tools/release/package.json: ${missing.join(', ')}. ` +
+    'Add each as a "workspace:*" devDependency of @tools/release — the check:pack and ' +
+    'check:published-diff turbo tasks hash packed packages via ^build, so an undeclared ' +
+    'package silently gets stale cached verdicts.'
+  );
+}

--- a/tools/release/src/checks/self-deps.test.ts
+++ b/tools/release/src/checks/self-deps.test.ts
@@ -1,0 +1,44 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { formatUndeclared, undeclaredMembers } from './self-deps.core.ts';
+
+describe('undeclaredMembers', () => {
+  const manifest = {
+    name: '@tools/release',
+    dependencies: { 'lit-ui-router': 'workspace:*' },
+    devDependencies: { 'lit-ui-router-mobx': 'workspace:*' },
+  };
+
+  it('passes when every publishable member is declared in any dep field', () => {
+    assert.deepEqual(
+      undeclaredMembers(['lit-ui-router', 'lit-ui-router-mobx'], manifest),
+      [],
+    );
+  });
+
+  it('reports undeclared members sorted', () => {
+    assert.deepEqual(
+      undeclaredMembers(
+        ['ui-router-navigation-location-plugin', 'lit-ui-router', 'a-new-pkg'],
+        manifest,
+      ),
+      ['a-new-pkg', 'ui-router-navigation-location-plugin'],
+    );
+  });
+
+  it('treats a manifest with no dep fields as declaring nothing', () => {
+    assert.deepEqual(undeclaredMembers(['lit-ui-router'], {}), [
+      'lit-ui-router',
+    ]);
+  });
+});
+
+describe('formatUndeclared', () => {
+  it('names the packages and the devDependency fix', () => {
+    const text = formatUndeclared(['a-new-pkg']);
+    assert.match(text, /a-new-pkg/);
+    assert.match(text, /"workspace:\*" devDependency/);
+    assert.match(text, /stale cached verdicts/);
+  });
+});

--- a/tools/release/src/checks/self-deps.ts
+++ b/tools/release/src/checks/self-deps.ts
@@ -1,0 +1,28 @@
+// IO shell for the self-dependency guard; decisions live in the pure,
+// unit-tested ./self-deps.core.ts.
+
+import { readFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { formatUndeclared, undeclaredMembers } from './self-deps.core.ts';
+import type { PackageManifest } from '@tools/shared/types.ts';
+
+// This file lives in <package>/src/checks.
+const manifestPath = join(
+  dirname(fileURLToPath(import.meta.url)),
+  '..',
+  '..',
+  'package.json',
+);
+
+/** Throw when a publishable workspace member lacks a dependency edge here. */
+export async function assertSelfDeclaredDeps(
+  publishable: string[],
+): Promise<void> {
+  const manifest = JSON.parse(
+    await readFile(manifestPath, 'utf8'),
+  ) as PackageManifest;
+  const missing = undeclaredMembers(publishable, manifest);
+  if (missing.length > 0) throw new Error(formatUndeclared(missing));
+}

--- a/tools/release/turbo.json
+++ b/tools/release/turbo.json
@@ -8,14 +8,13 @@
       "inputs": ["$TURBO_DEFAULT$"]
     },
     "check:pack": {
-      // Purely local (pack + inspect the packed manifest), so caching is
-      // sound: the verdict depends only on the manifests, the catalogs that
-      // substitute into them, and this package's own sources.
-      "inputs": [
-        "$TURBO_DEFAULT$",
-        "$TURBO_ROOT$/**/package.json",
-        "$TURBO_ROOT$/pnpm-workspace.yaml"
-      ]
+      // ^build restores fresh dist and folds every declared dependency's own
+      // inputs (manifest included) into this hash — the packed packages must
+      // be devDependencies here (self-guard in the check enforces it).
+      // pnpm-workspace.yaml carries the catalogs that substitute into packed
+      // manifests.
+      "dependsOn": ["^build"],
+      "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/pnpm-workspace.yaml"]
     },
     "resolve:published": {
       // Reads the live registry (the only mutable state here); never cache.
@@ -29,14 +28,15 @@
       // published-versions.json, written by resolve:published just before
       // this task and hashed as an input (turbo hashes explicitly listed
       // node_modules inputs; probed on 2.10.4).
+      // ^build restores fresh dist and folds every declared dependency's own
+      // inputs into this hash — the packed packages must be devDependencies
+      // here (self-guard in the check enforces it).
       // Escape hatch: `turbo run check:published-diff --force`.
+      "dependsOn": ["^build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "$TURBO_ROOT$/node_modules/.cache/release/published-versions.json",
-        "$TURBO_ROOT$/packages/**",
-        "$TURBO_ROOT$/**/package.json",
-        "$TURBO_ROOT$/pnpm-workspace.yaml",
-        "$TURBO_ROOT$/pnpm-lock.yaml"
+        "$TURBO_ROOT$/pnpm-workspace.yaml"
       ]
     }
   }

--- a/tools/release/turbo.json
+++ b/tools/release/turbo.json
@@ -32,6 +32,9 @@
       // inputs into this hash — the packed packages must be devDependencies
       // here (self-guard in the check enforces it).
       // Escape hatch: `turbo run check:published-diff --force`.
+      // PUBLISHED_DIFF_PACKAGES scopes dispatch re-runs; declared so scoped
+      // and full runs hash separately.
+      "env": ["PUBLISHED_DIFF_PACKAGES"],
       "dependsOn": ["^build"],
       "inputs": [
         "$TURBO_DEFAULT$",

--- a/tools/release/turbo.json
+++ b/tools/release/turbo.json
@@ -24,23 +24,24 @@
       // Cached: the verdict is a pure function of the pack surface and the
       // resolved published versions. Sound because npm tarballs are immutable
       // per version (and we practice publisher immutability) — the movable
-      // `latest` pointer is captured in node_modules/.cache/release/
-      // published-versions.json, written by resolve:published just before
-      // this task and hashed as an input (turbo hashes explicitly listed
-      // node_modules inputs; probed on 2.10.4).
+      // `latest` pointer is captured in .cache/published-versions.json,
+      // written by resolve:published just before this task and hashed as an
+      // input (explicitly listed gitignored inputs are hashed).
       // ^build restores fresh dist and folds every declared dependency's own
       // inputs into this hash — the packed packages must be devDependencies
       // here (self-guard in the check enforces it).
       // Escape hatch: `turbo run check:published-diff --force`.
       // PUBLISHED_DIFF_PACKAGES scopes dispatch re-runs; declared so scoped
-      // and full runs hash separately.
+      // runs (subset summary JSON) hash apart from full runs.
       "env": ["PUBLISHED_DIFF_PACKAGES"],
       "dependsOn": ["^build"],
       "inputs": [
         "$TURBO_DEFAULT$",
-        "$TURBO_ROOT$/node_modules/.cache/release/published-versions.json",
+        ".cache/published-versions.json",
         "$TURBO_ROOT$/pnpm-workspace.yaml"
-      ]
+      ],
+      // Cache replay materializes the summary the badge workflow reads.
+      "outputs": [".cache/published-diff-summary.json"]
     }
   }
 }

--- a/zizmor.yml
+++ b/zizmor.yml
@@ -2,7 +2,8 @@
 rules:
   dangerous-triggers:
     ignore:
-      # pull_request_target is deliberate: payload-only title lint, never checks out PR code
+      # pull_request_target is deliberate: payload-only title lint, never checks out PR code;
+      # hardened per the audit's own guidance (main-only branch filter + repository guard)
       - semantic-pr.yml
   artipacked:
     ignore:

--- a/zizmor.yml
+++ b/zizmor.yml
@@ -4,8 +4,6 @@ rules:
     ignore:
       # pull_request_target is deliberate: payload-only title lint, never checks out PR code
       - semantic-pr.yml
-      # workflow_run is deliberate: post-publish re-check, always checks out main, ignores the triggering payload
-      - published-diff.yml
   artipacked:
     ignore:
       # PAT checkout persists by design: release-it pushes the release branch

--- a/zizmor.yml
+++ b/zizmor.yml
@@ -4,6 +4,8 @@ rules:
     ignore:
       # pull_request_target is deliberate: payload-only title lint, never checks out PR code
       - semantic-pr.yml
+      # workflow_run is deliberate: post-publish re-check, always checks out main, ignores the triggering payload
+      - published-diff.yml
   artipacked:
     ignore:
       # PAT checkout persists by design: release-it pushes the release branch


### PR DESCRIPTION
Per-package "release owed?" badges on the README, powered by GitHub check runs + shields' native check-runs endpoint — plus the turbo graph work and machine-readable verdicts underneath.

## Badge mechanism: check runs, not a data branch

Each run of the new `Published Diff` workflow creates one completed check run per published package on main's head, named `published-diff (<pkg>)`. The README badges query them via shields' `github/check-runs` endpoint with `nameFilter` (URL-encoded to match the exact run name). No shields-endpoint JSON, no orphan data branch.

- **Orange = release owed, never CI failure**: drifting packages get conclusion `action_required` (renders orange on shields); clean packages get `success` (green). `failure` is deliberately unused — drift on main is "a release is owed", not "the tree is broken", and the workflow exits 0 either way (default informational mode, no `--strict`). Only real errors (resolve failure, check crash, typo'd dispatch scope) fail the job.
- check run `output.title` carries the verdict (`up to date with 1.7.0` / `unreleased changes vs 1.7.0 (28 shipped files differ)`); `output.summary` lists ship-affecting files expanded and ship-inert files collapsed in a `<details>` block.
- head_sha is the checked-out main head (`git rev-parse HEAD`), never `$GITHUB_SHA` — on `workflow_run` triggers that's the triggering workflow's context; attaching to main's current head keeps the badges (which query main, filter=latest) superseding stale same-name runs.

### Triggers

- `push` to main — the routine signal.
- `workflow_call` from **Publish to NPM**: a final `published_diff` job there (`needs: publish_npm`, job-scoped `permissions: {checks: write, contents: read}`) `uses:` this workflow after a successful publish — ordering guaranteed by `needs:`, fires only when the publish succeeded, and no zizmor dangerous-triggers exception needed (unlike `workflow_run`). release-it pushes the bump commit *before* npm `latest` moves, so the push-triggered run sees stale drift; this post-publish call flips the badge green. Calls always run the full package set (deliberately unscoped — avoids badge gaps on the fresh bump-commit head), take no inputs, and get `TURBO_TOKEN` via an explicit `workflow_call` secret (no `secrets: inherit`). No `continue-on-error`: a failed badge refresh after release stays visible; dispatch is the re-nudge. The explicit `ref: main` checkout matters here — a called workflow inherits the caller's (tag-ref) context.
- The `published_diff` mise task carries a usage spec: `--packages <names>` (env-bound to `PUBLISHED_DIFF_PACKAGES`, rendered in `mise run //tools/release:published_diff --help`); the run line forwards the flag back into the env var on the check invocation only (resolve stays unscoped by design). Bare, env-set, and `--packages` invocations all verified against the real check on mise 2026.7.5 — env-set and flag runs round-trip to the identical turbo hash. (CI's publish workflows pin mise-action to 2026.6.14; published-diff.yml uses the unpinned @v4 default, so no pin concern there.)
- `workflow_dispatch` with an optional `packages` input (comma-separated names; empty = all) as a scoped re-nudge. Scoped runs create check runs only for the named packages; a typo'd name fails the job loudly instead of silently no-oping. The scope travels as `PUBLISHED_DIFF_PACKAGES`, declared in the turbo task's `env` so a scoped run's subset summary caches under its own hash. No cron — dispatch is the only escape hatch.

### Prerelease consideration

Verdicts compare against the `latest` dist-tag by design: canary publishes to other dist-tags don't move `latest` and don't flip badges — an orange badge always means a stable release is owed.

## Cache-aligned summary output

The check **always** writes its per-package machine verdict to the canonical package-local path `tools/release/.cache/published-diff-summary.json`, declared as the turbo task's `outputs` — so a cache replay materializes it like any other build artifact (`--json <path>` remains an ad-hoc destination override). For symmetry, `published-versions.json` moved from root `node_modules/.cache/release/` to `tools/release/.cache/` too: `resolve:published` (still `cache: false`) writes it, and the check task's input for it is now a package-relative glob. `.cache/` is gitignored as a root convention (unanchored pattern, covers any future package-local `.cache`; nothing tracked matched it).

The summary shape — counts *and* file lists:

```json
{ "name": "lit-ui-router", "dir": "packages/lit-ui-router", "version": "1.7.0", "shipAffecting": 28, "shipInert": 37, "clean": false, "shipAffectingFiles": ["dist/core.js", "…"], "shipInertFiles": ["src/core.ts", "…"] }
```

The workflow therefore just runs the normal two-invocation turbo contract (`mise run //tools/release:published_diff`, a pure convention wrapper matching the repo's mise-step CI style), and `src/checks/publish-check-runs.ts` reads the canonical path by default (positional path overrides). It shells out to `gh api` itself (argv arrays through the shared `Exec` seam — chosen over emit-payloads-and-pipe so the workflow stays a one-line mise step and no jq lives in YAML). All shaping is pure and unit-tested in `publish-check-runs.core.ts`.

Sample dry-run payload against main's real state (`--dry-run` prints instead of calling gh):

```json
{
  "name": "published-diff (lit-ui-router)",
  "conclusion": "action_required",
  "title": "unreleased changes vs 1.7.0 (28 shipped files differ)",
  "summary": "A publish from main would ship 28 file(s) that differ from lit-ui-router@1.7.0:\n\n- `README.md`\n- `dist/core.d.ts`\n…\n\n<details>\n<summary>37 ship-inert file(s) — src/maps, never owe a release</summary>\n…"
}
```

(the mobx and nav-plugin packages produce `success` / `up to date with 0.3.3` / `0.2.2`.)

## Turbo graph: dependency edges instead of cross-package input globs

`check:pack` and `check:published-diff` (tools/release) previously hashed the rest of the repo via broad globs (`$TURBO_ROOT$/packages/**`, `$TURBO_ROOT$/**/package.json`, `pnpm-lock.yaml`). Now:

- `@tools/release` declares `workspace:*` devDependencies on the three published packages; both check tasks gain `dependsOn: ["^build"]` — fresh dist restored before packing, each dependency's own inputs propagating into the check's hash.
- Inputs shrink to `$TURBO_DEFAULT$` + `pnpm-workspace.yaml` (catalogs), plus `.cache/published-versions.json` for the diff check. Over-approximation still holds — cross-package coverage moved from globs to graph edges, nothing enumerates tsconfig includes.
- **Self-guard** for the static-edges-vs-dynamic-discovery gap: both check shells assert every dynamically discovered publishable package is declared in `tools/release/package.json`, failing loudly with the devDep to add — a future publishable package can't silently get stale cached verdicts (`src/checks/self-deps.core.ts`, unit-tested).

### Cache evidence

- ^build edge: appending a comment to `packages/lit-ui-router/src/pure.ts` cache-misses `lit-ui-router:build:*` and then `@tools/release:check:published-diff`; reverting hits again.
- **Replay materializes the summary**: on a warm cache, `rm -rf tools/release/.cache && turbo run resolve:published && turbo run check:published-diff` → check task cache **hit** (same hash `725a981b`, resolve rewrites byte-identical registry state) and `.cache/published-diff-summary.json` is restored by the replay with the full 3-package verdict.
- **Scoped runs hash apart**: `PUBLISHED_DIFF_PACKAGES=lit-ui-router-mobx` → cache miss under its own hash (`620d85ba`), subset JSON; the following unscoped run replays `725a981b` and restores the full summary.
- Root `pnpm check:published-diff` behavior unchanged (reports the expected lit-ui-router drift vs 1.7.0, exit 0 in default mode; `--strict` remains the failing-exit mode).

## README badges

Three shields check-runs badges under the existing badge block, captioned ``Published diff status (orange = unreleased ship-affecting changes on `main`)``, each linking to main's checks page. They render "no check runs" until the workflow's first main run, and lit-ui-router is expected **orange** until 1.7.1 ships — that IS the feature.

## Verification

- `turbo run test --filter=@tools/release`: 117 pass (self-deps guard, summary/scope shaping, check-run payloads/argv)
- `turbo run lint typecheck format:check`: green repo-wide; `lint:package-json`, `format:check:root`, and `lint:workflows` (actionlint + zizmor, incl. the new workflow and reusable-call wiring; the publish workflow's write permissions moved from workflow- to job-level to stay zizmor-clean with the second job) all green
- Ride-along hardening on `semantic-pr.yml` per zizmor's own pull_request_target guidance: `branches: [main]` on the trigger (a stale branch's old workflow file can never run) and a job-level `github.repository == 'simshanith/lit-ui-router'` guard (no execution in forks' stale copies). The trigger and its zizmor ignore stay — it remains the tamper-proof choice for a fork-facing required title check, and the audit flags the trigger regardless of hardening.
- Scoping proven locally: scoped env yields a one-package summary; `typo-pkg` exits 1 with the loud error
- The workflow itself can't run pre-merge (push:main + workflow_run only) — post-merge verification path is `workflow_dispatch`.
