### PR TITLE
ci: cache playwright/cypress binaries (retest)

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -55,22 +55,26 @@ jobs:
           # The Install Cypress step below downloads the binary; skipping it
           # here keeps download noise out of the pnpm postinstall output.
           CYPRESS_INSTALL_BINARY: '0'
-      - name: Resolve browser binary versions
+      - name: Resolve Playwright version
         # Cache keys derive from the installed packages, so they bust exactly
-        # on a playwright/cypress version bump and nothing else.
-        id: browser-versions
-        run: mise run //tools/build_and_test:browser_versions
+        # on a version bump and nothing else; one step per tool keeps the two
+        # caches independent.
+        id: playwright-version
+        run: mise run //tools/build_and_test:playwright_version
+      - name: Resolve Cypress version
+        id: cypress-version
+        run: mise run //tools/build_and_test:cypress_version
       - name: Cache Playwright browsers
         id: playwright-cache
         uses: actions/cache@v4
         with:
           path: ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ steps.browser-versions.outputs.playwright }}
+          key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.playwright }}
       - name: Cache Cypress binary
         uses: actions/cache@v4
         with:
           path: ~/.cache/Cypress
-          key: ${{ runner.os }}-cypress-${{ steps.browser-versions.outputs.cypress }}
+          key: ${{ runner.os }}-cypress-${{ steps.cypress-version.outputs.cypress }}
       - name: Install Playwright Browsers
         if: ${{ steps.playwright-cache.outputs.cache-hit != 'true' }}
         run: mise run //tools/build_and_test:playwright

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -59,10 +59,7 @@ jobs:
         # Cache keys derive from the installed packages, so they bust exactly
         # on a playwright/cypress version bump and nothing else.
         id: browser-versions
-        working-directory: tools/build_and_test
-        run: |
-          echo "playwright=$(node -p "require('playwright/package.json').version")" >> "$GITHUB_OUTPUT"
-          echo "cypress=$(node -p "require('cypress/package.json').version")" >> "$GITHUB_OUTPUT"
+        run: mise run //tools/build_and_test:browser_versions
       - name: Cache Playwright browsers
         id: playwright-cache
         uses: actions/cache@v4
@@ -81,8 +78,7 @@ jobs:
         # Browsers came from the cache; the fresh runner still needs the apt
         # OS deps that `--with-deps` would have installed on the miss path.
         if: ${{ steps.playwright-cache.outputs.cache-hit == 'true' }}
-        working-directory: tools/build_and_test
-        run: pnpm exec playwright install-deps
+        run: mise run //tools/build_and_test:playwright_deps
       - name: Install Cypress
         # `cypress install` is a near-no-op when the binary is cached; verify
         # still runs so the concurrent suites skip the first-use banner.

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -86,6 +86,8 @@ jobs:
       - name: Install Cypress
         # `cypress install` is a near-no-op when the binary is cached; verify
         # still runs so the concurrent suites skip the first-use banner.
+        # verify needs the OS libs the playwright dep steps install on both
+        # cache paths — never skip playwright_deps on hits.
         run: mise run //tools/build_and_test:cypress
       - name: Start shared Xvfb display
         # The vanilla and MobX Cypress suites run concurrently. Without a

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -55,9 +55,37 @@ jobs:
           # The Install Cypress step below downloads the binary; skipping it
           # here keeps download noise out of the pnpm postinstall output.
           CYPRESS_INSTALL_BINARY: '0'
+      - name: Resolve browser binary versions
+        # Cache keys derive from the installed packages, so they bust exactly
+        # on a playwright/cypress version bump and nothing else.
+        id: browser-versions
+        working-directory: tools/build_and_test
+        run: |
+          echo "playwright=$(node -p "require('playwright/package.json').version")" >> "$GITHUB_OUTPUT"
+          echo "cypress=$(node -p "require('cypress/package.json').version")" >> "$GITHUB_OUTPUT"
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ steps.browser-versions.outputs.playwright }}
+      - name: Cache Cypress binary
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/Cypress
+          key: ${{ runner.os }}-cypress-${{ steps.browser-versions.outputs.cypress }}
       - name: Install Playwright Browsers
+        if: ${{ steps.playwright-cache.outputs.cache-hit != 'true' }}
         run: mise run //tools/build_and_test:playwright
+      - name: Install Playwright OS deps
+        # Browsers came from the cache; the fresh runner still needs the apt
+        # OS deps that `--with-deps` would have installed on the miss path.
+        if: ${{ steps.playwright-cache.outputs.cache-hit == 'true' }}
+        working-directory: tools/build_and_test
+        run: pnpm exec playwright install-deps
       - name: Install Cypress
+        # `cypress install` is a near-no-op when the binary is cached; verify
+        # still runs so the concurrent suites skip the first-use banner.
         run: mise run //tools/build_and_test:cypress
       - name: Start shared Xvfb display
         # The vanilla and MobX Cypress suites run concurrently. Without a

--- a/tools/build_and_test/mise.toml
+++ b/tools/build_and_test/mise.toml
@@ -27,14 +27,16 @@ _.path = ["{{config_root}}/node_modules/.bin"]
 description = "Start the shared CI Xvfb display and export DISPLAY"
 run = "./src/start-xvfb.ts"
 
