### PR TITLE
build: consolidate variant outputs under dist/ — dist/hash, worker/dist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 
 # compiled output
 dist
-dist-*
 tmp
 
 # dependencies

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -12,7 +12,7 @@
     "builtin": true
   },
   "ignorePatterns": [
-    "**/dist/**",
+    "**/dist*/**",
     "**/coverage/**",
     "**/node_modules/**",
     "**/.vitepress/cache/**"

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -12,7 +12,7 @@
     "builtin": true
   },
   "ignorePatterns": [
-    "**/dist*/**",
+    "**/dist/**",
     "**/coverage/**",
     "**/node_modules/**",
     "**/.vitepress/cache/**"

--- a/TURBO.md
+++ b/TURBO.md
@@ -81,6 +81,9 @@ docs
 - `with` runs root-level tasks alongside workspace tasks (marked edges above)
 - `outputs` defines cacheable artifacts
 - `inputs` scopes cache invalidation
+- Build outputs live in `dist`-named dirs (`dist/`, nested `dist/<variant>`, or `dist-*` siblings), so every traversal ignore is one `**/dist*/**` glob
+
+Exceptions: `docs/api/**` (generated VitePress content, not a bundle output) and `tools/release/.cache/**` (turbo-hashed input cache).
 
 **Graph notes:**
 

--- a/TURBO.md
+++ b/TURBO.md
@@ -81,7 +81,8 @@ docs
 - `with` runs root-level tasks alongside workspace tasks (marked edges above)
 - `outputs` defines cacheable artifacts
 - `inputs` scopes cache invalidation
-- Build outputs live in `dist`-named dirs (`dist/`, nested `dist/<variant>`, or `dist-*` siblings), so every traversal ignore is one `**/dist*/**` glob
+- Every build output lives under a `dist/` dir, so every traversal ignore is one `**/dist/**` glob (no sibling `dist-*` patterns): single-output packages use plain `dist/`; multi-output packages namespace each variant as `dist/<variant>/` (disjoint outputs globs, each vite build empties only its own subdir)
+- Dot-dirs under `dist/` (e.g. `dist/.stats/`, uncached codecov probe output) are machinery, not artifact — packers include dot-dirs under `files: ["dist/**"]`, so shipped packages carry an explicit `!dist/.*/**` negation; `check:published-diff` backstops the boundary
 
 Exceptions: `docs/api/**` (generated VitePress content, not a bundle output) and `tools/release/.cache/**` (turbo-hashed input cache).
 

--- a/apps/README.md
+++ b/apps/README.md
@@ -110,11 +110,11 @@ prefix.
 Two builds stay separate, because they differ in more than a base prefix — but
 they recover their base the same way, so neither bakes one either:
 
-| Build                                | Serves                                                             | Location  |
-| ------------------------------------ | ------------------------------------------------------------------ | --------- |
-| `sample-app-lit-vanilla` `dist`      | `/app`, `/not-found-naive`, `/not-found-spa`, `/simulated-routing` | pushState |
-| `sample-app-lit-mobx` `dist`         | `/app-mobx`                                                        | pushState |
-| `sample-app-lit-vanilla` `dist/hash` | `/app-hash`                                                        | hash      |
+| Build                                   | Serves                                                             | Location  |
+| --------------------------------------- | ------------------------------------------------------------------ | --------- |
+| `sample-app-lit-vanilla` `dist/vanilla` | `/app`, `/not-found-naive`, `/not-found-spa`, `/simulated-routing` | pushState |
+| `sample-app-lit-mobx` `dist`            | `/app-mobx`                                                        | pushState |
+| `sample-app-lit-vanilla` `dist/hash`    | `/app-hash`                                                        | hash      |
 
 **Recovering the base.** `@uirouter/core`'s pushState location reads its base
 from the `<base href>` tag at plugin-install time

--- a/apps/README.md
+++ b/apps/README.md
@@ -114,7 +114,7 @@ they recover their base the same way, so neither bakes one either:
 | ------------------------------------ | ------------------------------------------------------------------ | --------- |
 | `sample-app-lit-vanilla` `dist`      | `/app`, `/not-found-naive`, `/not-found-spa`, `/simulated-routing` | pushState |
 | `sample-app-lit-mobx` `dist`         | `/app-mobx`                                                        | pushState |
-| `sample-app-lit-vanilla` `dist-hash` | `/app-hash`                                                        | hash      |
+| `sample-app-lit-vanilla` `dist/hash` | `/app-hash`                                                        | hash      |
 
 **Recovering the base.** `@uirouter/core`'s pushState location reads its base
 from the `<base href>` tag at plugin-install time

--- a/apps/sample-app-lit-vanilla/package.json
+++ b/apps/sample-app-lit-vanilla/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "build": "vite build",
-    "build:hash": "vite build --mode hash --outDir dist-hash",
+    "build:hash": "vite build --mode hash --outDir dist/hash",
     "codecov:bundle": "upload-bundle-stats sample-app-lit-vanilla-esm",
     "dev": "vite",
     "format": "oxfmt \"**/*.{js,ts,json,md,html}\"",

--- a/apps/sample-app-lit-vanilla/package.json
+++ b/apps/sample-app-lit-vanilla/package.json
@@ -4,9 +4,9 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "vite build",
+    "build": "vite build --outDir dist/vanilla",
     "build:hash": "vite build --mode hash --outDir dist/hash",
-    "codecov:bundle": "upload-bundle-stats sample-app-lit-vanilla-esm",
+    "codecov:bundle": "upload-bundle-stats sample-app-lit-vanilla-esm dist/vanilla",
     "dev": "vite",
     "format": "oxfmt \"**/*.{js,ts,json,md,html}\"",
     "format:check": "oxfmt --check \"**/*.{js,ts,json,md,html}\"",

--- a/apps/sample-app-lit-vanilla/turbo.json
+++ b/apps/sample-app-lit-vanilla/turbo.json
@@ -9,7 +9,7 @@
         "VITE_SAMPLE_APP_PUSH_STATE"
       ],
       "dependsOn": ["^build", "^transit"],
