### PR TITLE
build(examples): defer example npm ci to the tasks that need it

### DIFF
--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -1,0 +1,1 @@
+.install-lock-*/

--- a/examples/README.md
+++ b/examples/README.md
@@ -60,7 +60,7 @@ npm install
 npm run dev
 ```
 
-In the monorepo, a root `pnpm install` also installs each example's own npm dependencies via this package's `postinstall` hook. pnpm skips lifecycle scripts when the workspace is already up to date, so to restore a manually deleted `examples/<example-name>/node_modules` run the hook directly:
+In the monorepo, a root `pnpm install` also installs each example's own npm dependencies via this package's `postinstall` hook (skipped in CI, where the typecheck and embeds-build tasks install on demand). pnpm skips lifecycle scripts when the workspace is already up to date, so to restore a manually deleted `examples/<example-name>/node_modules` run the hook directly:
 
 ```bash
 pnpm --filter examples postinstall

--- a/examples/ensure-installs.ts
+++ b/examples/ensure-installs.ts
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+// Idempotent per-example `npm ci`: a lock-hash stamp makes warm dirs a no-op,
+// and an atomic mkdir lock serializes concurrent installers (typecheck and
+// build:embeds both self-provision; a turbo edge may not serialize them, #267).
+// --postinstall marks the local-convenience path: skipped in CI, where only
+// tasks that actually execute pay for the install.
+import { createHash } from 'node:crypto';
+import { spawn } from 'node:child_process';
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { setTimeout as sleep } from 'node:timers/promises';
+
+const root = dirname(fileURLToPath(import.meta.url));
+const EXAMPLES = ['helloworld', 'hellosolarsystem', 'hellogalaxy'];
+const STALE_LOCK_MS = 5 * 60_000;
+
+const args = process.argv.slice(2);
+const postinstall = args.includes('--postinstall');
+const names = args.filter((a) => !a.startsWith('--'));
+
+if (postinstall && process.env.CI) {
+  console.log(
+    '[ensure-installs] CI: deferred to the tasks that need example node_modules',
+  );
+  process.exit(0);
+}
+const invalid = names.filter((n) => !EXAMPLES.includes(n));
+if (invalid.length > 0) {
+  console.error(`[ensure-installs] unknown example(s): ${invalid.join(', ')}`);
+  process.exit(1);
+}
+
+function run(cmd: string, cmdArgs: string[]): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(cmd, cmdArgs, { cwd: root, stdio: 'inherit' });
+    child.on('error', reject);
+    child.on('close', (code) => {
+      if (code === 0) resolve();
+      else reject(new Error(`${cmd} ${cmdArgs.join(' ')} exited ${code}`));
+    });
+  });
+}
+
+async function ensure(name: string): Promise<void> {
+  const want = createHash('sha256')
+    .update(readFileSync(join(root, name, 'package-lock.json')))
+    .digest('hex');
+  const stampPath = join(root, name, 'node_modules', '.install-stamp');
+  const fresh = () =>
+    existsSync(stampPath) && readFileSync(stampPath, 'utf8') === want;
+  if (fresh()) return;
+
+  const lockDir = join(root, `.install-lock-${name}`);
+  for (;;) {
+    try {
+      mkdirSync(lockDir);
+      break;
+    } catch {
+      try {
+        if (Date.now() - statSync(lockDir).mtimeMs > STALE_LOCK_MS)
+          rmSync(lockDir, { recursive: true, force: true });
+      } catch {
+        // lock released between mkdir and stat; retry immediately
+      }
+      await sleep(500);
+    }
+  }
+  try {
+    if (fresh()) return; // the holder we waited on installed it
+    await run('npm', ['run', `example:install:${name}`]);
+    writeFileSync(stampPath, want);
+  } finally {
+    rmSync(lockDir, { recursive: true, force: true });
+  }
+}
+
+await Promise.all((names.length > 0 ? names : EXAMPLES).map(ensure));

--- a/examples/package.json
+++ b/examples/package.json
@@ -4,18 +4,18 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build:embeds": "node build-embeds.ts",
+    "build:embeds": "node ensure-installs.ts && node build-embeds.ts",
     "example:install:hellogalaxy": "npm ci --no-audit --no-fund --prefix hellogalaxy",
     "example:install:hellosolarsystem": "npm ci --no-audit --no-fund --prefix hellosolarsystem",
     "example:install:helloworld": "npm ci --no-audit --no-fund --prefix helloworld",
     "format": "oxfmt \"**/*.{ts,js,json,md,html}\"",
     "format:check": "oxfmt --check \"**/*.{ts,js,json,md,html}\"",
-    "postinstall": "concurrently \"npm:example:install:*\"",
+    "postinstall": "node ensure-installs.ts --postinstall",
     "lint": "oxlint .",
     "typecheck": "concurrently --names helloworld,hellosolarsystem,hellogalaxy --prefix-colors auto \"pnpm run typecheck:helloworld\" \"pnpm run typecheck:hellosolarsystem\" \"pnpm run typecheck:hellogalaxy\"",
