### PR TITLE
ci(release): scope the publish-gh install to the @tools/release closure

### DIFF
--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -56,9 +56,17 @@ depends = ["corepack_enable", "corepack_install"]
 # Flow: mise trust && mise install && mise run setup.
 # pnpm auto-enables --frozen-lockfile when CI is set (ci-info detection),
 # so one task serves local (plain) and CI (frozen) alike.
+# --release scopes the install to the @tools/release closure (--filter
+# @tools/release...) for the tag-only publish-gh job: the tag path needs only
+# release-it (a per-package devDep, invoked via `pnpm --filter <pkg> exec`)
+# and the @tools/release scripts, so it skips the docs/sample-app/e2e/server
+# trees the full install fetches — 10 of 22 projects.
 description = "Install workspace dependencies with the pnpm on PATH"
 depends = ["corepack"]
-run = "pnpm install"
+usage = '''
+flag "--release" help="Scope the install to the @tools/release closure (tag-job)"
+'''
+run = 'pnpm install ${usage_release:+--filter @tools/release...}'
 
 [tasks.lint_actionlint]
 description = "Lint GitHub Actions workflows for syntax/type errors"

--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -56,11 +56,6 @@ depends = ["corepack_enable", "corepack_install"]
 # Flow: mise trust && mise install && mise run setup.
 # pnpm auto-enables --frozen-lockfile when CI is set (ci-info detection),
 # so one task serves local (plain) and CI (frozen) alike.
-# --release scopes the install to the @tools/release closure (--filter
-# @tools/release...) for the tag-only publish-gh job: the tag path needs only
-# release-it (a per-package devDep, invoked via `pnpm --filter <pkg> exec`)
-# and the @tools/release scripts, so it skips the docs/sample-app/e2e/server
-# trees the full install fetches — 10 of 22 projects.
 description = "Install workspace dependencies with the pnpm on PATH"
 depends = ["corepack"]
 usage = '''

--- a/.github/workflows/publish-gh.yml
+++ b/.github/workflows/publish-gh.yml
@@ -79,7 +79,10 @@ jobs:
           # push credentials. Tools install fresh, checksum-verified against mise.lock.
           cache: false
       - name: Install dependencies
-        run: mise run setup
+        # --release scopes to the @tools/release closure: the tag path needs
+        # only release-it (per-package devDep) and the release scripts, so the
+        # full docs/sample-app/e2e install is skipped on this cold-store job.
+        run: mise run setup --release
       - name: Setup Git user
         run: mise run //tools/release:git_user
       - name: Tag

--- a/.github/workflows/publish-gh.yml
+++ b/.github/workflows/publish-gh.yml
@@ -79,9 +79,6 @@ jobs:
           # push credentials. Tools install fresh, checksum-verified against mise.lock.
           cache: false
       - name: Install dependencies
-        # --release scopes to the @tools/release closure: the tag path needs
-        # only release-it (per-package devDep) and the release scripts, so the
-        # full docs/sample-app/e2e install is skipped on this cold-store job.
         run: mise run setup --release
       - name: Setup Git user
         run: mise run //tools/release:git_user

--- a/tools/release/mise.toml
+++ b/tools/release/mise.toml
@@ -14,10 +14,11 @@
 # workflow step env, NEVER in mise [env] (which would override the step's).
 # Keep this file [tasks]-only: root [env]/_.path and [tools] are inherited,
 # and a tasks-only config stays inert for shells that merely cd in here.
-# Tasks assume node_modules exists: every workflow runs `mise run setup` as a
-# dedicated first step, so tasks don't re-declare `depends = ["//:setup"]`
-# (which re-ran pnpm install per step). Run `mise run setup` first when
-# invoking a task standalone.
+# Tasks assume node_modules exists: every workflow runs `mise run setup` first
+# (the tag-only publish-gh job runs `setup --release` — its `--filter
+# @tools/release...` closure covers every task here), so tasks don't re-declare
+# `depends = ["//:setup"]` (which re-ran pnpm install per step). Run
+# `mise run setup` first when invoking a task standalone.
 
 [tasks.git_user]
 # env: none. Refuses outside GITHUB_ACTIONS — writes --global git config.


### PR DESCRIPTION
## What

The tag-only `publish_gh` legs (all three matrix packages) run a full-workspace `pnpm install` — measured **~25s of each ~36s leg** — when the tag path only needs:

- `release-it` (a `catalog:` devDep of each *publishable* package, invoked via `pnpm --filter <pkg> exec -- release-it`), and
- the `@tools/release` node scripts (git identity, `git tag`, `git push`), which need `@tools/shared`.

Nothing in that path touches vitepress (`docs`), the five `sample-app-*`, `examples`, `ui-router-server`, cypress, or the `dts-backtest`/`vue-check`/`workers-builds` tools.

## Change

A `--release` flag on the `setup` mise task scopes the install to the `@tools/release` dependency closure:

```
pnpm install ${usage_release:+--filter @tools/release...}
```

`@tools/release` already devDepends the three publishable packages, so `--filter @tools/release...` pulls `release-it` in and one flag serves every matrix leg. `publish-gh.yml`'s install step becomes `mise run setup --release`.

**Selection (verified locally):** `10 of 22` workspace projects — excludes exactly `docs`, `sample-app-{lit-e2e,lit-mobx,lit-vanilla,routes,shared}`, `examples`, `ui-router-server`, `@tools/dts-backtest`, `@tools/vue-check`, `@tools/workers-builds`.

## Honest scope of the win

Not near-zero: the retained publishable packages still drag in their build/test devDeps (vitest, playwright core, typescript, oxc, lit). Expect a meaningful cut to the cold-store fetch/link, not elimination. The real number only shows on a live main-push tag run.

## Verification

- `mise run setup --release` → `Scope: 10 of 22`; bare `mise run setup` → `Scope: all 22` (flag toggles correctly, both frozen-lockfile-clean under `CI=1`).
- `lint_workflows` (actionlint + zizmor) and `oxfmt --check` clean.
- Tag/push logic untouched — only the install step's scope changes.

**Live verification.** The `tag-release` environment restricts deployments to `main` + `lit-ui-router@*` tags, so a feature-branch dispatch is blocked at the environment gate — no pre-merge CI dry-run. Two paths instead:

- **Natural:** this PR's own merge to main runs the `tag_push` legs with the scoped install; versions are unchanged so tags no-op (as #435's merge did) — the scoped install is exercised on the merge run for free.
- **Explicit post-merge dry-run** (creates no tags/publish): `gh workflow run "Tag & push" --ref main -f dryRun=true` — runs the real scoped install on the Linux cold store + `release-it --dry-run`.
