### PR TITLE
ci(release): spike — workflow_call publish-npm to retire the tag-trigger PAT

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -141,7 +141,7 @@ jobs:
 
   tag_push:
     # Gated tagging: rides the same run as main CI, so a red build_and_test
-    # (Check pack included) means no tag, hence no publish trigger.
+    # (Check pack included) means no tag, hence no publish call below.
     # workflow_dispatch on Tag & push is the documented CI-bypass escape hatch.
     needs: build_and_test
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
@@ -150,5 +150,52 @@ jobs:
       # the caller job's grant.
       contents: write
     uses: ./.github/workflows/publish-gh.yml
+
+  detect_release:
+    # The tag-push event used to name the released package in its ref; with
+    # tags pushed by GITHUB_TOKEN (triggering nothing, by design), this job
+    # recovers the signal: which <package>@<version> tags point at the commit
+    # this run validated. Empty on ordinary main pushes — publish_npm skips.
+    needs: tag_push
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    outputs:
+      packages: ${{ steps.new_tags.outputs.packages }}
+    steps:
+      - name: 'Checkout code'
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+          # the tags tag_push just pushed must be present to point at HEAD
+          fetch-depth: 0
+          fetch-tags: true
+      - name: Setup mise
+        uses: jdx/mise-action@v4
+      - name: Install dependencies
+        run: mise run setup
+      - name: Detect new release tags
+        id: new_tags
+        run: mise run //tools/release:new_tags
+
+  publish_npm:
+    # One publish per freshly tagged package, inside the same green main run.
+    # npm trusted publishing binds to the CALLER workflow file: each
+    # package's npmjs.com trusted publisher names build-test.yml +
+    # environment `publish` (the called job's environment claim).
+    needs: detect_release
+    if: ${{ needs.detect_release.outputs.packages != '[]' }}
+    strategy:
+      matrix:
+        package: ${{ fromJSON(needs.detect_release.outputs.packages) }}
+    permissions:
+      id-token: write # OIDC trusted publishing; ceiling for the called job
+      contents: write # GitHub release
+      attestations: write # build provenance attestation
+      artifact-metadata: write
+    uses: ./.github/workflows/publish-npm.yml
+    with:
+      package: ${{ matrix.package }}
     secrets:
-      GH_PERSONAL_ACCESS_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -189,11 +189,15 @@ jobs:
     strategy:
       matrix:
         package: ${{ fromJSON(needs.detect_release.outputs.packages) }}
+    # Ceiling for the WHOLE nested call graph: GitHub validates at parse time
+    # that no nested job requests beyond these (actionlint/zizmor lint files
+    # independently and can't see cross-file ceilings).
     permissions:
-      id-token: write # OIDC trusted publishing; ceiling for the called job
+      id-token: write # OIDC trusted publishing
       contents: write # GitHub release
       attestations: write # build provenance attestation
       artifact-metadata: write
+      checks: write # nested published-diff.yml call creates the badge check runs
     uses: ./.github/workflows/publish-npm.yml
     with:
       package: ${{ matrix.package }}

--- a/.github/workflows/publish-gh.yml
+++ b/.github/workflows/publish-gh.yml
@@ -1,6 +1,8 @@
 # Automatic tagging workflow - called by build-test.yml after main's
 # build_and_test job succeeds.
-# Creates git tags for releases, which then trigger the NPM publish workflow.
+# Creates git tags for releases. The tags trigger nothing: publish-npm is
+# workflow_call'ed by build-test.yml after this job (detect_release names the
+# freshly tagged packages), so the push rides GITHUB_TOKEN — no PAT.
 # Uses release-it with --no-increment to tag the current version without bumping.
 #
 # YAML here is triggers/permissions/secrets/environment/concurrency only; the
@@ -14,11 +16,10 @@ on:
   # only): no tag unless the whole main CI run — build, tests, lint,
   # typecheck, check:pack — is green.
   workflow_call:
-    secrets:
-      GH_PERSONAL_ACCESS_TOKEN:
-        required: true
   # Manual dispatch bypasses the CI gate — hotfix escape hatch; the protected
-  # tag-release environment still gates authorization.
+  # tag-release environment still gates authorization. A dispatched tag
+  # triggers no publish (tags trigger nothing now): follow up with the
+  # publish escape hatch documented in publish-npm.yml.
   workflow_dispatch:
     inputs:
       dryRun:
