### PR TITLE
chore(examples): lit-ui-router 1.7.1

### DIFF
--- a/examples/hellogalaxy/package-lock.json
+++ b/examples/hellogalaxy/package-lock.json
@@ -12,7 +12,7 @@
         "@uirouter/core": "^6.1.2",
         "@uirouter/visualizer": "^7.2.1",
         "lit": "^3.3.3",
-        "lit-ui-router": "^1.7.0"
+        "lit-ui-router": "^1.7.1"
       },
       "devDependencies": {
         "typescript": "^7.0.2",
@@ -113,6 +113,15 @@
       "peerDependencies": {
         "@emnapi/core": "^1.7.1",
         "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/runtime": {
+      "version": "0.140.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/runtime/-/runtime-0.140.0.tgz",
+      "integrity": "sha512-ZYZwESARwc2fB/vLHj+991uu3iGIsor3gPTA7wgouM6xEJzJsz11dt+/Xl5tUinERqmq6auyRhSMWzChhfez6w==",
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@oxc-project/types": {
@@ -1180,11 +1189,12 @@
       }
     },
     "node_modules/lit-ui-router": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/lit-ui-router/-/lit-ui-router-1.7.0.tgz",
-      "integrity": "sha512-UK69ySdMwrAILx8aG9TYcNLlg/Q2CCrs1nqwnKumFlQXeNvjf+heH5l1KdfDEyyuBYafrzGxUMOLEZ2esiX3Tw==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/lit-ui-router/-/lit-ui-router-1.7.1.tgz",
+      "integrity": "sha512-M2EJ1i4WLJ+5kHAtwHPr4OTotTvpqyYmw/skwjKOZeWdNkKrKgG9RRmxwYO2r58ovJMdOOgxdljzjm8oF7NkNw==",
       "license": "MIT",
       "dependencies": {
+        "@oxc-project/runtime": "0.140.0",
         "@uirouter/core": "^6.0.8",
         "lit": "^3.0.0"
       }

--- a/examples/hellogalaxy/package.json
+++ b/examples/hellogalaxy/package.json
@@ -13,7 +13,7 @@
     "@uirouter/core": "^6.1.2",
     "@uirouter/visualizer": "^7.2.1",
     "lit": "^3.3.3",
-    "lit-ui-router": "^1.7.0"
+    "lit-ui-router": "^1.7.1"
   },
   "devDependencies": {
     "typescript": "^7.0.2",

--- a/examples/hellosolarsystem/package-lock.json
+++ b/examples/hellosolarsystem/package-lock.json
@@ -11,7 +11,7 @@
         "@uirouter/core": "^6.1.2",
         "@uirouter/visualizer": "^7.2.1",
         "lit": "^3.3.3",
-        "lit-ui-router": "^1.7.0"
+        "lit-ui-router": "^1.7.1"
       },
       "devDependencies": {
         "typescript": "^7.0.2",
@@ -84,6 +84,15 @@
       "peerDependencies": {
         "@emnapi/core": "^1.7.1",
         "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/runtime": {
+      "version": "0.140.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/runtime/-/runtime-0.140.0.tgz",
+      "integrity": "sha512-ZYZwESARwc2fB/vLHj+991uu3iGIsor3gPTA7wgouM6xEJzJsz11dt+/Xl5tUinERqmq6auyRhSMWzChhfez6w==",
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@oxc-project/types": {
@@ -1130,11 +1139,12 @@
       }
     },
     "node_modules/lit-ui-router": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/lit-ui-router/-/lit-ui-router-1.7.0.tgz",
-      "integrity": "sha512-UK69ySdMwrAILx8aG9TYcNLlg/Q2CCrs1nqwnKumFlQXeNvjf+heH5l1KdfDEyyuBYafrzGxUMOLEZ2esiX3Tw==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/lit-ui-router/-/lit-ui-router-1.7.1.tgz",
+      "integrity": "sha512-M2EJ1i4WLJ+5kHAtwHPr4OTotTvpqyYmw/skwjKOZeWdNkKrKgG9RRmxwYO2r58ovJMdOOgxdljzjm8oF7NkNw==",
       "license": "MIT",
       "dependencies": {
+        "@oxc-project/runtime": "0.140.0",
         "@uirouter/core": "^6.0.8",
         "lit": "^3.0.0"
       }

--- a/examples/hellosolarsystem/package.json
+++ b/examples/hellosolarsystem/package.json
@@ -12,7 +12,7 @@
     "@uirouter/core": "^6.1.2",
     "@uirouter/visualizer": "^7.2.1",
     "lit": "^3.3.3",
-    "lit-ui-router": "^1.7.0"
+    "lit-ui-router": "^1.7.1"
   },
   "devDependencies": {
     "typescript": "^7.0.2",

--- a/examples/helloworld/package-lock.json
+++ b/examples/helloworld/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@uirouter/core": "^6.1.2",
         "lit": "^3.3.3",
-        "lit-ui-router": "^1.7.0"
+        "lit-ui-router": "^1.7.1"
       },
       "devDependencies": {
         "typescript": "^7.0.2",
@@ -83,6 +83,15 @@
       "peerDependencies": {
         "@emnapi/core": "^1.7.1",
         "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/runtime": {
+      "version": "0.140.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/runtime/-/runtime-0.140.0.tgz",
+      "integrity": "sha512-ZYZwESARwc2fB/vLHj+991uu3iGIsor3gPTA7wgouM6xEJzJsz11dt+/Xl5tUinERqmq6auyRhSMWzChhfez6w==",
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@oxc-project/types": {
@@ -1091,11 +1100,12 @@
       }
     },
     "node_modules/lit-ui-router": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/lit-ui-router/-/lit-ui-router-1.7.0.tgz",
-      "integrity": "sha512-UK69ySdMwrAILx8aG9TYcNLlg/Q2CCrs1nqwnKumFlQXeNvjf+heH5l1KdfDEyyuBYafrzGxUMOLEZ2esiX3Tw==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/lit-ui-router/-/lit-ui-router-1.7.1.tgz",
+      "integrity": "sha512-M2EJ1i4WLJ+5kHAtwHPr4OTotTvpqyYmw/skwjKOZeWdNkKrKgG9RRmxwYO2r58ovJMdOOgxdljzjm8oF7NkNw==",
       "license": "MIT",
       "dependencies": {
+        "@oxc-project/runtime": "0.140.0",
         "@uirouter/core": "^6.0.8",
         "lit": "^3.0.0"
       }

--- a/examples/helloworld/package.json
+++ b/examples/helloworld/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@uirouter/core": "^6.1.2",
     "lit": "^3.3.3",
-    "lit-ui-router": "^1.7.0"
+    "lit-ui-router": "^1.7.1"
   },
   "devDependencies": {
     "typescript": "^7.0.2",


### PR DESCRIPTION
Post-1.7.1 examples bump, same shape as #301/#247: `^1.7.0` → `^1.7.1` across the three tutorials, lockfiles refreshed (`npm install --package-lock-only`). StackBlitz verification to follow on this branch before merge.