### PR TITLE
test(lit-ui-router): register click suppression as a browser-project default

### DIFF
--- a/packages/lit-ui-router/src/specs/browser-test-utils.ts
+++ b/packages/lit-ui-router/src/specs/browser-test-utils.ts
@@ -22,10 +22,19 @@ export interface NativeClickSuppression {
   restore: () => void;
 }
 
+let active: NativeClickSuppression | undefined;
+
 // Hash hrefs resolve to the tester URL (live sessionId): an uncancelled
 // _blank/modifier/middle click boots a duplicate tester on the channel.
 // Bubble-phase so the router's element-level handler decides first.
+// Module singleton: the browser-project setup registers the default and
+// specs acquire the same handle — a second listener would record the
+// first one's preventDefault. A spec needing real default navigation
+// calls restore() and re-registers when done.
 export function suppressNativeClickNavigation(): NativeClickSuppression {
+  if (active) {
+    return active;
+  }
   const events: SuppressedNativeClick[] = [];
   const listener = (event: Event) => {
     const target = event.target instanceof Element ? event.target : null;
@@ -39,11 +48,13 @@ export function suppressNativeClickNavigation(): NativeClickSuppression {
   };
   window.addEventListener('click', listener);
   window.addEventListener('auxclick', listener);
-  return {
+  active = {
     events,
     restore: () => {
       window.removeEventListener('click', listener);
       window.removeEventListener('auxclick', listener);
+      active = undefined;
     },
   };
+  return active;
 }

--- a/packages/lit-ui-router/src/specs/ui-sref.spec.ts
+++ b/packages/lit-ui-router/src/specs/ui-sref.spec.ts
@@ -32,14 +32,16 @@ describe('uiSref directive', () => {
   let suppression: NativeClickSuppression;
 
   beforeEach(async () => {
+    // acquires the browser-project default (module singleton); clear its
+    // recordings so each test asserts only its own suppressed events
     suppression = suppressNativeClickNavigation();
+    suppression.events.length = 0;
     container = document.createElement('div');
     document.body.appendChild(container);
     await tick();
   });
 
   afterEach(async () => {
-    suppression.restore();
     // Remove DOM first to trigger directive disconnection
     container.remove();
     await tick(10);

--- a/packages/lit-ui-router/vitest.config.ts
+++ b/packages/lit-ui-router/vitest.config.ts
@@ -42,7 +42,7 @@ export default defineConfig({
         test: {
           name: 'browser',
           globals: true,
-          setupFiles: ['./vitest.setup.ts'],
+          setupFiles: ['./vitest.setup.ts', './vitest.setup.browser.ts'],
           include: browserOnlySpecs,
           browser: {
             enabled: true,

--- a/packages/lit-ui-router/vitest.setup.browser.ts
+++ b/packages/lit-ui-router/vitest.setup.browser.ts
@@ -1,0 +1,5 @@
+// Browser-project default: no spec may leak a real click's native
+// navigation — a popup at the tester URL is a duplicate tester.
+import { suppressNativeClickNavigation } from './src/specs/browser-test-utils.js';
+
+suppressNativeClickNavigation();


### PR DESCRIPTION
## What

Makes the browser-spec click suppression (#422) structural: it registers as a browser-project default via a dedicated setup file, so no future real-gesture spec can reintroduce the duplicate-tester popup conditions by omission.

## Design

- **Scoping**: new `vitest.setup.browser.ts` appended to the browser project's `setupFiles` only (`['./vitest.setup.ts', './vitest.setup.browser.ts']`). The happy-dom project keeps the shared setup untouched — no environment sniffing, no window listeners where they aren't needed (they'd be harmless there, but scoped is stated policy).
- **Composition** (the setup-level registration IS the handle source): `suppressNativeClickNavigation()` is now a module singleton — the setup file registers the default, and `ui-sref.spec.ts` acquires the *same* handle in `beforeEach`, clearing `events` so each test asserts only its own suppressed clicks. No second listener ever exists, which matters because a second listener would record the first one's `preventDefault` as `defaultPrevented: true` and corrupt the router-left-the-default-intact assertions. The spec's `afterEach` no longer restores (that would tear down the project default).
- **Opt-out**: a future spec wanting real default navigation calls `restore()` explicitly and re-registers when done — one sentence in the helper doc.

## Proof of single-instance composition

The suppression assertions are self-proving here: setup imports the helper as `./src/specs/browser-test-utils.js` and the spec as `./browser-test-utils.js` — if Vite resolved those to two module instances, two listeners would stack and the meta/`target="_blank"`/`rel="external"` assertions would fail on `defaultPrevented: true`. They pass, so the singleton is shared.

## Verification

- Browser + happy-dom projects: 165/165, zero `response:*`.
- `test:coverage` (forced): 165/165, zero `response:*`.
- `typecheck`, `lint`, `format:check` for the package + `format:check:root`: green.

## Relationship to the parked #424

#424 (the `@vitest/browser` patch removal) is parked until vitest-dev/vitest#9381 ships. This PR is the independent reintroduction insurance either way: with the patch present it's defense in depth; when the patch retires, it's the guarantee the popup conditions stay impossible in our specs.
