### PR TITLE
ci(dts-backtest): run current-TS leg on PR, full matrix on main push

### DIFF
--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -98,3 +98,8 @@ run = 'turbo run "${usage_package_name?}#build"'
 # forces a cache-bypassing rerun, ""/"false" respect the cache.
 description = "Run the full CI pipeline via turbo"
 run = "turbo run ci --ui=stream --log-order=stream"
+
+[tasks.dts_backtest_matrix]
+# Main-push companion to `ci`: PRs run only the current-TS dts-backtest leg.
+description = "Run the full dts-backtest TypeScript version matrix via turbo"
+run = "turbo run test:matrix --ui=stream --log-order=stream"

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -118,6 +118,16 @@ jobs:
           TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
           TURBO_API: ${{ vars.TURBO_API }}
           TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+      - name: dts-backtest full TS matrix
+        # Old-TS consumer risk only materializes for shipped packages, so the
+        # full version matrix runs on main pushes (still gating any release);
+        # PR runs cover the current-TS leg inside `ci` above.
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        run: mise run dts_backtest_matrix
+        env:
+          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+          TURBO_API: ${{ vars.TURBO_API }}
+          TURBO_TEAM: ${{ vars.TURBO_TEAM }}
       - name: Upload to Codecov
         # Branch-head runs skip upload; merge-head/main covers the same SHA.
         if: ${{ github.event_name != 'push' || github.ref == 'refs/heads/main' }}

--- a/tools/dts-backtest/README.md
+++ b/tools/dts-backtest/README.md
@@ -33,8 +33,15 @@ broken diagnostic filter silently classifying everything as third-party.
 ## Running
 
 ```sh
-turbo run test --filter=@tools/dts-backtest   # builds the packages first
+turbo run test --filter=@tools/dts-backtest          # current-TS leg (PR CI)
+turbo run test:matrix --filter=@tools/dts-backtest   # full version matrix (main-push CI)
 ```
+
+Both build the packages first. `node run.ts` defaults to the full matrix;
+`--versions=current` restricts it to the repo-current (native TS 7) leg.
+The old-TS legs only guard shipped packages, so the full matrix runs on
+main pushes — still ahead of any release — while PRs get fast current-TS
+feedback.
 
 ## Authoring rule for the published packages
 

--- a/tools/dts-backtest/package.json
+++ b/tools/dts-backtest/package.json
@@ -8,7 +8,8 @@
     "format": "oxfmt \"**/*.{ts,js,json,md}\"",
     "format:check": "oxfmt --check \"**/*.{ts,js,json,md}\"",
     "lint": "oxlint .",
-    "test": "node run.ts"
+    "test": "node run.ts --versions=current",
+    "test:matrix": "node run.ts --versions=full"
   },
   "devDependencies": {
     "@types/dom-navigation": "catalog:",

--- a/tools/dts-backtest/run.ts
+++ b/tools/dts-backtest/run.ts
@@ -316,11 +316,24 @@ async function selftestNative() {
   return true;
 }
 
-let ok = await selftest();
+// --versions=current runs only the repo-current (native TS 7) leg; the
+// default full matrix adds the pinned classic legs and their self-test.
+const versionsArg = process.argv
+  .find((arg) => arg.startsWith('--versions='))
+  ?.slice('--versions='.length);
+if (versionsArg !== undefined && !['current', 'full'].includes(versionsArg)) {
+  console.error(`unknown --versions=${versionsArg} (expected current|full)`);
+  process.exit(2);
+}
+const currentOnly = versionsArg === 'current';
+
+let ok = currentOnly ? true : await selftest();
 ok = (await selftestNative()) && ok;
-for (const specifier of API_VERSIONS) {
-  for (const configFile of CONFIGS) {
-    ok = run(specifier, configFile) && ok;
+if (!currentOnly) {
+  for (const specifier of API_VERSIONS) {
+    for (const configFile of CONFIGS) {
+      ok = run(specifier, configFile) && ok;
+    }
   }
 }
 for (const configFile of CONFIGS) {

--- a/turbo.json
+++ b/turbo.json
@@ -28,6 +28,12 @@
       "dependsOn": ["^build"],
       "inputs": ["fixtures/**", "run.ts", "tsconfig.fixture*.json"]
     },
+    // Full TS version matrix; distinct task name = distinct cache key from
+    // the current-leg-only #test above. Runs on main push, not the PR graph.
+    "@tools/dts-backtest#test:matrix": {
+      "dependsOn": ["^build"],
+      "inputs": ["fixtures/**", "run.ts", "tsconfig.fixture*.json"]
+    },
     "test:coverage": {
       "dependsOn": ["^build", "^test:coverage"],
       "inputs": ["src/**/*.ts", "vitest.config.ts"],


### PR DESCRIPTION
## Why

dts-backtest typechecks the built `dist/*.d.ts` consumer fixtures under every supported TypeScript version — the most expensive single guard on the PR hot path, and it forces `^build` into the `test` fan-out. Its old-TS-consumer risk only materializes for **shipped** packages, so catching it on main-push still blocks any tag/publish. The current-TS leg stays on PR because d.ts-shape regressions are introduced by ordinary source edits and deserve PR-time feedback.

## What

- `run.ts` grows a `--versions=current|full` flag, **defaulting to `full`** — plain `node run.ts` loses nothing. `current` runs only the repo-current (native TS 7) leg plus its native self-test; `full` is the existing behavior (classic self-test + 5.0/5.9/6 classic legs + 7 native legs, both module-resolution configs).
- Package scripts: `test` → `node run.ts --versions=current` (the PR fan-out leg); new `test:matrix` → `node run.ts --versions=full`. No script renamed.
- `turbo.json`: new `@tools/dts-backtest#test:matrix` task alongside the existing `#test` override, same `dependsOn: ["^build"]` and inputs.
- New root mise task `dts_backtest_matrix` (`turbo run test:matrix`), invoked from a `build-test.yml` step gated `if: github.event_name == 'push' && github.ref == 'refs/heads/main'` — the repo's existing main-push gating pattern; workflow edit kept minimal.
- README updated for the split.

## Cache-key safety

The version set is selected by args baked into two **different package scripts driven by two different turbo task names** (`test` vs `test:matrix`). Task name + command are both part of turbo's hash, so the current-leg and full-matrix runs can never alias each other's cache entries. No env-var selection, so no `env` declaration is needed and no undeclared input can leak into the hash.

## Verification

- `turbo run test --filter=@tools/dts-backtest` (exit 0): native self-test + TS 7.0.2 on both configs only.
- `turbo run test:matrix` (exit 0): both self-tests + TS 5.0.4 / 5.9.3 / 6.0.3 / 7.0.2 across `bundler` and `NodeNext` configs — full matrix intact.
- `turbo run ci --dry-run`: graph contains `@tools/dts-backtest#test`, zero occurrences of `test:matrix` — the PR hot path now carries only the current-TS leg.
- `mise run lint_workflows` (actionlint + zizmor): clean.
- `turbo run lint format:check --filter=@tools/dts-backtest` and `//#format:check:root`: clean.