### PR TITLE
ci: bump actions/cache v4 to v6 — v4 targets deprecated Node 20

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -66,12 +66,12 @@ jobs:
         run: mise run //tools/build_and_test:cypress_version
       - name: Cache Playwright browsers
         id: playwright-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.playwright }}
       - name: Cache Cypress binary
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.cache/Cypress
           key: ${{ runner.os }}-cypress-${{ steps.cypress-version.outputs.cypress }}


### PR DESCRIPTION
Every `build_and_test` run on main warns:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/cache@v4.

(e.g. [run 29674606531](https://github.com/simshanith/lit-ui-router/actions/runs/29674606531))

The two `actions/cache@v4` uses are the Playwright/Cypress browser-binary cache steps in `build-test.yml`. v5 moved the action to the Node 24 runtime; v6 is the same interface after an ESM migration (v5.1.0 and v6.1.0 carry the identical read-only-cache fix). GitHub-hosted runners satisfy the ≥2.327.1 runner requirement, so bumping straight to v6.

`mise run lint_workflows` (actionlint + zizmor) is clean.