### PR TITLE
test(lit-ui-router): cancel native click defaults in browser specs

### DIFF
--- a/packages/lit-ui-router/src/specs/browser-test-utils.ts
+++ b/packages/lit-ui-router/src/specs/browser-test-utils.ts
@@ -7,3 +7,43 @@ export function clickLocatedElement(
 ) {
   return page.elementLocator(element).click(options);
 }
+
+export interface SuppressedNativeClick {
+  type: string;
+  tag: string;
+  href: string | null;
+  /** as observed before this helper cancels the event */
+  defaultPrevented: boolean;
+}
+
+export interface NativeClickSuppression {
+  /** every click/auxclick that reached default-action stage, in order */
+  events: SuppressedNativeClick[];
+  restore: () => void;
+}
+
+// Hash hrefs resolve to the tester URL (live sessionId): an uncancelled
+// _blank/modifier/middle click boots a duplicate tester on the channel.
+// Bubble-phase so the router's element-level handler decides first.
+export function suppressNativeClickNavigation(): NativeClickSuppression {
+  const events: SuppressedNativeClick[] = [];
+  const listener = (event: Event) => {
+    const target = event.target instanceof Element ? event.target : null;
+    events.push({
+      type: event.type,
+      tag: target?.tagName.toLowerCase() ?? 'unknown',
+      href: target?.getAttribute('href') ?? null,
+      defaultPrevented: event.defaultPrevented,
+    });
+    event.preventDefault();
+  };
+  window.addEventListener('click', listener);
+  window.addEventListener('auxclick', listener);
+  return {
+    events,
+    restore: () => {
+      window.removeEventListener('click', listener);
+      window.removeEventListener('auxclick', listener);
+    },
+  };
+}

--- a/packages/lit-ui-router/src/specs/ui-sref.spec.ts
+++ b/packages/lit-ui-router/src/specs/ui-sref.spec.ts
@@ -20,19 +20,26 @@ import {
   routerGo,
   clickElement,
 } from './test-utils.js';