-      "outputs": ["dist/**", "!dist/hash/**"],
+      "outputs": ["dist/vanilla/**"],
       "with": ["build:hash"]
     },
     "build:hash": {
@@ -18,8 +18,7 @@
         "VITE_SAMPLE_APP_BASE_URL",
         "VITE_SAMPLE_APP_PUSH_STATE"
       ],
-      // after build: the main vite build empties dist/, dist/hash included
-      "dependsOn": ["^build", "^transit", "build"],
+      "dependsOn": ["^build", "^transit"],
       "outputs": ["dist/hash/**"]
     }
   }

--- a/apps/sample-app-lit-vanilla/turbo.json
+++ b/apps/sample-app-lit-vanilla/turbo.json
@@ -9,7 +9,7 @@
         "VITE_SAMPLE_APP_PUSH_STATE"
       ],
       "dependsOn": ["^build", "^transit"],
-      "outputs": ["dist/**"],
+      "outputs": ["dist/**", "!dist/hash/**"],
       "with": ["build:hash"]
     },
     "build:hash": {
@@ -18,8 +18,9 @@
         "VITE_SAMPLE_APP_BASE_URL",
         "VITE_SAMPLE_APP_PUSH_STATE"
       ],
-      "dependsOn": ["^build", "^transit"],
-      "outputs": ["dist-hash/**"]
+      // after build: the main vite build empties dist/, dist/hash included
+      "dependsOn": ["^build", "^transit", "build"],
+      "outputs": ["dist/hash/**"]
     }
   }
 }

