### PR TITLE
fix(release): files-only manifest drift with an identical file set is ship-inert

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,6 +51,9 @@ catalogs:
     '@types/node':
       specifier: ^24.13.3
       version: 24.13.3
+    '@types/pacote':
+      specifier: ^11.1.8
+      version: 11.1.8
     '@uirouter/core':
       specifier: ^6.1.2
       version: 6.1.2
@@ -135,6 +138,9 @@ catalogs:
     oxlint-tsgolint:
       specifier: 0.24.0
       version: 0.24.0
+    pacote:
+      specifier: ^22.0.0
+      version: 22.0.0
     playwright:
       specifier: ^1.61.1
       version: 1.61.1
@@ -900,12 +906,18 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.13.3
+      '@types/pacote':
+        specifier: 'catalog:'
+        version: 11.1.8
       lit-ui-router:
         specifier: workspace:*
         version: link:../../packages/lit-ui-router
       lit-ui-router-mobx:
         specifier: workspace:*
         version: link:../../packages/lit-ui-router-mobx
+      pacote:
+        specifier: 'catalog:'
+        version: 22.0.0
       typescript:
         specifier: 'catalog:'
         version: 7.0.2
@@ -1410,6 +1422,10 @@ packages:
     resolution: {integrity: sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
+  '@gar/promise-retry@1.0.3':
+    resolution: {integrity: sha512-GmzA9ckNokPypTg10pgpeHNQe7ph+iIKKmhKu3Ob9ANkswreCx7R3cKmY781K8QK3AqVL3xVh9A42JvIAbkkSA==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
   '@gerrit0/mini-shiki@3.23.0':
     resolution: {integrity: sha512-bEMORlG0cqdjVyCEuU0cDQbORWX+kYCeo0kV1lbxF5bt4r7SID2l9bqsxJEM0zndaxpOUT7riCyIVEuqq/Ynxg==}
 
@@ -1753,6 +1769,10 @@ packages:
       '@types/node':
         optional: true
 
+  '@isaacs/fs-minipass@4.0.1':
+    resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
+    engines: {node: '>=18.0.0'}
+
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
@@ -1798,6 +1818,43 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@npmcli/agent@5.0.2':
+    resolution: {integrity: sha512-EkzGmEsgbQ1rqWkRJe2P0oQHx/ylZozDUNPMXCklLuSFL3GY+QyEfBUjhjCsgGXzh4OGpnHvkboSQgczjP/jJg==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
+
+  '@npmcli/fs@6.0.0':
+    resolution: {integrity: sha512-AheOs4swKka/XLtht6xxJDPezlQ7K2IYQ9Y8lST4JLDjnralnWuMM9AE2CdVcgQJ5omrXhsRzM7F7aYmeZBvKQ==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
+
+  '@npmcli/git@8.0.0':
+    resolution: {integrity: sha512-5P1oo+TbxZNAiiMBtpzHA8QyEGh5D69LYLexNWJEDXLdxnAZvT/SLitGJBXxjtCE4ftAcFOS/Tu2185MeIjooQ==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
+
+  '@npmcli/installed-package-contents@5.0.0':
+    resolution: {integrity: sha512-6Ay12sf2Lh7U1ifvnS1mq7TZFeh/rXHMXye+kV7jQrANIubaoVcleeh4HdFumxhsRYwm9OaHycB5lYmSwGrcIQ==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
+    hasBin: true
+
+  '@npmcli/node-gyp@6.0.0':
+    resolution: {integrity: sha512-MFakpea4pcZNlHSTbMi15HK8RY8zl2UpgDtxhZCWOer+KRN3x7HFIMk/fKpOMgR55L4LIcA2qn8IHeyABhIFtw==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
+
+  '@npmcli/package-json@8.0.0':
+    resolution: {integrity: sha512-agNZzYQ18MR0wKp3Emg1q5QbcC8CXigYp3Z3CvB0Sax9Ge9aF4cVyyuSG+5SbACSrZUKTvMjVULWiE1RJA38wg==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
+
+  '@npmcli/promise-spawn@10.0.0':
+    resolution: {integrity: sha512-llZkSzeTsimFx64U+ThT2xQM2uEce8GIQUYvxgbB6ZFvBhV2LP9LeJJb3HT+syG0uCFLsTCHjV9SfC0WNU1vtA==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
+
+  '@npmcli/redact@5.0.0':
+    resolution: {integrity: sha512-3zcN5Q3yEmeyxXBzqB6fXPQFzYa2ROsGFSr69W0ArXIAGJqxl/aFECOVPD2kbkYPm0U/EHxFKgclK3UA9WQg5A==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
+
+  '@npmcli/run-script@11.0.0':
+    resolution: {integrity: sha512-leBRl6F5F0TvWut8m1/aZcMTUHi2vXjKeMJ/Ik1lW7Q7Yy16Dhtkklu+cEqQww1p1NeLnUNzV3+uwpzqRcy9vw==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
 
   '@octokit/auth-token@6.0.0':
     resolution: {integrity: sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==}
@@ -2816,6 +2873,30 @@ packages:
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
 
+  '@sigstore/bundle@5.0.0':
+    resolution: {integrity: sha512-wefjygudENbzbQMks1t5u34EP0fFoD0XvaEP7DOUP/sXKvogzEJYFw5E6pegGyp3onGWzVEYKVa3bNZWyTYX+A==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
+
+  '@sigstore/core@4.0.1':
+    resolution: {integrity: sha512-9v5hRjujn5NXq8o7XFEUgLyAtdr5Iisb4pzM05u3K61IS5q3hP3luWAndk0RkPPLTUFoTbg7Vb84UQ1ZQeajWQ==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
+
+  '@sigstore/protobuf-specs@0.5.1':
+    resolution: {integrity: sha512-/ScWUhhoFasJsSRGTVBwId1loQjjnjAfE4djL6ZhrXRpNCmPTnUKF5Jokd58ILseOMjzET3UrMOtJPS9sYeI0g==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+
+  '@sigstore/sign@5.0.0':
+    resolution: {integrity: sha512-DSFivqz9/i5AkwZ5fq0YdjaJlc4o1WeS2Zffon0kqtChx0vy4W9NOjkEet9bF2vkzOufX72eVH8kZBIGtcBp1w==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
+
+  '@sigstore/tuf@5.0.0':
+    resolution: {integrity: sha512-Zyqg9tcHps3uRAlKHLNmsW4ohsUZAjb9G+31r7lg0ICh/JOcadzmJsIRdjKljlRHpaR0K4aJ2kXXIdywdcdMlA==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
+
+  '@sigstore/verify@4.1.0':
+    resolution: {integrity: sha512-p/s720RiWxLG8XtmfdPfEJOlATA6H/2knFqmtQbFkHKN3IrhWGUwPfpQAf1UnQIEES9IaH6zzhfjkrhTfeSdZw==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
+
   '@simple-libs/child-process-utils@1.0.2':
     resolution: {integrity: sha512-/4R8QKnd/8agJynkNdJmNw2MBxuFTRcNFnE5Sg/G+jkSsV8/UBgULMzhizWWW42p8L5H7flImV2ATi79Ove2Tw==}
     engines: {node: '>=18'}
@@ -2866,6 +2947,14 @@ packages:
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@tufjs/canonical-json@2.0.0':
+    resolution: {integrity: sha512-yVtV8zsdo8qFHe+/3kw81dSLyF7D576A5cCFCi4X7B39tWT7SekaEFUnvnWJHz+9qO7qJTah1JbrDjWKqFtdWA==}
+    engines: {node: ^16.14.0 || >=18.0.0}
+
+  '@tufjs/models@5.0.0':
+    resolution: {integrity: sha512-U4mVcdFGOi6pt8n38LdWZp67Svn7ppnU1Pj8SGOVaBi1X4gm+G4ztQlLfkoJbKSHfjA6WeaiJp2A4V83AJF6nQ==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
 
   '@turbo/darwin-64@2.10.5':
     resolution: {integrity: sha512-ENvPwy3x5yS7MwNYHeWjqOBXkwIMp39Pd+/zXC6PoiNzF8EIvvLZOZZ+ny6L9x4WgS5vxUii2LM5gM+zjPdnWw==}
@@ -2942,6 +3031,9 @@ packages:
   '@types/mdurl@2.0.0':
     resolution: {integrity: sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==}
 
+  '@types/node-fetch@2.6.13':
+    resolution: {integrity: sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==}
+
   '@types/node@24.13.3':
     resolution: {integrity: sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==}
 
@@ -2950,6 +3042,18 @@ packages:
 
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
+
+  '@types/npm-package-arg@6.1.4':
+    resolution: {integrity: sha512-vDgdbMy2QXHnAruzlv68pUtXCjmqUk3WrBAsRboRovsOmxbfn/WiYCjmecyKjGztnMps5dWp4Uq2prp+Ilo17Q==}
+
+  '@types/npm-registry-fetch@8.0.9':
+    resolution: {integrity: sha512-7NxvodR5Yrop3pb6+n8jhJNyzwOX0+6F+iagNEoi9u1CGxruYAwZD8pvGc9prIkL0+FdX5Xp0p80J9QPrGUp/g==}
+
+  '@types/npmlog@7.0.0':
+    resolution: {integrity: sha512-hJWbrKFvxKyWwSUXjZMYTINsSOY6IclhvGOZ97M8ac2tmR9hMwmTnYaMdpGhvju9ctWLTPhCS+eLfQNluiEjQQ==}
+
+  '@types/pacote@11.1.8':
+    resolution: {integrity: sha512-/XLR0VoTh2JEO0jJg1q/e6Rh9bxjBq9vorJuQmtT7rRrXSiWz7e7NsvXVYJQ0i8JxMlBMPPYDTnrRe7MZRFA8Q==}
 
   '@types/parse-path@7.1.0':
     resolution: {integrity: sha512-EULJ8LApcVEPbrfND0cRQqutIOdiIgJ1Mgrhpy755r14xMohPTEpkV/k28SJvuOs9bHRFW8x+KeDAEPiGQPB9Q==}
@@ -2960,6 +3064,9 @@ packages:
 
   '@types/sizzle@2.3.10':
     resolution: {integrity: sha512-TC0dmN0K8YcWEAEfiPi5gJP14eJe30TTGjkvek3iM/1NdHHsdCA/Td6GvNndMOo/iSnIsZ4HuuhrYPDAmbxzww==}
+
+  '@types/ssri@7.1.5':
+    resolution: {integrity: sha512-odD/56S3B51liILSk5aXJlnYt99S6Rt9EFDDqGtJM26rKHApHcwyU/UoYHrzKkdkHMAIquGWCuHtQTbes+FRQw==}
 
   '@types/tmp@0.2.6':
     resolution: {integrity: sha512-chhaNf2oKHlRkDGt+tiKE2Z5aJ6qalm7Z9rlLdBwmOiAAf09YQvvoLXjWK4HWPF1xU/fqvMgfNfpVoBscA/tKA==}
@@ -3346,6 +3453,10 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  abbrev@5.0.0:
+    resolution: {integrity: sha512-/XrFJgzQQQHpti1raDJC6m4ws6aNktmjBlhk8Fdlk7LwCEuDoieEJJY9OFHjfiFJFFRM2tK+Ky/IsfbbmlMu1w==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -3363,6 +3474,10 @@ packages:
   agent-base@8.0.0:
     resolution: {integrity: sha512-QT8i0hCz6C/KQ+KTAbSNwCHDGdmUJl2tp2ZpNlGSWCfhUNVbYG2WLE3MdZGBAgXPV4GAvjGMxo+C1hroyxmZEg==}
     engines: {node: '>= 14'}
+
+  agent-base@9.0.0:
+    resolution: {integrity: sha512-TQf59BsZnytt8GdJKLPfUZ54g/iaUL2OWDSFCCvMOhsHduDQxO8xC4PNeyIkVcA5KwL2phPSv0douC0fgWzmnA==}
+    engines: {node: '>= 20'}
 
   ajv@6.15.0:
     resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
@@ -3528,6 +3643,10 @@ packages:
       magicast:
         optional: true
 
+  cacache@21.0.1:
+    resolution: {integrity: sha512-pTwz/uj3Jyp6WXdJ6fWhR+7LVxVs6RyroQSn7KJwHsSxXuyGSp0pcMVcwSwTpCFq1X2YG8QBe0W+vN+cr0SwzA==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
+
   cachedir@2.4.0:
     resolution: {integrity: sha512-9EtFOZR8g22CL7BWjJ9BUx1+A/djkofnyW3aOXZORNW2kxoUpx2h+uN2cOqwPmFhnpVmxg+KW2OjOSgChTEvsQ==}
     engines: {node: '>=6'}
@@ -3589,6 +3708,10 @@ packages:
   chokidar@5.0.0:
     resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
     engines: {node: '>= 20.19.0'}
+
+  chownr@3.0.0:
+    resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
+    engines: {node: '>=18'}
 
   ci-info@4.4.0:
     resolution: {integrity: sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==}
@@ -4107,6 +4230,9 @@ packages:
     resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
     engines: {node: '>=12.0.0'}
 
+  exponential-backoff@3.1.3:
+    resolution: {integrity: sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==}
+
   exsolve@1.1.0:
     resolution: {integrity: sha512-D+42+T12DdIlJM3uepa55qGiL3sYdLBOxIl2ifQCzCHz4c7eiolaHsi3BIqEr7JxBzxv2pYZQX9kw16ziMcEmw==}
 
@@ -4208,6 +4334,10 @@ packages:
   fs-extra@9.1.0:
     resolution: {integrity: sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==}
     engines: {node: '>=10'}
+
+  fs-minipass@3.0.3:
+    resolution: {integrity: sha512-XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
   fsevents@2.3.2:
     resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
@@ -4339,6 +4469,10 @@ packages:
   hookable@5.5.3:
     resolution: {integrity: sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==}
 
+  hosted-git-info@10.1.1:
+    resolution: {integrity: sha512-DeOnSPAvOndYKfw075gt8yZzQ7S2hNztw34zBTfhIzLhmBTswIBg5/y+pqu/VD5cYWm5goAFTusDmUEmKZ0PEQ==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
+
   hosted-git-info@8.1.0:
     resolution: {integrity: sha512-Rw/B2DNQaPBICNXEm8balFz9a6WpZrkCGpcWFpy7nCj+NyhSdqXipmfvtmWt9xGfp0wZnBxB+iVpLmQMYt47Tw==}
     engines: {node: ^18.17.0 || >=20.5.0}
@@ -4353,9 +4487,16 @@ packages:
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
+  http-cache-semantics@4.2.0:
+    resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
+
   http-proxy-agent@8.0.0:
     resolution: {integrity: sha512-7pose0uGgrCJeH2Qh4JcNhWZp3u/oNrWjNYDK4ydOLxOpTw8V8ogHFAmkz0VWq96JBFj4umVJpvmQi287rSYLg==}
     engines: {node: '>= 14'}
+
+  http-proxy-agent@9.1.0:
+    resolution: {integrity: sha512-2NxoveTT58mjYT4n3RPTEfCZGLMbidoO8XEieXfpSYxu+PQJ1qpx4ypwH6N+uF9twBPIvRRgvkvW5HUTYWENig==}
+    engines: {node: '>= 20'}
 
   http-signature@1.4.0:
     resolution: {integrity: sha512-G5akfn7eKbpDN+8nPS/cb57YeA1jLTVxjpCj7tmm3QKPdyDy7T+qSC40e9ptydSWvkwjSXw1VbkpyEm39ukeAg==}
@@ -4368,6 +4509,10 @@ packages:
   https-proxy-agent@8.0.0:
     resolution: {integrity: sha512-YYeW+iCnAS3xhvj2dvVoWgsbca3RfQy/IlaNHHOtDmU0jMqPI9euIq3Y9BJETdxk16h9NHHCKqp/KB9nIMStCQ==}
     engines: {node: '>= 14'}
+
+  https-proxy-agent@9.1.0:
+    resolution: {integrity: sha512-ag87y7cJJ9/3+GxFr8Oy4O5faDsGRGnBGsJj/YjOSsSx/5eadKLYTMPlzuR6obgoCDDm0abAAZitXXQkMOPSpA==}
+    engines: {node: '>= 20'}
 
   human-signals@1.1.1:
     resolution: {integrity: sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==}
@@ -4388,6 +4533,10 @@ packages:
 
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+
+  ignore-walk@9.0.0:
+    resolution: {integrity: sha512-tCBEZV2z2FNpIDl2vrhiWzIHzs4qOAuIDEO85eS02vZ3L1U3P56qpPL8GuGGAijDktAEaq2swMkO/Fmbo7YmfQ==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -4414,6 +4563,10 @@ packages:
   ini@6.0.0:
     resolution: {integrity: sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==}
     engines: {node: ^20.17.0 || >=22.9.0}
+
+  ini@7.0.0:
+    resolution: {integrity: sha512-ifK0CgjALofS5bkrcTy4RaQ9Vx2Knf/eLeIO+NaswQEpH1UblrtTSCIvN71qQDMq0PeQ/SSPojvEJp9vvvfr+w==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
 
   ip-address@10.2.0:
     resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
@@ -4509,6 +4662,10 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  isexe@4.0.0:
+    resolution: {integrity: sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==}
+    engines: {node: '>=20'}
+
   isstream@0.1.2:
     resolution: {integrity: sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==}
 
@@ -4559,6 +4716,10 @@ packages:
   json-parse-even-better-errors@2.3.1:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
 
+  json-parse-even-better-errors@6.0.0:
+    resolution: {integrity: sha512-2/8adwnK1/+Fdjyts4r6wSpfANWw8zdNhU9U/Llk59c6O+DjSisPWPykwoL8gZmocP9Dy64S7oie2g+Mia123A==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
+
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
 
@@ -4591,6 +4752,10 @@ packages:
 
   jsonfile@6.2.1:
     resolution: {integrity: sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==}
+
+  jsonparse@1.3.1:
+    resolution: {integrity: sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==}
+    engines: {'0': node >= 0.2.0}
 
   jsprim@2.0.2:
     resolution: {integrity: sha512-gqXddjPqQ6G40VdnI6T6yObEC+pDNvyP95wdQhkWkg7crHH3km5qP1FsOXEkzEQwnz6gz5qGTn1c2Y52wP3OyQ==}
@@ -4790,6 +4955,10 @@ packages:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
 
+  make-fetch-happen@16.0.1:
+    resolution: {integrity: sha512-uUv1yxHzaKVVEPfcFeGSNov/Cehjv08ovlY8ImTljgL7Q+SiA0dAYLQ6SYVa2kkKqNj4Y3aZEI7xv2teadie0A==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
+
   mark.js@8.11.1:
     resolution: {integrity: sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ==}
 
@@ -4878,12 +5047,40 @@ packages:
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
+  minipass-collect@2.0.1:
+    resolution: {integrity: sha512-D7V8PO9oaz7PWGLbCACuI1qEOsq7UKfLotx/C0Aet43fCUB/wfQ7DYeq2oR/svFJGYDHPr38SHATeaj/ZoKHKw==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  minipass-fetch@6.0.0:
+    resolution: {integrity: sha512-AWI8bKapGmgx/J0E6IGYSKj8TiHebZkmKWSs8raPSw8KXwgEAJ+Bw3+LSdXHR6T/RHKAWCOYk2MiLrYluaUU6w==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
+
+  minipass-flush@1.0.7:
+    resolution: {integrity: sha512-TbqTz9cUwWyHS2Dy89P3ocAGUGxKjjLuR9z8w4WUTGAVgEj17/4nhgo2Du56i0Fm3Pm30g4iA8Lcqctc76jCzA==}
+    engines: {node: '>= 8'}
+
+  minipass-pipeline@1.2.4:
+    resolution: {integrity: sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==}
+    engines: {node: '>=8'}
+
+  minipass-sized@2.0.0:
+    resolution: {integrity: sha512-zSsHhto5BcUVM2m1LurnXY6M//cGhVaegT71OfOXoprxT6o780GZd792ea6FfrQkuU4usHZIUczAQMRUE2plzA==}
+    engines: {node: '>=8'}
+
+  minipass@3.3.6:
+    resolution: {integrity: sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==}
+    engines: {node: '>=8'}
+
   minipass@7.1.3:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
 
   minisearch@7.2.0:
     resolution: {integrity: sha512-dqT2XBYUOZOiC5t2HRnwADjhNS2cecp9u+TJRiJ1Qp/f5qjkeT5APcGPjHw+bz89Ms8Jp+cG4AlE+QZ/QnDglg==}
+
+  minizlib@3.1.0:
+    resolution: {integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==}
+    engines: {node: '>= 18'}
 
   mobx@6.16.1:
     resolution: {integrity: sha512-syNcDdX3KT+Jq3je6eGjBhuc24Z68td2VG0zNFqRswaE433D9SNH5VRy/xrGbJsUixfppLLccXhAW9JSf6n+SQ==}
@@ -4910,6 +5107,10 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
+    engines: {node: '>= 0.6'}
+
   neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
 
@@ -4924,6 +5125,16 @@ packages:
   node-fetch-native@1.6.7:
     resolution: {integrity: sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==}
 
+  node-gyp@13.0.1:
+    resolution: {integrity: sha512-piOr0S10qy5THB+q5BdqkoOx65XL/tjTMUAit3vciPNp+snTOBnGunWH1Rz7XZUxf2T9uFrfT/Ty4+aC3yPeyg==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
+    hasBin: true
+
+  nopt@10.0.1:
+    resolution: {integrity: sha512-df3sBr/6ax9hSGuC3CspvLlbnX8cP5L5nZwXF8cGN8l0zSWR6BvzmQ6jPUKjvo6+/xdpkNvEcucBNUdBeeV13g==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
+    hasBin: true
+
   normalize-package-data@7.0.1:
     resolution: {integrity: sha512-linxNAT6M0ebEYZOx2tO6vBEFsVgnPpv+AVjk0wJHfaUIbq31Jm3T6vvZaarnOeWDh8ShnwXuaAyM7WT3RzErA==}
     engines: {node: ^18.17.0 || >=20.5.0}
@@ -4932,9 +5143,37 @@ packages:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
 
+  npm-bundled@6.0.0:
+    resolution: {integrity: sha512-EqdodKEW6pYM+dPxA66TZQfMEqVDiuzjDM9edSjuPI1mXUbUJwVxkgqMZSJvs8RTXz2CGq8HUol/AffTZX5g8w==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
+
+  npm-install-checks@9.0.0:
+    resolution: {integrity: sha512-t05Izcgi7p15cpldqoiXYpjzlkTTvBw33sgjmL/JjcvtV0ydbm2O4iEXO8A6smqComu5FAQhUas86HTMQ6Z1Uw==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
+
+  npm-normalize-package-bin@6.0.0:
+    resolution: {integrity: sha512-tdt4aFn9QamlhdN3HV2D2ccpBwO5/fyjjbXUxYA6uBjyekMZcZvDq0aSj9t5Jo+tih6AYFnt/cuIRn9013e0Uw==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
+
   npm-package-arg@13.0.2:
     resolution: {integrity: sha512-IciCE3SY3uE84Ld8WZU23gAPPV9rIYod4F+rc+vJ7h7cwAJt9Vk6TVsK60ry7Uj3SRS3bqRRIGuTp9YVlk6WNA==}
     engines: {node: ^20.17.0 || >=22.9.0}
+
+  npm-package-arg@14.0.0:
+    resolution: {integrity: sha512-69XQh3k+dtGa1p+7RaR57IuG3rCko96xr/nUfN4yDYBXbTYICiWcOpsFKLN2GtGE9cyIljE+f1exnaYt9MvM+Q==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
+
+  npm-packlist@11.3.0:
+    resolution: {integrity: sha512-cS1yVkyriZgQAbiK8PtwhZHEtsFOsKHsCg5Ww2ONckAvXIspgqd6o4WirOzvkupU24iMRZ4xtO4kb2iK2rbnag==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
+
+  npm-pick-manifest@12.0.0:
+    resolution: {integrity: sha512-8Fs3YLrnNOhrCdPNZy18MzNgVC58LTDAFzq1FdZO/p3BHeCC/coz+t4F5Pxabys8HJpyTUorMea26GkXsb4J/Q==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
+
+  npm-registry-fetch@20.0.1:
+    resolution: {integrity: sha512-vzc1svxw/kw1IRjFsLi6gaxe1Olqm88V0tIfu2u5raL0b1gChe6ZEXNkyUlKxUC7s/egt5NxZHkbY18tMKKLfQ==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
 
   npm-run-path@4.0.1:
     resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
@@ -5074,6 +5313,11 @@ packages:
     resolution: {integrity: sha512-eHXskJQU4aCiSfjhRfTVtCJ+22/EzLHgYgZv5Gj3teb3NJrnTMzq5BnKAWKvR+PLpknCO1PmOCImDuO+dX4Vaw==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
+  pacote@22.0.0:
+    resolution: {integrity: sha512-++VqeOZeL03uGM2MFLk96jGCSt1owBGkyFKoPr+trwNlZhCpjN2RrvwYxt8nTbs1wNMqSFYurq0TafVWkAIHig==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
+    hasBin: true
+
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
@@ -5189,6 +5433,10 @@ packages:
     resolution: {integrity: sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
+  proc-log@7.0.0:
+    resolution: {integrity: sha512-FYgfaA69XZ93zaXLoMNQ+ViDXGGBgR8aLh03txzcFhV+9xOXx7+8DLCULrKKpR9+GsH9ZfHm82aSUPpozX0Ztg==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
+
   process@0.11.10:
     resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
     engines: {node: '>= 0.6.0'}
@@ -5201,6 +5449,15 @@ packages:
 
   protocols@2.0.2:
     resolution: {integrity: sha512-hHVTzba3wboROl0/aWRRG9dMytgH6ow//STBZh43l/wQgmMhYhOFi0EHWAPtoCz9IAUymsyP0TSBHkhgMEGNnQ==}
+
+  proxy-agent-negotiate@1.1.0:
+    resolution: {integrity: sha512-N8IBcM3UgCVzz2L2Lqv8DVntDnnC8/hiV4nEDUPkqq72TPUgYWjQc+bdZlBPZK9LzPAvOY//gAt0S0DApoOXWQ==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      kerberos: ^2.0.0
+    peerDependenciesMeta:
+      kerberos:
+        optional: true
 
   proxy-agent@7.0.0:
     resolution: {integrity: sha512-okTgt79rHTvMHkr/Ney5rZpgCHh3g1g3tI5uhkgN5b7OeI3n0Q/ui1uv9OdrnZNJM9WIZJqZPh/UJs+YtO/TMQ==}
@@ -5403,6 +5660,10 @@ packages:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
 
+  sigstore@5.0.0:
+    resolution: {integrity: sha512-hJqJfoG/e4qFQaauQL00c6J6FrHLBGKtkFvW3JbTSIEFOhLrSjdSM/gWd/yUOfYo/gsERehTXGC1VZWX+9X4Dg==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
+
   sirv@3.0.2:
     resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
     engines: {node: '>=18'}
@@ -5422,6 +5683,10 @@ packages:
   smart-buffer@4.2.0:
     resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
     engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
+
+  socks-proxy-agent@10.1.0:
+    resolution: {integrity: sha512-WlMj/67cEJ6MDI1OcsnjuYKDNDoyPCCYZ249kuuXPiMDw9F8PXkVaQ7YWu3siTydfQ/4BEZcvGzu+aYvz7dDCQ==}
+    engines: {node: '>= 20'}
 
   socks-proxy-agent@9.0.0:
     resolution: {integrity: sha512-fFlbMlfsXhK02ZB8aZY7Hwxh/IHBV9b1Oq9bvBk6tkFWXvdAxUgA0wbw/NYR5liU3Y5+KI6U4FH3kYJt9QYv0w==}
@@ -5459,6 +5724,9 @@ packages:
   spdx-expression-parse@3.0.1:
     resolution: {integrity: sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==}
 
+  spdx-expression-parse@4.0.0:
+    resolution: {integrity: sha512-Clya5JIij/7C6bRR22+tnGXbc4VKlibKSVj2iHvVeX5iMW7s1SIQlqu699JkODJJIhh/pUu8L0/VLh8xflD+LQ==}
+
   spdx-license-ids@3.0.23:
     resolution: {integrity: sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==}
 
@@ -5470,6 +5738,10 @@ packages:
     resolution: {integrity: sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==}
     engines: {node: '>=0.10.0'}
     hasBin: true
+
+  ssri@14.0.0:
+    resolution: {integrity: sha512-jQxKI0yx0ZnTKrqjKkLDV2DXkBQn3k49JVmVqDGcDwKDtGDbImD/GXsq04KD0VVzCQQ9wZJYal3RwR1GzWTSow==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
@@ -5544,6 +5816,10 @@ packages:
   tabbable@6.5.0:
     resolution: {integrity: sha512-wieBHXygIm7OyQOu5hQlkk62/WyCFYGlWg7L6/ZCUZwx0o398Zkn4pVmMyfYhfMG8kGrj/Krt8eIk6UKC6VzwA==}
 
+  tar@7.5.20:
+    resolution: {integrity: sha512-9FcyK4PA6+WbzlTM9WhQm6vB5W7cP7dUiPsv1g7YDwEQnQ1CGpK3MGlKk/ITVWMk05kHZuBhmVhiv8LZoy/PFQ==}
+    engines: {node: '>=18'}
+
   throttleit@1.0.1:
     resolution: {integrity: sha512-vDZpf9Chs9mAdfY046mcPt8fg5QSZr37hEH4TXYBnDF+izxgrbRGUAAaBvIk/fJm9aOFCGFd1EsNg5AZCbnQCQ==}
 
@@ -5608,6 +5884,10 @@ packages:
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tuf-js@6.0.0:
+    resolution: {integrity: sha512-zlJVOIO68hmgo1//X4ENEcTGfuOTAtDPi8PsTsG+FyxD85E/ww1ZnwBbWo/yCEExGpI+Kilg7Z3qCdHX2BoJTQ==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
 
   tunnel-agent@0.6.0:
     resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
@@ -5707,6 +5987,10 @@ packages:
     resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
 
+  undici@8.7.0:
+    resolution: {integrity: sha512-N7iQtfyLhIMOFgQubvmLV26svHpO0bqKnAiWotTQCVKCmWrcGbBotPuW1x+xwYZ2VHdSTVUfPQQnlEt1/LouTQ==}
+    engines: {node: '>=22.19.0'}
+
   unenv@2.0.0-rc.24:
     resolution: {integrity: sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==}
 
@@ -5760,6 +6044,10 @@ packages:
   validate-npm-package-name@7.0.2:
     resolution: {integrity: sha512-hVDIBwsRruT73PbK7uP5ebUt+ezEtCmzZz3F59BSr2F6OVFnJ/6h8liuvdLrQ88Xmnk6/+xGGuq+pG9WwTuy3A==}
     engines: {node: ^20.17.0 || >=22.9.0}
+
+  validate-npm-package-name@8.0.0:
+    resolution: {integrity: sha512-SCv6OOV6Xj2/3cXy3dGmADluJTNcL3o7hZAglNPTe+WYuEuvxgJzxPrSDLZhF+CwyQOubqgecjMmTJGMVLWjYQ==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
 
   verror@1.10.0:
     resolution: {integrity: sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==}
@@ -5942,6 +6230,11 @@ packages:
     engines: {node: '>= 8'}
     hasBin: true
 
+  which@7.0.0:
+    resolution: {integrity: sha512-RancgH2dmbLdHl6LRhEqvklWMgl/Hdnun0Y90KhBOLkMefg8Qa7/Zel8Sm+8HEcP6DEjzsWzpkuBQEZok58isA==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
+    hasBin: true
+
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
@@ -6014,6 +6307,13 @@ packages:
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
+
+  yallist@4.0.0:
+    resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
+
+  yallist@5.0.0:
+    resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
+    engines: {node: '>=18'}
 
   yaml-eslint-parser@2.1.0:
     resolution: {integrity: sha512-1zo9KRfp6vIAXBEhWAz09ex3hUwh3T+/6dGbGteHvNseA0Uk4FgQnPES55klZ6cDzSy9FpgKS0D/CoLUvCCj4w==}
@@ -6510,6 +6810,8 @@ snapshots:
       '@eslint/core': 1.2.1
       levn: 0.4.1
 
+  '@gar/promise-retry@1.0.3': {}
+
   '@gerrit0/mini-shiki@3.23.0':
     dependencies:
       '@shikijs/engine-oniguruma': 3.23.0
@@ -6775,6 +7077,10 @@ snapshots:
     optionalDependencies:
       '@types/node': 24.13.3
 
+  '@isaacs/fs-minipass@4.0.1':
+    dependencies:
+      minipass: 7.1.3
+
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -6833,6 +7139,63 @@ snapshots:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
+
+  '@npmcli/agent@5.0.2':
+    dependencies:
+      agent-base: 9.0.0
+      http-proxy-agent: 9.1.0
+      https-proxy-agent: 9.1.0
+      lru-cache: 11.5.1
+      socks-proxy-agent: 10.1.0
+    transitivePeerDependencies:
+      - kerberos
+      - supports-color
+
+  '@npmcli/fs@6.0.0':
+    dependencies:
+      semver: 7.8.5
+
+  '@npmcli/git@8.0.0':
+    dependencies:
+      '@gar/promise-retry': 1.0.3
+      '@npmcli/promise-spawn': 10.0.0
+      ini: 7.0.0
+      lru-cache: 11.5.1
+      npm-pick-manifest: 12.0.0
+      proc-log: 7.0.0
+      semver: 7.8.5
+      which: 7.0.0
+
+  '@npmcli/installed-package-contents@5.0.0':
+    dependencies:
+      npm-bundled: 6.0.0
+      npm-normalize-package-bin: 6.0.0
+
+  '@npmcli/node-gyp@6.0.0': {}
+
+  '@npmcli/package-json@8.0.0':
+    dependencies:
+      '@npmcli/git': 8.0.0
+      glob: 13.0.6
+      hosted-git-info: 10.1.1
+      json-parse-even-better-errors: 6.0.0
+      proc-log: 7.0.0
+      semver: 7.8.5
+      spdx-expression-parse: 4.0.0
+
+  '@npmcli/promise-spawn@10.0.0':
+    dependencies:
+      which: 7.0.0
+
+  '@npmcli/redact@5.0.0': {}
+
+  '@npmcli/run-script@11.0.0':
+    dependencies:
+      '@npmcli/node-gyp': 6.0.0
+      '@npmcli/package-json': 8.0.0
+      '@npmcli/promise-spawn': 10.0.0
+      node-gyp: 13.0.1
+      proc-log: 7.0.0
 
   '@octokit/auth-token@6.0.0': {}
 
@@ -7500,6 +7863,39 @@ snapshots:
 
   '@shikijs/vscode-textmate@10.0.2': {}
 
+  '@sigstore/bundle@5.0.0':
+    dependencies:
+      '@sigstore/protobuf-specs': 0.5.1
+
+  '@sigstore/core@4.0.1': {}
+
+  '@sigstore/protobuf-specs@0.5.1': {}
+
+  '@sigstore/sign@5.0.0':
+    dependencies:
+      '@gar/promise-retry': 1.0.3
+      '@sigstore/bundle': 5.0.0
+      '@sigstore/core': 4.0.1
+      '@sigstore/protobuf-specs': 0.5.1
+      make-fetch-happen: 16.0.1
+      proc-log: 7.0.0
+    transitivePeerDependencies:
+      - kerberos
+      - supports-color
+
+  '@sigstore/tuf@5.0.0':
+    dependencies:
+      '@sigstore/protobuf-specs': 0.5.1
+      tuf-js: 6.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@sigstore/verify@4.1.0':
+    dependencies:
+      '@sigstore/bundle': 5.0.0
+      '@sigstore/core': 4.0.1
+      '@sigstore/protobuf-specs': 0.5.1
+
   '@simple-libs/child-process-utils@1.0.2':
     dependencies:
       '@simple-libs/stream-utils': 1.2.0
@@ -7556,6 +7952,13 @@ snapshots:
   '@speed-highlight/core@1.2.17': {}
 
   '@standard-schema/spec@1.1.0': {}
+
+  '@tufjs/canonical-json@2.0.0': {}
+
+  '@tufjs/models@5.0.0':
+    dependencies:
+      '@tufjs/canonical-json': 2.0.0
+      minimatch: 10.2.5
 
   '@turbo/darwin-64@2.10.5':
     optional: true
@@ -7620,6 +8023,11 @@ snapshots:
 
   '@types/mdurl@2.0.0': {}
 
+  '@types/node-fetch@2.6.13':
+    dependencies:
+      '@types/node': 25.0.9
+      form-data: 4.0.6
+
   '@types/node@24.13.3':
     dependencies:
       undici-types: 7.18.2
@@ -7630,6 +8038,27 @@ snapshots:
 
   '@types/normalize-package-data@2.4.4': {}
 
+  '@types/npm-package-arg@6.1.4': {}
+
+  '@types/npm-registry-fetch@8.0.9':
+    dependencies:
+      '@types/node': 25.0.9
+      '@types/node-fetch': 2.6.13
+      '@types/npm-package-arg': 6.1.4
+      '@types/npmlog': 7.0.0
+      '@types/ssri': 7.1.5
+
+  '@types/npmlog@7.0.0':
+    dependencies:
+      '@types/node': 25.0.9
+
+  '@types/pacote@11.1.8':
+    dependencies:
+      '@types/node': 25.0.9
+      '@types/npm-registry-fetch': 8.0.9
+      '@types/npmlog': 7.0.0
+      '@types/ssri': 7.1.5
+
   '@types/parse-path@7.1.0':
     dependencies:
       parse-path: 7.1.0
@@ -7637,6 +8066,10 @@ snapshots:
   '@types/sinonjs__fake-timers@8.1.1': {}
 
   '@types/sizzle@2.3.10': {}
+
+  '@types/ssri@7.1.5':
+    dependencies:
+      '@types/node': 25.0.9
 
   '@types/tmp@0.2.6': {}
 
@@ -7971,6 +8404,8 @@ snapshots:
   '@xn-sakina/rml-win32-x64-msvc@2.8.0':
     optional: true
 
+  abbrev@5.0.0: {}
+
   acorn-jsx@5.3.2(acorn@8.17.0):
     dependencies:
       acorn: 8.17.0
@@ -7984,6 +8419,8 @@ snapshots:
       - supports-color
 
   agent-base@8.0.0: {}
+
+  agent-base@9.0.0: {}
 
   ajv@6.15.0:
     dependencies:
@@ -8143,6 +8580,19 @@ snapshots:
     optionalDependencies:
       magicast: 0.5.3
 
+  cacache@21.0.1:
+    dependencies:
+      '@npmcli/fs': 6.0.0
+      fs-minipass: 3.0.3
+      glob: 13.0.6
+      lru-cache: 11.5.1
+      minipass: 7.1.3
+      minipass-collect: 2.0.1
+      minipass-flush: 1.0.7
+      minipass-pipeline: 1.2.4
+      p-map: 7.0.5
+      ssri: 14.0.0
+
   cachedir@2.4.0: {}
 
   call-bind-apply-helpers@1.0.2:
@@ -8207,6 +8657,8 @@ snapshots:
   chokidar@5.0.0:
     dependencies:
       readdirp: 5.0.0
+
+  chownr@3.0.0: {}
 
   ci-info@4.4.0: {}
 
@@ -8824,6 +9276,8 @@ snapshots:
 
   expect-type@1.4.0: {}
 
+  exponential-backoff@3.1.3: {}
+
   exsolve@1.1.0: {}
 
   extend@3.0.2: {}
@@ -8920,6 +9374,10 @@ snapshots:
       graceful-fs: 4.2.11
       jsonfile: 6.2.1
       universalify: 2.0.1
+
+  fs-minipass@3.0.3:
+    dependencies:
+      minipass: 7.1.3
 
   fsevents@2.3.2:
     optional: true
@@ -9085,6 +9543,10 @@ snapshots:
 
   hookable@5.5.3: {}
 
+  hosted-git-info@10.1.1:
+    dependencies:
+      lru-cache: 11.5.1
+
   hosted-git-info@8.1.0:
     dependencies:
       lru-cache: 10.4.3
@@ -9097,11 +9559,22 @@ snapshots:
 
   html-void-elements@3.0.0: {}
 
+  http-cache-semantics@4.2.0: {}
+
   http-proxy-agent@8.0.0:
     dependencies:
       agent-base: 8.0.0
       debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
+      - supports-color
+
+  http-proxy-agent@9.1.0:
+    dependencies:
+      agent-base: 9.0.0
+      debug: 4.4.3(supports-color@8.1.1)
+      proxy-agent-negotiate: 1.1.0
+    transitivePeerDependencies:
+      - kerberos
       - supports-color
 
   http-signature@1.4.0:
@@ -9124,6 +9597,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  https-proxy-agent@9.1.0:
+    dependencies:
+      agent-base: 9.0.0
+      debug: 4.4.3(supports-color@8.1.1)
+      proxy-agent-negotiate: 1.1.0
+    transitivePeerDependencies:
+      - kerberos
+      - supports-color
+
   human-signals@1.1.1: {}
 
   human-signals@2.1.0: {}
@@ -9135,6 +9617,10 @@ snapshots:
       safer-buffer: 2.1.2
 
   ieee754@1.2.1: {}
+
+  ignore-walk@9.0.0:
+    dependencies:
+      minimatch: 10.2.5
 
   ignore@5.3.2: {}
 
@@ -9152,6 +9638,8 @@ snapshots:
   ini@2.0.0: {}
 
   ini@6.0.0: {}
+
+  ini@7.0.0: {}
 
   ip-address@10.2.0: {}
 
@@ -9216,6 +9704,8 @@ snapshots:
 
   isexe@2.0.0: {}
 
+  isexe@4.0.0: {}
+
   isstream@0.1.2: {}
 
   issue-parser@7.0.1:
@@ -9267,6 +9757,8 @@ snapshots:
 
   json-parse-even-better-errors@2.3.1: {}
 
+  json-parse-even-better-errors@6.0.0: {}
+
   json-schema-traverse@0.4.1: {}
 
   json-schema-traverse@1.0.0: {}
@@ -9294,6 +9786,8 @@ snapshots:
       universalify: 2.0.1
     optionalDependencies:
       graceful-fs: 4.2.11
+
+  jsonparse@1.3.1: {}
 
   jsprim@2.0.2:
     dependencies:
@@ -9484,6 +9978,24 @@ snapshots:
     dependencies:
       semver: 7.8.5
 
+  make-fetch-happen@16.0.1:
+    dependencies:
+      '@gar/promise-retry': 1.0.3
+      '@npmcli/agent': 5.0.2
+      '@npmcli/redact': 5.0.0
+      cacache: 21.0.1
+      http-cache-semantics: 4.2.0
+      minipass: 7.1.3
+      minipass-fetch: 6.0.0
+      minipass-flush: 1.0.7
+      minipass-pipeline: 1.2.4
+      negotiator: 1.0.0
+      proc-log: 7.0.0
+      ssri: 14.0.0
+    transitivePeerDependencies:
+      - kerberos
+      - supports-color
+
   mark.js@8.11.1: {}
 
   markdown-it@14.3.0:
@@ -9575,9 +10087,41 @@ snapshots:
 
   minimist@1.2.8: {}
 
+  minipass-collect@2.0.1:
+    dependencies:
+      minipass: 7.1.3
+
+  minipass-fetch@6.0.0:
+    dependencies:
+      minipass: 7.1.3
+      minipass-sized: 2.0.0
+      minizlib: 3.1.0
+    optionalDependencies:
+      iconv-lite: 0.7.3
+
+  minipass-flush@1.0.7:
+    dependencies:
+      minipass: 3.3.6
+
+  minipass-pipeline@1.2.4:
+    dependencies:
+      minipass: 3.3.6
+
+  minipass-sized@2.0.0:
+    dependencies:
+      minipass: 7.1.3
+
+  minipass@3.3.6:
+    dependencies:
+      yallist: 4.0.0
+
   minipass@7.1.3: {}
 
   minisearch@7.2.0: {}
+
+  minizlib@3.1.0:
+    dependencies:
+      minipass: 7.1.3
 
   mobx@6.16.1: {}
 
@@ -9593,6 +10137,8 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
+  negotiator@1.0.0: {}
+
   neo-async@2.6.2: {}
 
   netmask@2.1.1: {}
@@ -9603,6 +10149,23 @@ snapshots:
 
   node-fetch-native@1.6.7: {}
 
+  node-gyp@13.0.1:
+    dependencies:
+      env-paths: 2.2.1
+      exponential-backoff: 3.1.3
+      graceful-fs: 4.2.11
+      nopt: 10.0.1
+      proc-log: 7.0.0
+      semver: 7.8.5
+      tar: 7.5.20
+      tinyglobby: 0.2.17
+      undici: 8.7.0
+      which: 7.0.0
+
+  nopt@10.0.1:
+    dependencies:
+      abbrev: 5.0.0
+
   normalize-package-data@7.0.1:
     dependencies:
       hosted-git-info: 8.1.0
@@ -9611,12 +10174,56 @@ snapshots:
 
   normalize-path@3.0.0: {}
 
+  npm-bundled@6.0.0:
+    dependencies:
+      npm-normalize-package-bin: 6.0.0
+
+  npm-install-checks@9.0.0:
+    dependencies:
+      semver: 7.8.5
+
+  npm-normalize-package-bin@6.0.0: {}
+
   npm-package-arg@13.0.2:
     dependencies:
       hosted-git-info: 9.0.3
       proc-log: 6.1.0
       semver: 7.8.5
       validate-npm-package-name: 7.0.2
+
+  npm-package-arg@14.0.0:
+    dependencies:
+      hosted-git-info: 10.1.1
+      proc-log: 7.0.0
+      semver: 7.8.5
+      validate-npm-package-name: 8.0.0
+
+  npm-packlist@11.3.0:
+    dependencies:
+      glob: 13.0.6
+      ignore-walk: 9.0.0
+      proc-log: 7.0.0
+
+  npm-pick-manifest@12.0.0:
+    dependencies:
+      npm-install-checks: 9.0.0
+      npm-normalize-package-bin: 6.0.0
+      npm-package-arg: 14.0.0
+      semver: 7.8.5
+
+  npm-registry-fetch@20.0.1:
+    dependencies:
+      '@npmcli/redact': 5.0.0
+      jsonparse: 1.3.1
+      make-fetch-happen: 16.0.1
+      minipass: 7.1.3
+      minipass-fetch: 6.0.0
+      minizlib: 3.1.0
+      npm-package-arg: 14.0.0
+      proc-log: 7.0.0
+    transitivePeerDependencies:
+      - kerberos
+      - supports-color
 
   npm-run-path@4.0.1:
     dependencies:
@@ -9863,6 +10470,29 @@ snapshots:
       validate-npm-package-license: 3.0.4
       validate-npm-package-name: 7.0.2
 
+  pacote@22.0.0:
+    dependencies:
+      '@gar/promise-retry': 1.0.3
+      '@npmcli/git': 8.0.0
+      '@npmcli/installed-package-contents': 5.0.0
+      '@npmcli/package-json': 8.0.0
+      '@npmcli/promise-spawn': 10.0.0
+      '@npmcli/run-script': 11.0.0
+      cacache: 21.0.1
+      fs-minipass: 3.0.3
+      minipass: 7.1.3
+      npm-package-arg: 14.0.0
+      npm-packlist: 11.3.0
+      npm-pick-manifest: 12.0.0
+      npm-registry-fetch: 20.0.1
+      proc-log: 7.0.0
+      sigstore: 5.0.0
+      ssri: 14.0.0
+      tar: 7.5.20
+    transitivePeerDependencies:
+      - kerberos
+      - supports-color
+
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
@@ -9954,6 +10584,8 @@ snapshots:
 
   proc-log@6.1.0: {}
 
+  proc-log@7.0.0: {}
+
   process@0.11.10: {}
 
   proper-lockfile@4.1.2:
@@ -9965,6 +10597,8 @@ snapshots:
   property-information@7.2.0: {}
 
   protocols@2.0.2: {}
+
+  proxy-agent-negotiate@1.1.0: {}
 
   proxy-agent@7.0.0(supports-color@8.1.1):
     dependencies:
@@ -10253,6 +10887,18 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
+  sigstore@5.0.0:
+    dependencies:
+      '@sigstore/bundle': 5.0.0
+      '@sigstore/core': 4.0.1
+      '@sigstore/protobuf-specs': 0.5.1
+      '@sigstore/sign': 5.0.0
+      '@sigstore/tuf': 5.0.0
+      '@sigstore/verify': 4.1.0
+    transitivePeerDependencies:
+      - kerberos
+      - supports-color
+
   sirv@3.0.2:
     dependencies:
       '@polka/url': 1.0.0-next.29
@@ -10272,6 +10918,14 @@ snapshots:
       is-fullwidth-code-point: 5.1.0
 
   smart-buffer@4.2.0: {}
+
+  socks-proxy-agent@10.1.0:
+    dependencies:
+      agent-base: 9.0.0
+      debug: 4.4.3(supports-color@8.1.1)
+      socks: 2.8.9
+    transitivePeerDependencies:
+      - supports-color
 
   socks-proxy-agent@9.0.0:
     dependencies:
@@ -10316,6 +10970,11 @@ snapshots:
       spdx-exceptions: 2.5.0
       spdx-license-ids: 3.0.23
 
+  spdx-expression-parse@4.0.0:
+    dependencies:
+      spdx-exceptions: 2.5.0
+      spdx-license-ids: 3.0.23
+
   spdx-license-ids@3.0.23: {}
 
   split2@4.2.0: {}
@@ -10331,6 +10990,10 @@ snapshots:
       jsbn: 0.1.1
       safer-buffer: 2.1.2
       tweetnacl: 0.14.5
+
+  ssri@14.0.0:
+    dependencies:
+      minipass: 7.1.3
 
   stackback@0.0.2: {}
 
@@ -10404,6 +11067,14 @@ snapshots:
 
   tabbable@6.5.0: {}
 
+  tar@7.5.20:
+    dependencies:
+      '@isaacs/fs-minipass': 4.0.1
+      chownr: 3.0.0
+      minipass: 7.1.3
+      minizlib: 3.1.0
+      yallist: 5.0.0
+
   throttleit@1.0.1: {}
 
   tiny-invariant@1.3.3: {}
@@ -10451,6 +11122,14 @@ snapshots:
   tslib@1.14.1: {}
 
   tslib@2.8.1: {}
+
+  tuf-js@6.0.0:
+    dependencies:
+      '@gar/promise-retry': 1.0.3
+      '@tufjs/models': 5.0.0
+      debug: 4.4.3(supports-color@8.1.1)
+    transitivePeerDependencies:
+      - supports-color
 
   tunnel-agent@0.6.0:
     dependencies:
@@ -10542,6 +11221,8 @@ snapshots:
 
   undici@7.28.0: {}
 
+  undici@8.7.0: {}
+
   unenv@2.0.0-rc.24:
     dependencies:
       pathe: 2.0.3
@@ -10596,6 +11277,8 @@ snapshots:
       spdx-expression-parse: 3.0.1
 
   validate-npm-package-name@7.0.2: {}
+
+  validate-npm-package-name@8.0.0: {}
 
   verror@1.10.0:
     dependencies:
@@ -10800,6 +11483,10 @@ snapshots:
     dependencies:
       isexe: 2.0.0
 
+  which@7.0.0:
+    dependencies:
+      isexe: 4.0.0
+
   why-is-node-running@2.3.0:
     dependencies:
       siginfo: 2.0.0
@@ -10871,6 +11558,10 @@ snapshots:
       powershell-utils: 0.1.0
 
   y18n@5.0.8: {}
+
+  yallist@4.0.0: {}
+
+  yallist@5.0.0: {}
 
   yaml-eslint-parser@2.1.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -21,6 +21,7 @@ catalog:
   '@types/dom-navigation': ^1.0.7
   '@types/lodash': ^4.17.24
   '@types/node': ^24.13.3
+  '@types/pacote': ^11.1.8
   '@uirouter/core': ^6.1.2
   '@uirouter/dsr': ^1.2.0
   '@uirouter/sticky-states': ^1.5.1
@@ -49,6 +50,7 @@ catalog:
   oxfmt: 0.58.0
   oxlint: 1.73.0
   oxlint-tsgolint: 0.24.0
+  pacote: ^22.0.0
   playwright: ^1.61.1
   release-it: ^20.2.1
   rimraf: ^6.1.3

--- a/tools/release/package.json
+++ b/tools/release/package.json
@@ -17,8 +17,10 @@
   "devDependencies": {
     "@tools/shared": "workspace:*",
     "@types/node": "catalog:",
+    "@types/pacote": "catalog:",
     "lit-ui-router": "workspace:*",
     "lit-ui-router-mobx": "workspace:*",
+    "pacote": "catalog:",
     "typescript": "catalog:",
     "ui-router-navigation-location-plugin": "workspace:*"
   }

--- a/tools/release/src/checks/check-pack.ts
+++ b/tools/release/src/checks/check-pack.ts
@@ -10,11 +10,9 @@
 // a temp dir, extracts the packed package.json, and delegates all decisions to
 // the pure, unit-tested functions in ./check-pack.core.ts.
 
-import { execFile } from 'node:child_process';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { promisify } from 'node:util';
 
 import {
   findUnsubstitutedRefs,
@@ -23,15 +21,9 @@ import {
 } from './check-pack.core.ts';
 import { pnpmPack } from './pack.ts';
 import { assertSelfDeclaredDeps } from './self-deps.ts';
+import { tarballManifest } from './tarball.ts';
 import type { PackageManifest } from '@tools/shared/types.ts';
 import { loadWorkspace, workspaceRoot } from '@tools/shared/workspace.ts';
-
-const run = promisify(execFile);
-
-// A package.json is always a JSON object; anything else can't hold dep fields.
-function isPackageManifest(value: unknown): value is PackageManifest {
-  return typeof value === 'object' && value !== null;
-}
 
 /** Pack one package and return the manifest from inside the tarball. */
 async function packedManifest(packageDir: string): Promise<PackageManifest> {
@@ -39,13 +31,8 @@ async function packedManifest(packageDir: string): Promise<PackageManifest> {
   const tarball = join(destination, 'package.tgz');
   try {
     await pnpmPack(packageDir, tarball);
-    const { stdout } = await run(
-      'tar',
-      ['-xzOf', tarball, 'package/package.json'],
-      { maxBuffer: 16 * 1024 * 1024 },
-    );
-    const parsed: unknown = JSON.parse(stdout);
-    return isPackageManifest(parsed) ? parsed : {};
+    // Malformed manifests reject in tarballManifest — loud, never a silent {}.
+    return await tarballManifest(tarball);
   } finally {
     await rm(destination, { recursive: true, force: true });
   }

--- a/tools/release/src/checks/check-packed-manifest.ts
+++ b/tools/release/src/checks/check-packed-manifest.ts
@@ -10,21 +10,12 @@
 // tarball and delegates all decisions to the pure, unit-tested functions in
 // ./check-pack.core.ts.
 
-import { execFile } from 'node:child_process';
-import { promisify } from 'node:util';
-
 import {
   findPackedManifestViolations,
   formatPackedManifestReport,
 } from './check-pack.core.ts';
+import { tarballManifest } from './tarball.ts';
 import type { PackageManifest } from '@tools/shared/types.ts';
-
-const run = promisify(execFile);
-
-// A package.json is always a JSON object; anything else can't hold dep fields.
-function isPackageManifest(value: unknown): value is PackageManifest {
-  return typeof value === 'object' && value !== null;
-}
 
 const [tarball, ...extra] = process.argv.slice(2);
 if (!tarball || extra.length > 0) {
@@ -32,13 +23,9 @@ if (!tarball || extra.length > 0) {
   process.exit(1);
 }
 
-const { stdout } = await run(
-  'tar',
-  ['-xzOf', tarball, 'package/package.json'],
-  { maxBuffer: 16 * 1024 * 1024 },
-);
-const parsed: unknown = JSON.parse(stdout);
-const manifest = isPackageManifest(parsed) ? parsed : {};
+// Malformed manifests reject in tarballManifest — the gate fails loudly,
+// never a silent `{}` that absence-checks would pass.
+const manifest = (await tarballManifest(tarball)) as PackageManifest;
 const { ok, text } = formatPackedManifestReport(
   findPackedManifestViolations(manifest),
 );

--- a/tools/release/src/checks/check-published-diff.core.ts
+++ b/tools/release/src/checks/check-published-diff.core.ts
@@ -36,6 +36,54 @@ export function isShipAffecting(file: string): boolean {
   return !(file.startsWith('src/') || /^dist\/.*\.map$/.test(file));
 }
 
+/** Manifest fields whose entire consumer effect is the packed file set. */
+export const MANIFEST_INERT_FIELDS: readonly string[] = ['files'];
+
+/** True when any diff header has a /dev/null side — a file added or removed. */
+export function hasFileSetChange(diffOutput: string): boolean {
+  return diffOutput
+    .split('\n')
+    .some(
+      (line) =>
+        (line.startsWith('+++ ') || line.startsWith('--- ')) &&
+        line.slice(4).trim() === '/dev/null',
+    );
+}
+
+/**
+ * Top-level manifest fields whose values differ between the two sides.
+ * Both arrive as parsed package.json objects read from the compared
+ * tarballs (tarballManifest); read/parse failures never reach here — the
+ * IO fails safe to ship-affecting.
+ */
+export function manifestDriftFields(
+  a: Record<string, unknown>,
+  b: Record<string, unknown>,
+): string[] {
+  const keys = new Set([...Object.keys(a), ...Object.keys(b)]);
+  return [...keys]
+    .filter((key) => JSON.stringify(a[key]) !== JSON.stringify(b[key]))
+    .sort();
+}
+
+/**
+ * package.json drift is ship-inert iff the packed file sets are identical
+ * AND every drifting field's consumer effect is captured by that file-set
+ * comparison (MANIFEST_INERT_FIELDS). A formatting-only diff (no field
+ * drift) is vacuously confined. Any other field, or any file-set change,
+ * stays ship-affecting.
+ */
+export function isManifestDriftInert(options: {
+  fileSetChanged: boolean;
+  driftFields: string[];
+}): boolean {
+  const { fileSetChanged, driftFields } = options;
+  return (
+    !fileSetChanged &&
+    driftFields.every((field) => MANIFEST_INERT_FIELDS.includes(field))
+  );
+}
+
 /** Split a diff's file list into ship-affecting and ship-inert. */
 export function classifyFiles(files: string[]): {
   shipAffecting: string[];
@@ -56,11 +104,11 @@ export type DiffResult = {
   latest?: string;
   /** Version in the working tree's manifest. */
   localVersion?: string;
-  /** `ship-inert` = only src/maps differ; release not owed. */
+  /** `ship-inert` = only src/maps/inert-manifest drift; release not owed. */
   status: 'clean' | 'drift' | 'ship-inert' | 'unpublished';
   /** Ship-affecting tarball paths; only meaningful for `drift`. */
   files?: string[];
-  /** Ship-inert paths (src/**, dist maps); listed, never owing. */
+  /** Ship-inert paths (src/**, dist maps, inert package.json); never owing. */
   shipInertFiles?: string[];
 };
 
@@ -153,7 +201,7 @@ export function formatReport(
     } else if (status === 'ship-inert') {
       const count = shipInertFiles?.length ?? 0;
       lines.push(
-        `  ${name}: src/map drift vs ${latest}${ahead} — ${count} ship-inert file(s):`,
+        `  ${name}: ship-inert drift vs ${latest}${ahead} — ${count} ship-inert file(s):`,
       );
       for (const file of shipInertFiles ?? []) lines.push(`      ◦ ${file}`);
     } else {

--- a/tools/release/src/checks/check-published-diff.test.ts
+++ b/tools/release/src/checks/check-published-diff.test.ts
@@ -5,7 +5,10 @@ import {
   changedFiles,
   classifyFiles,
   formatReport,
+  hasFileSetChange,
   isCleanDiff,
+  isManifestDriftInert,
+  manifestDriftFields,
   renderSummary,
   scopePackages,
   summarizeResults,
@@ -82,6 +85,121 @@ describe('classifyFiles', () => {
   });
 });
 
+// Manifests as read from the two compared tarballs (tarballManifest): a
+// files-glob-only edit (dot-dir negation) with an unchanged packed file set.
+const PUBLISHED_MANIFEST = {
+  name: 'lit-ui-router',
+  version: '1.7.1',
+  files: ['dist/**'],
+  exports: './dist/index.js',
+};
+const LOCAL_MANIFEST_417 = {
+  name: 'lit-ui-router',
+  version: '1.7.1',
+  files: ['dist/**', '!dist/.*/**'],
+  exports: './dist/index.js',
+};
+
+// A modification-only diff: package.json changed, both sides present.
+const MANIFEST_ONLY_DIFF = [
+  '--- lit-ui-router@1.7.1/package/package.json',
+  '+++ lit-ui-router-1.7.1.tgz/package/package.json',
+  '@@ -4,1 +4,1 @@',
+  '-  "files": ["dist/**"],',
+  '+  "files": ["dist/**", "!dist/.*/**"],',
+].join('\n');
+
+describe('hasFileSetChange', () => {
+  it('detects additions and deletions via /dev/null headers', () => {
+    assert.equal(hasFileSetChange(DRIFT_DIFF), true); // dist/removed.js → /dev/null
+  });
+
+  it('is false when every changed file exists on both sides', () => {
+    assert.equal(hasFileSetChange(MANIFEST_ONLY_DIFF), false);
+  });
+});
+
+describe('manifestDriftFields', () => {
+  it('lists exactly the top-level fields whose values differ', () => {
+    assert.deepEqual(
+      manifestDriftFields(PUBLISHED_MANIFEST, LOCAL_MANIFEST_417),
+      ['files'],
+    );
+  });
+
+  it('sees no drift across key-order differences', () => {
+    const reordered = {
+      exports: './dist/index.js',
+      version: '1.7.1',
+      name: 'lit-ui-router',
+      files: ['dist/**'],
+    };
+    assert.deepEqual(manifestDriftFields(PUBLISHED_MANIFEST, reordered), []);
+  });
+
+  it('reports fields present on only one side', () => {
+    assert.deepEqual(
+      manifestDriftFields(PUBLISHED_MANIFEST, {
+        ...PUBLISHED_MANIFEST,
+        types: './dist/index.d.ts',
+      }),
+      ['types'],
+    );
+  });
+});
+
+describe('isManifestDriftInert', () => {
+  it('files-only drift with an identical file set is inert', () => {
+    assert.equal(
+      isManifestDriftInert({
+        fileSetChanged: hasFileSetChange(MANIFEST_ONLY_DIFF),
+        driftFields: manifestDriftFields(
+          PUBLISHED_MANIFEST,
+          LOCAL_MANIFEST_417,
+        ),
+      }),
+      true,
+    );
+  });
+
+  it('a files change that alters the file set stays ship-affecting', () => {
+    assert.equal(
+      isManifestDriftInert({ fileSetChanged: true, driftFields: ['files'] }),
+      false,
+    );
+  });
+
+  it('any non-whitelisted field stays ship-affecting even with an identical file set', () => {
+    assert.equal(
+      isManifestDriftInert({
+        fileSetChanged: false,
+        driftFields: ['exports', 'files'],
+      }),
+      false,
+    );
+    assert.equal(
+      isManifestDriftInert({ fileSetChanged: false, driftFields: ['types'] }),
+      false,
+    );
+  });
+
+  it('a formatting-only manifest diff (no field drift) is vacuously inert', () => {
+    assert.equal(
+      isManifestDriftInert({ fileSetChanged: false, driftFields: [] }),
+      true,
+    );
+  });
+});
+
+describe('classifyFiles (manifest rule interplay)', () => {
+  it('without a manifest diff, classification is unchanged: package.json stays ship-affecting', () => {
+    assert.deepEqual(classifyFiles(['package.json', 'src/core.ts']), {
+      shipAffecting: ['package.json'],
+      shipInert: ['src/core.ts'],
+    });
+  });
+});
+
 describe('formatReport', () => {
   const clean = {
     name: 'lit-ui-router',
@@ -123,7 +241,7 @@ describe('formatReport', () => {
     const { ok, text } = formatReport([shipInert], { strict: true });
     assert.equal(ok, true);
     assert.match(text, /\(1 ship-inert\)/);
-    assert.match(text, /src\/map drift vs 1\.7\.1 — 2 ship-inert file\(s\)/);
+    assert.match(text, /ship-inert drift vs 1\.7\.1 — 2 ship-inert file\(s\)/);
     assert.match(text, /◦ src\/core\.ts/);
   });
 

--- a/tools/release/src/checks/check-published-diff.ts
+++ b/tools/release/src/checks/check-published-diff.ts
@@ -43,12 +43,16 @@ import {
   classifyFiles,
   type DiffResult,
   formatReport,
+  hasFileSetChange,
   isCleanDiff,
+  isManifestDriftInert,
+  manifestDriftFields,
   renderSummary,
   scopePackages,
   summarizeResults,
 } from './check-published-diff.core.ts';
 import { pnpmPack } from './pack.ts';
+import { fetchTarball, tarballManifest } from './tarball.ts';
 import { readPublishedVersions } from './published-versions.ts';
 import { assertSelfDeclaredDeps } from './self-deps.ts';
 import { loadWorkspace, workspaceRoot } from '@tools/shared/workspace.ts';
@@ -64,7 +68,11 @@ const MAX_BUFFER = 64 * 1024 * 1024;
 async function diffAgainstPublished(
   dir: string,
   spec: string,
-): Promise<string> {
+): Promise<{
+  diff: string;
+  localManifest?: Record<string, unknown>;
+  publishedManifest?: Record<string, unknown>;
+}> {
   const manifestPath = join(dir, 'package.json');
   const originalManifest = await readFile(manifestPath);
   const destination = await mkdtemp(join(tmpdir(), 'check-published-diff-'));
@@ -79,7 +87,25 @@ async function diffAgainstPublished(
       ['diff', `--diff=${spec}`, `--diff=${tarball}`],
       { cwd: workspaceRoot, maxBuffer: MAX_BUFFER },
     );
-    return stdout;
+    if (!changedFiles(stdout).includes('package.json')) {
+      return { diff: stdout };
+    }
+    // Both manifests as-shipped, read from the compared tarballs — the
+    // LOCAL side must come from the pack too (pnpm substitutes catalog:/
+    // workspace: refs at pack time; the on-disk manifest would false-drift).
+    // fetchTarball serves from pacote's cacache — npm diff already pulled
+    // the same tarball — so this costs no second download.
+    try {
+      const localManifest = await tarballManifest(tarball);
+      const publishedTarball = join(destination, 'published.tgz');
+      await fetchTarball(spec, publishedTarball);
+      const publishedManifest = await tarballManifest(publishedTarball);
+      return { diff: stdout, localManifest, publishedManifest };
+    } catch {
+      // Failed fetch/parse leaves the manifests undefined — package.json
+      // stays ship-affecting (fail safe).
+      return { diff: stdout };
+    }
   } finally {
     await writeFile(manifestPath, originalManifest);
     await rm(destination, { recursive: true, force: true });
@@ -142,12 +168,32 @@ async function main() {
       results.push({ name, dir, localVersion, status: 'unpublished' });
       continue;
     }
-    const diff = await diffAgainstPublished(packageDir, `${name}@${latest}`);
+    const { diff, localManifest, publishedManifest } =
+      await diffAgainstPublished(packageDir, `${name}@${latest}`);
     if (isCleanDiff(diff)) {
       results.push({ name, dir, latest, localVersion, status: 'clean' });
       continue;
     }
-    const { shipAffecting, shipInert } = classifyFiles(changedFiles(diff));
+    let { shipAffecting, shipInert } = classifyFiles(changedFiles(diff));
+    if (
+      shipAffecting.includes('package.json') &&
+      localManifest !== undefined &&
+      publishedManifest !== undefined
+    ) {
+      let manifestInert = false;
+      try {
+        manifestInert = isManifestDriftInert({
+          fileSetChanged: hasFileSetChange(diff),
+          driftFields: manifestDriftFields(publishedManifest, localManifest),
+        });
+      } catch {
+        // Unparsable manifest bytes stay ship-affecting.
+      }
+      if (manifestInert) {
+        shipAffecting = shipAffecting.filter((file) => file !== 'package.json');
+        shipInert = [...shipInert, 'package.json'].sort();
+      }
+    }
     results.push({
       name,
       dir,

--- a/tools/release/src/checks/tarball.test.ts
+++ b/tools/release/src/checks/tarball.test.ts
@@ -1,0 +1,76 @@
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { after, before, describe, it } from 'node:test';
+import { promisify } from 'node:util';
+
+import { tarballManifest } from './tarball.ts';
+
+const run = promisify(execFile);
+
+describe('tarballManifest', () => {
+  let dir: string;
+  let tarball: string;
+  const manifest = {
+    name: 'probe',
+    version: '1.0.0',
+    files: ['dist/**'],
+    _authorField: 'kept',
+  };
+
+  before(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'tarball-test-'));
+    await mkdir(join(dir, 'package'));
+    await writeFile(
+      join(dir, 'package', 'package.json'),
+      `${JSON.stringify(manifest)}\n`,
+    );
+    tarball = join(dir, 'probe.tgz');
+    await run('tar', ['-czf', tarball, '-C', dir, 'package/package.json']);
+  });
+
+  after(() => rm(dir, { recursive: true, force: true }));
+
+  it('returns the archived manifest fields verbatim, minus underscore metadata', async () => {
+    // pacote drops author `_`-prefixed fields (npm-reserved namespace) and
+    // the helper strips pacote's own injected fetch-metadata keys.
+    const { _authorField, ...content } = manifest;
+    assert.deepEqual(await tarballManifest(tarball), content);
+  });
+
+  it('rejects on a missing tarball (callers fail safe)', async () => {
+    await assert.rejects(tarballManifest(join(dir, 'nope.tgz')));
+  });
+
+  // The gate consumes this helper: malformed manifests must fail the check
+  // loudly, never normalize to a `{}` that absence-checks would pass.
+  const malformed = async (label: string, bytes: string) => {
+    const bad = await mkdtemp(join(tmpdir(), `tarball-${label}-`));
+    await mkdir(join(bad, 'package'));
+    await writeFile(join(bad, 'package', 'package.json'), bytes);
+    const tgz = join(bad, 'bad.tgz');
+    await run('tar', ['-czf', tgz, '-C', bad, 'package/package.json']);
+    return tgz;
+  };
+
+  it('rejects an unparsable manifest', async () => {
+    await assert.rejects(
+      tarballManifest(await malformed('syntax', '{not json')),
+    );
+  });
+
+  it('rejects a manifest that is not a package (array/empty object)', async () => {
+    // pacote resolves these to metadata-only manifests; the name/version
+    // assertion is what makes them loud.
+    await assert.rejects(
+      tarballManifest(await malformed('array', '[]')),
+      /not a package manifest/,
+    );
+    await assert.rejects(
+      tarballManifest(await malformed('empty', '{}')),
+      /not a package manifest/,
+    );
+  });
+});

--- a/tools/release/src/checks/tarball.ts
+++ b/tools/release/src/checks/tarball.ts
@@ -1,0 +1,48 @@
+// Shared IO helper for checks that read a packed tarball's manifest. Kept
+// out of the *.core.ts modules on purpose — those stay pure and
+// unit-testable; this is the one pacote wrapper both consumers share
+// (check-packed-manifest.ts and check-published-diff.ts).
+
+import pacote from 'pacote';
+
+// pacote.manifest on a file spec returns the archive's fields verbatim
+// (probe-verified against pnpm-packed and npm-published tarballs) except:
+// it drops any author underscore-prefixed field (npm reserves `_` for
+// internal metadata) and injects exactly these fetch-metadata keys, which
+// the helper strips back out.
+const PACOTE_METADATA_FIELDS = ['_id', '_integrity', '_resolved', '_from'];
+
+/**
+ * The literal package/package.json fields of a packed tarball; rejects when
+ * the archive is missing/unreadable OR the manifest is not a real package
+ * manifest. pacote itself rejects unparsable/null/string manifests; the
+ * name/version assertion closes the remaining gap (array/empty-object
+ * manifests resolve to metadata-only, which downstream absence-checks would
+ * silently pass — the old `: {}` fail-open).
+ */
+export async function tarballManifest(
+  tarball: string,
+): Promise<Record<string, unknown>> {
+  const manifest = (await pacote.manifest(tarball)) as unknown as Record<
+    string,
+    unknown
+  >;
+  if (
+    typeof manifest.name !== 'string' ||
+    typeof manifest.version !== 'string'
+  ) {
+    throw new Error(
+      `${tarball}: package/package.json is not a package manifest (no name/version)`,
+    );
+  }
+  return Object.fromEntries(
+    Object.entries(manifest).filter(
+      ([key]) => !PACOTE_METADATA_FIELDS.includes(key),
+    ),
+  );
+}
+
+/** Fetch a registry spec's published tarball to `dest` (cacache-cached). */
+export async function fetchTarball(spec: string, dest: string): Promise<void> {
+  await pacote.tarball.file(spec, dest);
+}


### PR DESCRIPTION
Refines the published-diff ship-affecting arbiter so #417's class of package.json drift stops owing releases.

## The rule (unchanged from review round 1)

package.json drift is classified **ship-inert** iff BOTH:

1. **(a) identical file sets** — the locally packed tarball and the registry tarball contain exactly the same file paths;
2. **(b) whitelist-confined manifest drift** — the manifest diff touches only fields whose *entire consumer effect is the packed file set*: initially exactly `["files"]`.

Any other field differing (`exports`, `types`, `main`, deps, peers, `bin`, `sideEffects`, anything) → ship-affecting, exactly as today. Both conditions required: a `files` change that *does* alter the file set stays affecting; a files-only manifest diff accompanied by file-set drift stays affecting. A formatting-only manifest diff (byte drift, zero top-level field drift) is vacuously confined and therefore inert under (a) — stated explicitly since key-order drift is a known historical release driver (0.3.4).

**Why file-set identity fully captures `files` semantics**: the field's only consumer-visible effect is which paths land in the tarball — npm evaluates it at pack time; installers never read it. Identical packed file lists prove the globs equivalent for this tree.

## Mechanism (round 3 — pacote, npm's own fetcher layer)

No diff-text reconstruction, no system-tar subprocess, no `npm pack` subprocess. Both sides converge to local files and one code path reads them:

- **Local side**: the tarball the check already packs (pnpm pack via the untouched publishPath machinery).
- **Registry side**: `pacote.tarball.file(spec, dest)` fetches the published tarball to a tmp file (cacache-served — npm diff already pulled the same bytes).
- **Both** manifests read via the shared helper `tarballManifest` (`src/checks/tarball.ts`): `pacote.manifest(<local tgz path>)` on each file, minus pacote's injected fetch-metadata keys (`_id`, `_integrity`, `_resolved`, `_from` — the probe-verified exact set).

**Semantics guard, probe-verified before wiring** (the packument trap is avoided by never passing a registry spec to `pacote.manifest`): against the repo's OWN pnpm-packed tarball (real machinery: manifest strip + `pnpm pack` of lit-ui-router, 16 manifest keys) AND the npm-published `lit-ui-router@1.7.1` tarball, `pacote.manifest`-on-file returned **zero missing keys and zero value differences** vs the literal `tar -xzOf` bytes, with exactly the four `_` keys added. One observed normalization, surfaced by the helper's unit test and documented in code: pacote drops author `_`-prefixed fields from the archive (npm-reserved namespace) — so an author `_field` is invisible to the field compare on both sides equally; npm itself treats `_` as non-content metadata, accepted as ecosystem-default behavior.

- **`manifestDriftFields`** compares the two parsed manifests' top-level fields structurally (core stays pure — takes objects). **`hasFileSetChange`** stays derived from the main diff's file headers (`/dev/null` side = add/remove) — untouched.
- **Fail safe**: any pacote rejection (fetch, unreadable archive) leaves the manifests undefined → package.json stays ship-affecting; the gate side keeps failing loudly.
- The 16MB `maxBuffer` bound from the tar reconciliation is retired with the subprocess: it existed to keep `execFile` from truncating output, not as a policy limit — with in-process parsing there is nothing to truncate.
- Deps added per convention: `pacote` (catalog: `^22.0.0`, published 2026-06-15 — clears minimumReleaseAge) + `@types/pacote` (catalog: `^11.1.8`; pacote ships no types) as tools/release devDependencies.
- Report wording: the ship-inert status line reads "ship-inert drift" (was "src/map drift" — no longer the only inert class).

## #417 motivation

#417 (`build: consolidate variant outputs under dist/`) adds `!dist/.*/**` to all three packages' `files` arrays (a19f1f9's package.json hunks). The excluded dot-directories were never packed, so the packed output is byte-identical — yet today's arbiter owes three releases for a no-op. With this change those hunks merge without owing anything.

## Shared-core impact analysis (publish gates unweakened)

The shared surfaces with the publish-time gates are `check-pack.core.ts`'s `STRIPPED_MANIFEST_FIELDS` (read-only, untouched) and the manifest extraction — ONE shared helper (`src/checks/tarball.ts`, the `pack.ts` shared-IO-wrapper pattern, now pacote-backed) consumed by both `check-packed-manifest.ts` (the check_tarball publish gate) and `check-published-diff.ts`. Behavior-preserving for the gate, probe-verified: every field its hygiene checks inspect (devDependencies, scripts, dep ranges) arrives verbatim; its tests pass unchanged. The helper has its own unit tests (verbatim round-trip vs a real archive incl. the `_`-field normalization, missing-tarball rejection).

## Gate hardening: the `isPackageManifest` fail-open fallback (removed)

Pre-existing in both `check-pack.ts` and `check-packed-manifest.ts`: an `isPackageManifest(parsed) ? parsed : {}` guard pair. The `: {}` arm was **fail-open in gate context** — a manifest that parsed to a non-object became `{}`, which trivially passes absence-checks (no unsubstituted refs, no leaked devDeps).

**What fed it / reachability**: the input is always the package.json inside a tarball that `pnpm pack` just produced (check:pack packs it itself; check_tarball receives the pack step's artifact from the same job's filesystem). pnpm pack cannot emit a manifest without name/version, and syntactically-invalid JSON already failed loudly (`JSON.parse` throw → non-zero). The fallback was reachable only for valid-JSON-non-object shapes (`[]`, `"x"`, `null`) in a corrupted or hand-crafted tarball — no realistic path in the current pipeline, but the gate silently passing garbage is wrong regardless. Notably the pacote swap alone would NOT have closed it: probed, pacote rejects unparsable/`null`/string manifests but **resolves `[]` and `{}`** to metadata-only manifests (→ `{}` after stripping).

**Fix**: both guards deleted; results typed directly (`tarballManifest` returns the manifest; one boundary cast where the shared `PackageManifest` type is needed — every downstream field access was already optional/defensive, verified). Malformed input now fails loudly at the shared helper: pacote's own rejections plus a minimal name/version assertion (one throw, no validation framework) closing the array/empty-object gap. Gate side: throw → non-zero exit. Reporter side: throw → existing fail-safe → ship-affecting. `check-pack.ts` also converges onto the shared `tarballManifest` helper (it still carried its own inline tar extraction — last duplicate gone). Covered by new gate-path tests: unparsable manifest rejects; `[]`/`{}` manifests reject with "not a package manifest".

## Test evidence

`tools/release` node --test suite: **144 pass / 0 fail**, including the four required cases on the new mechanism (fixtures are raw manifest JSON + npm-diff-shaped headers):
1. files-only drift + identical file set → inert (composed end-to-end from the #417-shaped fixtures)
2. files diff + file-set change → affecting
3. non-whitelisted field (`exports`, `types`) + identical file set → affecting
4. no manifest diff → classification unchanged (package.json stays ship-affecting)

Plus: structural-compare ignores formatting-only differences; unparsable sides throw (fail-safe path).

**Live re-rehearsal** (real registry, pacote mechanism — re-run both directions this round): baseline clean vs 1.7.1 → apply #417's exact `files` hunk → `ship-inert drift vs 1.7.1 — 1 ship-inert file(s): ◦ package.json`, check **passes** → revert. Control: a `sideEffects` edit instead → `SHIPS CHANGES vs 1.7.1 — 1 ship-affecting file(s): • package.json`. Both directions proven against the live registry.

## Release-gated caveat

None — the live runs exercise the full pack+fetch+extract+classify path. Post-merge observable: #417's merge should leave the main-push published-diff badges non-owing.
