### PR TITLE
ci(release): two-tier peer-floor check — merge-time signal + bump-time gate

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -87,6 +87,13 @@ jobs:
         run: mise run setup
       - name: Setup Git user
         run: mise run //tools/release:git_user
+      # Tier-2 peer-floor gate: a package whose published peer floor no
+      # longer typechecks must not bump. Deadlock-free: the remedy (release
+      # the peer) is a bump this gate skips. No-op without the script.
+      - name: Peer floor gate
+        run: mise run //tools/release:peer_floor_gate
+        env:
+          PACKAGE: ${{ inputs.package }}
       - name: Bump version
         # version calc, release branch, release-it commit+push, gh pr create —
         # see tools/release/src/steps/release-bump.ts for the phase-by-phase contract

--- a/.github/workflows/published-diff.yml
+++ b/.github/workflows/published-diff.yml
@@ -71,3 +71,14 @@ jobs:
         run: mise run //tools/release:publish_check_runs
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # Tier-1 peer-floor signal: "peer-floor (<pkg>)" check runs, one per
+      # package defining typecheck:peer-floor. action_required = the floor
+      # pin is stale (release the peer, then bump the floor); never fails
+      # this job. Reruns here flip green once the floor bump lands on main.
+      - name: Peer floor check runs
+        run: mise run //tools/release:peer_floor_check_runs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+          TURBO_API: ${{ vars.TURBO_API }}
+          TURBO_TEAM: ${{ vars.TURBO_TEAM }}

