### PR TITLE
ci(lint): keep package-json glob out of build outputs

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -9,7 +9,13 @@ import repoRules from './eslint.repo-rules.ts';
 
 export default defineConfig(
   globalIgnores([
+    // build outputs (per turbo.json outputs): parallel tasks rewrite these
+    // mid-lint, so the **/package.json glob must never traverse them
     '**/dist/**',
+    '**/dist-hash/**',
+    '**/dist-worker-stats/**',
+    'docs/api/**',
+    'tools/release/.cache/**',
     '**/coverage/**',
     '**/node_modules/**',
     '**/.vitepress/cache/**',


### PR DESCRIPTION
## What

Fixes a latent flake in #412's `lint:package-json` wiring: the `**/package.json` glob traversal walks build-output directories, and a parallel vite build rewriting `dist-hash/images/32` raced the eslint scandir to ENOENT during an unrelated PR's verification (warm re-run passed). Build outputs can be rewritten mid-lint by parallel turbo tasks — the traversal must never enter them.

One `globalIgnores` addition in `eslint.config.ts`, enumerated from the repo's actual turbo `outputs` declarations (not guessed):

| Ignore | Declared by |
|---|---|
| `**/dist/**` (already present) | root `build`/`build:js`/`build:types`, `examples */dist/**`, vanilla app `build` |
| `**/dist-hash/**` | `sample-app-lit-vanilla#build:hash` — **the observed race** |
| `**/dist-worker-stats/**` | `docs#bundle:worker` |
| `docs/api/**` | the three packages' `docs:api` (`../../docs/api/<pkg>/**`, `../../docs/api/reference/**`) |
| `tools/release/.cache/**` | `@tools/release` published-diff summary |
| `**/coverage/**` (already present) | `test:coverage` |

Single-file outputs (`dist/custom-elements.json`, `docs/worker/worker-configuration.d.ts`) live inside already-covered or source dirs and create no traversal. `node_modules` was already ignored (eslint also ignores it by default). No workspace package has its manifest under any of these paths — all 26 linted manifests sit at package roots.

## Proof the ignore prunes traversal

Planted `package.json` fixtures at `apps/sample-app-lit-vanilla/dist-hash/package.json` and `dist-hash/images/package.json` → `pnpm lint:package-json` green, still exactly 26 manifests in the TAP output, neither fixture linted, while the real `apps/sample-app-lit-vanilla/package.json` still is. Fixtures removed.

## Verification

- `pnpm lint:package-json` green (26/26)
- mobx negative proof intact: delete `build:types` → `repo/require-build-types` fires, revert → green
- `lint:root`, `typecheck:root`, `format:check` on the touched file all green
