### PR TITLE
ci(turbo): typecheck and lint depend on ^build:types only

### DIFF
--- a/docs/turbo.json
+++ b/docs/turbo.json
@@ -39,7 +39,7 @@
       "env": ["VITE_GOOGLE_ANALYTICS_TRACKING_ID"]
     },
     "typecheck": {
-      "dependsOn": ["^build", "^docs:api"],
+      "dependsOn": ["^build:types", "^docs:api"],
       "with": ["typecheck:vue", "typecheck:worker", "typecheck:worker:tests"]
     },
     "test": {
@@ -49,18 +49,18 @@
       "inputs": ["$TURBO_DEFAULT$"]
     },
     "typecheck:worker": {
-      "dependsOn": ["^build", "types:worker"],
+      "dependsOn": ["^build:types", "types:worker"],
       "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/tsconfig.base.json"]
     },
     "typecheck:worker:tests": {
       // The worker module rides into the test graph, so the generated
       // worker-configuration.d.ts must exist here too.
-      "dependsOn": ["^build", "types:worker"],
+      "dependsOn": ["^build:types", "types:worker"],
       "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/tsconfig.base.json"]
     },
     "lint": {
       // Type-aware oxlint reads worker/tsconfig.json, which needs the d.ts.
-      "dependsOn": ["^build", "types:worker"]
+      "dependsOn": ["^build:types", "types:worker"]
     },
     "types:worker": {
       "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/wrangler.jsonc"],
@@ -72,7 +72,7 @@
       "persistent": true
     },
     "typecheck:vue": {
-      "dependsOn": ["^build"],
+      "dependsOn": ["^build:types"],
       "inputs": [
         ".vitepress/env.d.ts",
         ".vitepress/theme/components/*.vue",

--- a/packages/ui-router-server/turbo.json
+++ b/packages/ui-router-server/turbo.json
@@ -10,7 +10,7 @@
       "with": ["typecheck:tests"]
     },
     "typecheck:tests": {
-      "dependsOn": ["^build"],
+      "dependsOn": ["^build:types"],
       "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/tsconfig.base.json"]
     }
   }

--- a/turbo.json
+++ b/turbo.json
@@ -57,7 +57,8 @@
     },
     "lint": {
       "with": ["//#lint:root", "//#lint:package-json", "//#lint:workflows"],
-      "dependsOn": ["^build"],
+      // type-aware oxlint resolves cross-package imports to dist d.ts only
+      "dependsOn": ["^build:types"],
       "inputs": [
         "**/*.ts",
         "**/*.js",
@@ -86,13 +87,14 @@
       ]
     },
     "typecheck": {
-      // ^build drops once every package is pass-split
-      "dependsOn": ["^build", "^build:types"],
+      // every package is pass-split (#369, #395, #396): types come from
+      // build:types alone, JS emit stays off the typecheck path
+      "dependsOn": ["^build:types"],
       "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/tsconfig.base.json"],
       "with": ["//#typecheck:root", "typecheck:src"]
     },
     "typecheck:src": {
-      "dependsOn": ["^build", "^build:types"],
+      "dependsOn": ["^build:types"],
       "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/tsconfig.base.json"]
     },
     "typecheck:peer-floor": {

--- a/turbo.json
+++ b/turbo.json
@@ -87,8 +87,7 @@
       ]
     },
     "typecheck": {
-      // every package is pass-split (#369, #395, #396): types come from
-      // build:types alone, JS emit stays off the typecheck path
+      // types come from build:types alone; JS emit stays off the typecheck path
       "dependsOn": ["^build:types"],
       "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/tsconfig.base.json"],
       "with": ["//#typecheck:root", "typecheck:src"]


### PR DESCRIPTION
The change root turbo.json has anticipated since #369: with every publishable package pass-split (#369, #395, #396), `typecheck`, `typecheck:src`, and `lint` drop `^build` for `^build:types` — JS transform/minify/CEM leave the static-analysis critical path. Package-level overrides updated in kind (docs `typecheck`/`typecheck:vue`/`typecheck:worker`/`typecheck:worker:tests`/`lint`, ui-router-server `typecheck:tests`).

**Legitimate JS consumers keep their edges**: `docs:api` (typedoc executes the built `@tools/typedoc-plugin` and its output feeds docs typecheck via `^docs:api`) and `@tools/dts-backtest` (consumes dist) are untouched.

## Verification

- **Clean-state proof**: all `dist/` deleted, `turbo run typecheck lint` → exit 0, 61 tasks, 23.1s. The only JS-emit tasks in the graph enter via the legitimate `docs#typecheck → ^docs:api → build` path.
- **Scoped assertion**: `turbo run typecheck lint --filter='!docs' --dry-run=json` → build-family tasks in the closure are **`build:types` ×16 only** — zero `build:js`, zero umbrella `build`, zero `build:custom-elements`.
- Full `turbo run ci` exercised by this PR's own CI (the graph change is identical there).

## Notes

- The satisfied "`^build` drops once every package is pass-split" comment is retired; comments state present constraints only.
- **Merge pairing**: #412's `repo/require-build-types` lint rule guards this edge structurally (a future dist-typed package without `build:types` fails lint at the source instead of failing a dependent's typecheck late), and its `tools/typedoc-plugin` fix covers a hazard this PR exposes — land the pair together or #412 promptly after.