@@ -65,18 +66,19 @@ jobs:
           # validated; dispatch runs check out the main tip.
           fetch-depth: 0
           fetch-tags: true
-          # PAT (not GITHUB_TOKEN): the pushed tag must trigger publish-npm,
-          # and the default token can't trigger other workflows. The push in
-          # //tools/release:tag_push rides these persisted credentials.
-          token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+          # GITHUB_TOKEN (job-scoped contents:write) persists on purpose: the
+          # push in //tools/release:tag_push rides these credentials. The tag
+          # need not trigger anything, so no PAT — GITHUB_TOKEN-created
+          # events spawning no workflows is now a feature, not a bug.
+          persist-credentials: true
       - name: Setup mise
         uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
         with:
           # task-env handling regressed before in unpinned mise; pin the version
           version: 2026.6.14
           # no restored tool cache (zizmor cache-poisoning): this job checks out
-          # with a persisted PAT, so a poisoned cache would run adjacent to live
-          # push credentials. Tools install fresh, checksum-verified against mise.lock.
+          # with persisted push credentials, so a poisoned cache would run
+          # adjacent to them. Tools install fresh, checksum-verified against mise.lock.
           cache: false
       - name: Install dependencies
         run: mise run setup
@@ -92,7 +94,7 @@ jobs:
           # dryRun is declared for workflow_dispatch only; called runs get an
           # empty value and always tag for real
           DRY_RUN: ${{ inputs.dryRun }}
-          GITHUB_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Push tag
         run: mise run //tools/release:tag_push
         # continue-on-error: a tag existing on the remote at a different commit is

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,5 +1,10 @@
-# NPM publish workflow - triggered by release tags.
-# Uses OIDC trusted publishing (no NPM_TOKEN needed).
+# NPM publish workflow - called by build-test.yml after main CI, tagging, and
+# release detection succeed (no tag trigger: the tag is pushed by
+# GITHUB_TOKEN earlier in the same chain and triggers nothing).
+# Uses OIDC trusted publishing (no NPM_TOKEN needed). SPIKE NOTE: npm's
+# trusted publisher validates the TOP-LEVEL (caller) workflow filename, so
+# each package's npmjs.com config must name build-test.yml — see the PR body
+# for the migration steps.
 # See: https://docs.npmjs.com/trusted-publishers
 # See: https://github.com/release-it/release-it/blob/19.2.2/docs/npm.md#trusted-publishing-oidc
 #
@@ -10,15 +15,27 @@
 name: Publish to NPM
 
 on:
-  push:
-    tags:
-      - 'lit-ui-router@*'
-      - 'lit-ui-router-mobx@*'
-      - 'ui-router-navigation-location-plugin@*'
+  # Called by build-test.yml's publish_npm job (needs: detect_release, one
+  # call per freshly tagged package): a publish happens only inside a green
+  # main CI run that just pushed the package's release tag.
+  workflow_call:
+    inputs:
+      package:
+        description: 'Package to publish (from build-test.yml detect_release)'
+        required: true
+        type: string
+    secrets:
+      TURBO_TOKEN:
+        required: false
+  # Escape-hatch dispatch. CAVEAT: npm's trusted publisher is bound to the
+  # caller workflow, which for a dispatch run is THIS file — a real publish
+  # from here fails the OIDC exchange unless the package's npmjs.com trusted
+  # publisher is temporarily repointed at publish-npm.yml. Dry runs never
+  # reach npm auth and always work.
   workflow_dispatch:
     inputs:
       package:
-        description: 'Package to publish (manual/dry-run testing only; real tag pushes derive this from the tag)'
+        description: 'Package to publish (see the OIDC caveat in this file: real publishes need the trusted publisher repointed)'
         required: true
         type: choice
         options:
@@ -38,7 +55,15 @@ env:
 jobs:
   publish_npm:
     runs-on: ubuntu-latest
-    # Protected environment adds approval gate before publishing
+    # Serialize per package across runs (call path and dispatch path share
+    # these groups): a re-run must not race a newer release of the same
+    # package. Job-level: GitHub ignores workflow-level concurrency in called
+    # workflows.
+    concurrency:
+      group: publish-npm-${{ inputs.package }}
+    # Protected environment adds approval gate before publishing. The OIDC
+    # token's environment claim is job-level, so it stays `publish` on the
+    # call path — npm's trusted publisher environment match keeps working.
     environment: publish
     permissions:
       id-token: write # Required for OIDC trusted publishing to NPM
