### PR TITLE
docs(theme): fix the StackBlitz badge frame — vp-doc img margin was the gap; level at 38px

### DIFF
--- a/docs/.vitepress/theme/components/StackBlitzEmbed.vue
+++ b/docs/.vitepress/theme/components/StackBlitzEmbed.vue
@@ -177,6 +177,8 @@ onUnmounted(() => {
 :deep(a img) {
   display: block;
   height: 32px;
+  /* .vp-doc gives content imgs 16px vertical margin — the actual gap culprit. */
+  margin: 0;
 }
 
 :deep(a:hover) {

--- a/docs/.vitepress/theme/components/StackBlitzEmbed.vue
+++ b/docs/.vitepress/theme/components/StackBlitzEmbed.vue
@@ -164,14 +164,16 @@ onUnmounted(() => {
   border-color: var(--vp-c-brand-1);
 }
 
-/* The slotted badge img is a fully-styled button; no frame of our own —
-   hover affordance is a brand ring instead. */
+/* Framed like the sibling .btn controls; border present in both states so
+   hover changes color only, never size. */
 :deep(a) {
   display: inline-flex;
   align-items: center;
   line-height: 0;
+  border: 1px solid var(--vp-c-divider);
   border-radius: 6px;
-  transition: box-shadow 0.2s;
+  overflow: hidden;
+  transition: border-color 0.2s;
 }
 
 :deep(a img) {
@@ -182,6 +184,6 @@ onUnmounted(() => {
 }
 
 :deep(a:hover) {
-  box-shadow: 0 0 0 2px var(--vp-c-brand-1);
+  border-color: var(--vp-c-brand-1);
 }
 </style>

--- a/docs/.vitepress/theme/components/StackBlitzEmbed.vue
+++ b/docs/.vitepress/theme/components/StackBlitzEmbed.vue
@@ -164,15 +164,14 @@ onUnmounted(() => {
   border-color: var(--vp-c-brand-1);
 }
 
-/* Frame hugs the slotted badge: no line box, radius clips the img corners. */
+/* The slotted badge img is a fully-styled button; no frame of our own —
+   hover affordance is a brand ring instead. */
 :deep(a) {
   display: inline-flex;
   align-items: center;
-  padding: 0;
   line-height: 0;
-  border: 1px solid var(--vp-c-divider);
   border-radius: 6px;
-  overflow: hidden;
+  transition: box-shadow 0.2s;
 }
 
 :deep(a img) {
@@ -181,6 +180,6 @@ onUnmounted(() => {
 }
 
 :deep(a:hover) {
-  border-color: var(--vp-c-brand-1);
+  box-shadow: 0 0 0 2px var(--vp-c-brand-1);
 }
 </style>

--- a/docs/.vitepress/theme/components/StackBlitzEmbed.vue
+++ b/docs/.vitepress/theme/components/StackBlitzEmbed.vue
@@ -178,7 +178,8 @@ onUnmounted(() => {
 
 :deep(a img) {
   display: block;
-  height: 32px;
+  /* 36px + the 1px frame = 38px, level with the sibling .btn controls. */
+  height: 36px;
   /* .vp-doc gives content imgs 16px vertical margin — the actual gap culprit. */
   margin: 0;
 }

--- a/docs/.vitepress/theme/components/StackBlitzEmbed.vue
+++ b/docs/.vitepress/theme/components/StackBlitzEmbed.vue
@@ -164,18 +164,23 @@ onUnmounted(() => {
   border-color: var(--vp-c-brand-1);
 }
 
-/* The slotted badge img is a fully-styled button; no frame of our own. */
+/* Frame hugs the slotted badge: no line box, radius clips the img corners. */
 :deep(a) {
   display: inline-flex;
   align-items: center;
+  padding: 0;
   line-height: 0;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 6px;
+  overflow: hidden;
 }
 
 :deep(a img) {
+  display: block;
   height: 32px;
 }
 
 :deep(a:hover) {
-  filter: brightness(1.1);
+  border-color: var(--vp-c-brand-1);
 }
 </style>

--- a/docs/.vitepress/theme/components/StackBlitzEmbed.vue
+++ b/docs/.vitepress/theme/components/StackBlitzEmbed.vue
@@ -164,11 +164,11 @@ onUnmounted(() => {
   border-color: var(--vp-c-brand-1);
 }
 
+/* The slotted badge img is a fully-styled button; no frame of our own. */
 :deep(a) {
   display: inline-flex;
   align-items: center;
-  border: 1px solid var(--vp-c-divider);
-  border-radius: 6px;
+  line-height: 0;
 }
 
 :deep(a img) {
@@ -176,6 +176,6 @@ onUnmounted(() => {
 }
 
 :deep(a:hover) {
-  border-color: var(--vp-c-brand-1);
+  filter: brightness(1.1);
 }
 </style>


### PR DESCRIPTION
The frame around the slotted `open_in_stackblitz.svg` badge rendered with a large gap — a box floating around a button. Root cause (found by live box-model bisection on the deployed preview): **VitePress's `.vp-doc` gives content images `margin: 16px 0`** for vertical rhythm, inflating the anchor to 162×64 around the 32px badge. Every framing variant tried before the diagnosis (frameless, frame-hugging, hover ring) inherited that margin, which is why they all looked wrong.

Final shape:
- `margin: 0` on the slotted img — the actual fix — plus `display: block` + `line-height: 0` for a tight box.
- Frame matches the sibling Fullscreen/refresh `.btn` controls: `1px` divider border + 6px radius, present in **both** states so hover changes border-color only — identical size at rest and hover. `overflow: hidden` clips the badge's own corners to the frame.
- Badge img at `height: 36px` → 38px framed total, level with the sibling buttons (which compute to 38px); the SVG scales cleanly.

Verified on the deployed branch preview via Playwright box-model measurement at each step: margin zeroed (anchor 32 = img 32), framed rest/hover heights identical, and a final all-controls height sweep after the 36px bump.