--- a/docs/.vitepress/vite.config.ts
+++ b/docs/.vitepress/vite.config.ts
@@ -97,12 +97,12 @@ export default defineConfig({
         // in. Its bundle is content-hashed against different env, so it
         // coexists with the vanilla one under /assets.
         {
-          src: 'node_modules/sample-app-lit-vanilla/dist-hash/assets/*',
+          src: 'node_modules/sample-app-lit-vanilla/dist/hash/assets/*',
           dest: 'assets',
           rename: { stripBase: true },
         },
         {
-          src: 'node_modules/sample-app-lit-vanilla/dist-hash/index.html',
+          src: 'node_modules/sample-app-lit-vanilla/dist/hash/index.html',
           dest: '',
           rename: { name: 'app-hash.html', stripBase: true },
         },
@@ -121,7 +121,7 @@ export default defineConfig({
         // Hash deep paths (`/app-hash/foo`) never happen under a hash client,
         // but a mistyped one gets the same honest 404 page as the other mounts.
         {
-          src: 'node_modules/sample-app-lit-vanilla/dist-hash/404.html',
+          src: 'node_modules/sample-app-lit-vanilla/dist/hash/404.html',
           dest: 'app-hash',
           rename: { stripBase: true },
         },

--- a/docs/.vitepress/vite.config.ts
+++ b/docs/.vitepress/vite.config.ts
@@ -69,16 +69,16 @@ export default defineConfig({
     }),
     examplesIndexPlugin(),
     // static-copy v4 matches files only and always preserves source directory
-    // structure; stripBase drops the node_modules/<app>/dist/<dir> prefix.
+    // structure; stripBase drops the node_modules/<app>/dist/<variant>/<dir> prefix.
     viteStaticCopy({
       targets: [
         {
-          src: 'node_modules/sample-app-lit-vanilla/dist/assets/*',
+          src: 'node_modules/sample-app-lit-vanilla/dist/vanilla/assets/*',
           dest: 'assets',
           rename: { stripBase: true },
         },
         {
-          src: 'node_modules/sample-app-lit-vanilla/dist/index.html',
+          src: 'node_modules/sample-app-lit-vanilla/dist/vanilla/index.html',
           dest: '',
           rename: { name: 'app.html', stripBase: true },
         },
@@ -109,7 +109,7 @@ export default defineConfig({
         // Per-mount 404 pages: the worker (docs/worker/index.ts) serves
         // <mount>/404.html with status 404 for unmatched paths in a mount.
         {
-          src: 'node_modules/sample-app-lit-vanilla/dist/404.html',
+          src: 'node_modules/sample-app-lit-vanilla/dist/vanilla/404.html',
           dest: 'app',
           rename: { stripBase: true },
         },
@@ -136,14 +136,14 @@ export default defineConfig({
         // images/ and static/ come from sample-app-shared and are identical
         // in both apps' dists; copy once so neither can silently clobber.
         {
-          src: 'node_modules/sample-app-lit-vanilla/dist/images/**',
+          src: 'node_modules/sample-app-lit-vanilla/dist/vanilla/images/**',
           dest: 'images',
-          rename: { stripBase: 4 },
+          rename: { stripBase: 5 },
         },
         {
-          src: 'node_modules/sample-app-lit-vanilla/dist/static/**',
+          src: 'node_modules/sample-app-lit-vanilla/dist/vanilla/static/**',
           dest: 'static',
-          rename: { stripBase: 4 },
+          rename: { stripBase: 5 },
         },
         // stripBase ignores the leading ../, so 3 = examples/<name>/dist.
         ...EMBEDDED_EXAMPLES.map((name) => ({

--- a/docs/package.json
+++ b/docs/package.json
@@ -5,8 +5,8 @@
   "type": "module",
   "scripts": {
     "build": "vitepress build .",
-    "bundle:worker": "mkdir -p dist && wrangler deploy --dry-run --outdir=\"$PWD/dist-worker-stats\"",
-    "codecov:bundle": "upload-bundle-stats docs-worker-esm dist-worker-stats --no-manifest",
+    "bundle:worker": "mkdir -p dist && wrangler deploy --dry-run --outdir=\"$PWD/worker/dist\"",
+    "codecov:bundle": "upload-bundle-stats docs-worker-esm worker/dist --no-manifest",
     "docs": "vitepress dev .",
     "docs:preview": "vitepress preview .",
     "format": "oxfmt \"**/*.{md,json,ts,vue}\"",

--- a/docs/turbo.json
+++ b/docs/turbo.json
@@ -10,10 +10,11 @@
       "inputs": [
         "package.json",
         "worker/**",
+        "!worker/dist/**",
         "$TURBO_ROOT$/wrangler.jsonc",
         "$TURBO_ROOT$/pnpm-lock.yaml"
       ],
-      "outputs": ["dist-worker-stats/**"]
+      "outputs": ["worker/dist/**"]
     },
     "codecov:bundle": {
       // Upload-only: ships the (possibly cache-replayed) dry-run artifact.

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -9,9 +9,9 @@ import repoRules from './eslint.repo-rules.ts';
 
 export default defineConfig(
   globalIgnores([
-    // build outputs (all dist-named by convention): parallel tasks rewrite
-    // these mid-lint, so the **/package.json glob must never traverse them
-    '**/dist*/**',
+    // build outputs (every output lives under a dist/ dir): parallel tasks
+    // rewrite these mid-lint, so the **/package.json glob must never traverse them
+    '**/dist/**',
     'docs/api/**',
     'tools/release/.cache/**',
     '**/coverage/**',

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -9,11 +9,9 @@ import repoRules from './eslint.repo-rules.ts';
 
 export default defineConfig(
   globalIgnores([
-    // build outputs (per turbo.json outputs): parallel tasks rewrite these
-    // mid-lint, so the **/package.json glob must never traverse them
-    '**/dist/**',
-    '**/dist-hash/**',
-    '**/dist-worker-stats/**',
+    // build outputs (all dist-named by convention): parallel tasks rewrite
+    // these mid-lint, so the **/package.json glob must never traverse them
+    '**/dist*/**',
     'docs/api/**',
     'tools/release/.cache/**',
     '**/coverage/**',

--- a/packages/lit-ui-router-mobx/package.json
+++ b/packages/lit-ui-router-mobx/package.json
@@ -24,6 +24,7 @@
   },
   "files": [
     "dist/**",
+    "!dist/.*/**",
     "src/*.ts"
   ],
   "type": "module",

--- a/packages/lit-ui-router/package.json
+++ b/packages/lit-ui-router/package.json
@@ -11,6 +11,7 @@
   },
   "files": [
     "dist/**",
+    "!dist/.*/**",
     "src/*.ts",
     "!src/*.spec.ts"
   ],

--- a/packages/navigation-location-plugin/package.json
+++ b/packages/navigation-location-plugin/package.json
@@ -23,6 +23,7 @@
   },
   "files": [
     "dist/**",
+    "!dist/.*/**",
     "src/*.ts",
     "!src/*.spec.ts"
   ],

--- a/tools/bundle-probe/src/upload-entry-bundles.ts
+++ b/tools/bundle-probe/src/upload-entry-bundles.ts
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 // Codecov bundle series per exported entry: rolldown (the vite-8-era
 // consumer bundler) emits each entry minified with declared dependencies and
-// peers external into dist-stats/, then the shared uploader ships one
+// peers external into dist/.stats/ (dot-dir: machinery, not artifact — the
+// packages' files negation keeps it out of the tarball), then the shared uploader ships one
 // <prefix>-<label>-esm series per entry. Entries and labels derive from the
 // exports map (see entries.ts); the optional prefix argument overrides the
 // package name (series continuity). CODECOV_TOKEN unset stays the uploader's
@@ -23,7 +24,7 @@ const uploader = fileURLToPath(
   import.meta.resolve('@tools/build_and_test/src/upload-bundle-stats.ts'),
 );
 
-const statsRoot = path.join(packageDir, 'dist-stats');
+const statsRoot = path.join(packageDir, 'dist', '.stats');
 await rm(statsRoot, { recursive: true, force: true });
 
 console.log(


### PR DESCRIPTION
## What

True consolidation of the scattered build-output dirs that #416 had to enumerate one-by-one — the class closes structurally instead of by bespoke ignore lists.

| Location | Before | After | Notes |
|---|---|---|---|
| vanilla main build | `dist/` (root) | `dist/vanilla/` | explicit outDir; each vite build empties only its own subdir |
| vanilla hash build | `dist-hash/` | `dist/hash/` | disjoint sibling; NO ordering needed — the earlier `build`→`build:hash` dependsOn and outputs negation both dropped once the main build stopped owning `dist/` wholesale (proven by out-of-order + marker-survival runs) |
| docs worker dry-run bundle | `docs/dist-worker-stats/` | `docs/worker/dist/` | beside its source; `worker/**` inputs negate the output dir |
| bundle-probe per-package stats | `dist-stats/` | `dist/.stats/` | dot-dir = machinery-not-artifact signal; **pnpm pack includes dot-dirs under `files: ["dist/**"]`** (probe-proven), so the three published packages carry a generalized `!dist/.*/**` negation — probe-proven on two planted dot-dirs (`dist/.stats/`, `dist/.probe/`): both excluded, 16 non-dot dist entries + src untouched. `check:published-diff` is the file-level backstop (`check:pack` guards manifests only). Caching untouched — `codecov:bundle` is `cache: false`, no turbo outputs ever declared stats, so the stale-restore trap is structurally absent. Tool-scoped placement (`tools/bundle-probe/dist/<pkg>`) rejected: cross-package writes for zero caching benefit |
| typedoc output | `docs/api/` | **stays** | generated VitePress *content* under srcDir, not a bundle output — vitepress must read it as source markdown; a documented exception |
| release cache | `tools/release/.cache/` | **out of scope** | turbo hashes it as an input (#375 machinery) |

Ignore payoff: #416's five build-output entries collapse to one `**/dist*/**` glob (eslint + oxlint); `.gitignore` already encoded the convention (`dist` + `dist-*`). Convention + exceptions documented in TURBO.md.

## Archaeology

- `dist-hash`: born in #364's per-mount `--mode`/`outDir` pattern (`build:<mount>` → `dist-<mount>`), which #364 itself later collapsed back to the one hash variant.
- `dist-worker-stats`: #373 (bundle invariants); `tools/release/.cache`: #375 (published-diff), deliberately input-hashed.
- The original sibling-vs-nested decision was made for codecov bundle-reporting extensibility. Verified against the actual machinery: bundle identity is an **explicit CLI string** (`upload-bundle-stats <name> [dir]`) — nothing derives names from directory geometry, on our side or codecov's. The intent (stable distinct bundle names) survives the layout change; the mechanism (sibling dirs) was not load-bearing.

## Codecov continuity

Published bundle names unchanged: `sample-app-lit-vanilla-esm`, `docs-worker-esm`. For the vanilla report, `@codecov/bundle-analyzer` names assets `path.relative(walkedDir, file)` and the uploader filters on vite-manifest membership — verified the manifest contains no `hash/` entries, so nested hash assets are structurally excluded from the report. (Upload itself not runnable locally — `CODECOV_TOKEN` unset — continuity is by construction, worth eyeballing on the first main run.)

## Why not `docs/dist/worker-stats`

Empirically ruled out: a planted probe file in `docs/dist` did not survive `vitepress build` — it wipes its outDir. Nesting there would force `bundle:worker` to order after **and cache-key couple to** the docs build, breaking the dependency-edged independence #375 engineered (`docs content can't affect the artifact`). `worker/dist` keeps that independence: proven by a back-to-back `bundle:worker` cache hit and by the artifact surviving a full docs build.

## Verification

- vanilla: fresh build emits `dist/` + `dist/hash/`, no turbo cycle (`with` + `dependsOn` coexist), second run all cache hits
- **e2e serving proof**: full hash-variant suite (`test:hash` — wrangler-served `/app-hash` from the docs worker) — All specs passed, 21/21
- docs: `bundle:worker` emits to `worker/dist`, cache-stable on rerun; full docs build green with the artifact intact and **no** vitepress content pollution from `worker/dist/README.md` (checked the built site)
- `lint:package-json` green (26 manifests); planted `dist/hash/package.json` fixture not traversed; mobx `require-build-types` negative proof still fires
- `lint`, `typecheck`, `format:check` green for docs + vanilla (27 tasks) and root legs



## dist/vanilla rework (round 2)

Rule landed: **single-output packages keep plain `dist/`; multi-output packages namespace every variant as `dist/<variant>/`** — so `sample-app-lit-mobx` stays plain `dist/` (no sibling variant; symmetry would buy nothing and touch every consumer).

Consumer-change list: vanilla `build` script outDir, turbo outputs (two plain disjoint globs), docs static-copy srcs — including the numeric `stripBase: 4 -> 5` for the deeper `images/`/`static/` paths (the segment-count gotcha; the vanilla e2e suite caught the nested `static/static` data fetches as "The transition errored" failures, green after the fix), codecov `buildDir` arg (`dist/vanilla` — bundle name unchanged), `apps/README`.

## dist/.stats per-surface dot-matching table

| Surface | Behavior with `dist/.stats/` | Proof |
|---|---|---|
| `pnpm pack`, `files: ["dist/**"]` | **INCLUDED** — dot-dir not excluded for free | planted `probe.json`, tarball listing |
| `pnpm pack` + `!dist/.*/**` | excluded | tarball listing, 17 -> 16 entries |
| turbo outputs | N/A — `codecov:bundle` is `cache: false`; stats were never a declared output | root turbo.json |
| eslint `**/package.json` traversal | not traversed (`**/dist*/**` ignore covers subpaths) | planted `dist/.stats/package.json`, 26-manifest count unchanged |
| oxlint package sweep | ignored | planted `debugger;` probe, lint green |
| `.gitignore` | ignored (inside `dist`) | `git check-ignore` |
| codecov analyzer | walks the explicit `statsRoot` arg fine | `codecov:bundle` run (token-unset skip path) |

`.gitignore` keeps `dist-*` purely as stale-tree protection — dropping it made a stale `dist-hash/` instantly break `format:check` locally.

## Round-2 proofs

- both e2e variants green against worker-served builds: vanilla 21/21, hash 21/21
- out-of-order build (`build:hash` first on empty dist, then `build`) and marker-survival both directions: no cross-wipe, no cycle; cache-hit rerun clean
- codecov structural: `dist/vanilla/.vite/manifest.json` present; manifest has no cross-variant entries; bundle names unchanged (upload itself not runnable locally, CODECOV_TOKEN unset)
- 59/59 test/lint/typecheck/format tasks green across all touched packages; `require-build-types` negative proof still fires; lint fixture probes green



## Final glob inventory (ignores exact, maintainer-ruled)

| Surface | Form |
|---|---|
| eslint globalIgnores | `**/dist/**` + `docs/api/**` + `tools/release/.cache/**` + coverage/node_modules/.vitepress-cache/.claude |
| .oxlintrc.json ignorePatterns | `**/dist/**` (+ unchanged non-dist entries) |
| .gitignore | `dist` only — the `dist-*` legacy entry is gone |
| turbo outputs (declarations) | exact: `dist/vanilla/**`, `dist/hash/**`, `worker/dist/**`, `dist/**` (single-output), `coverage/**`, `.cache/...` |
| shipped `files` | `dist/**` + `!dist/.*/**` + src globs |
| codecov buildDir args | exact: `dist/vanilla`, `worker/dist`, tool-internal `dist/.stats` |

**Transition note:** existing checkouts/worktrees holding orphaned `dist-hash/`, `dist-worker-stats/`, or `dist-stats/` dirs clean them once (`git clean -fdX apps docs packages` or targeted `rm`); a `format:check`/lint failure naming such a dir IS the signal and is self-explanatory. Observed once locally during the transition via a warm pre-consolidation turbo cache replay; with the merged configs nothing recreates them (verified: deleted, full 59-task verify, stayed gone).

## Publish-state analysis (files hunks are the separable second commit)

Merging the `files` hunks changes the published manifest of all three packages. Predicted post-merge diff, produced by this repo's own machinery (`resolve:published` + `check:published-diff --force` locally): **3 of 3 packages SHIP CHANGES — exactly one ship-affecting file each: `package.json`** (the `!dist/.*/**` line; vs registry latest `lit-ui-router@1.7.1`, `lit-ui-router-mobx@0.3.5`, `ui-router-navigation-location-plugin@0.2.3` — note the local run predates main catching up to 0.3.5/0.2.3, so the local-vs-registry report carries a release-in-flight caveat, but the files hunk is the only new delta this PR adds).

Can `dist/.stats` even exist at pack time in CI? **No, in both contexts:**
- `publish-npm.yml`: fresh checkout → mise setup → `//:build` (turbo build graph: `build:js`/`build:types`/`build:custom-elements`) → pack. `codecov:bundle` — the only stats writer — is not in the build graph.
- `check:published-diff`: `dependsOn ^build` only; same graph, same conclusion; fresh CI checkout.

So in CI the negation is pure defense-in-depth. It IS load-bearing for **local** packs and the **locally-run** published-diff check (a local `turbo ci` leaves `dist/.stats` behind; without the negation the local check would report a bogus ship-affecting diff).

**Sequencing options — maintainer's call, not decided here:**
1. **Merge both commits now**: published-diff flips orange on merge; three releases owed for a manifest-only line, right after 0.3.5/0.2.3 shipped.
2. **Split the second commit out** (`a19f1f9`, exactly the three one-line files hunks) to a parked follow-up that piggybacks each package's next natural release: no orange badge now; cost is that local packs/local published-diff runs can transiently include `dist/.stats` until it lands (CI packs are provably unaffected either way).