@@ -65,7 +90,8 @@ jobs:
       - name: Install dependencies
         run: mise run setup
       - name: Resolve package
-        # tag → package name (hostile-refname safe) → workspace directory
+        # inputs.package (call and dispatch alike) → workspace directory; the
+        # tag-ref fallback is dead on both paths since `package` is required
         id: info
         run: mise run //tools/release:package_info
         env:
@@ -105,7 +131,8 @@ jobs:
         env:
           PACKAGE_NAME: ${{ steps.info.outputs.package_name }}
           TARBALL: ${{ steps.pack.outputs.tarball }}
-          # only set on manual workflow_dispatch runs; real tag pushes always publish for real
+          # dryRun is declared for workflow_dispatch only; called runs get an
+          # empty value and always publish for real
           DRY_RUN: ${{ inputs.dryRun }}
           # scoped here: only release-it's GitHub release needs it (npm auth is OIDC)
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -32,10 +32,14 @@ The release workflows use GitHub protected environments to ensure proper authori
 
 ### Environment Secrets
 
-- **`GH_PERSONAL_ACCESS_TOKEN`** - Used by `bump-version` and `tag-release` environments for:
+- **`GH_PERSONAL_ACCESS_TOKEN`** - Used by the `bump-version` environment for:
   - Creating branches
