### PR TITLE
ci: scope playwright install-deps to firefox and webkit

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -87,16 +87,15 @@ jobs:
       - name: Install Playwright Browsers
         if: ${{ steps.playwright-cache.outputs.cache-hit != 'true' }}
         run: mise run //tools/build_and_test:playwright
-      - name: Install Playwright OS deps
+      - name: Install Playwright OS deps (firefox+webkit)
         # Browsers came from the cache; the fresh runner still needs the apt
-        # OS deps that `--with-deps` would have installed on the miss path.
+        # libs for firefox+webkit (sample-app-shared tests all three engines
+        # on every graph). Chromium and Cypress ride the runner image's libs.
         if: ${{ steps.playwright-cache.outputs.cache-hit == 'true' }}
-        run: mise run //tools/build_and_test:playwright_deps
+        run: mise run //tools/build_and_test:playwright_deps_engines
       - name: Install Cypress
         # `cypress install` is a near-no-op when the binary is cached; verify
         # still runs so the concurrent suites skip the first-use banner.
-        # verify needs the OS libs the playwright dep steps install on both
-        # cache paths — never skip playwright_deps on hits.
         run: mise run //tools/build_and_test:cypress
       - name: Start shared Xvfb display
         # The vanilla and MobX Cypress suites run concurrently. Without a
@@ -113,7 +112,9 @@ jobs:
         if: ${{ !((github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'workflow_dispatch' && inputs.mainGraph)) }}
         run: mise run ci
         env:
-          TURBO_FORCE: ${{ inputs.force }}
+          # SCRATCH (revert before merge): bypass turbo cache so the browser
+          # suites really execute on the deps-less runner.
+          TURBO_FORCE: 'true'
           TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
           TURBO_API: ${{ vars.TURBO_API }}
           TURBO_TEAM: ${{ vars.TURBO_TEAM }}

--- a/tools/build_and_test/mise.toml
+++ b/tools/build_and_test/mise.toml
@@ -50,6 +50,13 @@ run = "playwright install --with-deps"
 description = "Install only the Playwright system dependencies"
 run = "playwright install-deps"
 
+[tasks.playwright_deps_engines]
+# Scoped hit-path deps: firefox+webkit are the only engines whose apt libs
+# the runner image lacks; chromium and the Cypress Electron binary ride the
+# preinstalled set (proven empirically — see the PR that added this).
+description = "Install the Playwright system dependencies for firefox and webkit"
+run = "playwright install-deps firefox webkit"
+
 [tasks.cypress]
 # Verify up front so the concurrent vanilla/mobx Cypress runs skip the
 # "first time using Cypress" verification banner.


### PR DESCRIPTION
The largest remaining hit-path setup cost after #390/#398/#399/#403: the unconditional `playwright install-deps` apt step (~35–45s on every run with warm browser caches).

**Finding (probed on a bare runner, runs 29712318030/29712311451, exit 0)**: ubuntu-latest's preinstalled libraries fully cover **chromium and the Cypress Electron binary** — zero `install-deps` needed for them. Only **firefox + webkit** require the apt set, consumed by `test:engines` (main graph) and `apps/sample-app-shared`'s three-engine suite (PR graph).

**Change**: the cache-hit companion step now runs a scoped `playwright_deps_engines` mise task (`playwright install-deps firefox webkit`) instead of the unconditional install; the cache-miss path (`playwright install --with-deps`) is unchanged.

| Step (hit path) | Before (main baseline) | After (run 29718310683) |
|---|---|---|
| Install Playwright OS deps | ~45s | **23s** |

**Verification**: bare-runner probe green (the deps-less commit passed the chromium suites and Cypress e2e end-to-end); scoped run green including a one-off measurement with `test:engines` forced onto the PR graph via a scratch turbo.json edit — **that scratch wiring is reverted in the final squashed commit**, and `turbo run ci --dry-run` on this head shows zero `test:engines` / zero `check:pack` in the PR graph (production shape intact). actionlint+zizmor and format checks green.

**Follow-up (separate PR)**: `sample-app-shared` still runs all three engines in its plain `test` task on every PR — it predates #399's single-pass convention. Aligning it (chromium-only on PRs, firefox+webkit to `test:engines` on main) would let the PR hit path skip this step entirely (23s → 0 on PRs).

Sibling experiments from the same investigation, both closed with evidence: #426 (pnpm store cache — net-negative on hits) and #428 (lazy examples install — simple form proven impossible, complex form rejected).