### PR TITLE
fix(release): give published-diff check runs a details_url — the Resolve button went nowhere

### DIFF
--- a/tools/release/src/checks/publish-check-runs.core.ts
+++ b/tools/release/src/checks/publish-check-runs.core.ts
@@ -12,11 +12,18 @@ export type CheckRunPayload = {
   conclusion: 'success' | 'action_required';
   title: string;
   summary: string;
+  /** Only drifting runs set it; success keeps the default run link. */
+  details_url?: string;
 };
 
 /** The exact run name the README badge nameFilter must match. */
 export function checkRunName(packageName: string): string {
   return `published-diff (${packageName})`;
+}
+
+/** Where a drifting run's Resolve button lands: the release workflow's page. */
+export function releaseWorkflowUrl(repo: string): string {
+  return `https://github.com/${repo}/actions/workflows/bump-version.yml`;
 }
 
 /** Collapsed ship-inert listing appended to either verdict's summary. */
@@ -34,7 +41,10 @@ function inertDetails({ shipInert, shipInertFiles }: PackageSummary): string[] {
 }
 
 /** One package's summary → its Checks API payload. */
-export function toCheckRun(summary: PackageSummary): CheckRunPayload {
+export function toCheckRun(
+  summary: PackageSummary,
+  repo: string,
+): CheckRunPayload {
   const name = checkRunName(summary.name);
   if (summary.version === null) {
     return {
@@ -46,16 +56,21 @@ export function toCheckRun(summary: PackageSummary): CheckRunPayload {
   }
   const spec = `${summary.name}@${summary.version}`;
   if (summary.shipAffecting > 0) {
+    const releaseUrl = releaseWorkflowUrl(repo);
     return {
       name,
       conclusion: 'action_required',
       title: `unreleased changes vs ${summary.version} (${summary.shipAffecting} shipped files differ)`,
       summary: [
+        // workflow_dispatch inputs can't be URL-prefilled; the user picks the package there.
+        `To resolve: [release ${summary.name} via the bump-version workflow](${releaseUrl}) — select the package in its Run workflow menu.`,
+        '',
         `A publish from main would ship ${summary.shipAffecting} file(s) that differ from ${spec}:`,
         '',
         ...summary.shipAffectingFiles.map((file) => `- \`${file}\``),
         ...inertDetails(summary),
       ].join('\n'),
+      details_url: releaseUrl,
     };
   }
   return {
@@ -86,6 +101,9 @@ export function checkRunApiArgs(
     'status=completed',
     '-f',
     `conclusion=${payload.conclusion}`,
+    ...(payload.details_url === undefined
+      ? []
+      : ['-f', `details_url=${payload.details_url}`]),
     '-f',
     `output[title]=${payload.title}`,
     '-f',

--- a/tools/release/src/checks/publish-check-runs.test.ts
+++ b/tools/release/src/checks/publish-check-runs.test.ts
@@ -10,8 +10,7 @@ import {
 } from './publish-check-runs.core.ts';
 
 const REPO = 'simshanith/lit-ui-router';
-const RELEASE_URL =
-  'https://github.com/simshanith/lit-ui-router/actions/workflows/bump-version.yml';
+const RELEASE_URL = `https://github.com/${REPO}/actions/workflows/bump-version.yml`;
 
 const clean: PackageSummary = {
   name: 'lit-ui-router-mobx',

--- a/tools/release/src/checks/publish-check-runs.test.ts
+++ b/tools/release/src/checks/publish-check-runs.test.ts
@@ -5,8 +5,13 @@ import type { PackageSummary } from './check-published-diff.core.ts';
 import {
   checkRunApiArgs,
   checkRunName,
+  releaseWorkflowUrl,
   toCheckRun,
 } from './publish-check-runs.core.ts';
+
+const REPO = 'simshanith/lit-ui-router';
+const RELEASE_URL =
+  'https://github.com/simshanith/lit-ui-router/actions/workflows/bump-version.yml';
 
 const clean: PackageSummary = {
   name: 'lit-ui-router-mobx',
@@ -41,24 +46,39 @@ describe('checkRunName', () => {
 
 describe('toCheckRun', () => {
   it('maps a clean package to success with the published baseline named', () => {
-    const payload = toCheckRun(clean);
+    const payload = toCheckRun(clean, REPO);
     assert.equal(payload.conclusion, 'success');
     assert.equal(payload.title, 'up to date with 0.3.3');
     assert.match(payload.summary, /match lit-ui-router-mobx@0\.3\.3/);
     assert.doesNotMatch(payload.summary, /<details>/);
+    assert.equal(payload.details_url, undefined);
   });
 
   it('maps drift to action_required, never failure, with unit and baseline in the title', () => {
-    const payload = toCheckRun(drifting);
+    const payload = toCheckRun(drifting, REPO);
     assert.equal(payload.conclusion, 'action_required');
     assert.equal(
       payload.title,
       'unreleased changes vs 1.7.0 (2 shipped files differ)',
     );
+    assert.equal(payload.details_url, RELEASE_URL);
+  });
+
+  it('opens a drifting summary with the resolve line linking the release workflow', () => {
+    const { summary } = toCheckRun(drifting, REPO);
+    const [first] = summary.split('\n');
+    assert.equal(
+      first,
+      `To resolve: [release lit-ui-router via the bump-version workflow](${RELEASE_URL}) — select the package in its Run workflow menu.`,
+    );
+  });
+
+  it('never puts the resolve line on a clean summary', () => {
+    assert.doesNotMatch(toCheckRun(clean, REPO).summary, /To resolve/);
   });
 
   it('lists ship-affecting files expanded and ship-inert collapsed', () => {
-    const { summary } = toCheckRun(drifting);
+    const { summary } = toCheckRun(drifting, REPO);
     const details = summary.indexOf('<details>');
     assert.notEqual(details, -1);
     assert.equal(summary.indexOf('- `dist/core.js`') < details, true);
@@ -68,9 +88,16 @@ describe('toCheckRun', () => {
   });
 
   it('treats an unpublished package as success with nothing to diff', () => {
-    const payload = toCheckRun({ ...clean, version: null });
+    const payload = toCheckRun({ ...clean, version: null }, REPO);
     assert.equal(payload.conclusion, 'success');
     assert.match(payload.title, /never published/);
+    assert.equal(payload.details_url, undefined);
+  });
+});
+
+describe('releaseWorkflowUrl', () => {
+  it('composes the bump-version workflow page for the repo', () => {
+    assert.equal(releaseWorkflowUrl(REPO), RELEASE_URL);
   });
 });
 
@@ -82,6 +109,7 @@ describe('checkRunApiArgs', () => {
         conclusion: 'action_required',
         title: 'unreleased changes vs 1.7.0 (2 shipped files differ)',
         summary: 'body',
+        details_url: RELEASE_URL,
       }),
       [
         'api',
@@ -95,10 +123,25 @@ describe('checkRunApiArgs', () => {
         '-f',
         'conclusion=action_required',
         '-f',
+        `details_url=${RELEASE_URL}`,
+        '-f',
         'output[title]=unreleased changes vs 1.7.0 (2 shipped files differ)',
         '-f',
         'output[summary]=body',
       ],
+    );
+  });
+
+  it('omits details_url from the argv when the payload has none', () => {
+    const args = checkRunApiArgs(REPO, 'abc123', {
+      name: 'published-diff (lit-ui-router-mobx)',
+      conclusion: 'success',
+      title: 'up to date with 0.3.3',
+      summary: 'body',
+    });
+    assert.equal(
+      args.some((arg) => arg.startsWith('details_url=')),
+      false,
     );
   });
 });

--- a/tools/release/src/checks/publish-check-runs.ts
+++ b/tools/release/src/checks/publish-check-runs.ts
@@ -26,15 +26,15 @@ async function main() {
   }
   const summaries = parsed as PackageSummary[];
 
-  const payloads = summaries.map(toCheckRun);
+  // details_url needs the slug too; dry runs may fall back for URL shaping.
+  const repo = process.env.GITHUB_REPOSITORY ?? 'simshanith/lit-ui-router';
+  if (!process.env.GITHUB_REPOSITORY && !dryRun) {
+    throw new Error('GITHUB_REPOSITORY must be set (or pass --dry-run)');
+  }
+  const payloads = summaries.map((summary) => toCheckRun(summary, repo));
   if (dryRun) {
     console.log(JSON.stringify(payloads, null, 2));
     return;
-  }
-
-  const repo = process.env.GITHUB_REPOSITORY;
-  if (!repo) {
-    throw new Error('GITHUB_REPOSITORY must be set (or pass --dry-run)');
   }
   const { stdout } = await defaultExec('git', ['rev-parse', 'HEAD']);
   const headSha = stdout.trim();


### PR DESCRIPTION
The `action_required` check runs from #375 render a **Resolve** button in GitHub's UI that navigates to the check run's `details_url` — which was never set, so the button went nowhere. Now every check run gets one:

- **Drifting only** → the bump-version workflow page (`/actions/workflows/bump-version.yml`): Resolve lands where the Run-workflow dropdown starts a release. Since `workflow_dispatch` inputs can't be URL-prefilled, the drifting summary also opens with a resolve line — `To resolve: [release <pkg> via the bump-version workflow](…) — select the package in its Run workflow menu.`
- **Clean and never-published runs leave `details_url` unset** — the default run-link behavior is preferred there, so `checkRunApiArgs` omits the field entirely when absent.

The repo slug feeds in from `GITHUB_REPOSITORY` — the same seam the `gh api` call already used; `--dry-run` falls back to the canonical slug for URL shaping. Shaping stays pure (`releaseWorkflowUrl` + extended `toCheckRun` in `publish-check-runs.core.ts`) with tests for the drift URL, its absence on clean/never-published payloads, the resolve line's exact text and clean-summary absence, and the argv both with and without `details_url`.

Verified: 121 @tools/release tests green, repo-wide lint/typecheck/format green, and a `--dry-run` against the real cached summary shows lit-ui-router (action_required) pointing at bump-version.yml with both clean packages leaving `details_url` unset.