--- a/tools/release/mise.toml
+++ b/tools/release/mise.toml
@@ -99,6 +99,23 @@ run = [
 description = "Create per-package published-diff check runs from the summary JSON"
 run = "node src/checks/publish-check-runs.ts"
 
+[tasks.peer_floor_check_runs]
+# env: GH_TOKEN, GITHUB_REPOSITORY. Tier-1 peer-floor signal: runs each
+# opted-in package's typecheck:peer-floor via turbo and creates one check run
+# per package on the current HEAD — action_required on a stale floor, never a
+# job failure. Inert while no package defines the script.
+description = "Create per-package peer-floor check runs (merge-time signal, non-gating)"
+run = "node src/checks/peer-floor-check-runs.ts"
+
+[tasks.peer_floor_gate]
+# Tier-2 peer-floor gate: fails the bump of a package whose floor claim is
+# dishonest; no-ops for packages without the typecheck:peer-floor script.
+description = "Fail a bump when the package's published peer floor is stale"
+usage = '''
+flag "--package <package>" help="Package being bumped" required=#true env="PACKAGE"
+'''
+run = 'PACKAGE="${usage_package?}" node src/steps/release-peer-floor-gate.ts'
+
 [tasks.bump]
 # env: GH_TOKEN (gh pr create; the branch push rides checkout's PAT).
 description = "Compute the bumped version, branch, commit, push, and open the release PR"

--- a/tools/release/src/checks/peer-floor-check-runs.core.ts
+++ b/tools/release/src/checks/peer-floor-check-runs.core.ts
@@ -1,0 +1,71 @@
+// Pure shaping for the peer-floor check runs: per-package typecheck verdicts
+// in, Checks API payloads out. Tier 1 of the peer-floor plan — a merge-time
+// SIGNAL: action_required renders orange ("a floor bump is owed"), never a
+// CI failure; `failure` is deliberately unused, matching publish-check-runs.
+// A bump commit's rerun flips green once the floor bump lands. The IO
+// (workspace discovery, turbo, gh) lives in ./peer-floor-check-runs.ts.
+
+import type { Member } from '@tools/shared/workspace.ts';
+
+import type { CheckRunPayload } from './publish-check-runs.core.ts';
+import { releaseWorkflowUrl } from './publish-check-runs.core.ts';
+
+export const PEER_FLOOR_SCRIPT = 'typecheck:peer-floor';
+
+export type PeerFloorResult = {
+  name: string;
+  ok: boolean;
+};
+
+/** The exact run name a badge nameFilter would match. */
+export function peerFloorCheckRunName(packageName: string): string {
+  return `peer-floor (${packageName})`;
+}
+
+/** Members that opt in by defining the script; root never qualifies. */
+export function peerFloorMembers(members: Member[]): Member[] {
+  return members.filter(
+    (member) =>
+      member.dir !== '<root>' &&
+      typeof member.manifest?.scripts?.[PEER_FLOOR_SCRIPT] === 'string',
+  );
+}
+
+/** argv for one package's floor typecheck via turbo. */
+export function peerFloorTurboArgs(packageName: string): string[] {
+  return ['run', PEER_FLOOR_SCRIPT, `--filter=${packageName}`];
+}
+
+/** One package's verdict → its Checks API payload. */
+export function toPeerFloorCheckRun(
+  result: PeerFloorResult,
+  repo: string,
+): CheckRunPayload {
+  const name = peerFloorCheckRunName(result.name);
+  if (result.ok) {
+    return {
+      name,
+      conclusion: 'success',
+      title: 'src typechecks against the published peer floor',
+      summary:
+        `\`${PEER_FLOOR_SCRIPT}\` passed: ${result.name}'s src compiles ` +
+        'against the pinned floor of its published peer range.',
+    };
+  }
+  return {
+    name,
+    conclusion: 'action_required',
+    title: 'floor stale: release the peer, then bump the publishedPeer floor',
+    summary: [
+      `\`${PEER_FLOOR_SCRIPT}\` failed: ${result.name}'s src uses API absent`,
+      'from the pinned floor of its declared peer range — consumers installed',
+      'at the floor would break.',
+      '',
+      `To resolve: [release the peer package via the bump-version workflow](${releaseWorkflowUrl(repo)}),`,
+      'then raise the catalog:publishedPeer floor and the peerFloor pin in',
+      'pnpm-workspace.yaml. This run re-checks and flips green on the floor',
+      'bump commit.',
+    ].join('\n'),
+    // details_url: not settable — GitHub pins GITHUB_TOKEN-created check runs to their own page
+  };
+}

--- a/tools/release/src/checks/peer-floor-check-runs.test.ts
+++ b/tools/release/src/checks/peer-floor-check-runs.test.ts
@@ -1,0 +1,100 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import type { Member } from '@tools/shared/workspace.ts';
+
+import {
+  peerFloorCheckRunName,
+  peerFloorMembers,
+  peerFloorTurboArgs,
+  toPeerFloorCheckRun,
+} from './peer-floor-check-runs.core.ts';
+
+const REPO = 'simshanith/lit-ui-router';
+const RELEASE_URL = `https://github.com/${REPO}/actions/workflows/bump-version.yml`;
+
+const members: Member[] = [
+  { name: '<root>', dir: '<root>', manifest: { scripts: {} } },
+  {
+    name: 'lit-ui-router',
+    dir: 'packages/lit-ui-router',
+    manifest: { scripts: { build: 'tsc' } },
+  },
+  {
+    name: 'lit-ui-router-mobx',
+    dir: 'packages/lit-ui-router-mobx',
+    manifest: {
+      scripts: { 'typecheck:peer-floor': 'node peer-floor-guard.ts' },
+    },
+  },
+];
+
+describe('peerFloorCheckRunName', () => {
+  it('composes the exact per-package run name', () => {
+    assert.equal(
+      peerFloorCheckRunName('lit-ui-router-mobx'),
+      'peer-floor (lit-ui-router-mobx)',
+    );
+  });
+});
+
+describe('peerFloorMembers', () => {
+  it('selects only members defining the script, never the root', () => {
+    assert.deepEqual(
+      peerFloorMembers(members).map((member) => member.name),
+      ['lit-ui-router-mobx'],
+    );
+  });
+
+  it('is empty when no package opts in — the tier stays inert', () => {
+    assert.deepEqual(peerFloorMembers(members.slice(0, 2)), []);
+  });
+});
+
+describe('peerFloorTurboArgs', () => {
+  it('runs the task filtered to the one package', () => {
+    assert.deepEqual(peerFloorTurboArgs('lit-ui-router-mobx'), [
+      'run',
+      'typecheck:peer-floor',
+      '--filter=lit-ui-router-mobx',
+    ]);
+  });
+});
+
+describe('toPeerFloorCheckRun', () => {
+  it('maps an honest floor to success', () => {
+    const payload = toPeerFloorCheckRun(
+      { name: 'lit-ui-router-mobx', ok: true },
+      REPO,
+    );
+    assert.equal(payload.conclusion, 'success');
+    assert.equal(payload.name, 'peer-floor (lit-ui-router-mobx)');
+    assert.equal(
+      payload.title,
+      'src typechecks against the published peer floor',
+    );
+    assert.doesNotMatch(payload.summary, /To resolve/);
+  });
+
+  it('maps a stale floor to action_required, never failure', () => {
+    const payload = toPeerFloorCheckRun(
+      { name: 'lit-ui-router-mobx', ok: false },
+      REPO,
+    );
+    assert.equal(payload.conclusion, 'action_required');
+    assert.equal(
+      payload.title,
+      'floor stale: release the peer, then bump the publishedPeer floor',
+    );
+  });
+
+  it('names the remedy path in a stale summary', () => {
+    const { summary } = toPeerFloorCheckRun(
+      { name: 'lit-ui-router-mobx', ok: false },
+      REPO,
+    );
+    assert.match(summary, new RegExp(`\\(${RELEASE_URL}\\)`));
+    assert.match(summary, /catalog:publishedPeer floor and the peerFloor pin/);
+    assert.match(summary, /flips green on the floor/);
+  });
+});

--- a/tools/release/src/checks/peer-floor-check-runs.ts
+++ b/tools/release/src/checks/peer-floor-check-runs.ts
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+// Tier-1 peer-floor signal: discover workspace packages defining the
+// typecheck:peer-floor script, run each package's floor typecheck via turbo,
+// and create one check run per package on the current HEAD. Runs turbo
+// per package because a stale floor must become an orange check run, never a
+// job failure — this exits 0 whatever the verdicts. Inert (no packages, no
+// runs) until a package defines the script. `--dry-run` runs the typechecks
+// but prints payloads instead of calling gh. Shaping is pure and unit-tested
+// in ./peer-floor-check-runs.core.ts.
+
+import { defaultExec } from '@tools/shared/exec.ts';
+import { ensureGh } from '@tools/shared/gh.ts';
+import { loadWorkspace, workspaceRoot } from '@tools/shared/workspace.ts';
+
+import {
+  peerFloorMembers,
+  peerFloorTurboArgs,
+  toPeerFloorCheckRun,
+  type PeerFloorResult,
+} from './peer-floor-check-runs.core.ts';
+import { checkRunApiArgs } from './publish-check-runs.core.ts';
+
+async function main() {
+  const dryRun = process.argv.includes('--dry-run');
+  const repo = process.env.GITHUB_REPOSITORY ?? 'simshanith/lit-ui-router';
+  if (!process.env.GITHUB_REPOSITORY && !dryRun) {
+    throw new Error('GITHUB_REPOSITORY must be set (or pass --dry-run)');
+  }
+
+  const { members } = await loadWorkspace(workspaceRoot);
+  const results: PeerFloorResult[] = [];
+  for (const member of peerFloorMembers(members)) {
+    let ok = true;
+    try {
+      await defaultExec('turbo', peerFloorTurboArgs(member.name), {
+        cwd: workspaceRoot,
+      });
+    } catch {
+      // a stale floor is a signal, not a job failure
+      ok = false;
+    }
+    console.log(`${member.name}: ${ok ? 'floor honest' : 'floor stale'}`);
+    results.push({ name: member.name, ok });
+  }
+
+  const payloads = results.map((result) => toPeerFloorCheckRun(result, repo));
+  if (dryRun) {
+    console.log(JSON.stringify(payloads, null, 2));
+    return;
+  }
+  if (payloads.length === 0) {
+    console.log('no packages define typecheck:peer-floor — nothing to report');
+    return;
+  }
+  const { stdout } = await defaultExec('git', ['rev-parse', 'HEAD']);
+  const headSha = stdout.trim();
+  await ensureGh();
+  for (const payload of payloads) {
+    await defaultExec('gh', checkRunApiArgs(repo, headSha, payload));
+    console.log(
+      `created check run "${payload.name}" (${payload.conclusion}) on ${headSha}`,
+    );
+  }
+}
+
+main().catch((error: unknown) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/tools/release/src/steps/release-peer-floor-gate.core.ts
+++ b/tools/release/src/steps/release-peer-floor-gate.core.ts
@@ -1,0 +1,39 @@
+// Pure decision for the bump-time peer-floor gate — tier 2 of the peer-floor
+// plan: a package whose floor claim is dishonest must not bump. Deadlock-free
+// by construction: the failure demands a PEER release, and that peer's own
+// bump never defines the script against itself. Packages opt in by defining
+// the typecheck:peer-floor script; everyone else skips. The IO (workspace
+// load, turbo) lives in ./release-peer-floor-gate.ts.
+
+import type { Member } from '@tools/shared/workspace.ts';
+
+import {
+  PEER_FLOOR_SCRIPT,
+  peerFloorTurboArgs,
+} from '../checks/peer-floor-check-runs.core.ts';
+
+export type GateDecision =
+  | { kind: 'skip'; reason: string }
+  | { kind: 'check'; turboArgs: string[] };
+
+/** Skip when the member doesn't opt in; otherwise the filtered turbo argv. */
+export function gateDecision(
+  packageName: string,
+  members: readonly Member[],
+): GateDecision {
+  const member = members.find(
+    (candidate) => candidate.name === packageName && candidate.dir !== '<root>',
+  );
+  if (member === undefined) {
+    throw new Error(
+      `package ${JSON.stringify(packageName)} is not a workspace member`,
+    );
+  }
+  if (typeof member.manifest?.scripts?.[PEER_FLOOR_SCRIPT] !== 'string') {
+    return {
+      kind: 'skip',
+      reason: `${packageName} defines no ${PEER_FLOOR_SCRIPT} script — gate does not apply`,
+    };
+  }
+  return { kind: 'check', turboArgs: peerFloorTurboArgs(packageName) };
+}

--- a/tools/release/src/steps/release-peer-floor-gate.test.ts
+++ b/tools/release/src/steps/release-peer-floor-gate.test.ts
@@ -1,0 +1,47 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import type { Member } from '@tools/shared/workspace.ts';
+
+import { gateDecision } from './release-peer-floor-gate.core.ts';
+
+const members: Member[] = [
+  { name: '<root>', dir: '<root>', manifest: { scripts: {} } },
+  {
+    name: 'lit-ui-router',
+    dir: 'packages/lit-ui-router',
+    manifest: { scripts: { build: 'tsc' } },
+  },
+  {
+    name: 'lit-ui-router-mobx',
+    dir: 'packages/lit-ui-router-mobx',
+    manifest: {
+      scripts: { 'typecheck:peer-floor': 'node peer-floor-guard.ts' },
+    },
+  },
+];
+
+describe('gateDecision', () => {
+  it('checks a package that defines the script, filtered to that package', () => {
+    assert.deepEqual(gateDecision('lit-ui-router-mobx', members), {
+      kind: 'check',
+      turboArgs: ['run', 'typecheck:peer-floor', '--filter=lit-ui-router-mobx'],
+    });
+  });
+
+  it('skips a package without the script — the peer bump is never blocked', () => {
+    const decision = gateDecision('lit-ui-router', members);
+    assert.equal(decision.kind, 'skip');
+    assert.match(
+      decision.kind === 'skip' ? decision.reason : '',
+      /defines no typecheck:peer-floor script/,
+    );
+  });
+
+  it('rejects a non-member before running anything', () => {
+    assert.throws(
+      () => gateDecision('nonexistent-package', members),
+      /not a workspace member/,
+    );
+  });
+});

--- a/tools/release/src/steps/release-peer-floor-gate.ts
+++ b/tools/release/src/steps/release-peer-floor-gate.ts
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+// Bump-time peer-floor gate — bump-version.yml's Peer floor gate step:
+//   env in: PACKAGE
+// Fails the bump when the package's src no longer typechecks against the
+// pinned floor of its published peer range (the floor pin can only reference
+// published versions, so the remedy is releasing the peer first — which this
+// gate never blocks). No-ops for packages without the script. Tier 1's check
+// run on the eventual floor-bump commit re-checks and flips green. Decisions
+// live in ./release-peer-floor-gate.core.ts.
+
+import { requireEnv } from '@tools/shared/env.core.ts';
+import { defaultStream } from '@tools/shared/exec.ts';
+import { runMain } from '@tools/shared/gha.ts';
+import { loadWorkspace, workspaceRoot } from '@tools/shared/workspace.ts';
+
+import { gateDecision } from './release-peer-floor-gate.core.ts';
+
+runMain(async () => {
+  const packageName = requireEnv(process.env, 'PACKAGE');
+  const { members } = await loadWorkspace(workspaceRoot);
+  const decision = gateDecision(packageName, members);
+  if (decision.kind === 'skip') {
+    console.log(decision.reason);
+    return;
+  }
+  // nonzero turbo exit propagates and fails the bump
+  await defaultStream('turbo', decision.turboArgs, { cwd: workspaceRoot });
+});


### PR DESCRIPTION
Originally stacked on #388; after #388's squash-merge (and #393's ci:main restructure landing on main) the branch was **rebased onto main** — only the one implementation commit replays, #388's pre-squash commits dropped, base now `main`. Pairs with #383, which defines the `typecheck:peer-floor` task this PR wires up (both tiers are inert-by-discovery until #383 lands — see below, merge order between #383 and this PR is free).

**Placement vs #393's `ci:main` convention** ("future main-only guards join ci:main's dependsOn, not new steps"): tier 1 deliberately does NOT join `ci:main`. That target is a *gating* graph — a failing task fails `build_and_test` and blocks `tag_push` — and its job has no `checks: write`. Tier 1 needs the opposite semantics: exit 0 on a stale floor, per-package check-run reporting via gh. `published-diff.yml` already carries exactly those (main-push trigger, checks:write, exit-0-on-signal), so the step lives there. If `ci:main` ever grows a non-gating reporting seam, tier 1 could migrate; noted, not restructured here. Tier 2 is untouched by #393 (bump-version.yml).

## Design

PR #382 made the `lit-ui-router` peer floor (`catalog:publishedPeer`, `^1.7.0`) a manual promise; #383 built `typecheck:peer-floor`, which typechecks mobx src against the *published* floor version instead of the always-latest workspace link. #383 deliberately keeps it out of the `ci` graph: gating PRs on it would break atomic cross-package changes (a new core API + its mobx adoption in one PR can never pass — the floor pin can only reference published versions). This PR lands the settled two-tier home:

- **Tier 1 — signal at merge time, non-gating.** On main pushes (and the post-publish `workflow_call`), `published-diff.yml` runs each opted-in package's `typecheck:peer-floor` and creates per-package check runs in the published-diff style: `peer-floor (<pkg>)`, `success` when the floor pin typechecks, `action_required` (renders orange) when stale, with the remedy in `output.title` — "floor stale: release the peer, then bump the publishedPeer floor". Never fails a job, never blocks tags. No `details_url` — GitHub pins `GITHUB_TOKEN`-created check runs to their own page.
- **Tier 2 — enforce at release intent.** A pre-bump step in `bump-version.yml` fails the bump of a package whose floor claim is dishonest. Deadlock-free by construction: the failure demands a *peer* release, and the peer's own bump skips the gate (it defines no `typecheck:peer-floor` script), so the remedy is never blocked by the gate itself.
- **Why not #388's "no tag on red main" gate:** an atomic core-API + mobx PR would make main red post-merge with the ONLY remedy (release core) blocked by the red — a designed deadlock. Floor staleness is per-package coordination debt, not global main breakage; #388's gate stays reserved for globally-shipped correctness (check:pack, dts floors).
- **Tier interaction:** tier 1's check run re-executes on every main push, so the floor-bump commit that resolves a stale verdict flips its own check green.

## Implementation

- `tools/release/src/checks/peer-floor-check-runs.core.ts` + `.ts` + `.test.ts` — tier 1, house style (pure shaping + IO shell + node:test). Discovers opted-in packages from **workspace manifests** (pnpm's own resolver via `@tools/shared/workspace`, no hardcoding): any non-root member defining a `typecheck:peer-floor` script. Runs turbo per package (filtered) so a stale floor becomes an orange check run instead of a job failure; exits 0 regardless of verdicts; reuses `checkRunApiArgs`/`CheckRunPayload` from `publish-check-runs.core.ts`. `--dry-run` runs the typechecks but prints payloads.
- `tools/release/src/steps/release-peer-floor-gate.core.ts` + `.ts` + `.test.ts` — tier 2. `PACKAGE` arrives via step env per house convention (same as the Bump step); non-members rejected, script-less members skip with a stated reason, opted-in members run `turbo run typecheck:peer-floor --filter=<pkg>` and a nonzero exit fails the bump.
- `tools/release/mise.toml` — `peer_floor_check_runs` and `peer_floor_gate` tasks.
- `.github/workflows/published-diff.yml` — "Peer floor check runs" step after the published-diff check runs.
- `.github/workflows/bump-version.yml` — "Peer floor gate" step before the bump.

**Inert-by-discovery:** on this branch (no #383) zero packages define the script, so tier 1 creates no check runs and tier 2 skips everything — both workflows stay green whichever of #383/this merges first. Deviation from the sketch: the workflow step is the reporting script itself (which invokes turbo per package), not a bare `turbo run typecheck:peer-floor` step — a bare turbo step would fail the job on a stale floor (violating never-fail) and, pre-#383, error on the undefined task.

## Evidence

Unit tests (`node --test`, in `turbo run test --filter=@tools/release`): 19 tasks green, including the stale `action_required` payload shape, the honest `success` shape, discovery (root excluded, script-less excluded), gate skip/check/reject decisions.

Dry-runs against real state:

Current branch (pre-#383, inert): tier 1 prints `[]`, exit 0; gate for `lit-ui-router` prints "defines no typecheck:peer-floor script — gate does not apply", exit 0.

With #383 merged locally (mobx floor currently HONEST — pin 1.7.0, range ^1.7.0):

```
lit-ui-router-mobx: floor honest
[ { "name": "peer-floor (lit-ui-router-mobx)", "conclusion": "success",
    "title": "src typechecks against the published peer floor", ... } ]
tier1 dry-run exit=0
gate (PACKAGE=lit-ui-router-mobx): turbo 1 successful — bump proceeds
gate (PACKAGE=lit-ui-router): skip — gate does not apply
```

With #383 merged + mobx src temporarily importing a nonexistent peer API (the stale failure mode):

```
lit-ui-router-mobx: floor stale
[ { "name": "peer-floor (lit-ui-router-mobx)", "conclusion": "action_required",
    "title": "floor stale: release the peer, then bump the publishedPeer floor", ... } ]
tier1 stale dry-run exit=0     <- signal, never a job failure
gate stale exit=1              <- fails the bump
```

All local evidence merges/demos reverted; the branch contains only the implementation.

**Not executable pre-merge:** the workflows themselves can't run from a PR branch (`published-diff.yml` targets main's head; `bump-version.yml` is dispatch-only from the default branch). Post-merge verification path: `workflow_dispatch` of Published Diff (tier 1) and a `dryRun: true` Bump version dispatch (tier 2).

Checks: repo-wide `turbo run lint typecheck format:check` green, `@tools/release` test/lint/typecheck/format green, `lint:workflows` green.