-  - Pushing tags
-  - Creating PRs that trigger downstream workflows
+  - Creating PRs that trigger downstream workflows (branches/PRs pushed with
+    `GITHUB_TOKEN` would not trigger CI)
+
+  Tagging and publishing no longer use the PAT: tags are pushed with
+  `GITHUB_TOKEN` and publish runs as a `workflow_call` in the same CI chain,
+  so nothing needs to be triggered by the tag event.
 
 This is a [Fine-Grained Personal Access Token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#fine-grained-personal-access-tokens) with **Read** and **Write** access to [artifact metadata](https://docs.github.com/en/rest/authentication/permissions-required-for-fine-grained-personal-access-tokens?apiVersion=2022-11-28#repository-permissions-for-artifact-metadata), [attestations api](https://docs.github.com/en/rest/authentication/permissions-required-for-fine-grained-personal-access-tokens?apiVersion=2022-11-28#repository-permissions-for-attestations), [code](https://docs.github.com/en/rest/authentication/permissions-required-for-fine-grained-personal-access-tokens?apiVersion=2022-11-28#repository-permissions-for-contents), and [pull requests](https://docs.github.com/en/rest/authentication/permissions-required-for-fine-grained-personal-access-tokens?apiVersion=2022-11-28#repository-permissions-for-pull-requests)
 
@@ -96,19 +100,22 @@ Creates a release PR by:
 
 ### 3. Tag & Push (`publish-gh.yml`)
 
-**Triggers:** Push to `main`
+**Triggers:** `workflow_call` from `build-test.yml` after main CI passes; manual dispatch as a CI-bypass escape hatch
 
-When a release PR merges:
+When a release PR merges (and main CI is green):
 
 1. Uses release-it to create a git tag (`lit-ui-router@X.Y.Z`)
-2. Pushes the tag to origin
-3. Tag push triggers the publish workflow
+2. Pushes the tag to origin with `GITHUB_TOKEN` (the tag triggers nothing)
 
 **Note:** Uses `continue-on-error: true` because tagging is idempotent - if the tag already exists, the workflow succeeds.
 
 ### 4. Publish to NPM (`publish-npm.yml`)
 
-**Triggers:** Tag push matching `lit-ui-router@*`
+**Triggers:** `workflow_call` from `build-test.yml`, once per package whose fresh release tag points at the validated commit (`detect_release`); manual dispatch for dry runs (see the OIDC caveat in the workflow file)
+
+npm trusted publishing binds to the **top-level caller workflow**, so each
+package's npmjs.com trusted publisher names `build-test.yml` with
+environment `publish`.
 
 The final release stage:
 
@@ -165,14 +172,17 @@ For prereleases like `1.2.3-beta.0`:
 ### Tag workflow not running
 
 - Verify the PR was merged (not closed)
-- Check that `GH_PERSONAL_ACCESS_TOKEN` has correct permissions
+- Check that main CI (`build-test.yml`) passed — tagging and publishing run
+  as downstream jobs of the same run
 - Ensure the `tag-release` environment is configured
 
 ### NPM publish failing
 
-- Verify OIDC trusted publishing is configured on npmjs.com
+- Verify OIDC trusted publishing is configured on npmjs.com — workflow file
+  `build-test.yml` (the caller), environment `publish`
 - Check that the `publish` environment exists
-- Ensure tag format matches `lit-ui-router@*`
+- Ensure the release tag `<package>@<version>` points at the merged main
+  head (detect_release selects packages by exactly that)
 
 ### Fork PRs not running CI
 

--- a/tools/release/mise.toml
+++ b/tools/release/mise.toml
@@ -67,6 +67,15 @@ flag "--dry-run" help="Print the ref that would be pushed, push nothing" env="DR
 '''
 run = 'PACKAGE="${usage_package?}" DRY_RUN="${usage_dry_run:-}" node src/steps/release-tag-push.ts'
 
+[tasks.new_tags]
+# outputs: packages (JSON array of package names). The workflow_call publish
+# fan-out's package selector — the tag-push event used to carry this in the ref.
+description = "List packages whose release tag points at the given commit"
+usage = '''
+flag "--sha <sha>" help="Commit to inspect (CI: the validated main head)" required=#true env="GITHUB_SHA"
+'''
+run = 'GITHUB_SHA="${usage_sha?}" node src/steps/release-new-tags.ts'
+
 [tasks.publish]
 # env: GITHUB_TOKEN (release-it's GitHub release; npm auth is OIDC).
 description = "Publish the packed tarball to npm and cut the GitHub release"

--- a/tools/release/src/steps/release-new-tags.core.ts
+++ b/tools/release/src/steps/release-new-tags.core.ts
@@ -1,0 +1,36 @@
+// Pure logic for recovering the "which package released?" signal without a
+// tag-push event: with tags pushed by GITHUB_TOKEN nothing is triggered, so
+// the publish fan-out instead asks which workspace members' <name>@<version>
+// release tags point at the commit this CI run validated. A tag that already
+// existed at an older commit (unbumped package) doesn't point here; a tag
+// rejected at a different commit doesn't either — only tags freshly created
+// for THIS commit select a publish. The IO (git tag --points-at, loading the
+// workspace) lives in release-new-tags.ts.
+
+import type { Member } from '@tools/shared/workspace.ts';
+import { releaseTagName } from './release-tag-push.core.ts';
+
+/**
+ * Names of publishable workspace members whose release tag is among
+ * `tagsAtCommit`. Root and private members never publish; a member with no
+ * version can't compose a tag and is skipped rather than thrown — detection
+ * scans every member, unlike tag_push which targets one.
+ */
+export function newlyTaggedPackages(
+  members: readonly Member[],
+  tagsAtCommit: readonly string[],
+): string[] {
+  const tags = new Set(
+    tagsAtCommit.map((tag) => tag.trim()).filter((tag) => tag !== ''),
+  );
+  return members
+    .filter(
+      (member) =>
+        member.dir !== '<root>' &&
+        member.manifest?.private !== true &&
+        typeof member.manifest?.version === 'string' &&
+        member.manifest.version.trim() !== '' &&
+        tags.has(releaseTagName(member.name, member.manifest.version)),
+    )
+    .map((member) => member.name);
+}

--- a/tools/release/src/steps/release-new-tags.test.ts
+++ b/tools/release/src/steps/release-new-tags.test.ts
@@ -1,0 +1,58 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import type { Member } from '@tools/shared/workspace.ts';
+import { newlyTaggedPackages } from './release-new-tags.core.ts';
+
+const members: Member[] = [
+  { name: 'lit-ui-router', dir: '<root>', manifest: { version: '0.0.0' } },
+  {
+    name: 'lit-ui-router',
+    dir: 'packages/lit-ui-router',
+    manifest: { version: '1.8.0' },
+  },
+  {
+    name: 'lit-ui-router-mobx',
+    dir: 'packages/lit-ui-router-mobx',
+    manifest: { version: '0.3.4' },
+  },
+  { name: 'docs', dir: 'docs', manifest: { private: true, version: '1.8.0' } },
+  { name: 'unversioned', dir: 'tools/unversioned', manifest: {} },
+];
+
+describe('newlyTaggedPackages', () => {
+  it('selects members whose <name>@<version> tag points at the commit', () => {
+    assert.deepEqual(newlyTaggedPackages(members, ['lit-ui-router@1.8.0']), [
+      'lit-ui-router',
+    ]);
+  });
+
+  it('handles multi-package releases and raw git stdout lines', () => {
+    assert.deepEqual(
+      newlyTaggedPackages(members, [
+        'lit-ui-router@1.8.0',
+        'lit-ui-router-mobx@0.3.4',
+        '', // trailing newline from git tag --points-at
+      ]),
+      ['lit-ui-router', 'lit-ui-router-mobx'],
+    );
+  });
+
+  it('ignores stale tags, root, private, and unversioned members', () => {
+    // an unbumped package's current-version tag points at an OLDER commit,
+    // so it never appears in tagsAtCommit; a same-named tag for root or a
+    // private member must not select a publish either
+    assert.deepEqual(
+      newlyTaggedPackages(members, [
+        'lit-ui-router@1.7.9', // no member at this version
+        'docs@1.8.0', // private
+        'unversioned@', // never composable
+      ]),
+      [],
+    );
+  });
+
+  it('returns empty for a no-release main push', () => {
+    assert.deepEqual(newlyTaggedPackages(members, ['']), []);
+  });
+});

--- a/tools/release/src/steps/release-new-tags.ts
+++ b/tools/release/src/steps/release-new-tags.ts
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+// Detect which packages were released at this commit — build-test.yml's
+// detect_release step:
+//   env in:  GITHUB_SHA (the validated main head)
+//   outputs: packages (JSON array of workspace package names)
+// The workflow_call replacement for the tag-push event's ref: tag_push runs
+// earlier in the same chain, so any <package>@<version> tag pointing at this
+// commit is a release this run just cut. Decisions live in
+// ./release-new-tags.core.ts.
+
+import { defaultExec } from '@tools/shared/exec.ts';
+import { requireEnv } from '@tools/shared/env.core.ts';
+import { runMain, setOutput } from '@tools/shared/gha.ts';
+import { newlyTaggedPackages } from './release-new-tags.core.ts';
+import { loadWorkspace, workspaceRoot } from '@tools/shared/workspace.ts';
+
+runMain(async () => {
+  const sha = requireEnv(process.env, 'GITHUB_SHA');
+  const { stdout } = await defaultExec('git', ['tag', '--points-at', sha], {
+    cwd: workspaceRoot,
+  });
+  const { members } = await loadWorkspace(workspaceRoot);
+  const packages = newlyTaggedPackages(members, stdout.split('\n'));
+  console.log(
+    packages.length === 0
+      ? '(no release tags point at this commit)'
+      : packages.join('\n'),
+  );
+  await setOutput('packages', JSON.stringify(packages));
+});

--- a/zizmor.yml
+++ b/zizmor.yml
@@ -9,7 +9,8 @@ rules:
     ignore:
       # PAT checkout persists by design: release-it pushes the release branch
       - bump-version.yml
-      # PAT checkout persists by design: pushes release tags to trigger publish-npm
+      # GITHUB_TOKEN checkout persists by design: pushes release tags
+      # (which trigger nothing; publish-npm is workflow_call'ed instead)
       - publish-gh.yml
   unpinned-uses:
     config:


### PR DESCRIPTION
> **SPIKE / PROPOSAL — draft on purpose, not a merge candidate as-is.**
> **Verdict: feasible, but NOT worth it right now.** The mechanics work (details below), but the PAT does **not** actually retire — `bump-version.yml` still needs it — and post-#388 the publish path is already transitively CI-gated. What this buys is removing the PAT from the tagging path only, at the price of a manual, per-package npmjs.com trusted-publisher migration, a weaker re-publish escape hatch, and new fan-out machinery in the CI chain. Recommend parking until npm supports reusable-workflow-aware trusted publishers (or a second strong motivation appears). The PR exists as the discussion vehicle and a ready-to-go implementation if we decide otherwise.

## Investigation findings

### 1. npm trusted publishing binds to the CALLER workflow (make-or-break — answered)

npm's own docs ([Trusted publishers](https://docs.npmjs.com/trusted-publishers), troubleshooting section):

> "Some GitHub Actions workflows use `workflow_call` to invoke other workflows that run `npm publish` […] When this happens, validation checks the **calling workflow's name** instead of the workflow that actually contains the publish command, which can cause configuration mismatches."

i.e. npm matches the top-level `workflow`/`workflow_ref` OIDC claim, **not** `job_workflow_ref` (the callee). Consequences:

- Making `publish-npm.yml` a callee of `build-test.yml` is **workable**: each package's npmjs.com trusted publisher must name `build-test.yml` (environment `publish` still matches — the environment claim is job-level and survives `workflow_call`).
- npm allows **one trusted publisher per package**, so the caller filename is exclusive: once repointed at `build-test.yml`, a direct `workflow_dispatch` of `publish-npm.yml` fails the OIDC exchange (its caller claim is `publish-npm.yml`). There is no way to trust both. ([npm docs](https://docs.npmjs.com/trusted-publishers), [open upstream question npm/documentation#1755](https://github.com/npm/documentation/issues/1755) — unanswered by npm staff.)
- The trusted identity also **widens**: today it is "the 113-line publish workflow"; after migration it is "any run of the whole CI workflow file that reaches environment `publish`". The environment approval gate still applies, but the named trust anchor becomes the busiest workflow in the repo.

### 2. Attestation is fine under workflow_call

`actions/attest-build-provenance` in a called workflow signs with the callee as *Build Signer URI* (`job_workflow_ref`) and the caller as *Build Config URI* — GitHub explicitly [recommends reusable workflows for SLSA Build L3](https://docs.github.com/actions/security-guides/using-artifact-attestations-and-reusable-workflows-to-achieve-slsa-v1-build-level-3). `gh attestation verify --repo simshanith/lit-ui-router` keeps working (same repo); pin with `--signer-workflow` if desired. Not a blocker; the certificate identity just changes shape once.

### 3. What the tag trigger provided, and its replacement

Today (post-#388) the tag push event carries **which package** released, in the ref (`tools/release/src/steps/release-package-info.core.ts` parses it). Under `workflow_call` there is no event, so this spike adds a `detect_release` job: after `tag_push`, `git tag --points-at <validated sha>` intersected with workspace `<name>@<version>` (new `//tools/release:new_tags`, core + unit tests) yields the fresh-release list, and `publish_npm` fans out one call per package (`strategy.matrix` over the JSON output). Ordering is `build_and_test → tag_push → detect_release → publish_npm` — the tag exists and points at the exact validated commit before publish is called. Ordinary main pushes detect `[]` and skip publish entirely. Stale tags (unbumped packages) point at older commits and never match; a tag rejected at a different commit never matches either — no accidental republish.

Version flow is unchanged: `release-publish.ts` reads it from the checked-out manifest via release-it, and the call path checks out the caller's `github.sha` = the tagged commit.

### 4. Ergonomics lost

- **Independent re-publish**: today a failed publish re-runs from the tag-triggered run, decoupled from CI. Under this design the equivalents are (a) re-run the failed `publish_npm` leg of the main run (works for transient failures), or (b) `workflow_dispatch` of `publish-npm.yml` — which now **requires temporarily repointing the package's npmjs.com trusted publisher at `publish-npm.yml` and back** (dry runs still work; they never reach npm auth). That is a manual, error-prone hotfix path compared to today.
- **Tag & push dispatch hatch**: a manually dispatched tag now triggers nothing (by design), so a CI-bypass release becomes two dispatches plus a publisher flip. The per-package `tag-release-<pkg>` job concurrency from #388 is untouched; `publish_npm` gains its own per-package group.
- **First-publish runbook**: unchanged in shape, but the trusted publisher for a new package must name `build-test.yml` from day one.

### 5. PAT blast radius — the headline benefit shrinks on inspection

All `GH_PERSONAL_ACCESS_TOKEN` references:

| Site | After this spike |
|---|---|
| `publish-gh.yml` checkout token + release-it `GITHUB_TOKEN` | **Removed** — `GITHUB_TOKEN` (job-scoped `contents: write`) pushes the tag; nothing needs the event to trigger workflows |
| `build-test.yml` `tag_push` secret pass-through | **Removed** |
| `bump-version.yml` (checkout/push of the release branch + `gh pr create`) | **Stays.** A branch/PR created with `GITHUB_TOKEN` triggers no CI, so the release PR would sit unbuildable. This is the same "GITHUB_TOKEN events trigger nothing" mechanism, and no workflow_call trick applies to PR creation. |
| Environment secrets (via API): `bump-version`, `tag-release`, `publish` all carry the PAT | `tag-release` and `publish` copies become removable (`publish` never referenced it in the workflow — it is already vestigial there). `bump-version` keeps it. |
| `RELEASE.md` | Updated in this diff |

So: **the PAT survives**; this change removes it from two environments and from the code path that runs adjacent to release-it + tag pushing. Real but partial hardening.

## Migration (if we ever take this) — ordered, with rollback

1. Merge this PR during a quiet window (no release PRs in flight). From this moment tags trigger nothing, so **do not** merge a release PR before step 2.
2. On npmjs.com, for **each** of `lit-ui-router`, `lit-ui-router-mobx`, `ui-router-navigation-location-plugin`: Package → Settings → Trusted publisher → edit the GitHub Actions publisher: workflow filename `publish-npm.yml` → **`build-test.yml`**, environment stays **`publish`**. (Manual, per-package; there is no API.)
3. Canary-rehearse with a throwaway prerelease (the #331 recipe): bump → merge → confirm the chain `build_and_test → tag_push → detect_release → publish_npm (1 leg)` publishes to a throwaway dist-tag, badge/published-diff refresh runs (`publish-npm.yml → published-diff.yml` nesting is 3 levels, within GitHub's 4-level limit).
4. Only then: remove `GH_PERSONAL_ACCESS_TOKEN` from the `tag-release` and `publish` environments (leave `bump-version`).
5. **Rollback** at any point: revert the merge commit (restores the tag trigger + PAT plumbing) and flip the three trusted publishers back to `publish-npm.yml`. The PAT is still in the environments until step 4, so rollback is one revert + three UI edits.

Verification items a canary must prove (not provable from here): `GITHUB_TOKEN` tag push is accepted with any tag rulesets in place; the OIDC exchange succeeds with the repointed publisher; environment approval UX on the fan-out legs.

## What's in the diff

- `.github/workflows/publish-npm.yml` — `workflow_call` (required `package` input, explicit `TURBO_TOKEN` secret) replaces the tag trigger; dispatch kept for dry runs with the OIDC caveat documented in-file; per-package job-level concurrency (workflow-level is ignored in callees).
- `.github/workflows/build-test.yml` — `detect_release` + `publish_npm` call jobs appended after `tag_push`; caller job carries the ceiling for the whole nested call graph: `id-token`/`contents`/`attestations`/`artifact-metadata` write for the publish job, plus `checks: write` for the nested `published-diff.yml` call. (`artifact-metadata` is a documented permission scope — GitHub's [fine-grained PAT permissions reference](https://docs.github.com/en/rest/authentication/permissions-required-for-fine-grained-personal-access-tokens) lists "Artifact metadata" with the artifact storage/deployment-record endpoints — and already runs live on main's `publish-npm.yml` since 1.7.1.)
- `.github/workflows/publish-gh.yml` — PAT out, `GITHUB_TOKEN` push with explicit `persist-credentials: true`; comments updated.
- `tools/release/` — `new_tags` mise task + `release-new-tags.{core,test,}.ts` (pure core, unit-tested; smoke-run locally: `packages=[]` on a non-release commit).
- `RELEASE.md`, `zizmor.yml` — updated to the end-state (existing `artipacked` ignore retained, comment corrected; `mise run lint_workflows` is green, zero new findings).

Nothing here can auto-fire a publish before the npm-side migration: without the npmjs.com repoint, a called publish run fails at the OIDC exchange, and no release PR is in flight. No environments, secrets, or npm settings were touched.

**Known verification gap (bit this PR's first push):** actionlint/zizmor lint workflow files independently and cannot validate nested `workflow_call` permission ceilings — only GitHub's parser does, at run creation. The first commit under-granted the `publish_npm` caller job (missing `checks: write` for the nested published-diff call) and Build and Test hit `startup_failure` with no run created; the follow-up commit unions every permission any nested job requests into the caller job's ceiling. Reviewing changes to any workflow in this call graph means re-checking the ceilings by hand (or watching whether a run actually starts).

Rebased on main at #374 (includes #388, #389, #390). `turbo run test lint typecheck format:check --filter=@tools/release` green locally.

