### PR TITLE
ci(lit-ui-router-mobx): peer-floor typecheck against the published floor version

### DIFF
--- a/packages/lit-ui-router-mobx/package.json
+++ b/packages/lit-ui-router-mobx/package.json
@@ -48,7 +48,8 @@
     "lint": "oxlint .",
     "test": "VITEST_BROWSER_API_PORT=63330 vitest run",
     "test:coverage": "VITEST_BROWSER_API_PORT=63335 vitest run --coverage --browser=chromium",
-    "typecheck": "tsc -p tsconfig.json --noEmit"
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "typecheck:peer-floor": "node peer-floor-guard.ts && tsc -p tsconfig.peer-floor.json --noEmit"
   },
   "devDependencies": {
     "@release-it/conventional-changelog": "catalog:",
@@ -59,6 +60,7 @@
     "@vitest/coverage-v8": "catalog:",
     "lit": "catalog:",
     "lit-ui-router": "workspace:*",
+    "lit-ui-router-floor": "catalog:peerFloor",
     "mobx": "catalog:",
     "oxfmt": "catalog:",
     "playwright": "catalog:",

--- a/packages/lit-ui-router-mobx/peer-floor-guard.ts
+++ b/packages/lit-ui-router-mobx/peer-floor-guard.ts
@@ -1,0 +1,45 @@
+// The installed lit-ui-router-floor alias must equal the floor of the
+// catalog:publishedPeer lit-ui-router range, or the floor typecheck lies.
+import { readFileSync } from 'node:fs';
+
+const read = (url: URL) => readFileSync(url, 'utf8');
+
+const workspaceYaml = read(
+  new URL('../../pnpm-workspace.yaml', import.meta.url),
+);
+const rangeMatch = /publishedPeer:[\s\S]*?^\s+lit-ui-router: (\S+)$/m.exec(
+  workspaceYaml,
+);
+if (!rangeMatch) {
+  throw new Error(
+    'peer-floor-guard: no publishedPeer lit-ui-router range in pnpm-workspace.yaml',
+  );
+}
+const range = rangeMatch[1];
+
+// caret floor = the literal version; widen deliberately if the range shape changes
+const floorMatch = /^\^(\d+\.\d+\.\d+)$/.exec(range);
+if (!floorMatch) {
+  throw new Error(
+    `peer-floor-guard: unsupported range shape "${range}"; teach me its floor`,
+  );
+}
+const floor = floorMatch[1];
+
+const installed = (
+  JSON.parse(
+    read(
+      new URL('node_modules/lit-ui-router-floor/package.json', import.meta.url),
+    ),
+  ) as { version: string }
+).version;
+
+if (installed !== floor) {
+  throw new Error(
+    `peer-floor-guard: lit-ui-router-floor resolves to ${installed}, but the ` +
+      `floor of the declared peer range ${range} is ${floor}. ` +
+      'Repin the peerFloor catalog in pnpm-workspace.yaml and reinstall.',
+  );
+}
+
+console.log(`peer-floor-guard: floor pin ${installed} matches range ${range}`);

--- a/packages/lit-ui-router-mobx/tsconfig.json
+++ b/packages/lit-ui-router-mobx/tsconfig.json
@@ -5,8 +5,13 @@
   "compilerOptions": {
     "rootDir": ".",
     "noEmit": true,
-    "types": ["vitest/globals"]
+    "types": ["node", "vitest/globals"]
   },
-  "include": ["src/**/*", "vitest.config.ts", "vitest.setup.ts"],
+  "include": [
+    "src/**/*",
+    "peer-floor-guard.ts",
+    "vitest.config.ts",
+    "vitest.setup.ts"
+  ],
   "exclude": ["node_modules", "dist"]
 }

--- a/packages/lit-ui-router-mobx/tsconfig.peer-floor.json
+++ b/packages/lit-ui-router-mobx/tsconfig.peer-floor.json
@@ -1,0 +1,12 @@
+{
+  // Typechecks src against the published floor of the lit-ui-router peer range
+  // (the lit-ui-router-floor alias), not the linked workspace copy. Never emits.
+  "extends": "./tsconfig.build.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "paths": {
+      "lit-ui-router": ["./node_modules/lit-ui-router-floor/dist/index.d.ts"],
+      "lit-ui-router/*": ["./node_modules/lit-ui-router-floor/*"]
+    }
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -195,6 +195,10 @@ catalogs:
     wrangler:
       specifier: ^4.110.0
       version: 4.110.0
