### PR TITLE
build(typedoc-plugin): adopt two-pass oxc-emit build

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -931,6 +931,9 @@ importers:
 
   tools/typedoc-plugin-lit-ui-router:
     devDependencies:
+      '@tools/oxc-emit':
+        specifier: workspace:*
+        version: link:../oxc-emit
       '@types/node':
         specifier: 'catalog:'
         version: 24.13.3

--- a/tools/typedoc-plugin-lit-ui-router/package.json
+++ b/tools/typedoc-plugin-lit-ui-router/package.json
@@ -16,13 +16,16 @@
     }
   },
   "scripts": {
-    "build": "tsc",
-    "build:types": "tsc",
+    "build:js": "oxc-emit-js",
+    "build:types": "oxc-emit-dts",
     "format": "oxfmt \"**/*.{ts,js,json,md}\"",
     "format:check": "oxfmt --check \"**/*.{ts,js,json,md}\"",
-    "lint": "oxlint ."
+    "lint": "oxlint .",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "typecheck:src": "tsc -p tsconfig.src.json --noEmit"
   },
   "devDependencies": {
+    "@tools/oxc-emit": "workspace:*",
     "@types/node": "catalog:",
     "typedoc": "catalog:",
     "typescript": "catalog:typescript6-compat"

--- a/tools/typedoc-plugin-lit-ui-router/tsconfig.json
+++ b/tools/typedoc-plugin-lit-ui-router/tsconfig.json
@@ -1,12 +1,7 @@
 {
-  "extends": "../../tsconfig.base.json",
+  // tooling umbrella (IDE, tsgolint): no emit; typecheck:src enforces conformance
+  "extends": "./tsconfig.src.json",
   "compilerOptions": {
-    "types": ["node"],
-    "outDir": "./dist",
-    "declaration": true,
-    "declarationMap": true,
-    "sourceMap": true,
-    "rootDir": "./src"
-  },
-  "include": ["src/**/*.ts"]
+    "noEmit": true
+  }
 }

--- a/tools/typedoc-plugin-lit-ui-router/tsconfig.src.json
+++ b/tools/typedoc-plugin-lit-ui-router/tsconfig.src.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "types": ["node"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    // conformance guard for oxc-emit-dts, which never typechecks
+    "isolatedDeclarations": true
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## What

Refines #412's typedoc-plugin fix: that PR satisfied the new `repo/require-build-types` rule with `"build:types": "tsc"` beside `"build": "tsc"` — the identical full compile twice. This adopts the real pass-split per the repo convention (freshest small adoption: lit-ui-router-mobx, #395):

- `build:js` = `oxc-emit-js`, `build:types` = `oxc-emit-dts`; the `build` script is gone — the root turbo umbrella (`build` → `build:js` + `build:types`) covers it as a transit node, exactly like the published packages
- `tsconfig.src.json` with `isolatedDeclarations` (scope-suffixed naming) + `typecheck:src` as the conformance guard for the never-typechecking dts pass; `tsconfig.json` becomes the no-emit tooling umbrella; `typecheck` script added (the package previously typechecked only as a side effect of `build: tsc`)
- `@tools/oxc-emit` devDep, lockfile regenerated (`--frozen-lockfile` re-verified green)
- The source needed **zero** isolatedDeclarations annotations

## Functional proof — typedoc executes this plugin

Dist compared before/after (tsc emit vs oxc emit):
- identical file set (`diff` of `find` listings: empty)
- identical top-level module shape: 5 import/export statements each, export names byte-identical; ESM preserved (`type: module`, typedoc loads it via ESM import)
- `.d.ts` differences are cosmetic only (single→double quotes, JSDoc indent)

`turbo run docs:api` — the pipeline that loads and runs the plugin across all three packages — 18/18 tasks green on the oxc-built output.

## Verification

- `turbo run build lint typecheck typecheck:src format:check --filter=@tools/typedoc-plugin-lit-ui-router` — 11/11 green
- `pnpm lint:package-json` — `repo/require-build-types` (live on main since #412) green on the new shape
- `pnpm install --frozen-lockfile` green after lockfile regen
