### PR TITLE
test: move type-level tests out of runtime tiers + lint/turbo hygiene

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -368,6 +368,27 @@
       }
     },
     {
+      "files": [
+        "packages/ui-router-server/src/index.ts",
+        "packages/ui-router-server/src/redirects.ts",
+        "packages/ui-router-server/src/url-matcher.ts"
+      ],
+      "rules": {
+        "no-restricted-imports": [
+          "error",
+          {
+            "paths": [
+              {
+                "name": "@uirouter/core",
+                "allowTypeImports": true,
+                "message": "matcher tier stays core-free — a static @uirouter/core import defeats the lazy simulate boundary (treeshake.test.ts enforces the bundle); use `import type` or a dynamic import()."
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
       "files": ["tools/release/**/*.ts"],
       "rules": {
         "turbo/no-undeclared-env-vars": [

--- a/packages/lit-ui-router/src/specs/core.spec.ts
+++ b/packages/lit-ui-router/src/specs/core.spec.ts
@@ -447,7 +447,7 @@ describe('litViewsBuilder', () => {
     expect(typeof views?.$default.component).toBe('function');
   });
 
-  it('should register a bare argless LitElement class and deliver props via property (#244)', async () => {
+  it('should register a bare argless LitElement class and deliver props via property', async () => {
     @customElement('test-element-argless-1')
     class TestElement extends LitElement {}
 
@@ -495,10 +495,9 @@ describe('litViewsBuilder', () => {
   });
 });
 
-describe('typings regressions (#239)', () => {
+describe('typings regressions', () => {
   it('should recognize required-props templates as view declarations', () => {
-    // The assignability half lives in ./typings-regressions.types.ts,
-    // covered by `typecheck`; only the runtime guard call belongs here.
+    // Assignability half lives in ./typings-regressions.types.ts (typecheck).
     const template = (props: UIViewInjectedProps) =>
       html`<div>${props.transition?.from().name}</div>`;
     expect(isLitViewDeclarationTemplate(template)).toBe(true);

--- a/packages/lit-ui-router/src/specs/core.spec.ts
+++ b/packages/lit-ui-router/src/specs/core.spec.ts
@@ -496,19 +496,11 @@ describe('litViewsBuilder', () => {
 });
 
 describe('typings regressions (#239)', () => {
-  it('should accept required-props templates and Lit view declaration shapes', () => {
+  it('should recognize required-props templates as view declarations', () => {
+    // The assignability half lives in ./typings-regressions.types.ts,
+    // covered by `typecheck`; only the runtime guard call belongs here.
     const template = (props: UIViewInjectedProps) =>
       html`<div>${props.transition?.from().name}</div>`;
     expect(isLitViewDeclarationTemplate(template)).toBe(true);
-
-    // compiling without @ts-expect-error directives is the assertion
-    const stateDecl: LitStateDeclaration = {
-      name: 'typings-regression',
-      views: {
-        $default: template,
-        header: { component: () => html`<header>Header</header>` },
-      },
-    };
-    expect(Object.keys(stateDecl.views ?? {})).toHaveLength(2);
   });
 });

--- a/packages/lit-ui-router/src/specs/typings-regressions.types.ts
+++ b/packages/lit-ui-router/src/specs/typings-regressions.types.ts
@@ -1,0 +1,21 @@
+import { html } from 'lit';
+
+import type { LitStateDeclaration, UIViewInjectedProps } from '../interface.js';
+
+// Type-level regressions (#239) — compiling without @ts-expect-error
+// directives is the assertion, enforced by the package `typecheck` (the
+// umbrella tsconfig covers src/specs); never executed. The runtime half
+// (isLitViewDeclarationTemplate) lives in core.spec.ts.
+
+// A template with REQUIRED props must be accepted as a bare view declaration
+// alongside the object shape.
+export const template = (props: UIViewInjectedProps) =>
+  html`<div>${props.transition?.from().name}</div>`;
+
+export const stateDecl: LitStateDeclaration = {
+  name: 'typings-regression',
+  views: {
+    $default: template,
+    header: { component: () => html`<header>Header</header>` },
+  },
+};

--- a/packages/lit-ui-router/src/specs/typings-regressions.types.ts
+++ b/packages/lit-ui-router/src/specs/typings-regressions.types.ts
@@ -2,9 +2,8 @@ import { html } from 'lit';
 
 import type { LitStateDeclaration, UIViewInjectedProps } from '../interface.js';
 
-// Type-level regressions (#239) — compiling without @ts-expect-error
-// directives is the assertion, enforced by the package `typecheck` (the
-// umbrella tsconfig covers src/specs); never executed. The runtime half
+// Type-level regressions — the compile is the assertion (package `typecheck`;
+// umbrella tsconfig covers src/specs); never executed. Runtime half
 // (isLitViewDeclarationTemplate) lives in core.spec.ts.
 
 // A template with REQUIRED props must be accepted as a bare view declaration

--- a/packages/ui-router-server/test/upstream-seams.types.ts
+++ b/packages/ui-router-server/test/upstream-seams.types.ts
@@ -1,6 +1,4 @@
-import assert from 'node:assert/strict';
 import type { IncomingMessage, ServerResponse } from 'node:http';
-import { describe, it } from 'node:test';
 
 import type { Connect, Plugin, PreviewServer, ViteDevServer } from 'vite';
 
@@ -18,8 +16,9 @@ import type { ServerRouterPlugin, ViteMiddlewareServer } from '../src/vite.ts';
 // structural subset is only correct if it still MATCHES upstream where real
 // objects cross the seam. This file drift-guards that match at typecheck time:
 // `vite` and `@types/node` are dev-only, imported `import type` (erased, so
-// nothing ships and there's no test-runtime dep), and a diverged seam fails
-// `typecheck:tests`. Pure type-level — the runtime array is a plain [true × 6].
+// nothing ships), and a diverged seam fails `typecheck:tests`. Pure type-level
+// — the `.types.ts` name keeps it out of the node --test runtime glob; the
+// compile IS the assertion.
 
 // `true` iff From is assignable to To — tuple-wrapped so unions don't
 // distribute, honoring the same assignability the runtime relies on at a seam.
@@ -27,7 +26,7 @@ type AssignableTo<From, To> = [From] extends [To] ? true : false;
 
 // A diverged seam makes its slot's TYPE `false`, so the `true` initializer at
 // that position fails to compile ("Type 'true' is not assignable to 'false'").
-const seams: [
+export const seams: [
   // ./connect — a Connect stack (Express/Koa/Fastify/Vite, all on node:http)
   // hands the middleware real req/res, so each must satisfy the structural
   // param the middleware declares...
@@ -43,11 +42,3 @@ const seams: [
   AssignableTo<ViteDevServer, ViteMiddlewareServer>,
   AssignableTo<PreviewServer, ViteMiddlewareServer>,
 ] = [true, true, true, true, true, true];
-
-describe('structural host contracts', () => {
-  it('match upstream node:http and vite types at the seams', () => {
-    // The proof is the tuple's element types above (enforced by
-    // typecheck:tests); this only marks the file as exercised.
-    assert.deepEqual(seams, [true, true, true, true, true, true]);
-  });
-});

--- a/turbo.json
+++ b/turbo.json
@@ -51,7 +51,7 @@
       ]
     },
     "//#lint:root": {
-      "inputs": ["examples/**/*.{ts,js}", ".oxlintrc.json", "$TURBO_DEFAULT$"]
+      "inputs": [".oxlintrc.json", "$TURBO_DEFAULT$"]
     },
     "//#lint:package-json": {
       "inputs": [


### PR DESCRIPTION
Tier-4 grab-bag from the test audit: type-level tests move out of the runtime tiers, plus small hygiene. One commit per concern so any piece reverts cleanly.

## 1. `ui-router-server` upstream-seams → type-only fixture (8e1c0e3)

The `AssignableTo<>` tuple is pure type-level — the compile is the assertion, already enforced by `typecheck:tests`. Executing it under `node --test` only re-asserted a constant array. Renamed `test/upstream-seams.test.ts` → `test/upstream-seams.types.ts`: out of the `test/**/*.test.ts` runtime glob, still typechecked via `test/tsconfig.json`'s `"include": ["*.ts", ...]` (no glob change needed). The `node:test` scaffolding is stripped; `seams` is exported to avoid unused-locals.

**Negative test** — temporarily broke the first seam (`ConnectRequest & { seamBreak: true }`), `typecheck:tests` fails as required, then reverted:

```
test/upstream-seams.types.ts:44:6 - error TS2322: Type 'true' is not assignable to type 'false'.
44 ] = [true, true, true, true, true, true];
```

Suite went 427 → 426 tests, all passing (the removed one was the no-op runtime wrapper).

## 2. `lit-ui-router` #239 typings block → typecheck fixture (7401019)

The assignability half of the `typings regressions (#239)` block in `core.spec.ts` ("compiling without @ts-expect-error directives is the assertion") moves to `src/specs/typings-regressions.types.ts`, compiled by the umbrella `tsconfig.json` (`src/**/*` include → package `typecheck`), outside vitest's `src/specs/**/*.spec.ts` include, outside `tsconfig.src.json`'s isolatedDeclarations scope (`src/specs` excluded), and outside the published `files` globs (`src/*.ts` is top-level only). The runtime `isLitViewDeclarationTemplate(...)` call stays in the spec. Trivial rebase expected against the tier-3 happy-dom vitest-config PR — this edit is inside the spec file plus one new file.

## 3. Matcher-tier static-import lint (a0652f1)

New `.oxlintrc.json` override (modeled on the package's `no-restricted-globals` block): `no-restricted-imports` bans static `import ... from '@uirouter/core'` in the three matcher-tier modules — `src/index.ts`, `src/redirects.ts`, `src/url-matcher.ts` (the files `treeshake.test.ts`'s thesis protects; `src/simulate.ts` is the lazy tier and stays free to value-import core). `allowTypeImports: true` keeps the existing `import type` usage legal, and oxlint's rule doesn't flag dynamic `import()`. Complements the treeshake test (lint-time fail-fast); does not replace it.

**Negative test** — temporary static import appended to `src/index.ts`, then removed:

```
src/index.ts:377:1: error eslint(no-restricted-imports): '@uirouter/core' import is restricted from being used.
help: matcher tier stays core-free — a static @uirouter/core import defeats the lazy simulate boundary (treeshake.test.ts enforces the bundle); use `import type` or a dynamic import().
```

## 4. `//#lint:root` inputs hygiene (5c457d9)

The command runs `oxlint --ignore-pattern examples ...`, so `examples/**/*.{ts,js}` in its turbo inputs only busted the cache. Dropped; edit is exactly that input entry (root turbo.json is hot, rebases expected). Dry-run evidence: `//#lint:root` hashed **6463** `examples/` files before (the glob reached into untracked example `node_modules`), **22** after (just root `$TURBO_DEFAULT$` tracked files).

## 5. Orphaned `__screenshots__` baselines (no commit — local cleanup)

Deleted `packages/lit-ui-router/src/specs/__screenshots__/` (124K: 21 PNGs + a `.DS_Store`, dated 2026-01-02/03) from the working copy. Audit correction: no `toMatchScreenshot`/visual assertion has ever existed in tracked history (`git log -S toMatchScreenshot` is empty) — these were vitest browser-mode **failure** screenshots from the #68 unit-test bring-up (464bb16, 2026-01-03), not visual-regression baselines. The dir was gitignored (`**/specs/__screenshots__`, added in that same commit), so there is nothing to commit; the `.gitignore` line stays because vitest browser mode still writes failure screenshots there on any local spec failure.

## Verification

- `ui-router-server`: `typecheck`, `typecheck:tests`, `lint`, `format:check`, `test` (426 pass) green
- `lit-ui-router`: `typecheck`, `typecheck:src`, `lint`, `format:check`, `test` (27 files / 489 tests, 3 browsers) green
- Repo-wide `turbo run lint` (38 tasks) green under the new oxlint config; root `format:check`, `lint:root`, `lint:package-json` green
- `turbo run ci --dry-run=json` vs base 5ee810e: **task list identical**; every hash change traces to the three roots — `.oxlintrc.json` (input to every `lint` + root tasks), the two packages' file changes (+ their `^build`/transit dependents), and the `//#lint:root` task-definition edit
