### PR TITLE
ci: single vitest pass per PR — coverage carries correctness, engines matrix on main

### DIFF
--- a/packages/lit-ui-router/package.json
+++ b/packages/lit-ui-router/package.json
@@ -60,8 +60,9 @@
     "format": "oxfmt \"**/*.{ts,js,json,md}\"",
     "format:check": "oxfmt --check \"**/*.{ts,js,json,md}\"",
     "lint": "oxlint .",
-    "test": "VITEST_BROWSER_API_PORT=63320 vitest run",
+    "test": "VITEST_BROWSER_API_PORT=63320 vitest run --project=happy-dom --project=chrome",
     "test:coverage": "VITEST_BROWSER_API_PORT=63325 vitest run --coverage --project=happy-dom --project=chrome",
+    "test:engines": "VITEST_BROWSER_API_PORT=63321 vitest run --project=firefox --project=safari",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "typecheck:src": "tsc -p tsconfig.src.json --noEmit"
   },

--- a/packages/navigation-location-plugin/package.json
+++ b/packages/navigation-location-plugin/package.json
@@ -47,8 +47,9 @@
     "format": "oxfmt \"**/*.{ts,js,json,md}\"",
     "format:check": "oxfmt --check \"**/*.{ts,js,json,md}\"",
     "lint": "oxlint .",
-    "test": "VITEST_BROWSER_API_PORT=63340 vitest run",
+    "test": "VITEST_BROWSER_API_PORT=63340 vitest run --browser=chromium",
     "test:coverage": "VITEST_BROWSER_API_PORT=63345 vitest run --coverage --browser=chromium",
+    "test:engines": "VITEST_BROWSER_API_PORT=63341 vitest run --project=firefox --project=safari",
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "devDependencies": {

--- a/turbo.json
+++ b/turbo.json
@@ -20,7 +20,12 @@
     },
     "test": {
       "dependsOn": ["^test"],
-      "inputs": ["src/**/*.ts", "vitest.config.ts", "cypress.config.ts"],
+      "inputs": [
+        "src/**/*.ts",
+        "vitest.config.ts",
+        "vitest.setup.ts",
+        "cypress.config.ts"
+      ],
       "env": ["VITEST_BROWSER_API_PORT", "CI"],
       // CYPRESS_video: CI disables Cypress recording (build-test.yml);
       // strict env mode would scrub the override before it reaches Cypress.
@@ -38,9 +43,17 @@
     },
     "test:coverage": {
       "dependsOn": ["^build", "^test:coverage"],
-      "inputs": ["src/**/*.ts", "vitest.config.ts"],
+      "inputs": ["src/**/*.ts", "vitest.config.ts", "vitest.setup.ts"],
       "env": ["VITEST_BROWSER_API_PORT", "CI"],
       "outputs": ["coverage/**"]
+    },
+    // Firefox+WebKit full-suite pass for the vitest packages; chromium
+    // correctness rides test:coverage on PRs. Runs on main push, not the
+    // PR graph.
+    "test:engines": {
+      "dependsOn": ["^build"],
+      "inputs": ["src/**/*.ts", "vitest.config.ts", "vitest.setup.ts"],
+      "env": ["VITEST_BROWSER_API_PORT", "CI"]
     },
     "lint": {
       "with": ["//#lint:root", "//#lint:package-json", "//#lint:workflows"],
@@ -118,6 +131,7 @@
       // workflow steps.
       "dependsOn": [
         "ci:pull_request",
+        "test:engines",
         "@tools/release#check:pack",
         "@tools/dts-backtest#test:matrix"
       ]


### PR DESCRIPTION
## What

PRs were paying the vitest suites twice: `test` (all specs on every configured engine) **and** `test:coverage` (same specs again, instrumented). Per the agreed design, the coverage run carries correctness on PRs, and the cross-engine (firefox+webkit) pass becomes a main-only matrix. Rebased twice onto main (#391/#383 peer-floor, then #403 happy-dom split) — the engines matrix is reconciled with the post-#403 project layout.

## Final commands

| package | `test` (PR) | `test:coverage` (PR, correctness+coverage carrier) | `test:engines` (main only) |
|---|---|---|---|
| lit-ui-router | `vitest run --project=happy-dom --project=chrome` | `vitest run --coverage --project=happy-dom --project=chrome` (main's, unchanged) | `vitest run --project=firefox --project=safari` |
| navigation-location-plugin | `vitest run --browser=chromium` | `vitest run --coverage --browser=chromium` (main's, unchanged) | `vitest run --project=firefox --project=safari` |
| lit-ui-router-mobx | `vitest run` (happy-dom, main's, unchanged) | `vitest run --coverage` (main's, unchanged) | — (none, intentional) |

Selector note (verified empirically, vitest 4.1): with #403's `projects: [happy-dom, browser]` layout, browser-project *instances* are addressable directly as project names — `--project=chrome` / `--project=firefox` / `--project=safari` select single instances; there is no `browser (firefox)` compound name. Main's own `test:coverage --project=happy-dom --project=chrome` already relies on this; `test` and `test:engines` use the same mechanism. No vitest.config.ts files touched.

## No mobx engines leg — intentional, not lost coverage

After #403, lit-ui-router-mobx is happy-dom-only: no browser mode, no playwright instances — there are no engines to matrix. Its correctness+coverage carrier on PRs is the happy-dom `test:coverage` run (`vitest run --coverage`), i.e. a Node-side happy-dom environment, not a chromium pass. Cross-engine coverage correctly shrinks to lit-ui-router (`ui-sref.spec.ts` via its `browser` project — the only spec needing real gestures) + navigation-location-plugin (still real-browser instances).

## What runs where (dry-run + live verified)

- `ci:pull_request` / `ci`: zero `test:engines` occurrences. Vitest legs: lit happy-dom+chrome (plain + instrumented), nav chromium (plain + instrumented), mobx happy-dom (plain + instrumented). node --test packages and the cypress e2e app byte-identical to main behavior.
- `ci:main`: adds exactly two engines legs — lit `--project=firefox --project=safari` and nav `--project=firefox --project=safari` — alongside main's existing `@tools/release#check:pack` + `@tools/dts-backtest#test:matrix`. `typecheck:peer-floor` stays manual-only/workflow-wired per #391, preserved verbatim.
- New `test:engines` task in root turbo.json (`dependsOn: ["^build"]`, per-package ports 63321/63341) joins `ci:main`'s `dependsOn` per the post-#393 convention.
- Hygiene: `vitest.setup.ts` added to `test`/`test:coverage`/`test:engines` `inputs` (was missing — stale-cache hazard on setup-file edits).

## Measured (local, all green, 14/14 tasks)

- lit: `test` 165 tests/9.0s, `test:coverage` 165/9.2s, `test:engines` 50 tests (25 × firefox+safari)/12.7s
- nav: `test` 24/5.9s, `test:coverage` 24/5.9s, `test:engines` 48 (24 × 2 engines)/9.2s
- mobx: `test` 21/1.3s, `test:coverage` 21/1.2s

PRs shed the firefox+webkit browser work entirely (~22s of vitest wall-clock + 4 extra browser launches per uncached run); main pays it once per push, cached by the now-complete inputs.

## Local dev contract changes

- lit `pnpm test` = happy-dom + chromium instance (was: happy-dom + all 3 instances); nav `pnpm test` = chromium only (was 3 engines); mobx `pnpm test` unchanged.
- Full cross-engine run: `pnpm test:engines` (lit, nav) or `turbo run test:engines`.
- `mise run ci` drops only the duplicate firefox/webkit passes; `mise run ci_main` gains the engines matrix.
