### PR TITLE
ci: cache the pnpm store keyed on pnpm-lock.yaml (experiment)

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -58,6 +58,14 @@ jobs:
           persist-credentials: false
       - name: Setup mise
         uses: jdx/mise-action@v4
+      - name: Cache pnpm store
+        # restore-keys: a stale store still serves most packages (content-
+        # addressed); save happens only on an exact-key miss (lockfile change).
+        uses: actions/cache@v6
+        with:
+          path: ~/.local/share/pnpm/store
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: ${{ runner.os }}-pnpm-store-
       - name: Install dependencies
         run: mise run setup
         env:


### PR DESCRIPTION
Experiment (follow-on to the #390 cache experiment; sibling: #425, the playwright-deps squeeze — this lever split out per its experiment-2 handoff). **Verdict: CLOSE — net-negative on hits, net-negative on misses, and over pool budget.**

## Attribution (main run 29707357336, 16s step, no cache)

| Phase | Cost | Store cache addresses it? |
|---|---|---|
| corepack enable+install | 0.7s | no |
| pnpm resolution (lockfile check, 903 pkgs) | 2.0s | no |
| registry fetch + link (898 downloaded) | 6.3s | **yes (only this)** |
| dependency postinstalls (workerd, esbuild, cypress env-skipped, rs-module-lexer) | 1.0s | no |
| examples postinstall (`npm ci` ×3, npm's own cache/locks) | 4.9s | no |
| husky prepare | 0.1s | no |

Postinstalls do **not** dominate: workerd/esbuild `install.js` just link prebuilt binaries already fetched into the store, the Cypress binary is `CYPRESS_INSTALL_BINARY=0`-skipped, rs-module-lexer is trivial. pnpm 11's `--side-effects-cache` (experimental, off by default) has ~1.0s of addressable cost — not worth wiring. The examples tail consumes `examples/*/package-lock.json` via npm (`~/.npm` cache, `examples/*/node_modules`) and never touches the pnpm store; keying on `pnpm-lock.yaml` alone is correct, and that 4.9s is unreachable by this lever.

## Miss/hit timings (this PR's runs)

| Run | Path | Restore | Install | Save | Net vs 16s baseline |
|---|---|---|---|---|---|
| 29712481462 (push) | miss | 0s | 16s | 4s | **+4s** |
| 29712488559 (pull_request) | miss | 0s | 17s | 4s | **+5s** |
| 29718253897 (dispatch) | **hit** | 4s (212MB @ ~140MB/s) | 15s (`reused 898, downloaded 0`) | 0s (skipped) | **+3s** |

Root cause: the runner's pipe to the npm registry runs at the same ~140MB/s as the Actions cache backend, and pnpm overlaps fetch with link — so a fully warm store shaves only ~3s of install (6.3s→3.3s fetch+link), less than the 4s restore. The hit path is slower than no cache at all.

## Pool budget (would have killed it anyway)

212MB per (key × scope), full-store snapshot each save, no cross-entry dedup. Scopes don't share: head-branch push run, PR merge-ref run, and post-merge main each save their own copy of the same key (observed: two identical-key entries from the first push+PR pair). Lockfile churn on main: 47 commits / 15 days ≈ 22/week → ~22 keys × 3 scopes × 212MB ≈ **14GB/week from this cache alone** against the 10GB LRU pool (hot entries today: 455MB Playwright + 213MB Cypress + 87MB mise). `restore-keys` (wired here) only cheapens misses — it doesn't reduce save volume; a PR-closed cleanup workflow would still leave ~4.7GB/week of main-scope churn. No mitigation flips a timing-negative lever.

mise-action's cache was verified irrelevant: it stores the mise tool dir (87MB `mise-v1-*`), not the pnpm store.

Cache entries created by this experiment are deleted with its closure.
