### PR TITLE
docs: sync mise/turbo/contributing docs with the ci:main restructure

### DIFF
--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -92,11 +92,12 @@ flag "--package-name <package_name>" help="Package to build (turbo <name>#build)
 run = 'turbo run "${usage_package_name?}#build"'
 
 [tasks.ci]
+# turbo's `ci` is the back-compat alias of `ci:pull_request`.
 # env: TURBO_FORCE + TURBO_TOKEN/TURBO_API/TURBO_TEAM, which turbo reads from
 # the env itself (no CLI flags), plus CODECOV_TOKEN and WRANGLER_LOG for the
 # underlying tasks. TURBO_FORCE is the build-test deflake input: a truthy value
 # forces a cache-bypassing rerun, ""/"false" respect the cache.
-description = "Run the full CI pipeline via turbo"
+description = "Run the pull-request CI pipeline via turbo"
 run = "turbo run ci --ui=stream --log-order=stream"
 
 [tasks.ci_main]
@@ -106,6 +107,6 @@ description = "Run the main-push CI pipeline via turbo"
 run = "turbo run ci:main --ui=stream --log-order=stream"
 
 [tasks.dts_backtest_matrix]
-# Main-push companion to `ci`: PRs run only the current-TS dts-backtest leg.
+# Ad-hoc alias for the full dts-backtest TS matrix; CI runs it via ci_main.
 description = "Run the full dts-backtest TypeScript version matrix via turbo"
 run = "turbo run test:matrix --ui=stream --log-order=stream"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,8 +33,8 @@ pnpm's isolated `node_modules` means a workspace member's devDep binaries (`vite
 # format check, bundle checks) — what every PR runs
 pnpm run ci
 
-# PR pipeline plus the main-only guards (pack check, dts-backtest TS matrix)
-# — what a push to main runs
+# PR pipeline plus the main-only guards (Firefox/WebKit vitest engines pass,
+# pack check, dts-backtest TS matrix) — what a push to main runs
 mise run ci_main
 
 # Run unit tests only

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,8 +29,13 @@ pnpm's isolated `node_modules` means a workspace member's devDep binaries (`vite
 ## Running Tests
 
 ```bash
-# Run all tests
+# Run the PR CI pipeline (build, tests, coverage, lint, typecheck,
+# format check, bundle checks) — what every PR runs
 pnpm run ci
+
+# PR pipeline plus the main-only guards (pack check, dts-backtest TS matrix)
+# — what a push to main runs
+mise run ci_main
 
 # Run unit tests only
 pnpm --filter lit-ui-router test
@@ -51,8 +56,10 @@ current TypeScript — they only matter if they leak into a declaration
 type inside a function body emits nothing and is fine).
 
 This is enforced in CI by [`tools/dts-backtest`](./tools/dts-backtest/README.md),
-which typechecks the built declarations with TypeScript 5.0.4 and the
-current version, in `bundler` and `NodeNext` resolution modes. If
+which typechecks the built declarations in `bundler` and `NodeNext`
+resolution modes. PRs run the current-TS leg (`@tools/dts-backtest#test`);
+pushes to `main` run the full TypeScript version matrix down to 5.0.4
+(`@tools/dts-backtest#test:matrix`, part of the `ci:main` graph). If
 `@tools/dts-backtest#test` fails on your change, keep the newer-TS construct out
 of the public surface — or raise the floor, which is a semver-major
 discussion (see the tool README).
@@ -125,7 +132,8 @@ Releases are handled by maintainers using GitHub Actions. See [RELEASE.md](./REL
 
 1. Maintainer triggers "Bump version" workflow
 2. Release PR is created and reviewed
-3. Merge triggers automatic tagging
+3. Merge runs main CI; a green run tags the release automatically (manual
+   dispatch of "Tag & push" is the escape hatch)
 4. Tag triggers NPM publish and GitHub Release
 
 ## Deployment

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ pnpm's isolated `node_modules` means a workspace member's devDep binaries (`vite
 ```bash
 # Run the PR CI pipeline (build, tests, coverage, lint, typecheck,
 # format check, bundle checks) — what every PR runs
-pnpm run ci
+mise run ci
 
 # PR pipeline plus the main-only guards (Firefox/WebKit vitest engines pass,
 # pack check, dts-backtest TS matrix) — what a push to main runs
@@ -43,6 +43,8 @@ pnpm --filter lit-ui-router test
 # Run E2E tests
 pnpm --filter sample-app-lit-e2e test
 ```
+
+`mise run ci` and `mise run ci_main` are the same invocations CI uses. `pnpm run ci` remains as an alias for the PR pipeline.
 
 ## TypeScript authoring
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -9,7 +9,7 @@ The release process is automated through GitHub Actions with protected environme
 1. **Version Bump** - Create a release PR with version changes
 2. **Build & Test** - Validate the PR on CI
 3. **Merge** - Merge the release PR to main
-4. **Tag** - Automatically tag the release
+4. **Tag** - A green main CI run automatically tags the release
 5. **Publish** - Publish to NPM and create GitHub Release
 
 ## Tag and Branch Conventions
@@ -64,15 +64,21 @@ These are consumed by `build-test.yml` and `publish-npm.yml` to enable remote ca
 
 ### 1. Build and Test (`build-test.yml`)
 
-**Triggers:** Pull requests, pushes to `main`
+**Triggers:** Pull requests, branch and `main` pushes, manual dispatch
 
 Runs the CI pipeline including:
 
 - Build verification
 - Unit tests with Vitest
 - E2E tests with Playwright and Cypress
+- Lint, typecheck, format, and bundle checks
 - Coverage reporting to Codecov
 - PR coverage comments (on PRs)
+
+Pushes to `main` run the same graph plus the main-only guards (turbo
+`ci:main`): the pack-surface manifest check (`check:pack`) and the full
+dts-backtest TypeScript matrix. A green main run then calls the Tag & push
+workflow — a red run means no tag, hence no publish.
 
 **Security:** Only runs on first-party PRs (not forks) to protect secrets.
 
@@ -96,11 +102,11 @@ Creates a release PR by:
 
 ### 3. Tag & Push (`publish-gh.yml`)
 
-**Triggers:** Push to `main`
+**Triggers:** Called by Build and Test after a green `main` run (`workflow_call`); manual dispatch is the CI-bypass escape hatch
 
-When a release PR merges:
+When a release PR merges and main CI is green:
 
-1. Uses release-it to create a git tag (`lit-ui-router@X.Y.Z`)
+1. Uses release-it to create a git tag per package (`<package>@X.Y.Z`)
 2. Pushes the tag to origin
 3. Tag push triggers the publish workflow
 
@@ -108,7 +114,7 @@ When a release PR merges:
 
 ### 4. Publish to NPM (`publish-npm.yml`)
 
-**Triggers:** Tag push matching `lit-ui-router@*`
+**Triggers:** Tag push matching a published package tag (`lit-ui-router@*`, `lit-ui-router-mobx@*`, `ui-router-navigation-location-plugin@*`); manual dispatch for dry runs
 
 The final release stage:
 
@@ -118,6 +124,16 @@ The final release stage:
 4. Publishes to NPM using OIDC trusted publishing
 5. Creates a draft GitHub Release with the tarball
 6. Marks the GitHub Release as final
+
+### 5. Release signals (`release-signals.yml`)
+
+**Triggers:** Pushes to `main`; called by Publish to NPM after a publish; manual dispatch
+
+Non-gating per-package check runs on main's head — `published-diff (<pkg>)`
+(does the pack surface differ from the published `latest`?) and
+`peer-floor (<pkg>)` (is an adapter's published peer floor stale?). The
+README badges read these check runs; `action_required` renders orange,
+meaning a release or floor bump is owed — never a CI failure.
 
 ## Step-by-Step Release Process
 
@@ -136,7 +152,8 @@ The final release stage:
 
 3. **Merge the release PR:**
    - Merge with squash commit
-   - The merge triggers tagging automatically
+   - The merge runs main CI (including the main-only guards); a green run
+     triggers tagging automatically
 
 4. **Verify the release:**
    - Check Actions for tag-release workflow
@@ -165,6 +182,8 @@ For prereleases like `1.2.3-beta.0`:
 ### Tag workflow not running
 
 - Verify the PR was merged (not closed)
+- Check that the main Build and Test run is green — tagging only fires after
+  green main CI; `workflow_dispatch` on Tag & push is the escape hatch
 - Check that `GH_PERSONAL_ACCESS_TOKEN` has correct permissions
 - Ensure the `tag-release` environment is configured
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -76,9 +76,12 @@ Runs the CI pipeline including:
 - PR coverage comments (on PRs)
 
 Pushes to `main` run the same graph plus the main-only guards (turbo
-`ci:main`): the pack-surface manifest check (`check:pack`) and the full
-dts-backtest TypeScript matrix. A green main run then calls the Tag & push
-workflow — a red run means no tag, hence no publish.
+`ci:main`): the Firefox/WebKit vitest engines pass (`test:engines`), the
+pack-surface manifest check (`check:pack`), and the full dts-backtest
+TypeScript matrix. A green main run then calls the Tag & push workflow — a
+red run means no tag, hence no publish. Manual dispatch can run the
+`ci:main` graph on demand via the `mainGraph` input (combine with `force`
+to deflake the full main graph); tagging stays push-only.
 
 **Security:** Only runs on first-party PRs (not forks) to protect secrets.
 

--- a/TURBO.md
+++ b/TURBO.md
@@ -35,7 +35,7 @@ The root `turbo.json` defines shared task configurations inherited by all worksp
 ```
 ci:pull_request   (every PR and branch push; `ci` is its back-compat alias)
 ├── build         (outputs: dist/**)
-├── test          (inputs: src/**/*.ts, vitest.config.ts, cypress.config.ts)
+├── test          (inputs: src/**/*.ts, vitest.config.ts, vitest.setup.ts, cypress.config.ts)
 ├── test:coverage (outputs: coverage/**)
 ├── lint          (runs with //#lint:root, //#lint:package-json, //#lint:workflows)
 ├── typecheck     (runs with //#typecheck:root, typecheck:src)
@@ -45,6 +45,8 @@ ci:pull_request   (every PR and branch push; `ci` is its back-compat alias)
 
 ci:main           (main pushes only: the PR graph plus the main-only guards)
 ├── ci:pull_request
+├── test:engines                     (Firefox + WebKit full-suite vitest pass;
+                                      PR chromium correctness rides test:coverage)
 ├── @tools/release#check:pack        (pack-surface manifest check)
 └── @tools/dts-backtest#test:matrix  (full dts-backtest TS version matrix;
                                       PRs run only the current-TS #test leg)
@@ -81,21 +83,21 @@ docs
 
 Workspaces extend the root configuration using `"extends": ["//"]`:
 
-| Workspace                                          | Custom Configuration                                                                                                                       |
-| -------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| `packages/lit-ui-router`                           | Runs `build:custom-elements` with build, configures `docs:api` outputs                                                                     |
-| `packages/lit-ui-router-mobx`                      | Configures `docs:api` outputs                                                                                                              |
-| `packages/navigation-location-plugin`              | Configures `docs:api` outputs                                                                                                              |
-| `packages/ui-router-server`                        | `test` rides the `transit` chain (no build needed); adds `typecheck:tests`                                                                 |
-| `apps/sample-app-lit-vanilla`                      | Adds env vars for build (VITE\_\*), runs `build:hash` with build                                                                           |
-| `apps/sample-app-lit-mobx`                         | Adds env vars for build (VITE\_\*)                                                                                                         |
-| `apps/sample-app-lit-e2e`                          | Caches `test` via dependency edges; CYPRESS\_\* passes through un-hashed                                                                   |
-| `apps/sample-app-routes`, `apps/sample-app-shared` | Widens `test` inputs beyond the root's `src/**/*.ts` (non-TS/config surface)                                                               |
-| `docs`                                             | Adds `docs:preview`, `wrangler:dev`, worker tasks (`types:worker`, `typecheck:worker`, `bundle:worker`), requires `^docs:api` before build |
-| `examples`                                         | Adds `build:embeds` (tutorial apps built as docs embeds)                                                                                   |
-| `tools/release`                                    | Adds `check:pack`, `resolve:published` (uncached registry read), `check:published-diff`                                                    |
-| `tools/workers-builds`                             | Adds `check` (live Cloudflare API diff; uncached); over-approximated `test` inputs                                                         |
-| `tools/build_and_test`, `tools/shared`             | Over-approximated `test` inputs (`$TURBO_DEFAULT$`)                                                                                        |
+| Workspace                                                 | Custom Configuration                                                                                                                                                                                                |
+| --------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `packages/lit-ui-router`                                  | Runs `build:custom-elements` with build, configures `docs:api` outputs                                                                                                                                              |
+| `packages/lit-ui-router-mobx`                             | Configures `docs:api` outputs                                                                                                                                                                                       |
+| `packages/navigation-location-plugin`                     | Configures `docs:api` outputs                                                                                                                                                                                       |
+| `packages/ui-router-server`                               | `test` rides the `transit` chain (no build needed); adds `typecheck:tests`                                                                                                                                          |
+| `apps/sample-app-lit-vanilla`                             | Adds env vars for build (VITE\_\*), runs `build:hash` with build                                                                                                                                                    |
+| `apps/sample-app-lit-mobx`                                | Adds env vars for build (VITE\_\*)                                                                                                                                                                                  |
+| `apps/sample-app-lit-e2e`                                 | Caches `test` via dependency edges; CYPRESS\_\* passes through un-hashed                                                                                                                                            |
+| `apps/sample-app-routes`, `apps/sample-app-shared`        | Widens `test` inputs beyond the root's `src/**/*.ts` (non-TS/config surface)                                                                                                                                        |
+| `docs`                                                    | Adds `docs:preview`, `wrangler:dev`, worker tasks (`types:worker`, `typecheck:worker`, `typecheck:worker:tests`, `bundle:worker`); `test` runs the worker contract tests in node; requires `^docs:api` before build |
+| `examples`                                                | Adds `build:embeds` (tutorial apps built as docs embeds)                                                                                                                                                            |
+| `tools/release`                                           | Adds `check:pack`, `resolve:published` (uncached registry read), `check:published-diff`                                                                                                                             |
+| `tools/workers-builds`                                    | Adds `check` (live Cloudflare API diff; uncached); over-approximated `test` inputs                                                                                                                                  |
+| `tools/build_and_test`, `tools/shared`, `tools/happy-dom` | Over-approximated `test` inputs (`$TURBO_DEFAULT$`)                                                                                                                                                                 |
 
 ## Common Commands
 
@@ -122,7 +124,8 @@ turbo format
 # + bundle checks); `ci` is the back-compat alias of `ci:pull_request`
 turbo ci
 
-# PR pipeline plus the main-only guards (check:pack, dts-backtest TS matrix)
+# PR pipeline plus the main-only guards (Firefox/WebKit engines pass,
+# check:pack, dts-backtest TS matrix)
 turbo ci:main
 
 # Development server (persistent)
@@ -175,7 +178,7 @@ The GitHub Actions workflow (`.github/workflows/build-test.yml`) runs the CI pip
 5. **Coverage reports** - Vitest coverage for PR comments, Codecov upload
 6. **Tag** (main pushes only) - a green run calls the Tag & push workflow, so release tags fire only after green main CI
 
-Manual dispatch of the workflow has a `force` input (`TURBO_FORCE`) that bypasses the turbo cache — the deflake-reproduction path. CI also sets `CYPRESS_video: 'false'` (passed through un-hashed, so it never affects cache validity); local runs keep video recording.
+Manual dispatch of the workflow has two deflake inputs: `force` (`TURBO_FORCE`) bypasses the turbo cache, and `mainGraph` runs the `ci:main` superset on demand — combine them to deflake the full main graph without pushing a commit (tagging stays push-only). CI also sets `CYPRESS_video: 'false'` (passed through un-hashed, so it never affects cache validity); local runs keep video recording.
 
 ### CI Environment Variables
 
@@ -187,18 +190,19 @@ TURBO_TEAM: ${{ vars.TURBO_TEAM }} # Team identifier
 
 ### Task-to-CI Mapping
 
-| Turbo Task                        | CI Placement                                              |
-| --------------------------------- | --------------------------------------------------------- |
-| `build`                           | `ci:pull_request` (every PR and push)                     |
-| `test`                            | `ci:pull_request`                                         |
-| `test:coverage`                   | `ci:pull_request`, feeds coverage reports                 |
-| `lint`                            | `ci:pull_request`                                         |
-| `typecheck`                       | `ci:pull_request`                                         |
-| `format:check`                    | `ci:pull_request`                                         |
-| `check:bundle`, `codecov:bundle`  | `ci:pull_request`                                         |
-| `@tools/release#check:pack`       | `ci:main` only (main pushes)                              |
-| `@tools/dts-backtest#test:matrix` | `ci:main` only; PRs run the current-TS `#test` leg        |
-| `typecheck:peer-floor`            | Neither ci graph — Release signals check runs + bump gate |
+| Turbo Task                        | CI Placement                                                                              |
+| --------------------------------- | ----------------------------------------------------------------------------------------- |
+| `build`                           | `ci:pull_request` (every PR and push)                                                     |
+| `test`                            | `ci:pull_request`                                                                         |
+| `test:coverage`                   | `ci:pull_request`, feeds coverage reports                                                 |
+| `lint`                            | `ci:pull_request`                                                                         |
+| `typecheck`                       | `ci:pull_request`                                                                         |
+| `format:check`                    | `ci:pull_request`                                                                         |
+| `check:bundle`, `codecov:bundle`  | `ci:pull_request`                                                                         |
+| `test:engines`                    | `ci:main` only — Firefox + WebKit vitest pass (lit-ui-router, navigation-location-plugin) |
+| `@tools/release#check:pack`       | `ci:main` only (main pushes)                                                              |
+| `@tools/dts-backtest#test:matrix` | `ci:main` only; PRs run the current-TS `#test` leg                                        |
+| `typecheck:peer-floor`            | Neither ci graph — Release signals check runs + bump gate                                 |
 
 ## Remote Caching
 

--- a/TURBO.md
+++ b/TURBO.md
@@ -33,49 +33,64 @@ npm run dev
 The root `turbo.json` defines shared task configurations inherited by all workspaces:
 
 ```
-ci:pull_request   (every PR and branch push; `ci` is its back-compat alias)
-├── build         (outputs: dist/**)
-├── test          (inputs: src/**/*.ts, vitest.config.ts, vitest.setup.ts, cypress.config.ts)
-├── test:coverage (outputs: coverage/**)
-├── lint          (runs with //#lint:root, //#lint:package-json, //#lint:workflows)
-├── typecheck     (runs with //#typecheck:root, typecheck:src)
-├── format:check  (runs with //#format:check:root)
-├── check:bundle  (bundle invariants: size budgets, deps-none probes)
-└── codecov:bundle (bundle analysis upload; not cached)
+ci:pull_request
+├── build
+├── test
+├── test:coverage
+├── lint
+│   ├── //#lint:root           (with)
+│   ├── //#lint:package-json   (with)
+│   └── //#lint:workflows      (with)
+├── typecheck
+│   ├── //#typecheck:root      (with)
+│   └── typecheck:src          (with)
+├── format:check
+│   └── //#format:check:root   (with)
+├── check:bundle
+└── codecov:bundle
 
-ci:main           (main pushes only: the PR graph plus the main-only guards)
+ci:main
 ├── ci:pull_request
-├── test:engines                     (Firefox + WebKit full-suite vitest pass;
-                                      PR chromium correctness rides test:coverage)
-├── @tools/release#check:pack        (pack-surface manifest check)
-└── @tools/dts-backtest#test:matrix  (full dts-backtest TS version matrix;
-                                      PRs run only the current-TS #test leg)
+├── test:engines
+├── @tools/release#check:pack
+└── @tools/dts-backtest#test:matrix
 
 build
-├── ^build      (depends on workspace dependencies' builds)
-├── build:js    (own-package JS pass)
-└── build:types (own-package d.ts pass; self-chains via ^build:types)
+├── ^build
+├── build:js
+└── build:types
+    └── ^build:types
 
 dev
-└── ^build      (persistent, not cached)
+└── ^build
 
 e2e
 ├── ^build
 ├── ^docs
-└── ^e2e        (persistent, not cached)
+└── ^e2e
 
 docs
 ├── ^build
-└── ^docs:api   (persistent, not cached)
+└── ^docs:api
 ```
 
 **Key concepts:**
 
 - `^task` means "run this task on dependencies first"
-- `dependsOn` defines execution order
+- `dependsOn` defines execution order (unmarked edges above)
+- `with` runs root-level tasks alongside workspace tasks (marked edges above)
 - `outputs` defines cacheable artifacts
 - `inputs` scopes cache invalidation
-- `with` runs root-level tasks alongside workspace tasks
+
+**Graph notes:**
+
+- `ci:pull_request` is what every PR and branch push runs; `ci` is its back-compat alias. `ci:main` runs on main pushes only, adding the main-only guards.
+- `test:engines` is the Firefox + WebKit full-suite vitest pass (lit-ui-router, navigation-location-plugin); PR chromium correctness rides `test:coverage`.
+- `@tools/dts-backtest#test:matrix` runs the full TS version matrix; PRs run only the current-TS `test` leg.
+- `build` composes the two own-package passes: `build:js` (JS) and `build:types` (d.ts, self-chaining via `^build:types`).
+- `check:bundle` holds the bundle invariants (size budgets, deps-none probes); `codecov:bundle` uploads bundle analysis, uncached.
+- `dev`, `e2e`, and `docs` are persistent, uncached tasks.
+- Per-task `inputs`/`outputs` live in `turbo.json` itself — see [Cache Control](#cache-control).
 
 **Deliberately outside both ci graphs:** `typecheck:peer-floor` typechecks an adapter against its published peer-floor version. The floor pin can only reference published versions, so putting it in the ci graph would break atomic core-API + adapter-adoption PRs. It runs as a non-gating per-package check run on main pushes (the Release signals workflow) and as a hard gate at bump time.
 

--- a/TURBO.md
+++ b/TURBO.md
@@ -10,20 +10,15 @@ Turbo is the workspace devDependency (pinned in the pnpm catalog), resolved from
 
 Turbo manages these workspaces (defined in `pnpm-workspace.yaml`):
 
-| Directory    | Purpose                                   | In CI |
-| ------------ | ----------------------------------------- | ----- |
-| `packages/*` | Published libraries (lit-ui-router, etc.) | Yes   |
-| `apps/*`     | Sample applications and e2e tests         | Yes   |
-| `tools/*`    | Internal build tools                      | Yes   |
-| `docs`       | Documentation site                        | Yes   |
+| Directory    | Purpose                                     | In CI               |
+| ------------ | ------------------------------------------- | ------------------- |
+| `packages/*` | Published libraries (lit-ui-router, etc.)   | Yes                 |
+| `apps/*`     | Sample applications and e2e tests           | Yes                 |
+| `tools/*`    | Internal build tools                        | Yes                 |
+| `docs`       | Documentation site                          | Yes                 |
+| `examples`   | Standalone tutorial apps (helloworld, etc.) | Only `build:embeds` |
 
-**Excluded from turbo:**
-
-| Directory   | Purpose                                     |
-| ----------- | ------------------------------------------- |
-| `examples/` | Standalone tutorial apps (helloworld, etc.) |
-
-The `examples/` directory contains tutorial applications (helloworld, hellogalaxy, hellosolarsystem) that are intentionally excluded from turbo. These are standalone Vite dev servers meant for learning - they have no turbo.json files and are not part of the CI pipeline. They use npm (not pnpm) for Stackblitz compatibility:
+The apps inside `examples/` (helloworld, hellogalaxy, hellosolarsystem) are intentionally outside the main turbo graph. They are standalone Vite dev servers meant for learning, and they use npm (not pnpm) for Stackblitz compatibility. The one turbo touchpoint is `examples#build:embeds` (see `examples/turbo.json`), which builds them as embeds for the docs site:
 
 ```bash
 cd examples/helloworld
@@ -38,15 +33,26 @@ npm run dev
 The root `turbo.json` defines shared task configurations inherited by all workspaces:
 
 ```
-ci
-├── build       (outputs: dist/**)
-├── test        (inputs: src/**/*.ts, vitest.config.ts, cypress.config.ts)
+ci:pull_request   (every PR and branch push; `ci` is its back-compat alias)
+├── build         (outputs: dist/**)
+├── test          (inputs: src/**/*.ts, vitest.config.ts, cypress.config.ts)
 ├── test:coverage (outputs: coverage/**)
-├── lint        (runs with //#lint:root)
-└── format:check (runs with //#format:check:root)
+├── lint          (runs with //#lint:root, //#lint:package-json, //#lint:workflows)
+├── typecheck     (runs with //#typecheck:root, typecheck:src)
+├── format:check  (runs with //#format:check:root)
+├── check:bundle  (bundle invariants: size budgets, deps-none probes)
+└── codecov:bundle (bundle analysis upload; not cached)
+
+ci:main           (main pushes only: the PR graph plus the main-only guards)
+├── ci:pull_request
+├── @tools/release#check:pack        (pack-surface manifest check)
+└── @tools/dts-backtest#test:matrix  (full dts-backtest TS version matrix;
+                                      PRs run only the current-TS #test leg)
 
 build
-└── ^build      (depends on workspace dependencies' builds)
+├── ^build      (depends on workspace dependencies' builds)
+├── build:js    (own-package JS pass)
+└── build:types (own-package d.ts pass; self-chains via ^build:types)
 
 dev
 └── ^build      (persistent, not cached)
@@ -69,16 +75,27 @@ docs
 - `inputs` scopes cache invalidation
 - `with` runs root-level tasks alongside workspace tasks
 
+**Deliberately outside both ci graphs:** `typecheck:peer-floor` typechecks an adapter against its published peer-floor version. The floor pin can only reference published versions, so putting it in the ci graph would break atomic core-API + adapter-adoption PRs. It runs as a non-gating per-package check run on main pushes (the Release signals workflow) and as a hard gate at bump time.
+
 ### Workspace Extensions
 
 Workspaces extend the root configuration using `"extends": ["//"]`:
 
-| Workspace                     | Custom Configuration                                                         |
-| ----------------------------- | ---------------------------------------------------------------------------- |
-| `packages/lit-ui-router`      | Adds `build:custom-elements` before build, configures `docs:api`             |
-| `apps/sample-app-lit-vanilla` | Adds env vars for build (VITE\_\*)                                           |
-| `apps/sample-app-lit-e2e`     | Caches `test` via dependency edges; CYPRESS\_\* passes through un-hashed     |
-| `docs`                        | Adds `docs:preview`, `wrangler:dev` tasks, requires `^docs:api` before build |
+| Workspace                                          | Custom Configuration                                                                                                                       |
+| -------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| `packages/lit-ui-router`                           | Runs `build:custom-elements` with build, configures `docs:api` outputs                                                                     |
+| `packages/lit-ui-router-mobx`                      | Configures `docs:api` outputs                                                                                                              |
+| `packages/navigation-location-plugin`              | Configures `docs:api` outputs                                                                                                              |
+| `packages/ui-router-server`                        | `test` rides the `transit` chain (no build needed); adds `typecheck:tests`                                                                 |
+| `apps/sample-app-lit-vanilla`                      | Adds env vars for build (VITE\_\*), runs `build:hash` with build                                                                           |
+| `apps/sample-app-lit-mobx`                         | Adds env vars for build (VITE\_\*)                                                                                                         |
+| `apps/sample-app-lit-e2e`                          | Caches `test` via dependency edges; CYPRESS\_\* passes through un-hashed                                                                   |
+| `apps/sample-app-routes`, `apps/sample-app-shared` | Widens `test` inputs beyond the root's `src/**/*.ts` (non-TS/config surface)                                                               |
+| `docs`                                             | Adds `docs:preview`, `wrangler:dev`, worker tasks (`types:worker`, `typecheck:worker`, `bundle:worker`), requires `^docs:api` before build |
+| `examples`                                         | Adds `build:embeds` (tutorial apps built as docs embeds)                                                                                   |
+| `tools/release`                                    | Adds `check:pack`, `resolve:published` (uncached registry read), `check:published-diff`                                                    |
+| `tools/workers-builds`                             | Adds `check` (live Cloudflare API diff; uncached); over-approximated `test` inputs                                                         |
+| `tools/build_and_test`, `tools/shared`             | Over-approximated `test` inputs (`$TURBO_DEFAULT$`)                                                                                        |
 
 ## Common Commands
 
@@ -101,8 +118,12 @@ turbo format:check
 # Fix formatting
 turbo format
 
-# Full CI pipeline (build + test + coverage + lint + format:check)
+# PR CI pipeline (build + test + coverage + lint + typecheck + format:check
+# + bundle checks); `ci` is the back-compat alias of `ci:pull_request`
 turbo ci
+
+# PR pipeline plus the main-only guards (check:pack, dts-backtest TS matrix)
+turbo ci:main
 
 # Development server (persistent)
 turbo dev
@@ -145,13 +166,16 @@ turbo build --summarize
 
 ## CI Integration
 
-The GitHub Actions workflow (`.github/workflows/build-test.yml`) runs the full CI pipeline:
+The GitHub Actions workflow (`.github/workflows/build-test.yml`) runs the CI pipeline:
 
 1. **Checkout** - Clone repository
 2. **Setup** - mise installs Node.js (version pinned in `.nvmrc`) and corepack; `mise run setup` corepack-installs the `packageManager`-pinned pnpm, then installs dependencies
-3. **Install browsers** - Playwright and Cypress for e2e tests
-4. **Build and Test** - `turbo run ci`
+3. **Install browsers** - Playwright and Cypress for e2e tests, restored from `actions/cache` keyed on the installed package versions
+4. **Build and Test** - PRs and branch pushes run `mise run ci` (turbo `ci:pull_request`); main pushes run `mise run ci_main` (turbo `ci:main`, adding the main-only guards)
 5. **Coverage reports** - Vitest coverage for PR comments, Codecov upload
+6. **Tag** (main pushes only) - a green run calls the Tag & push workflow, so release tags fire only after green main CI
+
+Manual dispatch of the workflow has a `force` input (`TURBO_FORCE`) that bypasses the turbo cache — the deflake-reproduction path. CI also sets `CYPRESS_video: 'false'` (passed through un-hashed, so it never affects cache validity); local runs keep video recording.
 
 ### CI Environment Variables
 
@@ -163,13 +187,18 @@ TURBO_TEAM: ${{ vars.TURBO_TEAM }} # Team identifier
 
 ### Task-to-CI Mapping
 
-| Turbo Task      | CI Step                                   |
-| --------------- | ----------------------------------------- |
-| `build`         | Part of `ci` task                         |
-| `test`          | Part of `ci` task                         |
-| `test:coverage` | Part of `ci` task, feeds coverage reports |
-| `lint`          | Part of `ci` task                         |
-| `format:check`  | Part of `ci` task                         |
+| Turbo Task                        | CI Placement                                              |
+| --------------------------------- | --------------------------------------------------------- |
+| `build`                           | `ci:pull_request` (every PR and push)                     |
+| `test`                            | `ci:pull_request`                                         |
+| `test:coverage`                   | `ci:pull_request`, feeds coverage reports                 |
+| `lint`                            | `ci:pull_request`                                         |
+| `typecheck`                       | `ci:pull_request`                                         |
+| `format:check`                    | `ci:pull_request`                                         |
+| `check:bundle`, `codecov:bundle`  | `ci:pull_request`                                         |
+| `@tools/release#check:pack`       | `ci:main` only (main pushes)                              |
+| `@tools/dts-backtest#test:matrix` | `ci:main` only; PRs run the current-TS `#test` leg        |
+| `typecheck:peer-floor`            | Neither ci graph — Release signals check runs + bump gate |
 
 ## Remote Caching
 
@@ -244,7 +273,10 @@ Run these separately from cached tasks.
 
 Root tasks use `//#` prefix and require scripts in root `package.json`:
 
-- `//#lint:root` - lints examples directory
+- `//#lint:root` - lints root-level files (workspace directories excluded)
+- `//#lint:package-json` - lints every `package.json` and `pnpm-workspace.yaml`
+- `//#lint:workflows` - actionlint + zizmor over GitHub Actions workflows
+- `//#typecheck:root` - typechecks root-level scripts
 - `//#format:root` - formats root-level files
 - `//#format:check:root` - checks root-level formatting
 

--- a/tools/release/mise.toml
+++ b/tools/release/mise.toml
@@ -78,7 +78,8 @@ flag "--dry-run" help="release-it --dry-run: no npm publish, no GitHub release" 
 run = 'PACKAGE_NAME="${usage_package_name?}" TARBALL="${usage_tarball?}" DRY_RUN="${usage_dry_run:-}" node src/steps/release-publish.ts'
 
 [tasks.check_pack]
-# Main-push CI placement (not per-PR); publish's check_tarball is the last-line gate.
+# Ad-hoc alias for @tools/release#check:pack; CI runs it via ci_main.
+# publish's check_tarball is the last-line gate.
 description = "Run the pack-surface manifest check via turbo"
 run = "turbo run check:pack"
 


### PR DESCRIPTION
Docs-and-comments sync after the CI restructuring week (#388 #389 #390 #391/#383 #393 #373 #397 #398 #401 #405). No behavior changes — comments, descriptions, and contributor docs only.

## Stale claims fixed

**.config/mise/config.toml**
- `ci` description said "full CI pipeline"; it is the PR pipeline (`ci` = back-compat alias of `ci:pull_request`)
- `dts_backtest_matrix` comment described the old wiring ("Main-push companion to `ci`"); it is the ad-hoc alias — CI runs the matrix via `ci_main`

**tools/release/mise.toml**
- `check_pack` comment claimed the CI placement itself; it is the ad-hoc alias — CI runs `@tools/release#check:pack` via `ci_main`

**TURBO.md**
- `ci` graph diagram predated the split: now shows `ci:pull_request` (incl. previously missing `typecheck`, `check:bundle`, `codecov:bundle`) and `ci:main` with the main-only guards
- Note added: `typecheck:peer-floor` is deliberately outside both ci graphs (Release signals check runs + bump gate)
- Workspace-extensions table covered 4 of 15 overrides; reconciled against every package turbo.json — #398's e2e row kept verbatim
- `examples` was described as "no turbo.json files, not part of CI"; it carries `examples#build:embeds`
- CI Integration: PR vs main steps (`mise run ci` / `mise run ci_main`), browser-binary caching, tag call gated on green main CI, dispatch `force` deflake input, CI Cypress video off
- Task-to-CI mapping rebuilt around `ci:pull_request` / `ci:main` membership
- Root-tasks list was missing `lint:package-json`, `lint:workflows`, `typecheck:root`, and misdescribed `lint:root` as "lints examples directory"

**CONTRIBUTING.md**
- `pnpm run ci` framed as "run all tests"; now PR pipeline, with `mise run ci_main` documented as the main superset
- dts-backtest paragraph implied every CI run does the full TS matrix; PRs run the current-TS leg, main runs the matrix
- Release quick-overview: tagging fires only after green main CI; Tag & push dispatch is the escape hatch

**RELEASE.md**
- Build and Test triggers/steps updated (branch pushes, dispatch, main-only guards, gated tag call)
- Tag & Push trigger was "Push to main"; now workflow_call from a green main run, dispatch = CI-bypass escape hatch
- Publish triggers listed only `lit-ui-router@*`; all three package tag patterns publish
- Added the Release signals workflow (previously undocumented)
- Troubleshooting: "tag not running" now points at main CI being red first

## Verification
- `mise run lint_workflows` clean (no workflow edits)
- root `format:check` green (oxfmt over md)
- `mise tasks` name list unchanged vs main
- grep sweep: no doc claims PRs run check:pack or the full dts matrix (#399/#403 still open, so current vitest behavior left as-is)

## Update: rebased onto #399/#403/#410
- ci:main graph, task-to-CI mapping, and command comments now include `test:engines` (Firefox + WebKit vitest pass for lit-ui-router + navigation-location-plugin; PR chromium correctness rides `test:coverage`)
- Workspace table: `tools/happy-dom` row added; docs row now covers the node worker-contract `test` + `typecheck:worker:tests`
- `mainGraph` dispatch input documented beside `force` in TURBO.md and RELEASE.md (forced-main-graph deflake path; tagging stays push-only)
- root `test`/`test:coverage` input lists updated with `vitest.setup.ts`
- #395/#396 still open — mobx/nav pass-split not documented
