### PR TITLE
build(lit-ui-router-mobx): adopt two-pass oxc-emit build

### DIFF
--- a/packages/lit-ui-router-mobx/package.json
+++ b/packages/lit-ui-router-mobx/package.json
@@ -23,7 +23,8 @@
     "directory": "packages/lit-ui-router-mobx"
   },
   "files": [
-    "dist/**"
+    "dist/**",
+    "src/*.ts"
   ],
   "type": "module",
   "sideEffects": false,
@@ -39,7 +40,8 @@
     "./package.json": "./package.json"
   },
   "scripts": {
-    "build": "tsc -p tsconfig.build.json",
+    "build:js": "oxc-emit-js",
+    "build:types": "oxc-emit-dts",
     "changelog": "release-it --changelog --git.tagMatch=\"lit-ui-router-mobx@[0-9]*.[0-9]*.[0-9]*\"",
     "check:bundle": "check-bundle-inputs",
     "codecov:bundle": "upload-entry-bundles",
@@ -51,12 +53,14 @@
     "test": "VITEST_BROWSER_API_PORT=63330 vitest run",
     "test:coverage": "VITEST_BROWSER_API_PORT=63335 vitest run --coverage",
     "typecheck": "tsc -p tsconfig.json --noEmit",
-    "typecheck:peer-floor": "node peer-floor-guard.ts && tsc -p tsconfig.peer-floor.json --noEmit"
+    "typecheck:peer-floor": "node peer-floor-guard.ts && tsc -p tsconfig.peer-floor.json --noEmit",
+    "typecheck:src": "tsc -p tsconfig.src.json --noEmit"
   },
   "devDependencies": {
     "@release-it/conventional-changelog": "catalog:",
     "@tools/bundle-probe": "workspace:*",
     "@tools/happy-dom": "workspace:*",
+    "@tools/oxc-emit": "workspace:*",
     "@tools/typedoc-plugin-lit-ui-router": "workspace:*",
     "@types/node": "catalog:",
     "@uirouter/core": "catalog:",

--- a/packages/lit-ui-router-mobx/src/reaction-controller.ts
+++ b/packages/lit-ui-router-mobx/src/reaction-controller.ts
@@ -49,7 +49,7 @@ export class ReactionController<T> implements ReactiveController {
     host.addController(this);
   }
 
-  hostConnected() {
+  hostConnected(): void {
     this.dispose = reaction(
       this.expression,
       (value) => {
@@ -61,7 +61,7 @@ export class ReactionController<T> implements ReactiveController {
     );
   }
 
-  hostDisconnected() {
+  hostDisconnected(): void {
     this.dispose?.();
     this.dispose = undefined;
   }

--- a/packages/lit-ui-router-mobx/src/router-reaction-controller.ts
+++ b/packages/lit-ui-router-mobx/src/router-reaction-controller.ts
@@ -63,7 +63,7 @@ export class RouterReactionController<T> implements ReactiveController {
     host.addController(this);
   }
 
-  hostConnected() {
+  hostConnected(): void {
     const router =
       this.options.router ?? UIRouterLitElement.seekRouter(this.host);
     if (!router) {
@@ -85,7 +85,7 @@ export class RouterReactionController<T> implements ReactiveController {
     );
   }
 
-  hostDisconnected() {
+  hostDisconnected(): void {
     this.dispose?.();
     this.dispose = undefined;
   }

--- a/packages/lit-ui-router-mobx/tsconfig.json
+++ b/packages/lit-ui-router-mobx/tsconfig.json
@@ -1,12 +1,13 @@
 {
-  // Tooling umbrella (IDE, tsgolint, typedoc): src + specs, no emit.
-  // The build emits via tsconfig.build.json.
-  "extends": "./tsconfig.build.json",
+  // tooling umbrella (IDE, tsgolint, typedoc): src + specs, no emit
+  "extends": "./tsconfig.src.json",
   "compilerOptions": {
     "rootDir": ".",
     "noEmit": true,
     // Specs import @tools/happy-dom's source-exported .ts files.
     "allowImportingTsExtensions": true,
+    // specs are exempt; typecheck:src enforces conformance
+    "isolatedDeclarations": false,
     "types": ["node", "vitest/globals"]
   },
   "include": [

--- a/packages/lit-ui-router-mobx/tsconfig.peer-floor.json
+++ b/packages/lit-ui-router-mobx/tsconfig.peer-floor.json
@@ -1,7 +1,7 @@
 {
   // Typechecks src against the published floor of the lit-ui-router peer range
   // (the lit-ui-router-floor alias), not the linked workspace copy. Never emits.
-  "extends": "./tsconfig.build.json",
+  "extends": "./tsconfig.src.json",
   "compilerOptions": {
     "noEmit": true,
     "paths": {

--- a/packages/lit-ui-router-mobx/tsconfig.src.json
+++ b/packages/lit-ui-router-mobx/tsconfig.src.json
@@ -6,8 +6,9 @@
     "outDir": "dist",
     "rootDir": "src",
     "declaration": true,
-    "sourceMap": true
+    // conformance guard for oxc-emit-dts, which never typechecks
+    "isolatedDeclarations": true
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "**/*.spec.ts"]
+  "exclude": ["node_modules", "dist", "**/*.spec.ts", "src/specs"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -642,6 +642,9 @@ importers:
       '@tools/happy-dom':
         specifier: workspace:*
         version: link:../../tools/happy-dom
+      '@tools/oxc-emit':
+        specifier: workspace:*
+        version: link:../../tools/oxc-emit
       '@tools/typedoc-plugin-lit-ui-router':
         specifier: workspace:*
         version: link:../../tools/typedoc-plugin-lit-ui-router


### PR DESCRIPTION
Sequenced adoption of the pass-split build convention from #369 (see also the sibling navigation-location-plugin PR). Diff is strictly inside `packages/lit-ui-router-mobx` + lockfile; root `turbo.json` untouched (the `^build`→`^build:types` edge drop is a follow-up after both adoptions).

## What changed
- `build` (tsc -p tsconfig.build.json) → `build:js` (`oxc-emit-js`) + `build:types` (`oxc-emit-dts`), composed by the root umbrella `build` task.
- `tsconfig.build.json` → `tsconfig.src.json` (scope-suffixed naming), `isolatedDeclarations: true` conformance guard + `typecheck:src` script; tooling umbrella `tsconfig.json` mirrors lit's (specs exempt).
- 4 isolatedDeclarations annotations: explicit `: void` on `hostConnected`/`hostDisconnected` in both controllers (the known debt, exactly 4).
- Sourcemap design per lit: src referents (`src/*.ts` added to `files`), composed js maps (no `sourcesContent`), new `.d.ts.map`s.
- `@tools/oxc-emit` added as devDep. **No** `@oxc-project/runtime` — this package uses no decorators, emitted JS imports no helpers (verified by grep over dist).

## Untouched by design
- `catalog:publishedPeer` peer on lit-ui-router, vitest alias to `../lit-ui-router/src`, `@types/node` catalog pin.

## Dist diff vs main (tsc baseline)
- **d.ts:** formatting-only — double quotes, tab indent, JSDoc `*` gutter alignment, trailing `sourceMappingURL` comment. All signatures/JSDoc content identical.
- **js:** comments stripped, class fields lowered to constructor assignments + `static {}` block (tsconfig.base `useDefineForClassFields: false` parity), tab-indented codegen. No helper imports.
- **Ship-affecting deltas (intended):** `dist/specs/test-utils.*` no longer ships (test-only, same fix #369 made for lit); `.d.ts.map`s and `src/*.ts` referents now ship; js maps switch from inline-adjacent tsc maps to composed src-referent maps.

## Verification (all local, foreground)
- `turbo run build --filter=lit-ui-router-mobx` — green, dist compared file-by-file to a stashed main baseline.
- `turbo run test test:coverage lint typecheck --filter=lit-ui-router-mobx` — 16/16 green.
- `turbo run check:pack` — green; `pnpm pack --dry-run` manifest shows dist + 4 src referents, no specs.
- `turbo run test --filter=@tools/dts-backtest` (current-TS leg over this dist's d.ts) — green.
- Root `format:check` — green.