### PR TITLE
fix(release): show Build System section in release notes

### DIFF
--- a/packages/lit-ui-router-mobx/.release-it.json
+++ b/packages/lit-ui-router-mobx/.release-it.json
@@ -18,7 +18,29 @@
   "plugins": {
     "@release-it/conventional-changelog": {
       "preset": {
-        "name": "conventionalcommits"
+        "name": "conventionalcommits",
+        "types": [
+          {
+            "type": "feat",
+            "section": "Features"
+          },
+          {
+            "type": "fix",
+            "section": "Bug Fixes"
+          },
+          {
+            "type": "perf",
+            "section": "Performance Improvements"
+          },
+          {
+            "type": "revert",
+            "section": "Reverts"
+          },
+          {
+            "type": "build",
+            "section": "Build System"
+          }
+        ]
       },
       "gitRawCommitsOpts": {
         "path": "."

--- a/packages/lit-ui-router/.release-it.json
+++ b/packages/lit-ui-router/.release-it.json
@@ -18,7 +18,29 @@
   "plugins": {
     "@release-it/conventional-changelog": {
       "preset": {
-        "name": "conventionalcommits"
+        "name": "conventionalcommits",
+        "types": [
+          {
+            "type": "feat",
+            "section": "Features"
+          },
+          {
+            "type": "fix",
+            "section": "Bug Fixes"
+          },
+          {
+            "type": "perf",
+            "section": "Performance Improvements"
+          },
+          {
+            "type": "revert",
+            "section": "Reverts"
+          },
+          {
+            "type": "build",
+            "section": "Build System"
+          }
+        ]
       },
       "gitRawCommitsOpts": {
         "path": "."

--- a/packages/navigation-location-plugin/.release-it.json
+++ b/packages/navigation-location-plugin/.release-it.json
@@ -18,7 +18,29 @@
   "plugins": {
     "@release-it/conventional-changelog": {
       "preset": {
-        "name": "conventionalcommits"
+        "name": "conventionalcommits",
+        "types": [
+          {
+            "type": "feat",
+            "section": "Features"
+          },
+          {
+            "type": "fix",
+            "section": "Bug Fixes"
+          },
+          {
+            "type": "perf",
+            "section": "Performance Improvements"
+          },
+          {
+            "type": "revert",
+            "section": "Reverts"
+          },
+          {
+            "type": "build",
+            "section": "Build System"
+          }
+        ]
       },
       "gitRawCommitsOpts": {
         "path": "."


### PR DESCRIPTION
Prevention follow-up to the lit-ui-router-mobx@0.3.5 release-notes incident (repaired post-hoc via `gh release edit` — notes field only, per the immutable-releases policy).

## Incident + diagnosis

0.3.5's GitHub release body was release-it's raw fallback changelog — an unscoped, unformatted `* subject (sha)` list of every repo commit since the previous tag — while ui-router-navigation-location-plugin@0.2.3 (minutes earlier) and lit-ui-router-mobx@0.3.4 got proper conventionalcommits sections.

Evidence from the publish run logs (mobx run 29707477933, nav run 29707284131):

- The #302 range pin worked: the mobx run's "previous release tag" group printed `lit-ui-router-mobx@0.3.4` — correct despite the interleaved `ui-router-navigation-location-plugin@0.2.3` tag created 7 minutes earlier. **Not** a tagMatch/range regression, and back-to-back cross-package releasing was not the trigger.
- The scoped range `lit-ui-router-mobx@0.3.4..0.3.5` (path `packages/lit-ui-router-mobx`) contains only `build(lit-ui-router-mobx): … (#395)`, `test: … (#403)`, and the non-conventional `Release 0.3.5` bump commit. The conventionalcommits preset **hides** `build:`/`test:` by default, so the plugin's changelog rendered **empty** — and release-it silently substituted its default `git log` changelog (the open upstream silent-fallback behavior). Nav's 0.2.3 range happened to contain a `feat(release)` commit (#331 touched the package dir), so its plugin output was non-empty and everything looked fine.

**Trigger condition**: any release whose package-scoped commits since its previous tag are all preset-hidden types. In this repo that's a *common* release shape — releases are cut because `check:published-diff` flags ship-affecting drift, which is frequently `build:`-typed (0.3.5 itself: the two-pass build adoption). Release sequencing cannot avoid it.

## Fix

Add an explicit preset `types` list to all three publishable packages' `.release-it.json` (identical files, byte-for-byte): the four default visible sections (Features, Bug Fixes, Performance Improvements, Reverts) **plus `build` → "Build System"**. Unlisted types stay hidden. Ship-affecting `build:` releases now always produce a non-empty plugin changelog, so the silent fallback can't engage for this release class — and the notes actually say what shipped.

## Empirical verification (ad hoc, local)

Ran the real machinery dry against the incident range (all writes disabled in the base config + `--dry-run`):

```
pnpm --dir packages/lit-ui-router-mobx exec release-it --no-increment --dry-run \
  '--plugins.@release-it/conventional-changelog.gitRawCommitsOpts.from=lit-ui-router-mobx@0.3.4'
```

Output with this PR's config: `### Build System` + the #395 entry (with `closes #369`) — non-empty, scoped, formatted. The repaired 0.3.5 release body was set to exactly this output.

## Release-gated verification

The end-to-end proof is the next real release of any package (the publish workflow runs this config on the tag checkout): its notes should show preset sections — including "Build System" when the drift is build-typed — and never the raw `* subject (sha)` list. Piggyback on the next owed release; no dedicated dispatch needed.

## Residual risk (documented, not fixed here)

The upstream silent-fallback remains: a release whose scoped range is all *still-hidden* types (e.g. chore-only) would fall back the same way. That shape shouldn't occur under the published-diff release discipline; if it ever does, the same `types` list is the lever (add the offending type or a catch-all section). Upstream filings (tagMatch, silent fallback) remain open.
