### PR TITLE
build(navigation-location-plugin): adopt two-pass oxc-emit build

### DIFF
--- a/packages/navigation-location-plugin/package.json
+++ b/packages/navigation-location-plugin/package.json
@@ -22,7 +22,9 @@
     "directory": "packages/navigation-location-plugin"
   },
   "files": [
-    "dist/**"
+    "dist/**",
+    "src/*.ts",
+    "!src/*.spec.ts"
   ],
   "type": "module",
   "sideEffects": false,
@@ -38,7 +40,8 @@
     "./package.json": "./package.json"
   },
   "scripts": {
-    "build": "tsc -p tsconfig.build.json",
+    "build:js": "oxc-emit-js",
+    "build:types": "oxc-emit-dts",
     "changelog": "release-it --changelog --git.tagMatch=\"ui-router-navigation-location-plugin@[0-9]*.[0-9]*.[0-9]*\"",
     "check:bundle": "check-bundle-inputs",
     "codecov:bundle": "upload-entry-bundles navigation-location-plugin",
@@ -50,11 +53,13 @@
     "test": "VITEST_BROWSER_API_PORT=63340 vitest run --browser=chromium",
     "test:coverage": "VITEST_BROWSER_API_PORT=63345 vitest run --coverage --browser=chromium",
     "test:engines": "VITEST_BROWSER_API_PORT=63341 vitest run --project=firefox --project=safari",
-    "typecheck": "tsc -p tsconfig.json --noEmit"
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "typecheck:src": "tsc -p tsconfig.src.json --noEmit"
   },
   "devDependencies": {
     "@release-it/conventional-changelog": "catalog:",
     "@tools/bundle-probe": "workspace:*",
+    "@tools/oxc-emit": "workspace:*",
     "@tools/typedoc-plugin-lit-ui-router": "workspace:*",
     "@types/dom-navigation": "catalog:",
     "@types/node": "catalog:",

--- a/packages/navigation-location-plugin/src/index.ts
+++ b/packages/navigation-location-plugin/src/index.ts
@@ -97,7 +97,7 @@ export class NavigationLocationService extends BaseLocationServices {
    * @returns The current URL string (e.g., '/path?query=value#hash')
    * @internal
    */
-  protected _get() {
+  protected _get(): string {
     let { pathname, hash, search } = this._location;
     search = splitQuery(search)[1]; // strip ? if found
     hash = splitHash(hash)[1]; // strip # if found
@@ -122,7 +122,12 @@ export class NavigationLocationService extends BaseLocationServices {
    * @param replace - If true, replaces current entry instead of pushing
    * @internal
    */
-  protected _set(state: unknown, title: string, url: string, replace: boolean) {
+  protected _set(
+    state: unknown,
+    title: string,
+    url: string,
+    replace: boolean,
+  ): void {
     const basePrefix = this._getBasePrefix();
     const slash = url && !url.startsWith('/') ? '/' : '';
     const fullUrl =
@@ -144,7 +149,7 @@ export class NavigationLocationService extends BaseLocationServices {
    * Cleans up the location service by removing the navigation event listener.
    * @param router - The UIRouter instance
    */
-  public dispose(router: UIRouter) {
+  public dispose(router: UIRouter): void {
     super.dispose(router);
     globalRoot.navigation.removeEventListener(
       CURRENT_ENTRY_CHANGE_EVENT,
@@ -154,11 +159,12 @@ export class NavigationLocationService extends BaseLocationServices {
 }
 
 /** A [UIRouterPlugin](https://ui-router.github.io/core/docs/latest/interfaces/_interface_.uirouterplugin.html) that gets/sets the current location using the browser's `location` and `navigation` apis */
-export const navigationLocationPlugin = locationPluginFactory(
-  'vanilla.navigationLocation',
-  true,
-  NavigationLocationService satisfies {
-    new (uiRouter?: UIRouter): LocationServices;
-  },
-  BrowserLocationConfig,
-) satisfies (router: UIRouter) => LocationPlugin;
+export const navigationLocationPlugin: (router: UIRouter) => LocationPlugin =
+  locationPluginFactory(
+    'vanilla.navigationLocation',
+    true,
+    NavigationLocationService satisfies {
+      new (uiRouter?: UIRouter): LocationServices;
+    },
+    BrowserLocationConfig,
+  );

--- a/packages/navigation-location-plugin/tsconfig.json
+++ b/packages/navigation-location-plugin/tsconfig.json
@@ -1,10 +1,11 @@
 {
-  // Tooling umbrella (IDE, tsgolint, typedoc): src + specs, no emit.
-  // The build emits via tsconfig.build.json.
-  "extends": "./tsconfig.build.json",
+  // tooling umbrella (IDE, tsgolint, typedoc): src + specs, no emit
+  "extends": "./tsconfig.src.json",
   "compilerOptions": {
     "rootDir": ".",
     "noEmit": true,
+    // specs are exempt; typecheck:src enforces conformance
+    "isolatedDeclarations": false,
     "types": ["vitest/globals"]
   },
   "include": ["src/**/*", "vitest.config.ts"],

--- a/packages/navigation-location-plugin/tsconfig.src.json
+++ b/packages/navigation-location-plugin/tsconfig.src.json
@@ -6,8 +6,9 @@
     "outDir": "dist",
     "rootDir": "src",
     "declaration": true,
-    "sourceMap": true
+    // conformance guard for oxc-emit-dts, which never typechecks
+    "isolatedDeclarations": true
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "**/*.spec.ts"]
+  "exclude": ["node_modules", "dist", "**/*.spec.ts", "src/specs"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -702,6 +702,9 @@ importers:
       '@tools/bundle-probe':
         specifier: workspace:*
         version: link:../../tools/bundle-probe
+      '@tools/oxc-emit':
+        specifier: workspace:*
+        version: link:../../tools/oxc-emit
       '@tools/typedoc-plugin-lit-ui-router':
         specifier: workspace:*
         version: link:../../tools/typedoc-plugin-lit-ui-router


### PR DESCRIPTION
Second of the two sequenced adoption PRs following #369's pass-split build convention (sibling: lit-ui-router-mobx). Diff is strictly inside `packages/navigation-location-plugin` + lockfile.

## Changes
- Replace single `tsc -p tsconfig.build.json` build with `build:js` (oxc-emit-js) + `build:types` (oxc-emit-dts); root turbo's umbrella `build` sequences them.
- Rename `tsconfig.build.json` → `tsconfig.src.json` (scope-suffixed convention) with `isolatedDeclarations: true` as the conformance guard for oxc-emit-dts; umbrella `tsconfig.json` re-relaxes it for specs; new `typecheck:src` script.
- Four isolatedDeclarations conformance annotations in `src/index.ts`: explicit return types on `_get`/`_set`/`dispose`, and an explicit `(router: UIRouter) => LocationPlugin` annotation on `navigationLocationPlugin` (replacing the trailing `satisfies` of the same type).
- Sourcemap design B from #369: ship `src/*.ts` referents (`files` addition), composed `index.js.map`, new `index.d.ts.map` — both with single relative `../src/index.ts` source, no sourcesContent.
- `@tools/oxc-emit` devDep. No `@oxc-project/runtime` dependency needed — emitted JS uses no transform helpers (no decorators here).
- `@types/node` catalog pin and `@types/dom-navigation` untouched.

## dist diff vs main (pre-change baseline build)
- JS: byte-diff is oxc codegen formatting only (tabs, double quotes, comments stripped — comments never ship by design). Semantically identical.
- d.ts: equivalent modulo formatting, with **one semantic difference**: `navigationLocationPlugin` is now declared as `(router: UIRouter) => LocationPlugin` instead of tsc's inferred expansion `(uiRouter: UIRouter) => { name: string; service: LocationServices; configuration: LocationConfig; dispose: (router: UIRouter) => void; }`. The old structural type was already `satisfies`-checked against `(router: UIRouter) => LocationPlugin` on main, so this narrows the declaration to the named interface consumers were expected to use (param name also `uiRouter` → `router`, cosmetic).
- New file: `dist/index.d.ts.map` (declarationMap wasn't emitted before). `dist/index.js.map` sources now point at shipped `../src/index.ts` instead of embedding sourcesContent.

## Verification (all local, foreground)
- `turbo run build --filter=ui-router-navigation-location-plugin` green; dist tree compared against a main baseline build.
- `turbo run test test:coverage lint typecheck --filter=ui-router-navigation-location-plugin` green (typecheck now runs `typecheck:src` via `with`).
- `turbo run check:pack` green (fresh run, 3 publishable packages, manifests fully substituted).
- `turbo run test --filter=@tools/dts-backtest` green.
- Full `turbo run format:check` green.
- `pnpm pack --dry-run`: dist/{index.js,index.js.map,index.d.ts,index.d.ts.map} + src/index.ts.

Follow-up (not here): dropping `^build` from root typecheck lands after both adoption PRs.