### PR TITLE
Release 0.3.5

### DIFF
--- a/packages/lit-ui-router-mobx/package.json
+++ b/packages/lit-ui-router-mobx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lit-ui-router-mobx",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "MobX bindings for lit-ui-router: an observable router store and reaction-based Lit ReactiveControllers",
   "keywords": [
     "lit",


### PR DESCRIPTION
* fix(sample-app): drop the @uirouter/dsr patch — pristine types resolve under nodenext (#418) (89085c3)
* ci(lint): keep package-json glob out of build outputs (#416) (3bdce15)
* ci(turbo): typecheck and lint depend on ^build:types only (#411) (6465a55)
* build(typedoc-plugin): adopt two-pass oxc-emit build (#415) (53a6f12)
* ci(lint): build:types contract rule; TypeScript lint configs; lint all config files (#412) (bbede7a)
* ci(e2e): opt-in cypress video capture + artifact upload on dispatch (#413) (795e8b9)
* docs: sync mise/turbo/contributing docs with the ci:main restructure (#409) (f3db676)
* build(navigation-location-plugin): adopt two-pass oxc-emit build (#396) (5c6dbe3)
* build(lit-ui-router-mobx): adopt two-pass oxc-emit build (#395) (4668ac4)
* ci: dispatch input to run the ci:main graph on demand (#410) (3566feb)
* ci: single vitest pass per PR — coverage carries correctness, engines matrix on main (#399) (85c36c6)
* test: happy-dom project split — browser mode only for browser-dependent specs (#403) (fa578dc)
* ci(e2e): cache sample-app-lit-e2e test via dependency-edged inputs (#398) (f6c3182)
* docs(readme): badge rework (#408) (5787a17)
* test: demote location-plugin URL-shape assertions to package unit specs (#401) (4427ac2)
* test(sample-app-shared): demote feature-flags panel + dialog render coverage to component specs (#400) (5e86ce2)
* test: move type-level tests out of runtime tiers + lint/turbo hygiene (#402) (5e13cde)
* test(docs): relocate worker contract assertions from cypress to node tests against the worker module (#404) (4e12435)
* ci(e2e): disable cypress video in CI by default (#397) (910e7f7)
* ci: bump actions/cache v4 to v6 — v4 targets deprecated Node 20 (#406) (f78e0d8)
