### PR TITLE
build(lit-ui-router-mobx): pin lit-ui-router peer via catalog:publishedPeer

### DIFF
--- a/packages/lit-ui-router-mobx/package.json
+++ b/packages/lit-ui-router-mobx/package.json
@@ -73,7 +73,7 @@
   "peerDependencies": {
     "@uirouter/core": "catalog:publishedPeer",
     "lit": "catalog:publishedPeer",
-    "lit-ui-router": "workspace:^",
+    "lit-ui-router": "catalog:publishedPeer",
     "mobx": "catalog:publishedPeer"
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -77,6 +77,7 @@ catalogs:
     '@uirouter/core': ^6.0.8
     hono: ^4.0.0
     lit: ^3.0.0
+    lit-ui-router: ^1.7.0
     mobx: ^6.0.0
     typedoc: ^0.28.0
   typescript6-compat:


### PR DESCRIPTION
`workspace:^` pack-substitutes to `^<current lit-ui-router version>`, so every lit-ui-router release re-oranged mobx's published-diff badge with zero mobx commits (observed live minutes after 1.7.1: `unreleased changes vs 0.3.3 (1 shipped files differ)`). Pinning `lit-ui-router: ^1.7.0` in the `publishedPeer` catalog freezes the floor at the already-published range — the convention the other peers follow. Locally nothing changes: `linkWorkspacePackages` still links the workspace copy (1.7.1 satisfies ^1.7.0).

**Tradeoff to remember**: the floor no longer auto-tracks. When mobx starts needing newer lit-ui-router APIs, the catalog entry must be bumped by hand — and the linked workspace copy (always latest) masks a stale floor locally, so typecheck won't catch it. The published-diff badge won't either (a stale floor packs identically). Floor bumps ride on API-need, reviewed at PR time.

Verified with the scoped check (`--packages lit-ui-router-mobx`): peer values now byte-identical to 0.3.3. One residual: 0.3.3's manifest has `lit-ui-router` as the *last* peer key (pnpm re-appends `workspace:` substitutions at pack), while catalog substitution preserves source (sorted) position — an order-only, value-identical diff keeping the 1-file report until the next mobx publish normalizes the registry manifest. Follow-up: mobx 0.3.4 (manifest-normalization patch); after that the badge is src-changes-only.