### PR TITLE
fix(sample-app): resolve @uirouter/dsr types under nodenext via exports patch

### DIFF
--- a/apps/sample-app-shared/src/app/util/dsr-default-redirect-within.ts
+++ b/apps/sample-app-shared/src/app/util/dsr-default-redirect-within.ts
@@ -1,4 +1,4 @@
-import type { Transition, StateDeclaration } from '@uirouter/core';
+import type { TargetState, Transition, StateDeclaration } from '@uirouter/core';
 
 interface DsrStateDeclaration extends StateDeclaration {
   dsr?: {
@@ -12,7 +12,7 @@ interface DsrTransition extends Transition {
 
 export function dsrRedirectToDefaultFromWithin(
   transition: DsrTransition,
-  redirect: string,
+  redirect: TargetState,
 ) {
   const $state = transition.router.stateService;
   const toState = transition.to();

--- a/apps/sample-app-shared/src/router.config.ts
+++ b/apps/sample-app-shared/src/router.config.ts
@@ -5,10 +5,8 @@ import {
   LocationPlugin,
   Rejection,
   UIRouter,
-  type UIRouterPlugin,
 } from '@uirouter/core';
 import { StickyStatesPlugin } from '@uirouter/sticky-states';
-// @ts-expect-error - @uirouter/dsr lacks proper ESM exports field for nodenext resolution
 import { DSRPlugin } from '@uirouter/dsr';
 
 import { UIRouterLit, LitStateDeclaration } from 'lit-ui-router';
@@ -101,8 +99,7 @@ export function configureRouter(router = new UIRouterLit()) {
     );
   }
 
-  // the @ts-expect-error import above leaves DSRPlugin as `any`
-  router.plugin(DSRPlugin as new (router: UIRouter) => UIRouterPlugin);
+  router.plugin(DSRPlugin);
   router.plugin(StickyStatesPlugin);
 
   const { stateService, stateRegistry, urlService } = router;

--- a/patches/@uirouter__dsr.patch
+++ b/patches/@uirouter__dsr.patch
@@ -1,16 +1,48 @@
+diff --git a/lib/interface.d.ts b/lib/interface.d.ts
+index 2f37e616844419a94eff501762c3468c11c364b5..652aab1fc1ae31890b50fc214c45aef507b3fcc6 100644
+--- a/lib/interface.d.ts
++++ b/lib/interface.d.ts
+@@ -12,7 +12,7 @@ declare module '@uirouter/core/lib/state/stateObject' {
+ }
+ export declare type ParamPredicate = (param: Param) => boolean;
+ export declare type DSRProp = boolean | string | DSRFunction | DSRConfigObj;
+-export declare type DSRFunction = (...args: any[]) => boolean | DSRTarget;
++export declare type DSRFunction = (...args: any[]) => boolean | DSRTarget | TargetState;
+ export interface DSRTarget {
+     state?: StateOrName;
+     params?: RawParams;
+diff --git a/lib-esm/interface.d.ts b/lib-esm/interface.d.ts
+index 2f37e616844419a94eff501762c3468c11c364b5..652aab1fc1ae31890b50fc214c45aef507b3fcc6 100644
+--- a/lib-esm/interface.d.ts
++++ b/lib-esm/interface.d.ts
+@@ -12,7 +12,7 @@ declare module '@uirouter/core/lib/state/stateObject' {
+ }
+ export declare type ParamPredicate = (param: Param) => boolean;
+ export declare type DSRProp = boolean | string | DSRFunction | DSRConfigObj;
+-export declare type DSRFunction = (...args: any[]) => boolean | DSRTarget;
++export declare type DSRFunction = (...args: any[]) => boolean | DSRTarget | TargetState;
+ export interface DSRTarget {
+     state?: StateOrName;
+     params?: RawParams;
 diff --git a/package.json b/package.json
-index c969ff262b1e699632ebeb0a141a310e5becc706..b2a412673a337e06e7770a2789ea045f24b09658 100644
+index c969ff262b1e699632ebeb0a141a310e5becc706..324d1ce438bff5837105e1cea878b657ee81d5e9 100644
 --- a/package.json
 +++ b/package.json
-@@ -40,8 +40,9 @@
-     "node": ">=4.0.0"
-   },
+@@ -42,6 +42,17 @@
    "jsnext:main": "lib-esm/index.js",
--  "main": "lib/index.js",
--  "typings": "lib/index.d.ts",
-+  "main": "./lib/index.js",
-+  "types": "./lib/index.d.ts",
-+  "type": "module",
+   "main": "lib/index.js",
+   "typings": "lib/index.d.ts",
++  "exports": {
++    ".": {
++      "types": "./lib/index.d.ts",
++      "module": "./lib-esm/index.js",
++      "default": "./lib/index.js"
++    },
++    "./lib/*": "./lib/*",
++    "./lib-esm/*": "./lib-esm/*",
++    "./_bundles/*": "./_bundles/*",
++    "./package.json": "./package.json"
++  },
    "license": "MIT",
    "peerDependencies": {
      "@uirouter/core": ">=5.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -234,7 +234,7 @@ packageExtensionsChecksum: sha256-GeoK+J1KFKE+e2SY5vm8ItXeXnBlw5N6FlT+iEHePoo=
 
 patchedDependencies:
   '@api-viewer/docs': 6cfa0893375a4ba334488a5b9e4a56178c62231d864b5271bf4c7a25a0e4f9ac
-  '@uirouter/dsr': 85054b266dee7294d59dc8e0c386367422777df9777a26acb607455cb8217761
+  '@uirouter/dsr': 718bc381dfb5930ea8fefd93aa0ab760d1601e263312146417209d21bdd6eebe
   '@vitest/browser': 5d79da8178f159b23c7475d749ef63f29e9613181535363eb1697e7359f1e63f
   lit-dialog: d37197dba1504e881c6bcb8fed0d928fbcf4203821b2519be07c5d28cb069d5a
 
@@ -446,7 +446,7 @@ importers:
         version: 6.1.2
       '@uirouter/dsr':
         specifier: 'catalog:'
-        version: 1.2.0(patch_hash=85054b266dee7294d59dc8e0c386367422777df9777a26acb607455cb8217761)(@uirouter/core@6.1.2)
+        version: 1.2.0(patch_hash=718bc381dfb5930ea8fefd93aa0ab760d1601e263312146417209d21bdd6eebe)(@uirouter/core@6.1.2)
       '@uirouter/sticky-states':
         specifier: 'catalog:'
         version: 1.5.1(@uirouter/core@6.1.2)
@@ -7716,7 +7716,7 @@ snapshots:
 
   '@uirouter/core@6.1.2': {}
 
-  '@uirouter/dsr@1.2.0(patch_hash=85054b266dee7294d59dc8e0c386367422777df9777a26acb607455cb8217761)(@uirouter/core@6.1.2)':
+  '@uirouter/dsr@1.2.0(patch_hash=718bc381dfb5930ea8fefd93aa0ab760d1601e263312146417209d21bdd6eebe)(@uirouter/core@6.1.2)':
     dependencies:
       '@uirouter/core': 6.1.2
 


### PR DESCRIPTION
## What

Kills the `@ts-expect-error` on `import { DSRPlugin } from '@uirouter/dsr'` by making the package's real types resolve under nodenext, via the pnpm patch. Pre-existing debt, deliberately outside #412's scope.

## Why the old patch didn't work

`@uirouter/dsr` ships parallel CJS (`lib/`) and ESM (`lib-esm/`) builds but no `exports` field. The existing patch added `"type": "module"`, which is the wrong direction: the shipped `.d.ts` files use extensionless relative specifiers (`export * from './dsr'`), which only resolve when the declarations are interpreted as CommonJS. Under `"type": "module"` the index d.ts became an ESM-format file whose re-export chain was dead, so the import resolved but exported nothing (TS2305), and the suppression left `DSRPlugin` as `any`.

## The patch now

Keep the package CJS-formatted (no `type` field) and add a conditional exports map:

```json
"exports": {
  ".": {
    "types": "./lib/index.d.ts",
    "module": "./lib-esm/index.js",
    "default": "./lib/index.js"
  },
  "./lib/*": "./lib/*",
  "./lib-esm/*": "./lib-esm/*",
  "./_bundles/*": "./_bundles/*",
  "./package.json": "./package.json"
}
```

- `types` → the CJS-format declarations; `import { DSRPlugin }` typechecks via TS's CJS named-export interop.
- `module` (bundler-only condition) keeps Vite on the tree-shakeable `lib-esm` build; Node falls through to `default` (CJS), so nothing ESM-syntax is loaded as `.js` in a CJS package.

One more types-only line was needed: upstream declares `DSRFunction` returning `boolean | DSRTarget`, but the runtime calls `.state()` on the fn's return and its own built-in default fn returns the `TargetState` it receives — so the declared return type now admits `TargetState`. Our `dsrRedirectToDefaultFromWithin` helper is correspondingly typed with the `TargetState` redirect argument it actually receives (it was annotated `string`, which was never true at runtime).

## Evidence

`tsc -p apps/sample-app-shared --noEmit --explainFiles`:

```
node_modules/.pnpm/@uirouter+dsr@1.2.0_patch_hash=.../node_modules/@uirouter/dsr/lib/index.d.ts
   Imported via '@uirouter/dsr' from file 'src/router.config.ts' with packageId '@uirouter/dsr/lib/index.d.ts@1.2.0+@uirouter/core@6.1.2'
   File is CommonJS module because '.../@uirouter/dsr/package.json' does not have field "type"
```

Full declaration graph (`dsr.d.ts`, `interface.d.ts`, `DSRDataStore.d.ts`) loads; zero `@ts-expect-error` referencing `@uirouter/dsr` remain repo-wide. Surfacing the real types immediately caught the helper's wrong `string` annotation — the suppression had been hiding it.

- `turbo run typecheck lint` across sample-app-shared and dependents: green (53/53).
- e2e (`sample-app-lit-e2e`, all four app flavors + docs): all suites green, including the DSR redirect and sticky-states coverage in `sample_app.cy.js` (13 passing per flavor).
- `pnpm install --frozen-lockfile` clean after the patch-hash bump.

## Staged upstream fixes

The patch is the union of two staged upstream changes, split per ui-router's one-logical-change convention. The patch hunks map to the fork PRs byte-for-byte:

| Patch hunk | Staged upstream PR |
| --- | --- |
| `package.json` (exports map) | https://github.com/simshanith/dsr/pull/1 |
| `lib/interface.d.ts` + `lib-esm/interface.d.ts` (`DSRFunction` return type) | https://github.com/simshanith/dsr/pull/2 |

When upstream ships a release containing both, this pnpm patch should be deleted and the catalog bumped; if only one lands first, the patch shrinks to the remaining hunk(s).



## Competing approach

#418 is the patch-free variant: pristine 1.2.0 typechecks under nodenext (the old breakage was the legacy patch itself), so it deletes the patch and keeps a one-site `as DSRFunction` accommodation instead. Trade-off in one line: **this PR dogfoods exactly what we propose upstream (simshanith/dsr#1 + #2); #418 leaves nothing to maintain if upstream hibernates.** Maintainer picks one; the other closes.