+  peerFloor:
+    lit-ui-router-floor:
+      specifier: npm:lit-ui-router@1.7.0
+      version: 1.7.0
   publishedPeer:
     '@uirouter/core':
       specifier: ^6.0.8
@@ -620,6 +624,9 @@ importers:
       lit-ui-router:
         specifier: workspace:*
         version: link:../lit-ui-router
+      lit-ui-router-floor:
+        specifier: catalog:peerFloor
+        version: lit-ui-router@1.7.0
       mobx:
         specifier: 'catalog:'
         version: 6.16.1
@@ -4504,6 +4511,9 @@ packages:
 
   lit-html@3.3.3:
     resolution: {integrity: sha512-el8M6jK2o3RXBnrSHX3ZKrsN8zEV63pSExTO1wYJz7QndGYZ8353e2a5PPX+qHe2aGayfnchQmkAojaWAREOIA==}
+
+  lit-ui-router@1.7.0:
+    resolution: {integrity: sha512-UK69ySdMwrAILx8aG9TYcNLlg/Q2CCrs1nqwnKumFlQXeNvjf+heH5l1KdfDEyyuBYafrzGxUMOLEZ2esiX3Tw==}
 
   lit@2.8.0:
     resolution: {integrity: sha512-4Sc3OFX9QHOJaHbmTMk28SYgVxLN3ePDjg7hofEft2zWlehFL3LiAuapWc4U/kYwMYJSh2hTCPZ6/LIC7ii0MA==}
@@ -9112,6 +9122,11 @@ snapshots:
   lit-html@3.3.3:
     dependencies:
       '@types/trusted-types': 2.0.7
+
+  lit-ui-router@1.7.0:
+    dependencies:
+      '@uirouter/core': 6.1.2
+      lit: 3.3.3
 
   lit@2.8.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -73,6 +73,10 @@ catalog:
 catalogMode: prefer
 
 catalogs:
+  # exact published floor of the matching publishedPeer range; peer-floor-guard
+  # fails the typecheck:peer-floor task when the two drift apart
+  peerFloor:
+    lit-ui-router-floor: npm:lit-ui-router@1.7.0
   publishedPeer:
     '@uirouter/core': ^6.0.8
     hono: ^4.0.0

--- a/turbo.json
+++ b/turbo.json
@@ -68,11 +68,20 @@
       // ^build drops once every package is pass-split
       "dependsOn": ["^build", "^build:types"],
       "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/tsconfig.base.json"],
-      "with": ["//#typecheck:root", "typecheck:src"]
+      "with": ["//#typecheck:root", "typecheck:src", "typecheck:peer-floor"]
     },
     "typecheck:src": {
       "dependsOn": ["^build", "^build:types"],
       "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/tsconfig.base.json"]
+    },
+    "typecheck:peer-floor": {
+      // floor comes from the catalog; the aliased package is pinned by the lockfile
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "$TURBO_ROOT$/tsconfig.base.json",
+        "$TURBO_ROOT$/pnpm-workspace.yaml",
+        "$TURBO_ROOT$/pnpm-lock.yaml"
+      ]
     },
     "//#typecheck:root": {
       "inputs": ["$TURBO_DEFAULT$"]

--- a/turbo.json
+++ b/turbo.json
@@ -68,13 +68,15 @@
       // ^build drops once every package is pass-split
       "dependsOn": ["^build", "^build:types"],
       "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/tsconfig.base.json"],
