### PR TITLE
ci(lint): guard pnpm patches against silent no-ops on dependency bumps

### DIFF
--- a/check-patches.ts
+++ b/check-patches.ts
@@ -1,0 +1,82 @@
+// pnpm applies patches by exact file path, so a patched dependency bump can
+// rotate a content-hashed target filename and the patch silently no-ops.
+// Assert every patch target exists in the installed package and every added
+// line survives, for each entry in pnpm-workspace.yaml's patchedDependencies.
+import { globSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { parsePatch } from 'diff';
+
+import {
+  loadPatchedDependencies,
+  workspaceRoot,
+} from '@tools/shared/workspace.ts';
+
+const patchedDependencies = await loadPatchedDependencies(workspaceRoot);
+const entries = Object.entries(patchedDependencies);
+if (entries.length === 0) {
+  console.error('check-patches: no patchedDependencies declared');
+  process.exit(1);
+}
+
+let failed = false;
+const fail = (message: string) => {
+  failed = true;
+  console.error(`check-patches: ${message}`);
+};
+
+for (const [name, patchPath] of entries) {
+  const patch = readFileSync(join(workspaceRoot, patchPath), 'utf8');
+  // live installs of a patched dep are keyed with patch_hash; hash-less
+  // siblings are orphaned store dirs from other branches' installs
+  const installs = globSync(
+    join(
+      workspaceRoot,
+      'node_modules/.pnpm',
+      `${name.replace('/', '+')}@*patch_hash*`,
+      'node_modules',
+      name,
+    ),
+  );
+  if (installs.length === 0) {
+    fail(`${name}: patch declared but no patched install found`);
+    continue;
+  }
+
+  // a new path of /dev/null marks a deletion
+  for (const file of parsePatch(patch)) {
+    const target = file.newFileName;
+    if (!target || target === '/dev/null') continue;
+    const relPath = target.replace(/^b\//, '');
+    const added = file.hunks
+      .flatMap((hunk) => hunk.lines)
+      .filter((line) => line.startsWith('+'))
+      .map((line) => line.slice(1))
+      .filter((line) => line.trim() !== '');
+
+    for (const install of installs) {
+      let content: string;
+      try {
+        content = readFileSync(join(install, relPath), 'utf8');
+      } catch {
+        fail(`${name}: ${relPath} missing in ${install} (patch no-oped?)`);
+        continue;
+      }
+      for (const line of added) {
+        if (!content.includes(line)) {
+          fail(`${name}: ${relPath} lacks patched line: ${line.trim()}`);
+        }
+      }
+    }
+  }
+}
+
+if (failed) {
+  console.error(
+    'check-patches: regenerate with `pnpm patch <pkg>` against the new version, or drop the entry if upstream shipped the fix',
+  );
+  process.exit(1);
+}
+console.log(
+  `check-patches: ${entries.length} patches verified against installs`,
+);

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "build": "turbo run build",
     "check:pack": "turbo run check:pack",
+    "check:patches": "node check-patches.ts",
     "check:published-diff": "turbo run resolve:published && turbo run check:published-diff",
     "check:workers-builds": "turbo run @tools/workers-builds#check",
     "ci": "turbo run ci",
@@ -28,7 +29,9 @@
     "@commitlint/cli": "catalog:",
     "@commitlint/config-conventional": "catalog:",
     "@commitlint/types": "catalog:",
+    "@tools/shared": "workspace:*",
     "@types/node": "catalog:",
+    "diff": "catalog:",
     "eslint": "catalog:",
     "eslint-formatter-tap": "catalog:",
     "eslint-plugin-oxlint": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,6 +78,9 @@ catalogs:
     cypress:
       specifier: ^15.18.1
       version: 15.18.1
+    diff:
+      specifier: ^9.0.0
+      version: 9.0.0
     esbuild:
       specifier: ^0.28.1
       version: 0.28.1
@@ -256,9 +259,15 @@ importers:
       '@commitlint/types':
         specifier: 'catalog:'
         version: 21.2.0
+      '@tools/shared':
+        specifier: workspace:*
+        version: link:tools/shared
       '@types/node':
         specifier: 'catalog:'
         version: 24.13.3
+      diff:
+        specifier: 'catalog:'
+        version: 9.0.0
       eslint:
         specifier: 'catalog:'
         version: 10.7.0(jiti@2.7.0)(supports-color@8.1.1)
@@ -3998,6 +4007,10 @@ packages:
 
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
+
+  diff@9.0.0:
+    resolution: {integrity: sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==}
+    engines: {node: '>=0.3.1'}
 
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
@@ -8961,6 +8974,8 @@ snapshots:
   devlop@1.1.0:
     dependencies:
       dequal: 2.0.3
+
+  diff@9.0.0: {}
 
   dir-glob@3.0.1:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -30,6 +30,7 @@ catalog:
   '@vitest/coverage-v8': ^4.1.10
   concurrently: ^10.0.3
   cypress: ^15.18.1
+  diff: ^9.0.0
   esbuild: ^0.28.1
   eslint: ^10.7.0
   eslint-formatter-tap: ^9.0.1

--- a/tools/shared/src/workspace.ts
+++ b/tools/shared/src/workspace.ts
@@ -57,3 +57,13 @@ export async function loadWorkspace(root: string): Promise<{
   });
   return { members, workspaceManifest };
 }
