### PR TITLE
ci: fix TURBO_FORCE scratch leak; playwright deps only on the main graph

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -88,10 +88,10 @@ jobs:
         if: ${{ steps.playwright-cache.outputs.cache-hit != 'true' }}
         run: mise run //tools/build_and_test:playwright
       - name: Install Playwright OS deps (firefox+webkit)
-        # Browsers came from the cache; the fresh runner still needs the apt
-        # libs for firefox+webkit (sample-app-shared tests all three engines
-        # on every graph). Chromium and Cypress ride the runner image's libs.
-        if: ${{ steps.playwright-cache.outputs.cache-hit == 'true' }}
+        # Browsers came from the cache; only test:engines (main graph) needs
+        # the firefox+webkit apt libs — the PR graph is chromium-only, and
+        # chromium and Cypress ride the runner image's preinstalled set.
+        if: ${{ steps.playwright-cache.outputs.cache-hit == 'true' && ((github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'workflow_dispatch' && inputs.mainGraph)) }}
         run: mise run //tools/build_and_test:playwright_deps_engines
       - name: Install Cypress
         # `cypress install` is a near-no-op when the binary is cached; verify
@@ -112,9 +112,7 @@ jobs:
         if: ${{ !((github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'workflow_dispatch' && inputs.mainGraph)) }}
         run: mise run ci
         env:
-          # SCRATCH (revert before merge): bypass turbo cache so the browser
-          # suites really execute on the deps-less runner.
-          TURBO_FORCE: 'true'
+          TURBO_FORCE: ${{ inputs.force }}
           TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
           TURBO_API: ${{ vars.TURBO_API }}
           TURBO_TEAM: ${{ vars.TURBO_TEAM }}


### PR DESCRIPTION
Two changes to build-test.yml, one urgent:

## 1. Regression fix: hardcoded TURBO_FORCE leaked to main in #425

The #425 squash kept an experiment-era scratch edit: `TURBO_FORCE: 'true'` on the `ci` step (its own "revert before merge" comment intact). **Every PR/branch run since #425 merged has bypassed the turbo cache** — full rebuilds and full suites on unrelated changes, silently. Restored to the deflake-input wiring (`${{ inputs.force }}`), matching the `ci_main` step. The main-push path was unaffected (`ci_main` always had the correct wiring).

Regression window: #425's merge → this merge. Post-merge signal: the first unrelated-change PR run should show cache hits (`FULL TURBO`-style) again in the Build and Test step.

## 2. PR-path playwright deps → 0s

With #431 merged, `test:engines` (main graph) is the only consumer of the firefox+webkit apt libs — the PR graph is chromium-only and rides the runner image's preinstalled set (probed in #425). The scoped deps step now carries the same main-graph condition as the `ci_main` step: cache-hit **and** (push-to-main or `mainGraph` dispatch).

| Playwright OS deps (hit path) | pre-#425 | post-#425 | after this PR |
|---|---|---|---|
| PR / branch runs | ~45s | ~23s | **0s (skipped)** |
| main pushes / mainGraph dispatches | ~45s | ~23s | ~23s |

Event trace: pull_request/branch-push → deps skipped, chromium suites on preinstalled libs; main push → deps installed, engines matrix runs; dispatch default → skipped; dispatch `mainGraph=true` → installed. Cache-miss path (`playwright install --with-deps`) unchanged on all events — it must provision all browsers for cache integrity.

actionlint + zizmor clean; format green; push-gated conditions live-verify on the first main push after merge, per usual.