### PR TITLE
test(docs): relocate worker contract assertions from cypress to node tests against the worker module

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -310,7 +310,8 @@
         "tools/shared/**/*.test.ts",
         "tools/workers-builds/**/*.test.ts",
         "packages/ui-router-server/test/**/*.test.ts",
-        "apps/sample-app-routes/test/**/*.test.ts"
+        "apps/sample-app-routes/test/**/*.test.ts",
+        "docs/worker/test/**/*.test.ts"
       ],
       "rules": {
         "typescript/no-floating-promises": "off"

--- a/apps/sample-app-lit-e2e/src/docs/docs_site.cy.js
+++ b/apps/sample-app-lit-e2e/src/docs/docs_site.cy.js
@@ -1,3 +1,8 @@
+// A browser smoke of the deployed docs site. The worker's HTTP contract
+// (statuses, redirects, noindex, shell aliasing, 404-page policy) lives in
+// docs/worker/test/worker.test.ts, run against the worker module itself; the
+// two cy.request specs kept here assert built-asset/assets-binding behavior
+// that has no lower-level home.
 describe('docs site', () => {
   it('renders the home page', () => {
     cy.visit('/');
@@ -49,13 +54,16 @@ describe('docs site', () => {
   });
 
   it('serves the embedded example apps same-origin', () => {
-    // Only embed-unique content proves the asset deployed, not a fallback.
+    // Built-asset coverage, not worker logic: only embed-unique content
+    // proves the asset deployed, not a fallback.
     cy.request('/examples/helloworld/')
       .its('body')
       .should('include', 'Hello World - lit-ui-router Tutorial');
   });
 
   it('serves a real 404 for unknown urls', () => {
+    // Assets-binding behavior (not_found_handling: "404-page"), not worker
+    // logic: the worker never runs for paths outside the mounts.
     cy.request({ url: '/definitely-missing', failOnStatusCode: false }).then(
       (response) => {
         expect(response.status).to.eq(404);
@@ -65,170 +73,11 @@ describe('docs site', () => {
     );
   });
 
-  it('serves the app shell for real routes under the spa mounts', () => {
-    for (const mount of ['/app', '/app-mobx']) {
-      // The root (hash-mode home) plus a static and a parameterized route.
-      for (const path of ['/', '/welcome', '/contacts/1/edit']) {
-        cy.request(`${mount}${path}`).then((response) => {
-          expect(response.status, `${mount}${path}`).to.eq(200);
-          // Prefix only: the mobx shell's title carries a " (MobX)" suffix.
-          expect(response.body).to.include('<title>UI-Router Lit sample app');
-          // Flagships are indexable; only the exhibits carry noindex.
-          expect(response.headers, `${mount}${path}`).to.not.have.property(
-            'x-robots-tag',
-          );
-        });
-      }
-    }
-  });
-
-  it('serves the per-app 404 page for unknown urls under the spa mounts', () => {
-    // The flagship rung (not-found-static): a dedicated 404 page, not the
-    // shell — 404/200 byte-identical shells read as soft-404s and muddy
-    // entrance analytics. The page drives the user back into its own app.
-    for (const mount of ['/app', '/app-mobx']) {
-      for (const path of [
-        '/definitely-not-a-route',
-        '/contacts/1/edit/extra',
-      ]) {
-        const url = `${mount}${path}`;
-        cy.request({ url, failOnStatusCode: false }).then((response) => {
-          expect(response.status, url).to.eq(404);
-          // Prefix only: the mobx page's title carries a " (MobX)" suffix.
-          expect(response.body).to.include(
-            '<title>404 | UI-Router Lit sample app',
-          );
-          expect(response.body).to.include(`href="${mount}/welcome"`);
-          expect(response.headers['content-type'], url).to.include('text/html');
-          // Not a route, so no canonical Link header (unlike shell 200s).
-          expect(response.headers, url).to.not.have.property('link');
-          // Flagships stay indexable; only the exhibits carry noindex.
-          expect(response.headers, url).to.not.have.property('x-robots-tag');
-        });
-      }
-    }
-  });
-
-  it('302s the flagship mount root — hash mode is not first-class there', () => {
-    // A hash client enters at the bare mount; the browser GETs it with the
-    // route in the (unsent) fragment. The flagship root 302s to /welcome,
-    // moving the browser to a new path — so a flagship mount can't host a hash
-    // app. That limitation is the reason for the dedicated /app-hash mount.
-    for (const mount of ['/app', '/app-mobx']) {
-      cy.request({ url: mount, followRedirect: false }).then((response) => {
-        expect(response.status, mount).to.eq(302);
-        expect(response.headers.location, mount).to.eq(`${mount}/welcome`);
-      });
-    }
-  });
-
-  it('serves the hash-demo shell at 200 at its root, with no redirect', () => {
-    // The dedicated hash mount: the fragment carries the route, so the server
-    // only ever sees the bare mount and must serve the shell there without a
-    // 302 (a redirect would strip the fragment's route on entry). Both the
-    // bare and trailing-slash forms answer 200 with the hash shell; the mount
-    // is a real demo, not an exhibit, so it stays indexable.
-    for (const url of ['/app-hash', '/app-hash/']) {
-      cy.request({ url, followRedirect: false }).then((response) => {
-        expect(response.status, url).to.eq(200);
-        expect(response.body, url).to.include(
-          '<title>UI-Router Lit sample app',
-        );
-        expect(response.headers, url).to.not.have.property('x-robots-tag');
-      });
-    }
-    // A mistyped deep path (never produced by a hash client) is an honest 404.
-    cy.request({
-      url: '/app-hash/no/such/route',
-      failOnStatusCode: false,
-    }).then((response) => {
-      expect(response.status).to.eq(404);
-    });
-  });
-
-  it('serves the shell at 200 for everything under the naive exhibit', () => {
-    // The not-found-naive rung: the classic SPA-host fallback (the soft-404
-    // anti-pattern baseline) — no server routing at all.
-    for (const url of [
-      '/not-found-naive',
-      '/not-found-naive/anything/at/all',
-    ]) {
-      cy.request(url).then((response) => {
-        expect(response.status, url).to.eq(200);
-        expect(response.body).to.include('<title>UI-Router Lit sample app');
-        // Exhibit responses opt out of indexing: this rung IS the soft-404.
-        expect(response.headers['x-robots-tag'], url).to.eq('noindex');
-      });
-    }
-  });
-
-  it('serves the honest-404 SPA exhibit — 200 for real routes, 404-shell for misses', () => {
-    // The /not-found-spa exhibit is the flagship shape plus one difference: a
-    // miss serves the app shell at an honest 404 (the `otherwise` projection —
-    // a status'd shell) instead of the flagship's static 404 page. Real routes
-    // and the root redirect earn a shell-200, exactly like the flagship.
-    cy.request({ url: '/not-found-spa', followRedirect: false }).then(
-      (response) => {
-        expect(response.status, '/not-found-spa').to.eq(302);
-        expect(response.headers.location).to.eq('/not-found-spa/welcome');
-        expect(response.headers['x-robots-tag']).to.eq('noindex');
-      },
-    );
-    // Real routes (static and parameterized) serve the shell at 200.
-    for (const path of ['/welcome', '/contacts/1/edit']) {
-      const url = `/not-found-spa${path}`;
-      cy.request(url).then((response) => {
-        expect(response.status, url).to.eq(200);
-        expect(response.body).to.include('<title>UI-Router Lit sample app');
-        expect(response.headers['x-robots-tag'], url).to.eq('noindex');
-      });
-    }
-    // A genuine miss serves the shell at an honest 404 — the body IS the app
-    // shell (the other 404 pattern, side by side with the flagship's static
-    // page), and a 404 carries no canonical Link.
-    for (const url of ['/not-found-spa/any/path', '/not-found-spa/nope']) {
-      cy.request({ url, failOnStatusCode: false }).then((response) => {
-        expect(response.status, url).to.eq(404);
-        expect(response.body).to.include('<title>UI-Router Lit sample app');
-        expect(response.headers, url).to.not.have.property('link');
-        expect(response.headers['x-robots-tag'], url).to.eq('noindex');
-      });
-    }
-  });
-
-  it('computes full router verdicts under the simulate exhibit', () => {
-    // The simulated-routing rung: same tables, every verdict computed by a
-    // headless @uirouter/core transition server-side.
-    cy.request({
-      url: '/simulated-routing/?flag=1',
-      followRedirect: false,
-    }).then((response) => {
-      expect(response.status).to.eq(302);
-      expect(response.headers.location).to.eq(
-        '/simulated-routing/welcome?flag=1',
-      );
-      expect(response.headers['x-robots-tag']).to.eq('noindex');
-    });
-    cy.request('/simulated-routing/welcome').then((response) => {
-      expect(response.status).to.eq(200);
-      expect(response.body).to.include('<title>UI-Router Lit sample app');
-      expect(response.headers['x-robots-tag']).to.eq('noindex');
-    });
-    cy.request({
-      url: '/simulated-routing/garbage',
-      failOnStatusCode: false,
-    }).then((response) => {
-      expect(response.status).to.eq(404);
-      expect(response.body).to.include('<title>UI-Router Lit sample app');
-      expect(response.headers['x-robots-tag']).to.eq('noindex');
-    });
-  });
-
   it('renders real routes client-side under every aliased exhibit', () => {
-    // The regression this fix addresses. Each exhibit now ships its own build
-    // whose VITE_SAMPLE_APP_BASE_URL matches its prefix, so the client router
-    // strips that prefix and renders the real route — where the shared /app
-    // shell used to resolve every foreign prefix to the in-app 404 (e.g.
+    // The regression this fix addresses. Each aliased exhibit serves the one
+    // base-agnostic vanilla shell, whose client derives its base from
+    // location.pathname at boot and renders the real route — where the shared
+    // /app shell used to resolve every foreign prefix to the in-app 404 (e.g.
     // "No state matched the URL /simulated-routing/welcome").
     for (const mount of [
       '/not-found-spa',
@@ -241,14 +90,11 @@ describe('docs site', () => {
     }
   });
 
-  it('shows the soft-404: naive serves 200, the client renders its 404 view', () => {
+  it('shows the soft-404: the client renders its 404 view on a naive miss', () => {
     // The naive rung's whole lesson: the server answers 200 for a path that
-    // does not exist (bad for crawlers), yet the client — now correctly based
-    // at /not-found-naive/ — resolves it to the in-app 404 view. Server and
-    // client disagree; that gap IS the anti-pattern.
-    cy.request('/not-found-naive/definitely-not-a-route')
-      .its('status')
-      .should('eq', 200);
+    // does not exist (pinned in the worker's node tests), yet the client —
+    // correctly based at /not-found-naive/ — resolves it to the in-app 404
+    // view. Server and client disagree; that gap IS the anti-pattern.
     cy.visit('/not-found-naive/definitely-not-a-route');
     cy.contains('404 Page Not Found');
   });

--- a/docs/package.json
+++ b/docs/package.json
@@ -12,9 +12,10 @@
     "format": "oxfmt \"**/*.{md,json,ts,vue}\"",
     "format:check": "oxfmt --check \"**/*.{md,json,ts,vue}\"",
     "lint": "oxlint .",
+    "test": "node --test \"worker/test/*.test.ts\"",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "typecheck:vue": "vue-check docs/tsconfig.vue.json",
-    "typecheck:worker": "tsc -p worker/tsconfig.json --noEmit",
+    "typecheck:worker": "tsc -p worker/tsconfig.json --noEmit && tsc -p worker/test/tsconfig.json --noEmit",
     "types:worker": "wrangler types worker/worker-configuration.d.ts",
     "wrangler:dev": "wrangler dev"
   },
@@ -30,6 +31,7 @@
   "devDependencies": {
     "@tools/build_and_test": "workspace:*",
     "@tools/vue-check": "workspace:*",
+    "@types/node": "catalog:",
     "oxfmt": "catalog:",
     "typescript": "catalog:",
     "vite": "catalog:",

--- a/docs/package.json
+++ b/docs/package.json
@@ -15,7 +15,8 @@
     "test": "node --test \"worker/test/*.test.ts\"",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "typecheck:vue": "vue-check docs/tsconfig.vue.json",
-    "typecheck:worker": "tsc -p worker/tsconfig.json --noEmit && tsc -p worker/test/tsconfig.json --noEmit",
+    "typecheck:worker": "tsc -p worker/tsconfig.json --noEmit",
+    "typecheck:worker:tests": "tsc -p worker/test/tsconfig.json --noEmit",
     "types:worker": "wrangler types worker/worker-configuration.d.ts",
     "wrangler:dev": "wrangler dev"
   },

--- a/docs/turbo.json
+++ b/docs/turbo.json
@@ -42,6 +42,12 @@
       "dependsOn": ["^build", "^docs:api"],
       "with": ["typecheck:vue", "typecheck:worker"]
     },
+    "test": {
+      // The worker contract tests run the worker module in node; workspace
+      // sources resolve directly (no build), but the root task's src/**
+      // inputs would miss worker/**, so over-approximate.
+      "inputs": ["$TURBO_DEFAULT$"]
+    },
     "typecheck:worker": {
       "dependsOn": ["^build", "types:worker"],
       "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/tsconfig.base.json"]

--- a/docs/turbo.json
+++ b/docs/turbo.json
@@ -40,7 +40,7 @@
     },
     "typecheck": {
       "dependsOn": ["^build", "^docs:api"],
-      "with": ["typecheck:vue", "typecheck:worker"]
+      "with": ["typecheck:vue", "typecheck:worker", "typecheck:worker:tests"]
     },
     "test": {
       // The worker contract tests run the worker module in node; workspace
@@ -49,6 +49,12 @@
       "inputs": ["$TURBO_DEFAULT$"]
     },
     "typecheck:worker": {
+      "dependsOn": ["^build", "types:worker"],
+      "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/tsconfig.base.json"]
+    },
+    "typecheck:worker:tests": {
+      // The worker module rides into the test graph, so the generated
+      // worker-configuration.d.ts must exist here too.
       "dependsOn": ["^build", "types:worker"],
       "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/tsconfig.base.json"]
     },

--- a/docs/worker/test/tsconfig.json
+++ b/docs/worker/test/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  // The node --test graph; only here do node types exist. The worker module
+  // rides in, so the generated worker-configuration.d.ts must too.
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "allowImportingTsExtensions": true,
+    "erasableSyntaxOnly": true,
+    "lib": ["ES2022"],
+    "types": ["node"]
+  },
+  "include": ["*.ts", "../index.ts", "../worker-configuration.d.ts"]
+}

--- a/docs/worker/test/worker.test.ts
+++ b/docs/worker/test/worker.test.ts
@@ -1,0 +1,231 @@
+import assert from 'node:assert/strict';
+import { beforeEach, describe, it } from 'node:test';
+
+import worker from '../index.ts';
+
+// The docs worker's HTTP contract, exercised on the production code path: the
+// real module (real sample-app-routes mounts, real ui-router-server fetch
+// adapter, the worker's own shell aliasing / noindex / 404-page policy) with
+// only the assets binding mocked. Which ASSET PATH the worker fetches is the
+// assertion that replaces the old Cypress body-title checks — the built
+// bodies themselves stay covered by the docs suite's cy.visit smokes.
+const ORIGIN = 'http://docs.test';
+
+// Stand-ins for docs/dist: the three shell builds, the flagship 404 pages,
+// and a default that plays the binding's own 404.html handling.
+const ASSET_TABLE: Record<string, { body: string; headers: HeadersInit }> = {
+  '/app': { body: 'vanilla-shell', headers: { 'Content-Type': 'text/html' } },
+  '/app-mobx': { body: 'mobx-shell', headers: { 'Content-Type': 'text/html' } },
+  '/app-hash': { body: 'hash-shell', headers: { 'Content-Type': 'text/html' } },
+  '/app/404.html': {
+    body: 'vanilla-404-page',
+    headers: { 'Content-Type': 'text/html; charset=utf-8' },
+  },
+  '/app-mobx/404.html': {
+    body: 'mobx-404-page',
+    headers: { 'Content-Type': 'text/html; charset=utf-8' },
+  },
+};
+
+// The worker feeds the binding Requests (shell, pass-through) and bare URLs
+// (the 404-page probe), so normalize both.
+const pathnameOf = (input: Request | URL | string): string =>
+  new URL(input instanceof Request ? input.url : String(input)).pathname;
+
+let assetCalls: string[] = [];
+beforeEach(() => {
+  assetCalls = [];
+});
+
+const env = {
+  ASSETS: {
+    fetch: (input: Request | URL | string) => {
+      const pathname = pathnameOf(input);
+      assetCalls.push(pathname);
+      const asset = ASSET_TABLE[pathname];
+      return Promise.resolve(
+        asset
+          ? new Response(asset.body, { status: 200, headers: asset.headers })
+          : new Response('binding-404-page', {
+              status: 404,
+              headers: { 'Content-Type': 'text/html' },
+            }),
+      );
+    },
+  },
+} as unknown as Parameters<typeof worker.fetch>[1];
+
+// Plain GETs, like the Cypress cy.request calls these tests replace; the
+// worker judges every request it receives (shouldHandle: () => true — it only
+// runs for the run_worker_first prefixes).
+const dispatch = (path: string) =>
+  worker.fetch(new Request(`${ORIGIN}${path}`), env);
+
+describe('flagship mounts (/app, /app-mobx)', () => {
+  it('serves each mount its own shell at 200 for real routes, indexable', async () => {
+    for (const mount of ['/app', '/app-mobx']) {
+      for (const path of ['/welcome', '/contacts/1/edit']) {
+        assetCalls = [];
+        const res = await dispatch(`${mount}${path}`);
+        assert.equal(res.status, 200, `${mount}${path}`);
+        // The flagship serves its OWN build (mobx bindings differ) — the old
+        // cy title check ("(MobX)" suffix) becomes the shell asset path.
+        assert.deepEqual(assetCalls, [mount], `${mount}${path}`);
+        assert.equal(await res.text(), ASSET_TABLE[mount].body);
+        // A matched route is canonical at the shell; flagships are indexable.
+        assert.equal(res.headers.get('Link'), `<${mount}>; rel="canonical"`);
+        assert.equal(res.headers.get('X-Robots-Tag'), null, `${mount}${path}`);
+      }
+    }
+  });
+
+  it('302s the mount root to /welcome — hash mode is not first-class there', async () => {
+    for (const mount of ['/app', '/app-mobx']) {
+      const res = await dispatch(mount);
+      assert.equal(res.status, 302, mount);
+      assert.equal(res.headers.get('Location'), `${mount}/welcome`, mount);
+      assert.equal(res.headers.get('X-Robots-Tag'), null, mount);
+    }
+  });
+
+  it('serves the per-app 404 page, re-wrapped at an honest 404', async () => {
+    for (const mount of ['/app', '/app-mobx']) {
+      for (const path of [
+        '/definitely-not-a-route',
+        '/contacts/1/edit/extra',
+      ]) {
+        assetCalls = [];
+        const res = await dispatch(`${mount}${path}`);
+        assert.equal(res.status, 404, `${mount}${path}`);
+        // The miss is mount-owned: the worker asked for that app's 404 page.
+        assert.deepEqual(assetCalls, [`${mount}/404.html`]);
+        assert.equal(await res.text(), ASSET_TABLE[`${mount}/404.html`].body);
+        // The page's own headers ride along (content-type included) …
+        assert.match(
+          res.headers.get('Content-Type') ?? '',
+          /text\/html/,
+          `${mount}${path}`,
+        );
+        // … but not a route, so no canonical Link, and still indexable.
+        assert.equal(res.headers.get('Link'), null, `${mount}${path}`);
+        assert.equal(res.headers.get('X-Robots-Tag'), null, `${mount}${path}`);
+      }
+    }
+  });
+});
+
+describe('/app-hash (the hash-location demo)', () => {
+  it('serves its own shell at 200 at the root, with no redirect', async () => {
+    // The fragment carries the route: a 302 at the bare mount would strip it
+    // on entry, so both root forms must answer 200 with the hash shell.
+    for (const path of ['/app-hash', '/app-hash/']) {
+      assetCalls = [];
+      const res = await dispatch(path);
+      assert.equal(res.status, 200, path);
+      assert.deepEqual(assetCalls, ['/app-hash'], path);
+      assert.equal(await res.text(), ASSET_TABLE['/app-hash'].body);
+      assert.equal(res.headers.get('Location'), null, path);
+      assert.equal(res.headers.get('X-Robots-Tag'), null, path);
+    }
+  });
+
+  it('answers an honest 404 for deep paths a hash client never produces', async () => {
+    const res = await dispatch('/app-hash/no/such/route');
+    assert.equal(res.status, 404);
+  });
+});
+
+describe('/not-found-naive (the soft-404 exhibit)', () => {
+  it('serves the vanilla shell at 200 for everything, noindexed', async () => {
+    // No routing at all — the classic SPA-host fallback, bypassing the
+    // router. Every response is the aliased vanilla shell at a lying 200;
+    // noindex quarantines the anti-pattern from crawlers.
+    for (const path of [
+      '/not-found-naive',
+      '/not-found-naive/anything/at/all',
+      '/not-found-naive/definitely-not-a-route',
+    ]) {
+      assetCalls = [];
+      const res = await dispatch(path);
+      assert.equal(res.status, 200, path);
+      assert.deepEqual(assetCalls, ['/app'], path);
+      assert.equal(await res.text(), ASSET_TABLE['/app'].body);
+      assert.equal(res.headers.get('X-Robots-Tag'), 'noindex', path);
+    }
+  });
+});
+
+describe('/not-found-spa (the honest-404 SPA exhibit)', () => {
+  it('302s the mount root to its welcome, noindexed', async () => {
+    const res = await dispatch('/not-found-spa');
+    assert.equal(res.status, 302);
+    assert.equal(res.headers.get('Location'), '/not-found-spa/welcome');
+    assert.equal(res.headers.get('X-Robots-Tag'), 'noindex');
+  });
+
+  it('serves the aliased vanilla shell at 200 for real routes', async () => {
+    for (const path of ['/welcome', '/contacts/1/edit']) {
+      assetCalls = [];
+      const res = await dispatch(`/not-found-spa${path}`);
+      assert.equal(res.status, 200, path);
+      // The exhibit has no build of its own: the mount-agnostic vanilla
+      // shell serves here (shellPath aliasing), deriving its base at boot.
+      assert.deepEqual(assetCalls, ['/app'], path);
+      assert.equal(await res.text(), ASSET_TABLE['/app'].body);
+      assert.equal(res.headers.get('X-Robots-Tag'), 'noindex', path);
+    }
+  });
+
+  it('serves the shell at an honest 404 for genuine misses', async () => {
+    for (const path of ['/not-found-spa/any/path', '/not-found-spa/nope']) {
+      assetCalls = [];
+      const res = await dispatch(path);
+      assert.equal(res.status, 404, path);
+      // The body IS the app shell (the `otherwise` projection — a status'd
+      // shell), not a static 404 page; a 404 carries no canonical Link.
+      assert.deepEqual(assetCalls, ['/app'], path);
+      assert.equal(await res.text(), ASSET_TABLE['/app'].body);
+      assert.equal(res.headers.get('Link'), null, path);
+      assert.equal(res.headers.get('X-Robots-Tag'), 'noindex', path);
+    }
+  });
+});
+
+describe('/simulated-routing (the simulate-strategy exhibit)', () => {
+  it('302s the root with the request search merged into the Location', async () => {
+    const res = await dispatch('/simulated-routing/?flag=1');
+    assert.equal(res.status, 302);
+    assert.equal(
+      res.headers.get('Location'),
+      '/simulated-routing/welcome?flag=1',
+    );
+    assert.equal(res.headers.get('X-Robots-Tag'), 'noindex');
+  });
+
+  it('serves the aliased vanilla shell at 200 for a computed match', async () => {
+    const res = await dispatch('/simulated-routing/welcome');
+    assert.equal(res.status, 200);
+    assert.deepEqual(assetCalls, ['/app']);
+    assert.equal(await res.text(), ASSET_TABLE['/app'].body);
+    assert.equal(res.headers.get('X-Robots-Tag'), 'noindex');
+  });
+
+  it('serves the shell at an honest 404 for a computed miss', async () => {
+    const res = await dispatch('/simulated-routing/garbage');
+    assert.equal(res.status, 404);
+    assert.deepEqual(assetCalls, ['/app']);
+    assert.equal(await res.text(), ASSET_TABLE['/app'].body);
+    assert.equal(res.headers.get('X-Robots-Tag'), 'noindex');
+  });
+});
+
+describe('outside the mounts', () => {
+  it('passes a mountless path straight through to the assets binding', async () => {
+    // In production the worker never sees these (run_worker_first scopes it
+    // to the mounts); if one ever reaches it, the binding still answers.
+    const res = await dispatch('/guides/');
+    assert.deepEqual(assetCalls, ['/guides/']);
+    assert.equal(res.status, 404);
+    assert.equal(res.headers.get('X-Robots-Tag'), null);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -511,6 +511,9 @@ importers:
       '@tools/vue-check':
         specifier: workspace:*
         version: link:../tools/vue-check
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.13.3
       oxfmt:
         specifier: 'catalog:'
         version: 0.58.0
@@ -519,13 +522,13 @@ importers:
         version: 7.0.2
       vite:
         specifier: 'catalog:'
-        version: 8.1.3(@types/node@25.0.9)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)
+        version: 8.1.3(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)
       vite-plugin-static-copy:
         specifier: 'catalog:'
-        version: 4.1.1(vite@8.1.3(@types/node@25.0.9)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 4.1.1(vite@8.1.3(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
       vitepress:
         specifier: 'catalog:'
-        version: 2.0.0-alpha.18(@types/node@25.0.9)(axios@1.18.1)(change-case@5.4.4)(esbuild@0.28.1)(jiti@2.7.0)(postcss@8.5.16)(typescript@7.0.2)(yaml@2.9.0)
+        version: 2.0.0-alpha.18(@types/node@24.13.3)(axios@1.18.1)(change-case@5.4.4)(esbuild@0.28.1)(jiti@2.7.0)(postcss@8.5.16)(typescript@7.0.2)(yaml@2.9.0)
       wrangler:
         specifier: 'catalog:'
         version: 4.110.0
@@ -7652,10 +7655,10 @@ snapshots:
 
   '@ungap/structured-clone@1.3.2': {}
 
-  '@vitejs/plugin-vue@6.0.7(vite@8.1.3(@types/node@25.0.9)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(vue@3.5.39(typescript@7.0.2))':
+  '@vitejs/plugin-vue@6.0.7(vite@8.1.3(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(vue@3.5.39(typescript@7.0.2))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
-      vite: 8.1.3(@types/node@25.0.9)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)
+      vite: 8.1.3(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)
       vue: 3.5.39(typescript@7.0.2)
 
   '@vitest/browser-playwright@4.1.10(playwright@1.61.1)(vite@8.1.3(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(vitest@4.1.10)':
@@ -10527,6 +10530,14 @@ snapshots:
       typescript: '@typescript/typescript6@6.0.2'
       vue-tsc: 3.3.7(@typescript/typescript6@6.0.2)
 
+  vite-plugin-static-copy@4.1.1(vite@8.1.3(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)):
+    dependencies:
+      chokidar: 3.6.0
+      p-map: 7.0.5
+      picocolors: 1.1.1
+      tinyglobby: 0.2.17
+      vite: 8.1.3(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)
+
   vite-plugin-static-copy@4.1.1(vite@8.1.3(@types/node@25.0.9)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)):
     dependencies:
       chokidar: 3.6.0
@@ -10563,7 +10574,7 @@ snapshots:
       jiti: 2.7.0
       yaml: 2.9.0
 
-  vitepress@2.0.0-alpha.18(@types/node@25.0.9)(axios@1.18.1)(change-case@5.4.4)(esbuild@0.28.1)(jiti@2.7.0)(postcss@8.5.16)(typescript@7.0.2)(yaml@2.9.0):
+  vitepress@2.0.0-alpha.18(@types/node@24.13.3)(axios@1.18.1)(change-case@5.4.4)(esbuild@0.28.1)(jiti@2.7.0)(postcss@8.5.16)(typescript@7.0.2)(yaml@2.9.0):
     dependencies:
       '@docsearch/css': 4.6.3
       '@docsearch/js': 4.6.3
@@ -10573,7 +10584,7 @@ snapshots:
       '@shikijs/transformers': 4.3.1
       '@shikijs/types': 4.3.1
       '@types/markdown-it': 14.1.2
-      '@vitejs/plugin-vue': 6.0.7(vite@8.1.3(@types/node@25.0.9)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(vue@3.5.39(typescript@7.0.2))
+      '@vitejs/plugin-vue': 6.0.7(vite@8.1.3(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(vue@3.5.39(typescript@7.0.2))
       '@vue/devtools-api': 8.1.5
       '@vue/shared': 3.5.39
       '@vueuse/core': 14.3.0(vue@3.5.39(typescript@7.0.2))
@@ -10582,7 +10593,7 @@ snapshots:
       mark.js: 8.11.1
       minisearch: 7.2.0
       shiki: 4.3.1
-      vite: 8.1.3(@types/node@25.0.9)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)
+      vite: 8.1.3(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)
       vue: 3.5.39(typescript@7.0.2)
     optionalDependencies:
       postcss: 8.5.16


### PR DESCRIPTION
Returns the docs Cypress suite to a true browser smoke by relocating its server-contract assertions to node tests that exercise the same code path. Relocation rule honored: new tests and cy removals land in this one PR — no coverage gap.

## Why the tests land where they do

Investigation of what answers these requests in production:

- `wrangler.jsonc` `run_worker_first` routes every mount prefix **including the bare roots** through `docs/worker/index.ts`. Every relocated `cy.request` assertion was answered by that module.
- The worker is a thin composition: `createServerRouter({ mounts })` over the real `sample-app-routes` tables + `ui-router-server/fetch`'s `createFetchHandler`, plus four pieces of **docs-specific policy** — the naive-exhibit router bypass, exhibit `X-Robots-Tag: noindex` layering, vanilla-shell aliasing (`shellPath`), and the per-app `404.html` re-wrap (`serveNotFound`).
- The **library** halves are already pinned lower: verdicts over the real mounts table in `apps/sample-app-routes/test/routes.test.ts`, and verdict→HTTP adapter mechanics (mergeSearch Locations, status'd-shell relabel, canonical Link, validator stripping) in `packages/ui-router-server/test/fetch.test.ts`. Re-asserting them in `ui-router-server/test/` against a copied config would NOT be the production code path.
- The only uncovered layer was the worker composition itself. The new `docs/worker/test/worker.test.ts` (13 tests, `node --test`) imports the worker's default export and dispatches real `Request`s at it, mocking **only** the `env.ASSETS` binding — identical production code end to end. The old body-title checks (which existed to prove *which* shell answered) become assertions on the exact asset path the worker fetches, which is stronger; that the built shells actually render stays covered by the remaining `cy.visit` smokes.

No changes to `packages/ui-router-server/` were needed — nothing the cy suite asserted was untested library behavior. (The planned commit scope `test(ui-router-server)` became `test(docs)` accordingly.)

## Assertion mapping (old cy spec → new owner)

| Old cy test (docs_site.cy.js) | New owner | Why same code path |
|---|---|---|
| serves the app shell for real routes under the spa mounts | `docs/worker/test/worker.test.ts` :: flagship mounts › *serves each mount its own shell at 200 for real routes, indexable* | worker module dispatch; own-shell asset path replaces the title check. The `/` leg (cy followed redirects) = root-302 test ∘ this test |
| 302s the flagship mount root | worker.test.ts :: flagship mounts › *302s the mount root to /welcome* | worker module dispatch (bare roots are `run_worker_first`) |
| serves the per-app 404 page for unknown urls under the spa mounts | worker.test.ts :: flagship mounts › *serves the per-app 404 page, re-wrapped at an honest 404* | worker's `serveNotFound` policy: `${mount}/404.html` probe, content-type ride-along, no Link, no noindex |
| serves the hash-demo shell at 200 at its root, with no redirect | worker.test.ts :: /app-hash › *serves its own shell at 200 at the root…* + *answers an honest 404 for deep paths…* | worker module dispatch over the real `hashDemo` mount |
| serves the shell at 200 for everything under the naive exhibit | worker.test.ts :: /not-found-naive › *serves the vanilla shell at 200 for everything, noindexed* | the worker's router-bypass branch + noindex wrapper |
| serves the honest-404 SPA exhibit — 200/302/404-shell | worker.test.ts :: /not-found-spa › *302s the mount root…*, *serves the aliased vanilla shell at 200…*, *serves the shell at an honest 404…* | worker dispatch; shell aliasing to `/app` asserted explicitly |
| computes full router verdicts under the simulate exhibit | worker.test.ts :: /simulated-routing › three tests (incl. `?flag=1` merged into the Location) | worker dispatch over the real `simulate`-strategy mount |
| shows the soft-404 (cy.request 200 half) | covered by the naive worker test above | — |
| shows the soft-404 (cy.visit half) | **stays in cy**, request line dropped | client-rendering is browser behavior |
| serves the embedded example apps same-origin | **stays in cy** (unchanged) | built-asset deployment (`examples/` embed copied into docs/dist) — no worker code involved; not provable at node level |
| serves a real 404 for unknown urls | **stays in cy** (unchanged) | assets-binding behavior (`not_found_handling: "404-page"`); the worker never runs outside the mounts — not provable at node level |
| home / SPA nav / API reference / ExampleEmbed / aliased-exhibit client routes / in-app 404 boot | **stay in cy** (unchanged) | the browser smokes |

Plus one new node test with no cy ancestor: *outside the mounts › passes a mountless path straight through to the assets binding* (the worker's `null` pass-through).

**Docs suite count: 16 → 9** (6 pure visit smokes + the visit-only soft-404 lesson + the 2 asset/binding request specs declared un-relocatable above).

## Plumbing

- `docs/package.json`: `test` script (`node --test "worker/test/*.test.ts"`), new scope-suffixed `typecheck:worker:tests` script (`tsc -p worker/test/tsconfig.json`) — `typecheck:worker` stays exactly what it checked before this PR — and `@types/node: catalog:` declared explicitly (was resolving via hoisting).
- `docs/turbo.json`: `test` task with over-approximated `$TURBO_DEFAULT$` inputs (root task's `src/**` inputs would miss `worker/**`); `typecheck:worker:tests` task (dependsOn `^build` + `types:worker`) added to `typecheck.with` alongside `typecheck:vue`/`typecheck:worker` — the ui-router-server `typecheck:tests` precedent. Root turbo.json untouched.
- `.oxlintrc.json`: `docs/worker/test/**/*.test.ts` added to the existing node-test `no-floating-promises` override list.
- `docs/worker/test/tsconfig.json`: node-typed graph including the worker module and the generated `worker-configuration.d.ts` (via the existing `types:worker` dependency).

## Verification (all local, foreground, logged)

- `turbo run test --filter=docs --filter=ui-router-server --filter=sample-app-routes` — green (13 new docs tests pass on the real worker module).
- Full e2e via `turbo run test --filter=sample-app-lit-e2e` against a local `wrangler dev` build: **5/5 suites green**, docs suite `9 passing`.
- `turbo run lint typecheck format:check` across docs, sample-app-lit-e2e, ui-router-server, sample-app-routes — green.
- `turbo run typecheck --filter=docs` fans out to all three `with` legs (`typecheck:vue`, `typecheck:worker`, `typecheck:worker:tests` — dry-run lists the new task; real run green). Negative proof: an injected type error in `worker.test.ts` fails exactly the `docs:typecheck:worker:tests` leg (TS2322), green again after revert; `format:check` green.

