### PR TITLE
docs: point published-diff badges at the workflow runs page

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@
 
 Published diff status (orange = unreleased ship-affecting changes on `main`)
 
-[![lit-ui-router published diff](https://img.shields.io/github/check-runs/simshanith/lit-ui-router/main?nameFilter=published-diff%20%28lit-ui-router%29&label=lit-ui-router)](https://github.com/simshanith/lit-ui-router/commit/main/checks)
-[![lit-ui-router-mobx published diff](https://img.shields.io/github/check-runs/simshanith/lit-ui-router/main?nameFilter=published-diff%20%28lit-ui-router-mobx%29&label=lit-ui-router-mobx)](https://github.com/simshanith/lit-ui-router/commit/main/checks)
-[![ui-router-navigation-location-plugin published diff](https://img.shields.io/github/check-runs/simshanith/lit-ui-router/main?nameFilter=published-diff%20%28ui-router-navigation-location-plugin%29&label=ui-router-navigation-location-plugin)](https://github.com/simshanith/lit-ui-router/commit/main/checks)
+[![lit-ui-router published diff](https://img.shields.io/github/check-runs/simshanith/lit-ui-router/main?nameFilter=published-diff%20%28lit-ui-router%29&label=lit-ui-router)](https://github.com/simshanith/lit-ui-router/actions/workflows/published-diff.yml?query=branch%3Amain)
+[![lit-ui-router-mobx published diff](https://img.shields.io/github/check-runs/simshanith/lit-ui-router/main?nameFilter=published-diff%20%28lit-ui-router-mobx%29&label=lit-ui-router-mobx)](https://github.com/simshanith/lit-ui-router/actions/workflows/published-diff.yml?query=branch%3Amain)
+[![ui-router-navigation-location-plugin published diff](https://img.shields.io/github/check-runs/simshanith/lit-ui-router/main?nameFilter=published-diff%20%28ui-router-navigation-location-plugin%29&label=ui-router-navigation-location-plugin)](https://github.com/simshanith/lit-ui-router/actions/workflows/published-diff.yml?query=branch%3Amain)
 
 ### lit-ui-router: State based routing for Lit (v2+)
 


### PR DESCRIPTION
The badge links from #375 targeted `commit/main/checks`, assuming GitHub resolves branch names in that path — it 404s. Retarget all three badges at the stable workflow-runs view filtered to main:

`https://github.com/simshanith/lit-ui-router/actions/workflows/published-diff.yml?query=branch%3Amain`

One click from badge to the run list; the run's check output carries the per-package drift detail.