### PR TITLE
test(sample-app-shared): chromium on PRs, engines matrix on main

### DIFF
--- a/apps/sample-app-shared/package.json
+++ b/apps/sample-app-shared/package.json
@@ -11,7 +11,8 @@
     "format": "oxfmt \"**/*.{js,ts,json,md,css}\"",
     "format:check": "oxfmt --check \"**/*.{js,ts,json,md,css}\"",
     "lint": "oxlint .",
-    "test": "VITEST_BROWSER_API_PORT=63350 vitest run",
+    "test": "VITEST_BROWSER_API_PORT=63350 vitest run --project=chrome",
+    "test:engines": "VITEST_BROWSER_API_PORT=63351 vitest run --project=firefox --project=safari",
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {

--- a/apps/sample-app-shared/turbo.json
+++ b/apps/sample-app-shared/turbo.json
@@ -5,6 +5,10 @@
     "test": {
       // Dialog.spec.ts asserts styles.css rules; root inputs only track *.ts
       "inputs": ["src/**", "vitest.config.ts"]
+    },
+    "test:engines": {
+      // same specs as test; same styles.css input widening applies
+      "inputs": ["src/**", "vitest.config.ts"]
     }
   }
 }


### PR DESCRIPTION
## What

`apps/sample-app-shared` was created after the #399/#403 vitest single-pass convention shipped and never adopted it: its plain `test` script ran all three browser instances (chromium, firefox, webkit) on every PR. This PR aligns it with the packages:

- `test` → `vitest run --project=chrome` (chromium-only, the PR-graph correctness carrier)
- new `test:engines` → `vitest run --project=firefox --project=safari` (own API port 63351), picked up automatically by the root `test:engines` fan-out on the `ci:main` graph
- package `turbo.json` gains a matching `test:engines` inputs override — the specs assert `styles.css` rules and root inputs only track `*.ts`, same widening the existing `test` override does

Coverage note: sample-app-shared has no `test:coverage` script — its PR correctness carrier is `test` itself, so chromium-only `test` IS the carrier. No coverage surface changes.

## Why now

PR #425 (in flight — scopes `playwright install-deps` to firefox+webkit, 45s→23s) identified sample-app-shared's three-engine PR-graph suite as the ONLY remaining PR-path consumer of the firefox/webkit apt libs. With this alignment in, a follow-up can gate the install-deps step to main-graph runs only, dropping it to 0s on PRs.

That workflow gating is deliberately NOT in this PR — it is the successor step. This PR touches no workflow files, so it composes with #425 in either merge order (whichever lands second rebases trivially).

## Verification (local)

- `pnpm run test` (chromium): 2 files, 3 tests passed
- `pnpm run test:engines` (firefox+webkit): 4 files, 6 tests passed — previously all 9 (3 tests × 3 browsers) ran on every PR
- `turbo run ci:main --dry-run`: `sample-app-shared#test:engines` scheduled with the new command, dependent of `sample-app-shared#ci:main`
- `turbo run ci --dry-run` (PR graph): `sample-app-shared#test` is chromium-only; no `test:engines` node
- `turbo run lint typecheck format:check --filter=sample-app-shared` (incl. root with-tasks): 12/12 green
