### PR TITLE
ci: demote check:pack to main-push and gate tagging on full main CI via workflow_call

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -79,6 +79,15 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
           # Silence per-request [wrangler:info] logging from the e2e dev server.
           WRANGLER_LOG: warn
+      - name: Check pack
+        # Main-push only (demoted from the per-PR ci graph); a failure here
+        # fails build_and_test, so the tag_push call job below never runs.
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        run: mise run //tools/release:check_pack
+        env:
+          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+          TURBO_API: ${{ vars.TURBO_API }}
+          TURBO_TEAM: ${{ vars.TURBO_TEAM }}
       - name: Upload to Codecov
         # Branch-head runs skip upload; merge-head/main covers the same SHA.
         if: ${{ github.event_name != 'push' || github.ref == 'refs/heads/main' }}
@@ -89,3 +98,17 @@ jobs:
           plugins: noop
           fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}
+
+  tag_push:
+    # Gated tagging: rides the same run as main CI, so a red build_and_test
+    # (Check pack included) means no tag, hence no publish trigger.
+    # workflow_dispatch on Tag & push is the documented CI-bypass escape hatch.
+    needs: build_and_test
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+    permissions:
+      # The called tagging job pushes tags; called workflows can't exceed
+      # the caller job's grant.
+      contents: write
+    uses: ./.github/workflows/publish-gh.yml
+    secrets:
+      GH_PERSONAL_ACCESS_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}

--- a/.github/workflows/publish-gh.yml
+++ b/.github/workflows/publish-gh.yml
@@ -1,4 +1,5 @@
-# Automatic tagging workflow - runs on every push to main.
+# Automatic tagging workflow - called by build-test.yml after main's
+# build_and_test job succeeds.
 # Creates git tags for releases, which then trigger the NPM publish workflow.
 # Uses release-it with --no-increment to tag the current version without bumping.
 #
@@ -9,9 +10,15 @@
 name: Tag & push
 
 on:
-  push:
-    branches:
-      - main
+  # Called by build-test.yml's tag_push job (needs: build_and_test, main push
+  # only): no tag unless the whole main CI run — build, tests, lint,
+  # typecheck, check:pack — is green.
+  workflow_call:
+    secrets:
+      GH_PERSONAL_ACCESS_TOKEN:
+        required: true
+  # Manual dispatch bypasses the CI gate — hotfix escape hatch; the protected
+  # tag-release environment still gates authorization.
   workflow_dispatch:
     inputs:
       dryRun:
@@ -24,22 +31,24 @@ on:
 env:
   HUSKY: 0
 
-# Serialize runs: a run that checks out before a sibling run pushes its tag
-# will re-create that tag, get its push rejected, and release-it's rollback
-# then deletes the tag from the remote.
-# The queue alone is not enough: release-it's own push sends main + tag
-# together, so a main push that lands mid-run rejects the whole push and the
-# rollback deletes the tag. Hence tagging (:tag, --git.push false) and
-# pushing (:tag_push, tag ref only) are separate tasks.
-concurrency:
-  group: tag-release
-
-permissions:
-  contents: write
-
 jobs:
   publish_gh:
     runs-on: ubuntu-latest
+    # Serialize per package across runs (call path and dispatch path share
+    # these groups): a run that checks out before a sibling run pushes its tag
+    # will re-create that tag, get its push rejected, and release-it's
+    # rollback then deletes the tag from the remote.
+    # The queue alone is not enough: release-it's own push sends main + tag
+    # together, so a main push that lands mid-run rejects the whole push and
+    # the rollback deletes the tag. Hence tagging (:tag, --git.push false) and
+    # pushing (:tag_push, tag ref only) are separate tasks.
+    # Job-level (not workflow-level): GitHub ignores workflow-level
+    # concurrency in called workflows. Per-package groups: one shared group
+    # would cancel the third matrix leg (max one running + one pending each).
+    concurrency:
+      group: tag-release-${{ matrix.package }}
+    permissions:
+      contents: write
     # Protected environment ensures only authorized pushes create tags
     environment: tag-release
     strategy:
@@ -52,6 +61,8 @@ jobs:
       - name: 'Checkout code'
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          # Called runs inherit the caller's github.sha — the commit CI
+          # validated; dispatch runs check out the main tip.
           fetch-depth: 0
           fetch-tags: true
           # PAT (not GITHUB_TOKEN): the pushed tag must trigger publish-npm,
