### PR TITLE
ci: dispatch input to run the ci:main graph on demand

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -18,6 +18,11 @@ on:
         description: 'Bypass turbo cache (deflake reproduction: rebuild/retest everything)'
         type: boolean
         default: false
+      # Deflake path for the main-only guards without pushing a commit.
+      mainGraph:
+        description: 'Run the ci:main superset (main-only guards included); combine with force to deflake the full main graph'
+        type: boolean
+        default: false
 
 # Standard husky CI setup: skip the prepare-script git-hook install on CI installs.
 env:
@@ -100,7 +105,8 @@ jobs:
       - name: Build and Test
         # TURBO_FORCE carries the deflake input through env (never `${{ }}`
         # in run lines); turbo parses ""/"false" as cache-respecting.
-        if: ${{ github.event_name != 'push' || github.ref != 'refs/heads/main' }}
+        # Exact complement of the ci_main step below: one of the two runs.
+        if: ${{ !((github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'workflow_dispatch' && inputs.mainGraph)) }}
         run: mise run ci
         env:
           TURBO_FORCE: ${{ inputs.force }}
@@ -117,7 +123,8 @@ jobs:
         # dts-backtest full TS matrix) in one parallel turbo invocation; a
         # failure fails build_and_test, so the tag_push call job never runs.
         # Future main-only guards join ci:main's dependsOn, not new steps.
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        # mainGraph dispatches run this graph too; tag_push stays push-only.
+        if: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'workflow_dispatch' && inputs.mainGraph) }}
         run: mise run ci_main
         env:
           TURBO_FORCE: ${{ inputs.force }}


### PR DESCRIPTION
Closes the deflake scope gap: a `workflow_dispatch` of Build and Test could only run the `ci` graph — the main-only guards (check:pack, dts-backtest `test:matrix`, soon `test:engines`) were reachable only by pushing a commit to main. New boolean input `mainGraph` (default false) routes a dispatch to `mise run ci_main` instead; combine with `force` to deflake the full main graph cache-bypassed.

## What changed

One file, `.github/workflows/build-test.yml`:

- New `workflow_dispatch` input `mainGraph` (boolean, default false).
- The two Build and Test step conditions are now exact complements — exactly one runs per event:
  - `ci_main` step: `(push && main) || (workflow_dispatch && inputs.mainGraph)`
  - `ci` step: the negation of the above.
- All env (TURBO_FORCE, TURBO_*, CODECOV_TOKEN, WRANGLER_LOG, CYPRESS_video) already sat on both steps — unchanged.

Expression safety: `workflow_dispatch` boolean inputs are real booleans in the `inputs` context (no string compare), and `inputs.*` is null on push/PR events — every use of `inputs.mainGraph` is conjoined with `github.event_name == 'workflow_dispatch'`, so the conditions are null-safe on all events.

## Event trace

| Event | Build and Test step | tag_push | Codecov upload |
| --- | --- | --- | --- |
| pull_request | `ci` | skipped | yes |
| push (branch head) | `ci` | skipped | no |
| push (main) | `ci_main` | **runs** (needs green) | yes |
| dispatch, defaults | `ci` | skipped | yes |
| dispatch, mainGraph=true | `ci_main` | **skipped** | yes |
| dispatch, mainGraph+force | `ci_main`, cache-bypassed | **skipped** | yes |

## No-tag invariant

The `tag_push` job's gate (`github.event_name == 'push' && github.ref == 'refs/heads/main'`) is untouched: a dispatched `ci_main` run exercises the main graph but can never tag — tagging still requires a real main push (or the documented Tag & push dispatch escape hatch). The Codecov upload condition is also untouched.

## Verification

- `mise run lint_workflows` (actionlint + zizmor): clean — "No findings to report."
- Root `format:check`: green.
- Build and Test starts on this PR head (run id in PR checks; no startup_failure).

## Post-merge note

Dispatch runs execute the default-branch workflow file, so the new input only live-verifies via a real dispatch after merge: dispatch with `mainGraph=true`, confirm the run executes the `Build and Test (main)` step (turbo summary includes check:pack + test:matrix) and that no Tag & push jobs appear in the run.