-    "typecheck:hellogalaxy": "tsc -p hellogalaxy",
-    "typecheck:hellosolarsystem": "tsc -p hellosolarsystem",
-    "typecheck:helloworld": "tsc -p helloworld"
+    "typecheck:hellogalaxy": "node ensure-installs.ts hellogalaxy && tsc -p hellogalaxy",
+    "typecheck:hellosolarsystem": "node ensure-installs.ts hellosolarsystem && tsc -p hellosolarsystem",
+    "typecheck:helloworld": "node ensure-installs.ts helloworld && tsc -p helloworld"
   },
   "devDependencies": {
     "concurrently": "catalog:",

--- a/examples/package.json
+++ b/examples/package.json
@@ -11,7 +11,7 @@
     "format": "oxfmt \"**/*.{ts,js,json,md,html}\"",
     "format:check": "oxfmt --check \"**/*.{ts,js,json,md,html}\"",
     "postinstall": "node ensure-installs.ts --postinstall",
-    "lint": "oxlint .",
+    "lint": "node ensure-installs.ts && oxlint .",
     "typecheck": "concurrently --names helloworld,hellosolarsystem,hellogalaxy --prefix-colors auto \"pnpm run typecheck:helloworld\" \"pnpm run typecheck:hellosolarsystem\" \"pnpm run typecheck:hellogalaxy\"",
     "typecheck:hellogalaxy": "node ensure-installs.ts hellogalaxy && tsc -p hellogalaxy",
     "typecheck:hellosolarsystem": "node ensure-installs.ts hellosolarsystem && tsc -p hellosolarsystem",

--- a/examples/turbo.json
+++ b/examples/turbo.json
@@ -5,6 +5,7 @@
     "build:embeds": {
       "inputs": [
         "build-embeds.ts",
+        "ensure-installs.ts",
         "*/index.html",
         "*/package.json",
         "*/package-lock.json",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,6 +21,7 @@
     "eslint.config.ts",
     "eslint.repo-rules.ts",
     "examples/build-embeds.ts",
+    "examples/ensure-installs.ts",
     "tools/dts-backtest/run.ts",
     "tools/vue-check/bin.ts"
   ]


### PR DESCRIPTION
Follow-on to the #426 install-attribution work (setup-cost experiment line; sibling: #425, playwright-deps). #426's attribution table showed the "Install dependencies" step's largest untouched slice is the examples postinstall — `npm ci` ×3, **4.9s of every CI install** — while its consumers were turbo cache hits in 6/6 sampled main runs.

## Change

- The `examples` postinstall hook skips in CI (`--postinstall` + `CI` env); locally it still provisions all three examples on plain `pnpm install` — **local dev is unchanged** (the gate is CI-only), and repeat installs now no-op via the stamp.
- Every task whose program reads example node_modules self-provisions through `examples/ensure-installs.ts`: a lock-hash stamp in `node_modules/.install-stamp` makes warm dirs a no-op, and an atomic `mkdir` lock serializes concurrent installers.

**Complete consumer set** (second commit — CI caught `examples#lint` missing from the first): `examples#typecheck` (tsc per example), `examples#build:embeds` (vite builds), `examples#lint` (type-aware oxlint: tsgolint builds each example's program from its tsconfig — without node_modules, imports resolve as `error` type and no-unsafe-* fires, run 29718862193). Not consumers: `format`/`format:check` (oxfmt is textual), `//#lint:root` (ignores `examples`). Root turbo `lint`/`typecheck` inputs are `$TURBO_DEFAULT$` and `examples#build:embeds` explicitly lists `*/package-lock.json` + `ensure-installs.ts` — lock changes bust all consumers.

## Alternative shapes probed and rejected

- **Dedicated install task edge (`cache: false`)**: probed empirically — a `cache:false` dependency executes even when every dependent cache-hits (`probe:install: cache bypass, force executing` under `build:embeds: cache hit, replaying logs`). Since lint/typecheck sit in every CI graph, that shape re-pays the npm ci on 100% of runs — it moves the 4.9s, never removes it. (Also: a task named `install` would collide with npm's install lifecycle hook.)
- **Install task with `outputs: node_modules`**: closes the warm-restore hole but ships a ~301MB (measured) platform-specific artifact (esbuild/rollup/vite natives) through the remote cache shared between macOS dev machines and linux CI — wrong-platform poisoning plus a restore heavier than the 4.9s it saves.
- Why #267's failures stay fixed: a task that **executes** ensures its own node_modules first; a task that cache-hits needs none (lint/typecheck replay logs; build:embeds restores `*/dist`, which is all docs consumes — verified nothing downstream reads example node_modules at runtime). The mkdir lock replaces the serializing turbo edge #267 dropped.

## Verification matrix (local)

| Case | Result |
|---|---|
| `CI=1 pnpm --filter examples postinstall` | skip line, no npm ci |
| plain `pnpm install` (no CI) | hook installs all three examples |
| cold `turbo run lint typecheck build:embeds --filter=examples --force` (7 tasks, max contention) | exactly 3 installs, 7/7 green |
| warm `--force` rerun (tasks execute, stamps fresh) | 0 installs, 7/7 green |
| unrelated-change shape (no `--force`) | 7/7 cached, 0 installs — the win intact |
| cold `turbo run lint --filter=examples --force` (the CI failure reproduced) | 3 installs, lint 0 errors |
| `turbo run build --filter=docs` | embeds built, all three examples in `docs/dist/examples/` |

## Accounting (live CI)

Install dependencies step: **16s baseline (main) → 11s on this PR's runs (−5s, every run)**. Task-miss runs pay the same npm ci they pay today, inside the task, at the observed miss rate (example locks: 10 changes/month). No new Actions cache entries — zero pool impact.
