### PR TITLE
ci: pin published-diff concurrency to a literal group

### DIFF
--- a/.github/workflows/published-diff.yml
+++ b/.github/workflows/published-diff.yml
@@ -29,9 +29,11 @@ on:
 env:
   HUSKY: 0
 
-# One run at a time, newest wins; every run targets main's current head.
+# One refresh at a time, newest wins; every run targets main's current head.
+# Literal group: github.workflow evaluates to the CALLER's name on
+# workflow_call, which would split called refreshes from push refreshes.
 concurrency:
-  group: ${{ github.workflow }}
+  group: published-diff
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
On `workflow_call`, `${{ github.workflow }}` evaluates to the **caller's** workflow name, so post-publish refresh legs grouped as "Publish to NPM" while push/dispatch refreshes grouped as "Published Diff" — two separate newest-wins pools. Observed live during the 1.7.1 plumbing test: the canary's called refresh cancelled the dry-run's called refresh (same caller group), but a push-triggered refresh could interleave with a called one — letting a slow orange re-check finish after a fresh green one on the same SHA and leave a stale badge until the next event.

Pinning a literal `group: published-diff` puts every refresh — push, workflow_call, workflow_dispatch — in one newest-wins group, making the cancel semantics deliberate.

Side effect worth naming: a superseded refresh still marks its *caller* run (e.g. a publish run) as cancelled even when the publish job itself succeeded — cosmetic, observed on the stage-0 dry-run (publish_npm success, refresh cancelled by the canary's). Accepted; the alternative (continue-on-error) would hide real refresh failures.