### PR TITLE
docs: make Tutorial, Guides, Sample App sidebar groups collapsible

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -37,6 +37,7 @@ function makeSidebar() {
     },
     {
       text: 'Tutorial',
+      collapsed: true,
       items: [
         { text: 'Hello World', link: '/tutorial/helloworld' },
         { text: 'Hello Solar System', link: '/tutorial/hellosolarsystem' },
@@ -46,6 +47,7 @@ function makeSidebar() {
     },
     {
       text: 'Guides',
+      collapsed: true,
       items: [
         { text: 'Overview', link: '/guides/' },
         { text: 'Location Plugins', link: '/guides/location-plugins' },
@@ -96,6 +98,7 @@ function makeSidebar() {
     },
     {
       text: 'Sample App',
+      collapsed: true,
       items: [
         { text: 'Overview', link: '/sample-app' },
         { text: 'Vanilla', link: '/app', target: '_self' },


### PR DESCRIPTION
Adds `collapsed: true` to the Tutorial, Guides, and Sample App sidebar groups in the VitePress config so they start collapsed and get a collapse toggle (previously they were static, always-expanded groups).

VitePress auto-expands the group containing the active page, so navigating into a tutorial or guide still shows its section open. Note VitePress has no desktop-only knob — this applies to the mobile sidebar too, which is arguably a win there as well.

Verified: `turbo run build --filter=docs` passes.