-      "with": ["//#typecheck:root", "typecheck:src", "typecheck:peer-floor"]
+      "with": ["//#typecheck:root", "typecheck:src"]
     },
     "typecheck:src": {
       "dependsOn": ["^build", "^build:types"],
       "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/tsconfig.base.json"]
     },
     "typecheck:peer-floor": {
+      // manual-only: not in ci — the floor pin can only reference published
+      // versions, so gating would break atomic core-API + mobx-adoption PRs
       // floor comes from the catalog; the aliased package is pinned by the lockfile
       "inputs": [
         "$TURBO_DEFAULT$",


### PR DESCRIPTION
## What

Spike from the #382 follow-up: the `catalog:publishedPeer` floor (`lit-ui-router: ^1.7.0`) is now a manual promise, and nothing verified it. Local typecheck/tests resolve `lit-ui-router` to the linked workspace copy (always latest), so mobx src using an unreleased API passes everything locally while breaking every consumer installed at the floor.

New task: `lit-ui-router-mobx#typecheck:peer-floor` typechecks src against the PUBLISHED floor version, not the workspace copy.

### Pieces

- **`peerFloor` catalog** (pnpm-workspace.yaml): `lit-ui-router-floor: npm:lit-ui-router@1.7.0`. The alias must live in a catalog — `pnpm/json-enforce-catalog` rejects inline `npm:` specs in package.json (only `workspace`/`link`/`file`/`portal` stay inline). That lands the pin two lines above the range it mirrors, which is the best adjacency available.
- **devDep** `"lit-ui-router-floor": "catalog:peerFloor"` in `packages/lit-ui-router-mobx`.
- **`tsconfig.peer-floor.json`**: extends `tsconfig.build.json` (src only, specs excluded — the shipped surface), `noEmit`, `paths` remapping `lit-ui-router` → `./node_modules/lit-ui-router-floor/dist/index.d.ts`. Never emits, invisible to the normal build/typecheck.
- **`peer-floor-guard.ts`**: the pin cannot be derived — `npm:lit-ui-router@^1.7.0` resolves to the range's NEWEST (that's the workspace copy's job), so the floor is necessarily a literal pin. The guard makes drift loud: it compares the INSTALLED alias version against the floor of the `catalog:publishedPeer` range (caret floor = the literal version; any other range shape throws "teach me its floor"). Reading the installed manifest rather than the yaml spec guards the actual artifact tsc checks.
- **turbo**: root `typecheck:peer-floor` task (inputs over-approximate: `$TURBO_DEFAULT$` + `tsconfig.base.json` + `pnpm-workspace.yaml` + `pnpm-lock.yaml` — the catalog defines the floor, the lockfile pins the alias content). No `dependsOn` — the aliased package is prebuilt registry content.
- **NOT in CI — manual-only, by design.** The task is defined and cached but deliberately absent from root `typecheck`'s `with:` (and every other path into the `ci` graph). Gating CI on it would break atomic cross-package PRs: a new core API plus its mobx adoption in one change can never pass, because the floor pin can only reference *published* versions. Invoke it when reviewing mobx changes that touch lit-ui-router APIs:

  ```
  turbo run typecheck:peer-floor --filter=lit-ui-router-mobx
  ```

  Verified after unhooking: `turbo run typecheck --dry-run` no longer lists `typecheck:peer-floor` anywhere in the task graph; standalone run stays green; repo-wide `lint typecheck format:check` 77/77 (the peer-floor task is the dropped 78th).

### Settled future home: the two-tier plan (implemented separately, stacked on #388)

This PR stays manual-only on its branch; the wiring lands in a follow-up stacked on #388's workflow restructure:

- **Tier 1 — signal at merge time, non-gating.** On main pushes, run `typecheck:peer-floor` and report per-package check runs in the published-diff style: `success` when the floor pin typechecks, `action_required` (renders orange) when stale, with the remedy in `output.title` ("floor stale: release lit-ui-router, then bump the publishedPeer floor"). Never fails a job, never blocks tags.
- **Tier 2 — enforce at release intent.** A pre-tag step in `bump-version.yml` runs `turbo run typecheck:peer-floor --filter=<the package being bumped>` — fails the bump of a package whose floor claim is dishonest. Deadlock-free by construction: the core release the failure demands is never blocked by it. Per-package opt-in via turbo's filter no-op on absent scripts.
- **Why not the #388 "no tag on red main" gate:** an atomic core-API + mobx PR would make main red post-merge with the ONLY remedy (release core) blocked by the red — a designed deadlock. Floor staleness is per-package coordination debt, not global main breakage; #388's gate stays reserved for globally-shipped correctness (check:pack, dts floors).
- **Sequencing:** implementation stacked on #388 (`ci/check-pack-main-push`) to build on its workflow restructure rather than conflict. Tier 1's check run on a bump commit re-runs and flips green once the floor bump lands.

## Evidence A: green on current src against 1.7.0

```
lit-ui-router-mobx:typecheck:peer-floor: $ node peer-floor-guard.ts && tsc -p tsconfig.peer-floor.json --noEmit
lit-ui-router-mobx:typecheck:peer-floor: peer-floor-guard: floor pin 1.7.0 matches range ^1.7.0
 Tasks:    7 successful, 7 total
```

Repo-wide `turbo run lint typecheck format:check`: 78/78 green. `lint:package-json`: 24/24 ok. mobx vitest: 63 passed. Vitest peer graph untouched by the alias install: `ls node_modules/.pnpm | grep vitest` identical before/after (11 entries).

## Evidence B: the failure mode, demonstrated

Diffing published `1.7.0` vs `1.7.1` d.ts found no API additions (1.7.1 only REMOVED the accidentally-shipped `dist/specs/test-utils` exports, plus sourcemap/format noise), so no real floor-missing API exists in today's range. Simulated the exact real-world shape instead — an unreleased API on main:

1. Appended `export const unreleasedFloorDemoApi = (): void => {};` to workspace `packages/lit-ui-router/src/pure.ts` (simulating a 1.8-only API).
2. Imported and called it from mobx `src/index.ts`.
3. Rebuilt lit-ui-router types, then:

```
$ tsc -p tsconfig.json --noEmit          # normal typecheck (workspace copy)
normal typecheck exit=0                   # ← green: the lie this spike exists to catch
$ tsc -p tsconfig.peer-floor.json --noEmit
src/index.ts:6:10 - error TS2305: Module '"lit-ui-router"' has no exported member 'unreleasedFloorDemoApi'.
floor typecheck exit=1                    # ← the floor check catches it
```

Both demo edits reverted.

**Guard drift demo** — repinned the `peerFloor` catalog to `npm:lit-ui-router@1.7.1` (range still `^1.7.0`), reinstalled:

```
Error: peer-floor-guard: lit-ui-router-floor resolves to 1.7.1, but the floor of the
declared peer range ^1.7.0 is 1.7.0. Repin the peerFloor catalog in pnpm-workspace.yaml
and reinstall.
guard exit=1
```

Reverted to 1.7.0.

## Investigation: the range-matrix backtest (not implemented)

**Empirical range membership.** `npm view lit-ui-router versions --json` lists 28 versions; semver-satisfying `^1.7.0` today: exactly **1.7.0 and 1.7.1** (the `1.7.1-canary.*` prereleases are excluded by caret semantics; `alpha`/`canary` dist-tags never enter the range).

**Design sketch for all-in-range checking.** One alias per distinct version (`lit-ui-router-1.7.1: npm:lit-ui-router@1.7.1`, …), one `tsconfig.peer-<version>.json` each — or one tsconfig templated by a generator that rewrites the alias list. pnpm aliases are static manifest entries, so something must maintain the list:

- *Auto-widening* (a generator queries the registry at check time, adds aliases for new in-range versions): re-introduces exactly the registry-driven CI variance this repo has been squeezing out — a `lit-ui-router` release would flip mobx CI red/green with zero mobx commits, and turbo caching becomes incoherent (inputs would have to include "the registry's answer today").
- *Static list + bump ritual*: same recurring cost as the floor pin, multiplied by version count, plus a guard extending peer-floor-guard to assert the alias set equals the in-range set (that guard itself needs the registry, pushing the variance into a softer advisory check).

The floor pin's bump ritual is the acceptable cost: it is one line, already guarded, and only moves when the floor deliberately moves.

**What intermediate versions actually buy.** For a d.ts typecheck, an intermediate version only matters when a signature *changed shape* mid-range — present at floor, present at latest, but incompatible in between (or vice versa). Under caret discipline that is rare-to-never for additive ranges; today's range has zero such versions (1.7.1's delta is removals + formatting). The two ends already cover the promise: **floor = the weakest declared promise (this spike)**; **latest ≈ the workspace copy, checked implicitly by the normal typecheck every commit**. Verdict: **floor-only is sufficient** until the range spans a version where an API mobx uses changed shape — the realistic trigger would be a deprecate-and-reshape inside a caret range, which this repo's own release discipline makes unlikely. If the range ever widens past a known reshape, add exactly that one version, not the whole matrix.

**Runtime-test matrix (vitest per version).** Deferred deliberately. Each version would need its own resolution of `lit-ui-router` inside vitest's module graph — either N vitest configs with resolve aliases or N installs — and this workspace's vitest peer graph is fragile (`@types/node` peer-keying splits instances; the `@vitest/browser` patch is content-hash-pinned per version). Browser-mode runs also cost a Playwright instance per version per run. The d.ts floor check catches the compile-time API-absence class; runtime behavioral drift within a caret range is better caught by the (separate, existing) release verification of `lit-ui-router` itself than by an N×matrix in mobx CI.

## Deviations

- Commit type is `ci(lit-ui-router-mobx)` — commitlint's type-enum has no `spike`; the PR title keeps the requested spike framing.
- The guard file is included in mobx's umbrella `tsconfig.json` (`types` gains `"node"`) — oxlint's type-aware rules report error-typed values for files outside any tsconfig. `@types/node` was already a mobx devDep; vitest config untouched.
- `tsconfig.peer-floor.json` also maps `lit-ui-router/*` → the alias package root: src has no subpath imports today, but the mapping keeps a future `lit-ui-router/dist/*` import from silently resolving to the workspace copy.
