### PR TITLE
ci(e2e): cache sample-app-lit-e2e test via dependency-edged inputs

### DIFF
--- a/TURBO.md
+++ b/TURBO.md
@@ -77,7 +77,7 @@ Workspaces extend the root configuration using `"extends": ["//"]`:
 | ----------------------------- | ---------------------------------------------------------------------------- |
 | `packages/lit-ui-router`      | Adds `build:custom-elements` before build, configures `docs:api`             |
 | `apps/sample-app-lit-vanilla` | Adds env vars for build (VITE\_\*)                                           |
-| `apps/sample-app-lit-e2e`     | Disables test caching for e2e tests                                          |
+| `apps/sample-app-lit-e2e`     | Caches `test` via dependency edges; CYPRESS\_\* passes through un-hashed     |
 | `docs`                        | Adds `docs:preview`, `wrangler:dev` tasks, requires `^docs:api` before build |
 
 ## Common Commands

--- a/apps/sample-app-lit-e2e/turbo.json
+++ b/apps/sample-app-lit-e2e/turbo.json
@@ -8,7 +8,16 @@
     },
     "test": {
       "dependsOn": ["build", "^test"],
-      "cache": false
+      // $TURBO_DEFAULT$: the root task's globs miss the .cy.js specs; served
+      // content invalidates via the build edge to docs#build.
+      // wrangler.jsonc: `wrangler dev` discovers it upward at serve time.
+      "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/wrangler.jsonc"],
+      "env": ["CI"],
+      // CYPRESS_* is pass-through, not env: artifact knobs (video) must not
+      // affect cache validity.
+      "passThroughEnv": ["WRANGLER_LOG", "CYPRESS_*"],
+      // Videos/screenshots stay uncached side effects.
+      "outputs": []
     }
   }
 }


### PR DESCRIPTION
## What

`apps/sample-app-lit-e2e#test` (start-server-and-test wrangler dev + 5 concurrent Cypress suites, ~124 tests) ran `cache: false` on every PR. This flips it to a cached task so PRs that touch nothing the suite exercises skip it (~98s local, more in CI).

## Design: dependency edges over hand-listed cross-package inputs

Cross-package invalidation rides the existing task graph — no enumerated globs (repo rule: inputs must over-approximate):

```
test → build → ^build → docs#build → { examples#build:embeds, sample apps, packages/*, ui-router-server, types:worker }
```

`docs#build` hashes all of `docs/` via `$TURBO_DEFAULT$` (markdown, `.vitepress/`, `worker/`) and reaches root `wrangler.jsonc` through its `types:worker` edge; `docs#build`'s `outputs: dist/**` means a cache-restored build still materializes exactly what `wrangler dev` serves.

Own-package coverage: the inherited root `test` inputs (`src/**/*.ts`) matched only **4 files** — every `.cy.js` spec, both fixture and runner script, and `cypress.docs.config.ts` were unhashed. Now `$TURBO_DEFAULT$` (17 files: all 5 specs, runner, both configs, fixtures) plus `$TURBO_ROOT$/wrangler.jsonc` listed directly for explicitness (wrangler discovers config upward from `docs/` at serve time).

## Env

- `env: ["CI"]` — kept from the root task.
- `passThroughEnv: ["WRANGLER_LOG", "CYPRESS_*"]` — **deliberately un-hashed.** #387 adds a `CYPRESS_video` toggle in CI; video on/off changes artifacts, not results, so it must not invalidate (or wrongly validate) the cache. Pass-through makes it reach Cypress under turbo's strict env mode without entering the hash.
- `outputs: []` — videos/screenshots stay uncached side effects (gitignored).

## Verification (hash controls, `--dry-run=json`)

Baseline hash `8b9bda4dc6d1e7bd`. Each control appends a byte to one file, re-hashes, reverts.

| Control | File | Expectation | Result |
|---|---|---|---|
| P1 docs markdown | `docs/index.md` | change | ✅ CHANGED |
| P2 package src | `packages/lit-ui-router/src/index.ts` | change | ✅ CHANGED |
| P3 spec file | `apps/sample-app-lit-e2e/src/integration/sample_app.cy.js` | change | ✅ CHANGED |
| P4 sample app src | `apps/sample-app-lit-vanilla/src/main.ts` | change | ✅ CHANGED |
| P5 wrangler config | `wrangler.jsonc` | change | ✅ CHANGED |
| P6 worker src | `docs/worker/index.ts` | change | ✅ CHANGED |
| N1 unrelated tool | `tools/release/src/checks/resolve-published.ts` | no change | ✅ UNCHANGED |
| N2 workflow file | `.github/workflows/build-test.yml` | no change | ✅ UNCHANGED |

(`packages/lit-ui-router/README.md` also invalidates — over-approximation via the package's `$TURBO_DEFAULT$` build inputs, conservative by design.)

## Real run

Full local run on this branch: **5/5 suites green** (vanilla 91.3s, mobx 72.3s, docs 28.4s, hash 72.3s, navigation 90.2s; 1m38s wall). Immediate re-run: **cache hit, 473ms, FULL TURBO**, same hash `8b9bda4dc6d1e7bd`.
