### PR TITLE
ci: rename published-diff workflow to release-signals

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -119,6 +119,6 @@ jobs:
     permissions:
       checks: write
       contents: read
-    uses: ./.github/workflows/published-diff.yml
+    uses: ./.github/workflows/release-signals.yml
     secrets:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}

--- a/.github/workflows/release-signals.yml
+++ b/.github/workflows/release-signals.yml
@@ -1,8 +1,9 @@
-# Published-diff check runs on main's head — one per package, named
-# "published-diff (<pkg>)"; the README badges read them via shields'
-# check-runs endpoint. action_required renders orange = a release is owed,
-# never a CI failure, so this job succeeds whether or not drift exists.
-name: Published Diff
+# Non-gating release signals on main's head, reported as per-package check
+# runs: "published-diff (<pkg>)" (README badges read them via shields'
+# check-runs endpoint) and "peer-floor (<pkg>)". action_required renders
+# orange = a release/floor-bump is owed, never a CI failure — this job
+# succeeds whether or not any signal is orange.
+name: Release signals
 
 on:
   push:
@@ -33,7 +34,7 @@ env:
 # Literal group: github.workflow evaluates to the CALLER's name on
 # workflow_call, which would split called refreshes from push refreshes.
 concurrency:
-  group: published-diff
+  group: release-signals
   cancel-in-progress: true
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@
 
 Published diff status (orange = unreleased ship-affecting changes on `main`)
 
-[![lit-ui-router published diff](https://img.shields.io/github/check-runs/simshanith/lit-ui-router/main?nameFilter=published-diff%20%28lit-ui-router%29&label=lit-ui-router)](https://github.com/simshanith/lit-ui-router/actions/workflows/published-diff.yml?query=branch%3Amain)
-[![lit-ui-router-mobx published diff](https://img.shields.io/github/check-runs/simshanith/lit-ui-router/main?nameFilter=published-diff%20%28lit-ui-router-mobx%29&label=lit-ui-router-mobx)](https://github.com/simshanith/lit-ui-router/actions/workflows/published-diff.yml?query=branch%3Amain)
-[![ui-router-navigation-location-plugin published diff](https://img.shields.io/github/check-runs/simshanith/lit-ui-router/main?nameFilter=published-diff%20%28ui-router-navigation-location-plugin%29&label=ui-router-navigation-location-plugin)](https://github.com/simshanith/lit-ui-router/actions/workflows/published-diff.yml?query=branch%3Amain)
+[![lit-ui-router published diff](https://img.shields.io/github/check-runs/simshanith/lit-ui-router/main?nameFilter=published-diff%20%28lit-ui-router%29&label=lit-ui-router)](https://github.com/simshanith/lit-ui-router/actions/workflows/release-signals.yml?query=branch%3Amain)
+[![lit-ui-router-mobx published diff](https://img.shields.io/github/check-runs/simshanith/lit-ui-router/main?nameFilter=published-diff%20%28lit-ui-router-mobx%29&label=lit-ui-router-mobx)](https://github.com/simshanith/lit-ui-router/actions/workflows/release-signals.yml?query=branch%3Amain)
+[![ui-router-navigation-location-plugin published diff](https://img.shields.io/github/check-runs/simshanith/lit-ui-router/main?nameFilter=published-diff%20%28ui-router-navigation-location-plugin%29&label=ui-router-navigation-location-plugin)](https://github.com/simshanith/lit-ui-router/actions/workflows/release-signals.yml?query=branch%3Amain)
 
 ### lit-ui-router: State based routing for Lit (v2+)
 


### PR DESCRIPTION
The workflow now emits two signal families — `published-diff (<pkg>)` and `peer-floor (<pkg>)` check runs — so the file-level name shifts to what it actually is: the non-gating **release signals** workflow (per-package, check-run-reported, never blocks anything).

Mechanical rename with all touchpoints:
- `published-diff.yml` → `release-signals.yml`, `name: Release signals`, header comment covers both signal families
- `publish-npm.yml`'s `uses:` path
- README badge **link** targets (the badge images are untouched — shields' `nameFilter` keys on the check-run names, which keep their accurate per-signal identities)
- pinned `concurrency: group:` → `release-signals` (one transitional push may briefly run old- and new-group refreshes side by side; they're idempotent)

Check-run names, badge rendering, and all scripts are unchanged.