### PR TITLE
build(lint): ban workspace: refs in shipped dep fields of publishable packages

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -87,6 +87,24 @@ export default defineConfig(
     },
   },
   {
+    // Shipped dep fields of publishable packages must not use workspace: refs:
+    // pnpm's pack-substitution re-appends the substituted entry, breaking the
+    // sorted published manifest. devDependencies is exempt (stripped at pack;
+    // workspace:* is correct there), as are private manifests (never packed).
+    files: ['packages/*/package.json'],
+    rules: {
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector:
+            'JSONObjectExpression:not(:has(> JSONProperty[key.value="private"][value.value=true])) > JSONProperty:matches([key.value="dependencies"], [key.value="peerDependencies"], [key.value="optionalDependencies"]) > JSONObjectExpression > JSONProperty > JSONLiteral[value=/^workspace:/]',
+          message:
+            'workspace: refs in shipped fields get pack-substituted with re-appended key order, breaking published-manifest sorting — use catalog:publishedPeer (or a version range) instead.',
+        },
+      ],
+    },
+  },
+  {
     // examples/* are standalone `npm ci` projects (StackBlitz): inline versions required.
     files: ['examples/*/package.json'],
     rules: {


### PR DESCRIPTION
## Why

pnpm's \`workspace:\` pack-substitution re-appends the substituted entry to the END of the dep map, breaking the sorted-manifest guarantee for published packages. This bit us live: mobx 0.3.3's published manifest has \`lit-ui-router\` last, causing a persistent order-only published-diff report. #382 removed the last \`workspace:\` ref from shipped fields; this PR makes the class structurally impossible via \`lint:package-json\`.

## What

New \`no-restricted-syntax\` block in the manifest-only \`eslint.config.js\`, scoped to \`packages/*/package.json\`:

- Flags any \`workspace:\`-prefixed value in \`dependencies\`, \`peerDependencies\`, or \`optionalDependencies\`.
- **Private exemption**: the selector anchors on the root \`JSONObjectExpression\` and only fires when it lacks \`"private": true\`. Empirical esquery note: \`:has(> JSONProperty[...] > JSONLiteral[value=true])\` (two chained child combinators inside \`:has\`) matches nothing in esquery 1.7.0 — the working form is a single-step attribute path, \`:not(:has(> JSONProperty[key.value="private"][value.value=true]))\`. Verified standalone against esquery + jsonc-eslint-parser before wiring in: private:true exempt, private:false and public flagged.
- **devDependencies deliberately NOT covered**: stripped at pack, so \`workspace:*\` is correct there.

## Verification

1. **Baseline**: \`pnpm run lint:package-json\` green on current main (24/24 ok — no violations exist post-#382).
2. **Negative**: temporarily reverted mobx's \`lit-ui-router\` peer to \`workspace:^\` → lint FAILED on \`packages/lit-ui-router-mobx/package.json\` with the new message ("workspace: refs in shipped fields get pack-substituted with re-appended key order, breaking published-manifest sorting — use catalog:publishedPeer (or a version range) instead."); reverted.
3. **Private exemption**: temporarily added \`"lit-ui-router": "workspace:*"\` to \`dependencies\` AND \`"navigation-location-plugin": "workspace:*"\` to \`devDependencies\` of private \`packages/ui-router-server\` → lint stayed green (exit 0, no failures); reverted.
4. **Repo-wide**: \`turbo run lint format:check\` → 57/57 tasks successful (root/tools/apps manifests untouched by the \`packages/*\` glob; oxfmt green on the config).