### PR TITLE
fix(release): check-run ship-inert summary names the manifest-only class too

### DIFF
--- a/tools/release/src/checks/publish-check-runs.core.ts
+++ b/tools/release/src/checks/publish-check-runs.core.ts
@@ -30,7 +30,7 @@ function inertDetails({ shipInert, shipInertFiles }: PackageSummary): string[] {
   return [
     '',
     '<details>',
-    `<summary>${shipInert} ship-inert file(s) — src/maps, never owe a release</summary>`,
+    `<summary>${shipInert} ship-inert file(s) — src/maps or manifest-only churn; never owe a release</summary>`,
     '',
     ...shipInertFiles.map((file) => `- \`${file}\``),
     '',

--- a/tools/release/src/checks/publish-check-runs.test.ts
+++ b/tools/release/src/checks/publish-check-runs.test.ts
@@ -81,7 +81,10 @@ describe('toCheckRun', () => {
     assert.equal(summary.indexOf('- `dist/core.js`') < details, true);
     assert.equal(summary.indexOf('- `package.json`') < details, true);
     assert.equal(summary.indexOf('- `src/core.ts`') > details, true);
-    assert.match(summary, /<summary>1 ship-inert file\(s\)/);
+    assert.match(
+      summary,
+      /<summary>1 ship-inert file\(s\) — src\/maps or manifest-only churn; never owe a release<\/summary>/,
+    );
   });
 
   it('treats an unpublished package as success with nothing to diff', () => {


### PR DESCRIPTION
Since #427, files-only manifest drift (identical file set, drift confined to the `files` whitelist) is classified ship-inert — but the check-run `<summary>` label still read "src/maps, never owe a release", describing only the original class. A `package.json` row under that label contradicted its own heading.

One-line wording fix: `src/maps or manifest-only churn; never owe a release`. Test tightened to assert the full summary line.

Verified: tools/release 144/144, root format:check clean.