@@ -78,7 +89,8 @@ jobs:
         continue-on-error: true
         env:
           PACKAGE: ${{ matrix.package }}
-          # only set on manual workflow_dispatch runs; pushes to main always tag for real
+          # dryRun is declared for workflow_dispatch only; called runs get an
+          # empty value and always tag for real
           DRY_RUN: ${{ inputs.dryRun }}
           GITHUB_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
       - name: Push tag

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 <img src="docs/public/images/lit-ui-router.svg" alt="Lit UI Router" width="120" height="120">
 
 [![Main Branch CI](https://github.com/simshanith/lit-ui-router/actions/workflows/build-test.yml/badge.svg?branch=main)](https://github.com/simshanith/lit-ui-router/actions/workflows/build-test.yml?query=branch%3Amain)
+[![Tag & push (escape hatch)](https://github.com/simshanith/lit-ui-router/actions/workflows/publish-gh.yml/badge.svg?branch=main&event=workflow_dispatch)](https://github.com/simshanith/lit-ui-router/actions/workflows/publish-gh.yml?query=branch%3Amain+event%3Aworkflow_dispatch)
 [![npm](https://img.shields.io/npm/v/lit-ui-router.svg)](https://www.npmjs.com/package/lit-ui-router)
 [![GitHub Release](https://img.shields.io/github/v/release/simshanith/lit-ui-router?filter=lit-ui-router@*)](https://github.com/simshanith/lit-ui-router/releases/?q=lit-ui-router)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)

--- a/tools/release/mise.toml
+++ b/tools/release/mise.toml
@@ -77,6 +77,11 @@ flag "--dry-run" help="release-it --dry-run: no npm publish, no GitHub release" 
 '''
 run = 'PACKAGE_NAME="${usage_package_name?}" TARBALL="${usage_tarball?}" DRY_RUN="${usage_dry_run:-}" node src/steps/release-publish.ts'
 
+[tasks.check_pack]
+# Main-push CI placement (not per-PR); publish's check_tarball is the last-line gate.
+description = "Run the pack-surface manifest check via turbo"
+run = "turbo run check:pack"
+
 [tasks.published_diff]
 description = "Resolve published versions, then run the published-diff check (two turbo invocations: turbo hashes inputs at run startup, so resolve must write before the check's hash computes)"
 usage = '''

--- a/turbo.json
+++ b/turbo.json
@@ -85,8 +85,7 @@
         "lint",
         "typecheck",
         "format:check",
-        "codecov:bundle",
-        "@tools/release#check:pack"
+        "codecov:bundle"
       ]
     },
     "codecov:bundle": {


### PR DESCRIPTION
Final design (maintainer-iterated): check:pack demoted off PRs, and tagging gated on full main CI via `workflow_call` — the repo's published-diff call precedent, with **no zizmor exception needed**.

- **PRs never run `check:pack`** — removed from the turbo `ci` graph, dropping N× `pnpm pack` invocations from every PR.
- **Every main push runs it** — a main-push-gated `Check pack` step inside `build_and_test` (turbo-cached, TURBO_* remote-cache env).
- **Tagging rides the same run**: a `tag_push` job in build-test.yml (`needs: build_and_test`, main-push only) `uses: ./.github/workflows/publish-gh.yml`. The chain: `Check pack` fails → `build_and_test` fails → `tag_push` never runs → no tag → no publish trigger. Same for any other main CI failure — tag-on-red-main is gone as a failure mode, and the caller and callee share `github.sha`, so the tagged commit is exactly the one CI validated (no head_sha plumbing needed).

## Why check:pack moved off PRs

Its failure mode — unsubstituted `catalog:`/`workspace:` refs in a packed manifest (the historical 1.3.0–1.5.0 broken-publish class) — can only harm a real publish, which happens downstream of main. Main-push placement preserves "main is releasable"; the needs-edge upgrades that from reporting to enforcement.

## What changed

- `turbo.json`: `@tools/release#check:pack` removed from the `ci` task's `dependsOn`. Turbo task, package script, and pack surface untouched.
- `tools/release/mise.toml`: new `check_pack` task (`turbo run check:pack`), the single-line `mise run` step convention.
- `.github/workflows/build-test.yml`: main-push `Check pack` step in `build_and_test`; new `tag_push` job calling publish-gh.yml, mirroring the publish-npm → published-diff call precedent (explicit `secrets:` passing, job-level `permissions`), with `contents: write` granted on the caller job (called workflows can't exceed the caller job's grant); `build_and_test`'s own permissions stay `contents: read`.
- `.github/workflows/publish-gh.yml`: `push: main`/`workflow_run` trigger replaced with `workflow_call` (declares the `GH_PERSONAL_ACCESS_TOKEN` secret; call secrets aren't inherited implicitly). `workflow_dispatch` + dryRun kept as the escape hatch. No job-level gate `if` — the caller's needs-edge is the gate; dispatch runs skip the caller entirely. `dryRun` is declared for dispatch only, so called runs get an empty value and tag for real. Protected `tag-release` environment kept on the callee job (environment protection applies in reusable workflows). `contents: write` stays job-scoped.
- `zizmor.yml`: **no new exceptions** — the workflow_run `dangerous-triggers` ignore from the previous revision is gone; that remediation is the point of this rework. The pre-existing `artipacked` exception for publish-gh.yml (PAT persists by design) is unchanged.
- `README.md`: badge decision below.

## Concurrency (load-bearing, moved)

GitHub ignores workflow-level `concurrency` in called workflows, so the `tag-release` serialization (re-created tags → rejected push → release-it rollback deleting remote tags) moved to **job-level on the callee's `publish_gh` job**: `group: tag-release-${{ matrix.package }}`. Job-level concurrency in a reusable workflow's job does apply, and both the call path and the dispatch path execute this job, so the two paths serialize against each other in the same groups. Per-package groups (not one shared group) because a concurrency group holds at most one running + one pending job — a single group would cancel the third matrix leg. Cross-run, same-package serialization is what the tag-race hazard needs; the tag/tag_push task split still covers the mid-run main-push case, per the retained comment.

## Monitoring (demotion ≠ disappearance)

Called workflows don't create their own workflow runs, so a workflow_run-event badge would go blank. Split instead:

- **Gated tagging signal = the existing Main Branch CI badge** (first in the row): a Check pack or tag_push failure fails the Build and Test run on main and shows there.
- **Escape-hatch surface = the Tag & push badge**, repointed to `?branch=main&event=workflow_dispatch` and labeled "(escape hatch)": the only events that still appear as Tag & push runs are manual dispatches, so the badge shows the last bypass/dryRun outcome instead of going dark. Root README only, matching repo convention.

## Recovery paths when main is red

1. **Flaky red main** — re-run `build_and_test` (optionally with the `force` deflake input); re-runs keep the push event, so a green re-run's `tag_push` job fires on the validated sha.
2. **Deliberate force (hotfix)** — `workflow_dispatch` on Tag & push with dryRun=false tags the main tip regardless of CI state (documented on the trigger in publish-gh.yml). Authorization is still gated by the protected `tag-release` environment.

## What still protects publishes

1. Main-push `check:pack` + the needs-edge — red main means no tag.
2. `publish-npm.yml`'s `check_tarball` step — same shared core (`check-pack.core.ts`) against the actual publish tarball, the last-line gate; also covers dispatch-bypass tags.
3. `check:published-diff` main-push runs — flag ship-affecting drift on the pack surface.

## Verification

- `turbo run ci --dry-run`: **0 occurrences of `check:pack`** in the PR graph (19 packages, all other ci legs present).
- `mise run //tools/release:check_pack`: passes — `✓ pack check passed — 3 publishable packages, all packed manifests fully substituted.`
- `mise run lint_workflows` (actionlint + zizmor): clean **without any new zizmor exception** (3 ignored = the pre-existing documented ones).
- `turbo run lint typecheck format:check --filter=@tools/release --filter=//` + `//#format:check:root`: all green.

## Post-merge caveat

Push-gated workflow changes can't be exercised pre-merge. Live-verify on the first push to main after merge: `build_and_test` runs the `Check pack` step, then `tag_push / publish_gh (<pkg>)` jobs appear inside the same Build and Test run on the validated sha, tags land (or no-op on unchanged versions), and the Main Branch CI badge reflects the whole chain. A dispatch dryRun afterward confirms the escape hatch and populates its badge.