-import { clickLocatedElement } from './browser-test-utils.js';
+import {
+  clickLocatedElement,
+  suppressNativeClickNavigation,
+  NativeClickSuppression,
+} from './browser-test-utils.js';
 
 describe('uiSref directive', () => {
   let container: HTMLElement;
   let router: UIRouterLit | undefined;
+  let suppression: NativeClickSuppression;
 
   beforeEach(async () => {
+    suppression = suppressNativeClickNavigation();
     container = document.createElement('div');
     document.body.appendChild(container);
     await tick();
   });
 
   afterEach(async () => {
+    suppression.restore();
     // Remove DOM first to trigger directive disconnection
     container.remove();
     await tick(10);
@@ -181,6 +188,10 @@ describe('uiSref directive', () => {
       await tick();
 
       expect(preventDefaultSpy).toHaveBeenCalled();
+      // the event reached default-action stage already cancelled by the router
+      expect(suppression.events).toContainEqual(
+        expect.objectContaining({ type: 'click', defaultPrevented: true }),
+      );
     });
 
     it('should pass params to navigation', async () => {
@@ -212,6 +223,9 @@ describe('uiSref directive', () => {
       await tick();
 
       expect(goSpy).not.toHaveBeenCalled();
+      // delivery is platform-split (macOS turns ctrl-click into contextmenu);
+      // whatever arrived must still have its default intact
+      expect(suppression.events.filter((e) => e.defaultPrevented)).toEqual([]);
     });
 
     it('should ignore click with meta key', async () => {
@@ -225,6 +239,15 @@ describe('uiSref directive', () => {
       await tick();
 
       expect(goSpy).not.toHaveBeenCalled();
+      // positive proof: the click reached default-action stage with its
+      // default intact — the suppression helper was the only preventer
+      expect(suppression.events).toEqual([
+        expect.objectContaining({
+          type: 'click',
+          tag: 'a',
+          defaultPrevented: false,
+        }),
+      ]);
     });
 
     it('should ignore middle button click', async () => {
@@ -238,6 +261,15 @@ describe('uiSref directive', () => {
       await tick();
 
       expect(goSpy).not.toHaveBeenCalled();
+      // middle clicks arrive as auxclick (never click); its default — open
+      // in a new tab — must reach us intact
+      expect(suppression.events).toEqual([
+        expect.objectContaining({
+          type: 'auxclick',
+          tag: 'a',
+          defaultPrevented: false,
+        }),
+      ]);
     });
 
     it('should ignore right button click', async () => {
@@ -250,6 +282,9 @@ describe('uiSref directive', () => {
       await tick();
 
       expect(goSpy).not.toHaveBeenCalled();
+      // right clicks surface as contextmenu (and browser-dependent auxclick);
+      // whatever arrived must still have its default intact
+      expect(suppression.events.filter((e) => e.defaultPrevented)).toEqual([]);
     });
   });
 
@@ -276,6 +311,15 @@ describe('uiSref directive', () => {
       await tick();
 
       expect(goSpy).not.toHaveBeenCalled();
+      // positive proof: the click reached default-action stage with its
+      // default (open the href in a new tab) intact
+      expect(suppression.events).toEqual([
+        expect.objectContaining({
+          type: 'click',
+          tag: 'a',
+          defaultPrevented: false,
+        }),
+      ]);
     });
 
     it('should ignore click with rel="external"', async () => {
@@ -300,6 +344,13 @@ describe('uiSref directive', () => {
       await tick();
 
       expect(goSpy).not.toHaveBeenCalled();
+      expect(suppression.events).toEqual([
+        expect.objectContaining({
+          type: 'click',
+          tag: 'a',
+          defaultPrevented: false,
+        }),
+      ]);
     });
   });
 


### PR DESCRIPTION
## What

Prevents the duplicate-tester conditions in the browser specs: a window-level listener cancels the native click default after the router's handler has decided, so real-gesture clicks (`target="_blank"`, modifier, middle) never open a popup at the tester URL.

**Stack**: the `@vitest/browser` patch removal builds on this PR — #424 is based on this branch and must merge after it (the patch is only removable with this prevention in place). This PR is compatible with the patch; both active is fine.

## Root cause, empirically confirmed

Probed from inside a live chrome tester:

- The tester URL is `/?sessionId=<uuid>&iframeId=<spec-path>`.
- uiSref's anchors carry **fragment hrefs** (`#/home`, from memoryLocationPlugin), which resolve to the **full tester URL including the live `sessionId` and `iframeId`**. An uncancelled `target="_blank"`, modifier, or middle click therefore opens a duplicate tester that joins the same `vitest:<sessionId>` BroadcastChannel with the same iframeId — the `response:*` echo ping-pong the `@vitest/browser` patch guards.
- **No SPA fallback**: `/dead-end`, `/home`, and even bare `/` (no sessionId) all return **404** — tester HTML is served only at exactly `/` with a valid `?sessionId` (invalid → 400). (Upstream-relevant color for vitest-dev/vitest#9381: the vulnerable surface is the session URL itself, not arbitrary-path fallback. The orchestrator at `/__vitest_test__/` does adopt the latest live session when opened without a sessionId — 200 confirmed — but nothing in our tests links there.)

## Approach chosen: preventDefault (over href-based variants)

1. **preventDefault after the router's decision** (chosen) — no window ever opens, harness-level, independent of server behavior.
2. **Bare non-empty hrefs** — collapses on the evidence: uiSref itself generates and re-asserts the href on every re-render, so spec-level href surgery fights the directive under test.
3. **Inert fixture safespot page** — same href-surgery flaw, plus a served asset for zero gain: with no fallback, a 404 popup is already maximally inert.

Placement: `suppressNativeClickNavigation()` in `browser-test-utils.ts` registers **window-level bubble** listeners (`click` + `auxclick` for middle-click). Target-phase element listeners always run before ancestor bubble listeners, so the router's element-level handler decides strictly first. Verified the handler does **not** consult `event.defaultPrevented` today (so the non-interception assertions are not vacuous either way); the ordering guards the day it adopts that standard check. Registered per-test in `ui-sref.spec.ts` (the only real-click spec) with cleanup in `afterEach`.

## Teeth proof

With prevention active, the router's guard was temporarily broken to intercept modified/targeted clicks. Result: **`should ignore click with meta key` and `should ignore click with target="_blank"` FAILED** (2 failed | 23 passed) — the assertions still detect interception regressions. Reverted. (Ctrl and middle pass even with a broken guard because chromium never delivers a `click` event for those gestures — macOS ctrl-click emits `contextmenu`, middle emits `auxclick`; pre-existing, unaffected by the preventer, which cancels defaults but never stops propagation.)

## Observability with assertions (no console noise)

`suppressNativeClickNavigation()` returns `{ events, restore }` — each suppressed `click`/`auxclick` is recorded as `{ type, tag, href, defaultPrevented }`, with `defaultPrevented` captured **before** the helper cancels the event. The non-interception specs assert on it:

- meta / `target="_blank"` / `rel="external"`: exactly one recorded `click` on the anchor with `defaultPrevented: false` — positive proof the event reached default-action stage with the router leaving the default intact (the helper was the only preventer).
- middle: exactly one recorded `auxclick` with `defaultPrevented: false` (middle clicks never arrive as `click`).
- ctrl / right: delivery is platform-split (macOS turns ctrl-click into `contextmenu`; right-click surfaces as `contextmenu` plus browser-dependent `auxclick`), so these assert whatever arrived had its default intact — no forced symmetry.
- plain click (`should prevent default on click`): the recorded event has `defaultPrevented: true` — positive proof of router interception from the default-action stage, complementing the spy.

No console logging: the `events` array is the debug affordance — on a failing assertion its full contents appear in the assertion diff.

### Teeth, doubled

- Guard broken to intercept modified/targeted clicks: `meta` and `target="_blank"` fail (2 failed | 23 passed) — as before.
- Guard broken to **swallow the default without navigating** (`event.preventDefault()` on the ignore path, no `go`): the `stateService.go` spies all pass — this regression class is invisible to them — and **3 specs fail purely on the suppression assertions** (`meta`, `target="_blank"`, `rel="external"`), with the recorded `defaultPrevented: true` visible in the diff. Both breaks reverted.

## Verification (this PR standalone — patch still present)

`turbo run test` and `test:coverage` for lit-ui-router, forced: 165/165 both, zero `response:*` occurrences.

## Residual-vector survey

Real-gesture clicks exist only in `ui-sref.spec.ts` (chrome project); no `window.open` and no other `target="_blank"` in any spec. A future spec doing real clicks on fragment-href anchors would need the same helper — it lives next to `clickLocatedElement` where such a spec would find it.
