### PR TITLE
ci: schedule main-only guards via a ci:main turbo target

### DIFF
--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -99,6 +99,12 @@ run = 'turbo run "${usage_package_name?}#build"'
 description = "Run the full CI pipeline via turbo"
 run = "turbo run ci --ui=stream --log-order=stream"
 
+[tasks.ci_main]
+# Superset of `ci` (same env contract): adds the main-only guard tasks
+# (@tools/release#check:pack, @tools/dts-backtest#test:matrix) to the graph.
+description = "Run the main-push CI pipeline via turbo"
+run = "turbo run ci:main --ui=stream --log-order=stream"
+
 [tasks.dts_backtest_matrix]
 # Main-push companion to `ci`: PRs run only the current-TS dts-backtest leg.
 description = "Run the full dts-backtest TypeScript version matrix via turbo"

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -100,6 +100,7 @@ jobs:
       - name: Build and Test
         # TURBO_FORCE carries the deflake input through env (never `${{ }}`
         # in run lines); turbo parses ""/"false" as cache-respecting.
+        if: ${{ github.event_name != 'push' || github.ref != 'refs/heads/main' }}
         run: mise run ci
         env:
           TURBO_FORCE: ${{ inputs.force }}
@@ -109,25 +110,21 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
           # Silence per-request [wrangler:info] logging from the e2e dev server.
           WRANGLER_LOG: warn
-      - name: Check pack
-        # Main-push only (demoted from the per-PR ci graph); a failure here
-        # fails build_and_test, so the tag_push call job below never runs.
+      - name: Build and Test (main)
+        # ci:main = the PR graph plus the main-only guards (check:pack,
+        # dts-backtest full TS matrix) in one parallel turbo invocation; a
+        # failure fails build_and_test, so the tag_push call job never runs.
+        # Future main-only guards join ci:main's dependsOn, not new steps.
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-        run: mise run //tools/release:check_pack
+        run: mise run ci_main
         env:
+          TURBO_FORCE: ${{ inputs.force }}
           TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
           TURBO_API: ${{ vars.TURBO_API }}
           TURBO_TEAM: ${{ vars.TURBO_TEAM }}
-      - name: dts-backtest full TS matrix
-        # Old-TS consumer risk only materializes for shipped packages, so the
-        # full version matrix runs on main pushes (still gating any release);
-        # PR runs cover the current-TS leg inside `ci` above.
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-        run: mise run dts_backtest_matrix
-        env:
-          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-          TURBO_API: ${{ vars.TURBO_API }}
-          TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+          # Silence per-request [wrangler:info] logging from the e2e dev server.
+          WRANGLER_LOG: warn
       - name: Upload to Codecov
         # Branch-head runs skip upload; merge-head/main covers the same SHA.
         if: ${{ github.event_name != 'push' || github.ref == 'refs/heads/main' }}

--- a/turbo.json
+++ b/turbo.json
@@ -83,7 +83,7 @@
     "//#typecheck:root": {
       "inputs": ["$TURBO_DEFAULT$"]
     },
-    "ci": {
+    "ci:pull_request": {
       "dependsOn": [
         "build",
         "test",
@@ -98,6 +98,20 @@
     "check:bundle": {
       "dependsOn": ["transit"],
       "inputs": ["$TURBO_DEFAULT$"]
+    },
+    "ci:main": {
+      // PR graph plus the main-only guards, scheduled by one turbo
+      // invocation; future main-only guards join this dependsOn, not new
+      // workflow steps.
+      "dependsOn": [
+        "ci:pull_request",
+        "@tools/release#check:pack",
+        "@tools/dts-backtest#test:matrix"
+      ]
+    },
+    "ci": {
+      // back-compat alias: `mise run ci` / `pnpm run ci` keep working
+      "dependsOn": ["ci:pull_request"]
     },
     "codecov:bundle": {
       "dependsOn": ["build"],


### PR DESCRIPTION
Makes the main-push CI gate a first-class turbo target instead of serial workflow steps. Follow-up to #388 (check:pack main-push gate) and #389 (dts-backtest full matrix on main).

## Design

- `ci:pull_request` — exactly the previous `ci` graph (build, test, test:coverage, lint, typecheck, format:check, codecov:bundle).
- `ci:main` — `ci:pull_request` plus the main-only guards `@tools/release#check:pack` and `@tools/dts-backtest#test:matrix`, scheduled and parallelized by ONE turbo invocation instead of three serial `mise run` workflow steps.
- `ci` — back-compat alias (dependsOn `ci:pull_request`): the `mise run ci` / `pnpm run ci` contract keeps working unchanged.
- mise: new `ci_main` task (`turbo run ci:main`, same env contract as `ci`). The `dts_backtest_matrix` and `//tools/release:check_pack` mise tasks stay (ad-hoc use); they're just no longer wired into workflows.
- build-test.yml: the `Build and Test` step is now event-conditional — `mise run ci` on everything that isn't a main push (PRs, branch heads, workflow_dispatch), `mise run ci_main` on main pushes. The two main-push guard steps are deleted. The `tag_push` job's needs/gating is untouched: a ci:main failure fails `build_and_test`, so no tag.

**Extensibility win**: future main-only guards join `ci:main`'s `dependsOn` in turbo.json — no new workflow steps, no new env plumbing, and turbo parallelizes them against the rest of the graph instead of running them serially after it.

**Caching**: the ci umbrellas have no outputs and never did; member tasks keep their own names and hashes, so nothing aliases. `check:pack` and `test:matrix` cache exactly as before (distinct task names = distinct hash spaces).

## Verification

- `turbo run ci:main --dry-run`: 19× {ci:main, ci:pull_request, build, test, test:coverage, lint, typecheck, format:check, codecov:bundle} — the full PR graph — **plus exactly one `@tools/release#check:pack` and one `@tools/dts-backtest#test:matrix`**.
- `turbo run ci --dry-run`: same PR graph via the alias, **0 occurrences** of check:pack / test:matrix — per-PR behavior unchanged vs main.
- `turbo run @tools/release#check:pack` (real run): `✓ pack check passed — 3 publishable packages, all packed manifests fully substituted.`
- `mise run lint_workflows` (actionlint + zizmor): clean — "No findings to report."
- `mise run ci_main --help`: task registered.

## Post-merge caveat

The `ci_main` leg is push-to-main-gated and can't be exercised pre-merge; the first main push after merge should show a single `Build and Test (main)` step whose turbo summary includes check:pack and the dts-backtest matrix, followed by `tag_push` as before.
