### PR TITLE
ci(e2e): opt-in cypress video capture + artifact upload on dispatch

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -23,6 +23,10 @@ on:
         description: 'Run the ci:main superset (main-only guards included); combine with force to deflake the full main graph'
         type: boolean
         default: false
+      cypressVideo:
+        description: 'Record Cypress videos and upload them as a run artifact (e2e debugging)'
+        type: boolean
+        default: false
 
 # Standard husky CI setup: skip the prepare-script git-hook install on CI installs.
 env:
@@ -116,8 +120,9 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
           # Silence per-request [wrangler:info] logging from the e2e dev server.
           WRANGLER_LOG: warn
-          # Cypress video off in CI; configs keep video:true for local runs.
-          CYPRESS_video: 'false'
+          # Cypress video off in CI (configs keep video:true for local runs);
+          # the cypressVideo dispatch input re-enables it for debugging.
+          CYPRESS_video: ${{ inputs.cypressVideo == true }}
       - name: Build and Test (main)
         # ci:main = the PR graph plus the main-only guards (check:pack,
         # dts-backtest full TS matrix) in one parallel turbo invocation; a
@@ -134,8 +139,20 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
           # Silence per-request [wrangler:info] logging from the e2e dev server.
           WRANGLER_LOG: warn
-          # Cypress video off in CI; configs keep video:true for local runs.
-          CYPRESS_video: 'false'
+          # Cypress video off in CI (configs keep video:true for local runs);
+          # the cypressVideo dispatch input re-enables it for debugging.
+          CYPRESS_video: ${{ inputs.cypressVideo == true }}
+      - name: Upload Cypress videos
+        # Videos exist only when the dispatch input turned recording on;
+        # !cancelled() keeps videos from failed suites — the debugging case.
+        # An early failure before Cypress leaves no files, hence warn.
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.cypressVideo && !cancelled() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: cypress-videos
+          path: apps/sample-app-lit-e2e/cypress/videos*/
+          retention-days: 5
+          if-no-files-found: warn
       - name: Upload to Codecov
         # Branch-head runs skip upload; merge-head/main covers the same SHA.
         if: ${{ github.event_name != 'push' || github.ref == 'refs/heads/main' }}


### PR DESCRIPTION
Closes #387 — the opt-in half deferred from #397, now that the cost question resolved (public repo: artifact storage free, `retention-days: 5` bounds it).

## What

- `cypressVideo` workflow_dispatch input (boolean, default false) for e2e debugging.
- `CYPRESS_video: ${{ inputs.cypressVideo == true }}` on **both** Build and Test steps — a dispatch may take either step now that `mainGraph` exists, so both honor it. The expression is null-safe: on push/PR `inputs` is empty, `null == true` → `false`.
- `Upload Cypress videos` step: `actions/upload-artifact@v7` (major-tag pin, matching neighbors under the zizmor `actions/*: ref-pin` policy), `path: apps/sample-app-lit-e2e/cypress/videos*/` — covers all five suites' videosFolders (`videos`, `videos-docs`, `videos-hash`, `videos-mobx`, `videos-navigation`, re-verified against current configs), `retention-days: 5`, `if-no-files-found: warn` (a dispatch that fails before Cypress legitimately has no files).

The turbo `passThroughEnv` plumbing (`CYPRESS_video` past strict env mode) already landed in #397; no turbo.json change here.

## Event trace

| Event | `CYPRESS_video` | Upload step |
|---|---|---|
| push / pull_request | `false` | skipped |
| dispatch, defaults | `false` | skipped |
| dispatch, `cypressVideo` | `true` | runs, `!cancelled()` — uploads on suite failure too |
| dispatch, `cypressVideo` + `mainGraph` | `true` (ci_main step) | runs |
| dispatch, `cypressVideo` + `force` | `true`, cache bypassed | runs |

## Verification (local)

- `CYPRESS_video=true cypress run --spec ./src/integration/dialog.cy.js`: passes, produces `cypress/videos/dialog.cy.js.mp4` — the exact string the `== true` expression emits.
- 'false' direction previously proven end-to-end on #397 through the full CI path (`CYPRESS_video=false turbo run test --filter=sample-app-lit-e2e`, strict env → start-server-and-test → 5 concurrent suites: 5/5 passed, 0 mp4s).
- `mise run lint_workflows` clean (zizmor + actionlint); `oxfmt --check` clean.
- `git cherry` vs origin/main: single own commit, no foreign commits.