-[tasks.browser_versions]
-# env: GITHUB_OUTPUT (step-output target). Emits the installed playwright and
-# cypress versions as `playwright=`/`cypress=` outputs for the cache keys.
-description = "Emit installed playwright/cypress versions to GITHUB_OUTPUT"
-run = [
-  "node -p \"'playwright=' + require('playwright/package.json').version\" >> \"$GITHUB_OUTPUT\"",
-  "node -p \"'cypress=' + require('cypress/package.json').version\" >> \"$GITHUB_OUTPUT\"",
-]
+[tasks.playwright_version]
+# env: GITHUB_OUTPUT (step-output target). One task per browser tool so each
+# cache step derives its key alone.
+description = "Emit the installed playwright version to GITHUB_OUTPUT"
+run = "node -p \"'playwright=' + require('playwright/package.json').version\" >> \"$GITHUB_OUTPUT\""
+
+[tasks.cypress_version]
+# env: GITHUB_OUTPUT (step-output target).
+description = "Emit the installed cypress version to GITHUB_OUTPUT"
+run = "node -p \"'cypress=' + require('cypress/package.json').version\" >> \"$GITHUB_OUTPUT\""
 
 [tasks.playwright]
 # The vitest browser legs need the Playwright browsers + system deps; the

--- a/tools/build_and_test/mise.toml
+++ b/tools/build_and_test/mise.toml
@@ -27,11 +27,26 @@ _.path = ["{{config_root}}/node_modules/.bin"]
 description = "Start the shared CI Xvfb display and export DISPLAY"
 run = "./src/start-xvfb.ts"
 
+[tasks.browser_versions]
+# env: GITHUB_OUTPUT (step-output target). Emits the installed playwright and
+# cypress versions as `playwright=`/`cypress=` outputs for the cache keys.
+description = "Emit installed playwright/cypress versions to GITHUB_OUTPUT"
+run = [
+  "node -p \"'playwright=' + require('playwright/package.json').version\" >> \"$GITHUB_OUTPUT\"",
+  "node -p \"'cypress=' + require('cypress/package.json').version\" >> \"$GITHUB_OUTPUT\"",
+]
+
 [tasks.playwright]
 # The vitest browser legs need the Playwright browsers + system deps; the
 # binary comes from this package's own devDependency.
 description = "Install the Playwright browsers with system dependencies"
 run = "playwright install --with-deps"
+
+[tasks.playwright_deps]
+# The cache-hit companion to `playwright`: browsers restored from cache, apt
+# OS deps still needed on a fresh runner.
+description = "Install only the Playwright system dependencies"
+run = "playwright install-deps"
 
 [tasks.cypress]
 # Verify up front so the concurrent vanilla/mobx Cypress runs skip the


### PR DESCRIPTION
## Experiment: retest browser-binary caching in CI

This was a **measurement PR**, not an assumed win. Numbers are in; verdict at the bottom.

### What it does
- `actions/cache` for `~/.cache/ms-playwright` and `~/.cache/Cypress`, keyed on `runner.os` + the **installed** playwright/cypress version (resolved via `node -p require(...)version` from `tools/build_and_test`), so keys bust exactly on version bumps and nothing else.
- On a Playwright cache **hit**: skip `mise run //tools/build_and_test:playwright` and run only `playwright install-deps` (the apt OS deps that `--with-deps` would have installed — those can't ride the cache across fresh runners). On a **miss**: the mise task runs unchanged.
- Cypress install/verify runs unconditionally: `cypress install` is a near-no-op when the binary is present, and `cypress verify` still pre-warms the concurrent suites.
- Pipeline logic lives in mise tasks per repo convention (review pass, 8b89442): `browser_versions` emits the versions to `GITHUB_OUTPUT`, `playwright_deps` is the cache-hit apt leg; every run line is a one-line `mise run`. Existing task names/APIs unchanged. actionlint + zizmor clean (`actions/*` is ref-pin-allowed by policy, so `@v4` stays a tag pin).

### Prior attempt (archaeology)
This repo DID try this once, on day one of CI (2025-07-24, pre-mise era):
- `c0964f2` added `actions/cache@v4` for both caches, keyed on `hashFiles('**/pnpm-lock.yaml')` — a key that busts on *any* dependency change, and with no install-step gating, so `--with-deps` apt work ran in full even on hits.
- Removed ~minutes later in `68a6841` (part of the same rapid "updates" iteration that also tried and dropped the `mcr.microsoft.com/playwright` container image). No rationale recorded in commit messages.

The structural question was whether the un-cacheable apt OS-deps step dominates. Measured answer: it costs 23s on the hit path — real, but less than half of the 50–80s combined download+apt step, so caching still nets positive.

### Timings (measured)

Baseline = 3 recent uncached runs (29669694397, 29669481368, 29669051665). Miss/hit = run 29670322442, first attempt vs re-run.

| Step | Baseline (3 runs) | Cache miss | Cache hit |
|---|---|---|---|
| Cache restore (playwright + cypress) | — | 1s | 8s |
| Install Playwright Browsers | 56 / 62 / 80s | 50s | skipped |
| Install Playwright OS deps (apt) | (inside above) | skipped | 23s |
| Install Cypress | 13 / 17 / 12s | 14s | 4s |
| Cache save (post steps) | — | 11s | 0s |
| **Setup-path subtotal** | **69 / 79 / 92s** | **76s** | **35s** |
| Total job (indicative only) | 235 / 248 / 272s | 235s | 191s |

*Turbo-step wall clock is deliberately excluded — remote-cache warmth confounds it; only the setup steps are directly comparable. "Build and Test" was 129–151s across all five runs, uncorrelated with caching.*

### Verdict
**Hit saves ~35–55s net of restore cost (setup path 35s vs 69–92s baseline); miss costs ~12s of restore+save overhead once per playwright/cypress bump.** The apt `install-deps` residual (23s) is the floor — browser downloads were the majority of the old step after all. Every PR gets two runs (push + pull_request) plus re-runs, all hitting after the first save, so the win compounds. Recommendation: **keep**.
