### PR TITLE
ci(turbo): split codecov:bundle out of the ci graphs to surface FULL TURBO

### DIFF
--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -107,8 +107,6 @@ description = "Run the main-push CI pipeline via turbo"
 run = "turbo run ci:main --ui=stream --log-order=stream"
 
 [tasks.codecov_bundle]
-# Separate invocation on purpose: codecov:bundle is cache:false (an upload),
-# so keeping it out of the ci graphs lets them report >>> FULL TURBO.
 # env: CODECOV_TOKEN plus the ambient TURBO_* remote-cache config.
 description = "Upload bundle-analysis stats to Codecov via turbo"
 run = "turbo run codecov:bundle --ui=stream --log-order=stream"

--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -94,8 +94,8 @@ run = 'turbo run "${usage_package_name?}#build"'
 [tasks.ci]
 # turbo's `ci` is the back-compat alias of `ci:pull_request`.
 # env: TURBO_FORCE + TURBO_TOKEN/TURBO_API/TURBO_TEAM, which turbo reads from
-# the env itself (no CLI flags), plus CODECOV_TOKEN and WRANGLER_LOG for the
-# underlying tasks. TURBO_FORCE is the build-test deflake input: a truthy value
+# the env itself (no CLI flags), plus WRANGLER_LOG for the underlying
+# tasks. TURBO_FORCE is the build-test deflake input: a truthy value
 # forces a cache-bypassing rerun, ""/"false" respect the cache.
 description = "Run the pull-request CI pipeline via turbo"
 run = "turbo run ci --ui=stream --log-order=stream"
@@ -105,6 +105,13 @@ run = "turbo run ci --ui=stream --log-order=stream"
 # (@tools/release#check:pack, @tools/dts-backtest#test:matrix) to the graph.
 description = "Run the main-push CI pipeline via turbo"
 run = "turbo run ci:main --ui=stream --log-order=stream"
+
+[tasks.codecov_bundle]
+# Separate invocation on purpose: codecov:bundle is cache:false (an upload),
+# so keeping it out of the ci graphs lets them report >>> FULL TURBO.
+# env: CODECOV_TOKEN plus the ambient TURBO_* remote-cache config.
+description = "Upload bundle-analysis stats to Codecov via turbo"
+run = "turbo run codecov:bundle --ui=stream --log-order=stream"
 
 [tasks.dts_backtest_matrix]
 # Ad-hoc alias for the full dts-backtest TS matrix; CI runs it via ci_main.

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -140,11 +140,6 @@ jobs:
           # the cypressVideo dispatch input re-enables it for debugging.
           CYPRESS_video: ${{ inputs.cypressVideo == true }}
       - name: Upload Codecov bundle stats
-        # Split from the ci graphs: codecov:bundle is cache:false (an upload
-        # runs every time), and as an in-graph dep it masked the >>> FULL
-        # TURBO signal. Its build dep cache-hits from the step above. No
-        # TURBO_FORCE: forcing an upload is meaningless and would only
-        # force-rebuild its deps.
         run: mise run codecov_bundle
         env:
           TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -116,7 +116,6 @@ jobs:
           TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
           TURBO_API: ${{ vars.TURBO_API }}
           TURBO_TEAM: ${{ vars.TURBO_TEAM }}
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
           # Silence per-request [wrangler:info] logging from the e2e dev server.
           WRANGLER_LOG: warn
           # Cypress video off in CI (configs keep video:true for local runs);
@@ -135,12 +134,23 @@ jobs:
           TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
           TURBO_API: ${{ vars.TURBO_API }}
           TURBO_TEAM: ${{ vars.TURBO_TEAM }}
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
           # Silence per-request [wrangler:info] logging from the e2e dev server.
           WRANGLER_LOG: warn
           # Cypress video off in CI (configs keep video:true for local runs);
           # the cypressVideo dispatch input re-enables it for debugging.
           CYPRESS_video: ${{ inputs.cypressVideo == true }}
+      - name: Upload Codecov bundle stats
+        # Split from the ci graphs: codecov:bundle is cache:false (an upload
+        # runs every time), and as an in-graph dep it masked the >>> FULL
+        # TURBO signal. Its build dep cache-hits from the step above. No
+        # TURBO_FORCE: forcing an upload is meaningless and would only
+        # force-rebuild its deps.
+        run: mise run codecov_bundle
+        env:
+          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+          TURBO_API: ${{ vars.TURBO_API }}
+          TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       - name: Upload Cypress videos
         # Videos exist only when the dispatch input turned recording on;
         # !cancelled() keeps videos from failed suites — the debugging case.

--- a/turbo.json
+++ b/turbo.json
@@ -128,6 +128,9 @@
       "inputs": ["$TURBO_DEFAULT$"]
     },
     "ci:pull_request": {
+      // codecov:bundle is deliberately absent: cache:false deps execute on
+      // every run, which would mask the >>> FULL TURBO signal; the workflow
+      // uploads it as its own step after this graph.
       "dependsOn": [
         "build",
         "test",
@@ -135,8 +138,7 @@
         "lint",
         "typecheck",
         "format:check",
-        "check:bundle",
-        "codecov:bundle"
+        "check:bundle"
       ]
     },
     "check:bundle": {

--- a/turbo.json
+++ b/turbo.json
@@ -128,9 +128,6 @@
       "inputs": ["$TURBO_DEFAULT$"]
     },
     "ci:pull_request": {
-      // codecov:bundle is deliberately absent: cache:false deps execute on
-      // every run, which would mask the >>> FULL TURBO signal; the workflow
-      // uploads it as its own step after this graph.
       "dependsOn": [
         "build",
         "test",


### PR DESCRIPTION
## Why

`codecov:bundle` is the only `cache: false` task in the CI graphs (it's an upload — it must execute every run). As a `dependsOn` of `ci:pull_request` it guaranteed at least one cache miss per run, so turbo never printed `>>> FULL TURBO` and cache health was illegible at a glance. The #433 TURBO_FORCE leak sat unnoticed for a window partly because the signal it would have shown up in didn't exist.

## What

- `turbo.json`: `codecov:bundle` dropped from `ci:pull_request` (comment records why it must stay out); task definition unchanged.
- `.config/mise/config.toml`: new `codecov_bundle` task (`turbo run codecov:bundle`), same stream flags as the ci tasks.
- `build-test.yml`: new unconditional "Upload Codecov bundle stats" step after both ci steps — runs on the PR path, main path, and dispatches, exactly where the in-graph task ran before. Its `build` dep cache-hits from the preceding step, so the second turbo invocation costs ~1s. No `TURBO_FORCE` on it (forcing an upload is meaningless and would only force-rebuild deps). `CODECOV_TOKEN` moves off the ci steps — nothing left in those graphs reads it.

Failure semantics unchanged: the step still fails `build_and_test`, so a broken upload still blocks the tag gate on main.

Side effect: local `mise run ci` / `pnpm run ci` no longer attempt the Codecov upload — arguably more correct locally; `mise run codecov_bundle` exists for ad-hoc use.

## Verified

- `turbo run ci --dry=json` and `ci:main --dry=json`: **0** `codecov:bundle` nodes (was: in every run).
- `turbo run codecov:bundle --dry=json`: all 21 nodes (7 real scripts + the usual no-op nodes), identical shape to what the ci graph scheduled before.
- `lint_workflows` (actionlint + zizmor) clean, root `format:check` clean, `mise tasks` lists `codecov_bundle`.

Live proof on this PR's own run: the `mise run ci` step should print `>>> FULL TURBO`-adjacent cache summaries unmasked; after merge, a doc-only PR should show the full signal.