### PR TITLE
fix(release): drop check-run details_url — GitHub pins GITHUB_TOKEN check runs to their own page

### DIFF
--- a/tools/release/src/checks/publish-check-runs.core.ts
+++ b/tools/release/src/checks/publish-check-runs.core.ts
@@ -12,8 +12,6 @@ export type CheckRunPayload = {
   conclusion: 'success' | 'action_required';
   title: string;
   summary: string;
-  /** Only drifting runs set it; success keeps the default run link. */
-  details_url?: string;
 };
 
 /** The exact run name the README badge nameFilter must match. */
@@ -21,7 +19,7 @@ export function checkRunName(packageName: string): string {
   return `published-diff (${packageName})`;
 }
 
-/** Where a drifting run's Resolve button lands: the release workflow's page. */
+/** The release workflow's page, linked from a drifting run's resolve line. */
 export function releaseWorkflowUrl(repo: string): string {
   return `https://github.com/${repo}/actions/workflows/bump-version.yml`;
 }
@@ -70,7 +68,7 @@ export function toCheckRun(
         ...summary.shipAffectingFiles.map((file) => `- \`${file}\``),
         ...inertDetails(summary),
       ].join('\n'),
-      details_url: releaseUrl,
+      // details_url: not settable — GitHub pins GITHUB_TOKEN-created check runs to their own page
     };
   }
   return {
@@ -101,9 +99,6 @@ export function checkRunApiArgs(
     'status=completed',
     '-f',
     `conclusion=${payload.conclusion}`,
-    ...(payload.details_url === undefined
-      ? []
-      : ['-f', `details_url=${payload.details_url}`]),
     '-f',
     `output[title]=${payload.title}`,
     '-f',

--- a/tools/release/src/checks/publish-check-runs.test.ts
+++ b/tools/release/src/checks/publish-check-runs.test.ts
@@ -50,7 +50,6 @@ describe('toCheckRun', () => {
     assert.equal(payload.title, 'up to date with 0.3.3');
     assert.match(payload.summary, /match lit-ui-router-mobx@0\.3\.3/);
     assert.doesNotMatch(payload.summary, /<details>/);
-    assert.equal(payload.details_url, undefined);
   });
 
   it('maps drift to action_required, never failure, with unit and baseline in the title', () => {
@@ -60,7 +59,6 @@ describe('toCheckRun', () => {
       payload.title,
       'unreleased changes vs 1.7.0 (2 shipped files differ)',
     );
-    assert.equal(payload.details_url, RELEASE_URL);
   });
 
   it('opens a drifting summary with the resolve line linking the release workflow', () => {
@@ -90,7 +88,6 @@ describe('toCheckRun', () => {
     const payload = toCheckRun({ ...clean, version: null }, REPO);
     assert.equal(payload.conclusion, 'success');
     assert.match(payload.title, /never published/);
-    assert.equal(payload.details_url, undefined);
   });
 });
 
@@ -108,7 +105,6 @@ describe('checkRunApiArgs', () => {
         conclusion: 'action_required',
         title: 'unreleased changes vs 1.7.0 (2 shipped files differ)',
         summary: 'body',
-        details_url: RELEASE_URL,
       }),
       [
         'api',
@@ -122,25 +118,10 @@ describe('checkRunApiArgs', () => {
         '-f',
         'conclusion=action_required',
         '-f',
-        `details_url=${RELEASE_URL}`,
-        '-f',
         'output[title]=unreleased changes vs 1.7.0 (2 shipped files differ)',
         '-f',
         'output[summary]=body',
       ],
-    );
-  });
-
-  it('omits details_url from the argv when the payload has none', () => {
-    const args = checkRunApiArgs(REPO, 'abc123', {
-      name: 'published-diff (lit-ui-router-mobx)',
-      conclusion: 'success',
-      title: 'up to date with 0.3.3',
-      summary: 'body',
-    });
-    assert.equal(
-      args.some((arg) => arg.startsWith('details_url=')),
-      false,
     );
   });
 });

--- a/tools/release/src/checks/publish-check-runs.ts
+++ b/tools/release/src/checks/publish-check-runs.ts
@@ -26,7 +26,7 @@ async function main() {
   }
   const summaries = parsed as PackageSummary[];
 
-  // details_url needs the slug too; dry runs may fall back for URL shaping.
+  // The resolve line's URL needs the slug too; dry runs may fall back.
   const repo = process.env.GITHUB_REPOSITORY ?? 'simshanith/lit-ui-router';
   if (!process.env.GITHUB_REPOSITORY && !dryRun) {
     throw new Error('GITHUB_REPOSITORY must be set (or pass --dry-run)');


### PR DESCRIPTION
Live finding from run 88136784616: GitHub **overrides `details_url` on check runs created with the Actions `GITHUB_TOKEN`**, pinning it to the check run's own page — the API returned `app: github-actions` with `details_url` = the run's self-URL despite our script sending the bump-version workflow URL. Controlling `details_url` requires a custom GitHub App token, so #378's `details_url` plumbing is dead code. This removes it:

- `CheckRunPayload.details_url` field, its conditional argv emission, and their tests — gone.
- `releaseWorkflowUrl` survives solely as the source for the drifting summary's resolve line (`To resolve: [release <pkg> via the bump-version workflow](…) — select the package in its Run workflow menu.`) — which the same live run proved comes through intact; that's the working affordance.
- One terse comment left where the field was set — `details_url: not settable — GitHub pins GITHUB_TOKEN-created check runs to their own page` — so it doesn't get re-added.

Parked alternative: creating the runs with a custom GitHub App token would unlock both `details_url` and `actions[]` one-click resolve buttons; not worth an App for this today.

Verified: 120 @tools/release tests green, repo-wide lint/typecheck/format green, `--dry-run` against the real cached summary shows the resolve line still first on the drifting package and no `details_url` on any payload.
