### PR TITLE
ci(e2e): disable cypress video in CI by default

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -110,6 +110,8 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
           # Silence per-request [wrangler:info] logging from the e2e dev server.
           WRANGLER_LOG: warn
+          # Cypress video off in CI; configs keep video:true for local runs.
+          CYPRESS_video: 'false'
       - name: Build and Test (main)
         # ci:main = the PR graph plus the main-only guards (check:pack,
         # dts-backtest full TS matrix) in one parallel turbo invocation; a
@@ -125,6 +127,8 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
           # Silence per-request [wrangler:info] logging from the e2e dev server.
           WRANGLER_LOG: warn
+          # Cypress video off in CI; configs keep video:true for local runs.
+          CYPRESS_video: 'false'
       - name: Upload to Codecov
         # Branch-head runs skip upload; merge-head/main covers the same SHA.
         if: ${{ github.event_name != 'push' || github.ref == 'refs/heads/main' }}

--- a/turbo.json
+++ b/turbo.json
@@ -22,7 +22,9 @@
       "dependsOn": ["^test"],
       "inputs": ["src/**/*.ts", "vitest.config.ts", "cypress.config.ts"],
       "env": ["VITEST_BROWSER_API_PORT", "CI"],
-      "passThroughEnv": ["WRANGLER_LOG"]
+      // CYPRESS_video: CI disables Cypress recording (build-test.yml);
+      // strict env mode would scrub the override before it reaches Cypress.
+      "passThroughEnv": ["WRANGLER_LOG", "CYPRESS_video"]
     },
     "@tools/dts-backtest#test": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
Refs #387 — partially addresses it; the issue stays open for the opt-in half.

## What

CI-only, minimal scope per maintainer direction:

- `CYPRESS_video: 'false'` as step-level env on both `mise run ci` / `mise run ci_main` steps in `build-test.yml`. Cypress maps `CYPRESS_<key>` env vars onto config with higher precedence than the config file, so both configs keep `video: true` — `cypress open` and all local runs are untouched.
- `CYPRESS_video` added to the root `test` task's `passThroughEnv` in `turbo.json`: turbo's strict env mode would otherwise scrub the var before it reaches the e2e task (same reason `WRANGLER_LOG` is there).

No dispatch input, no artifact upload — see below.

## Deferred to #387: opt-in param + artifact upload

The re-enable knob is investigational pending a storage/cloud-cost discussion; an input that records videos with no retrieval path is a dead knob, so neither ships here. Concrete design for that discussion:

- `workflow_dispatch` input `cypressVideo` (boolean, default false); the step env becomes `CYPRESS_video: ${{ inputs.cypressVideo == true }}` (evaluates `'false'` on push/PR where `inputs` is empty; dispatch runs take the non-main `mise run ci` step, so the input reaches the right leg).
- `actions/upload-artifact@v7` step gated `if: ${{ !cancelled() && inputs.cypressVideo == true }}` (failure runs still upload — the debugging case) with `path: apps/sample-app-lit-e2e/cypress/videos*/`, which covers all five suites' videosFolders: `videos` (vanilla), `videos-docs`, `videos-hash`, `videos-mobx`, `videos-navigation`. zizmor policy: `actions/*` is ref-pin trusted.

Notes: `allowCypressEnv: false` in both configs is unrelated — it gates `Cypress.env()` exposure to browser code (#226), not `CYPRESS_*` config overrides. No `*.mp4` files are committed in-tree (`apps/sample-app-lit-e2e/.gitignore` ignores `cypress/`), so nothing to clean up.

## Verification (local)

- Control — one spec (`location_plugins.cy.js`), default config: passes, produces `cypress/videos/location_plugins.cy.js.mp4`.
- Same spec with `CYPRESS_video=false`: passes, **0** mp4 files, no "Compressing" step in output.
- Full chain through the exact CI path — `CYPRESS_video=false turbo run test --filter=sample-app-lit-e2e` (strict env → start-server-and-test → concurrently → 5 suites): `✓ e2e tests passed — 5/5 suites in 66.6s`, **0** mp4 files across all videosFolders (screenshots dirs only).
- `mise run lint_workflows` clean (zizmor + actionlint); `oxfmt --check` clean on both changed files.