+
+/** patchedDependencies from pnpm-workspace.yaml: package name -> patch path. */
+export async function loadPatchedDependencies(
+  root: string,
+): Promise<Record<string, string>> {
+  const { readWorkspaceManifest } =
+    await import('@pnpm/workspace.read-manifest');
+  const workspaceManifest = await readWorkspaceManifest(root);
+  return workspaceManifest?.patchedDependencies ?? {};
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,7 @@
     "lib": ["ES2022"]
   },
   "include": [
+    "check-patches.ts",
     "commitlint.config.ts",
     "eslint.config.ts",
     "eslint.repo-rules.ts",

--- a/turbo.json
+++ b/turbo.json
@@ -56,7 +56,12 @@
       "env": ["VITEST_BROWSER_API_PORT", "CI"]
     },
     "lint": {
-      "with": ["//#lint:root", "//#lint:package-json", "//#lint:workflows"],
+      "with": [
+        "//#lint:root",
+        "//#lint:package-json",
+        "//#lint:workflows",
+        "//#check:patches"
+      ],
       // type-aware oxlint resolves cross-package imports to dist d.ts only
       "dependsOn": ["^build:types"],
       "inputs": [
@@ -68,6 +73,17 @@
     },
     "//#lint:root": {
       "inputs": [".oxlintrc.json", "$TURBO_DEFAULT$"]
+    },
+    "//#check:patches": {
+      // pnpm-lock.yaml carries the patch hashes, so a dependency bump that
+      // could rotate a patch target re-runs the check
+      "inputs": [
+        "check-patches.ts",
+        "patches/**",
+        "pnpm-workspace.yaml",
+        "pnpm-lock.yaml",
+        "tools/shared/src/**"
+      ]
     },
     "//#lint:package-json": {
       "inputs": [


### PR DESCRIPTION
## What

Necessity audit of the repo's pnpm patches, plus a loud-failure guard for the known silent-no-op gotcha. The guard is generic: every `patchedDependencies` entry — present and future — is auto-covered.

## Patch inventory (current state)

| Patch | What it fixes | Status | Verdict |
| --- | --- | --- | --- |
| `patches/lit-dialog.patch` | Removes a value-import of `TemplateResult` from `lit` — verified not a runtime export (`'TemplateResult' in await import('lit')` → `false`), so the unpatched import fails under ESM | `lit-dialog@2.0.1` is latest, last published 2022 — effectively unmaintained | **resident** |
| `patches/@api-viewer__docs.patch` | Adds the missing `types` field (and normalizes `main`) so nodenext resolves the shipped declarations | Installed `1.0.0-pre.10` is the latest published version (2024-04); no release carries a fix | **resident** |
| `patches/@vitest__browser.patch` | `isEmbedded` guard against duplicate testers echoing `response:*` events | **Departing via #424**: #422's spec-level prevention (merged) makes it unnecessary; upstream fix staged as vitest-dev/vitest#9381 | departing |

When #424 lands, the guard's residents are lit-dialog + @api-viewer/docs only — both unmaintained upstream, so the patches (and this guard) are long-lived.

## The guard

`check-patches.ts` (root, node-run via type stripping like the repo's other root scripts): for every `pnpm-workspace.yaml` `patchedDependencies` entry, asserts each patch-target file exists in the patched install and every added line survives.

- **YAML parsing**: `patchedDependencies` is read through `@tools/shared/workspace.ts`'s new `loadPatchedDependencies` — pnpm's own `readWorkspaceManifest` (already a @tools/shared dependency), not hand-parsed YAML.
- **Diff parsing**: the patch files are parsed with jsdiff's `parsePatch` (`diff` catalogued as a root devDependency) — target files from each entry's new path (pnpm's `b/` prefix stripped, `/dev/null` skipped as deletion), added lines from the hunks. No hand-rolled unified-diff parsing.
- **Install matching**: patched installs are globbed by `patch_hash` in the store path, so orphaned hash-less store dirs left by other branches' installs can't false-positive (a live install of a patched dep always carries the hash).
- **Wiring**: `//#check:patches` runs with the root lint family (`with` on `lint`); turbo inputs keyed on `pnpm-lock.yaml` (carries the patch hashes) plus `tools/shared/src/**`, so exactly the bumps that can rotate a hashed filename re-run the check.

Failure modes proven loud (simulated, then restored):

- marker line edited out of the installed tester bundle →
  `check-patches: @vitest/browser: ... lacks patched line: const isEmbedded = window.self !== window.top;` (exit 1)
- target filename rotated →
  `check-patches: @vitest/browser: ... missing in node_modules/.pnpm/@vitest+browser@4.1.10_patch_hash=... (patch no-oped?)` (exit 1)

The failure output ends with the bump-time procedure (`pnpm patch <pkg>` regen, or drop the entry once upstream ships).

## Verification

- `check-patches`: 3/3 patches verified — via the script directly and through the turbo `with`-wiring (`//:check:patches` runs alongside any `lint`); both negative proofs re-run after the YAML-parsing swap.
- Root lint / typecheck / format green; `@tools/shared` test/lint/typecheck green with the new export.
- vitest patch functionality itself was proven in the #422/#424 line of work (browser suite + coverage, zero `response:*`).

## Interaction with #424

#424 removes the `@vitest/browser` patch. Whichever lands second is trivially reconciled: the guard is patch-agnostic and simply has one fewer resident.
