### PR TITLE
ci(release): skip the Cypress binary in the setup task, not per-workflow

### DIFF
--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -61,7 +61,15 @@ depends = ["corepack"]
 usage = '''
 flag "--release" help="Scope the install to the @tools/release closure (tag-job)"
 '''
+# --release scopes the install to the @tools/release closure (tag-job).
 run = 'pnpm install ${usage_release:+--filter @tools/release...}'
+
+[tasks.setup.env]
+# The base install never provisions the Cypress binary: the dedicated
+# //tools/build_and_test:cypress task (cache-restored in CI) installs it on
+# demand for the suites that need it, so every install skips the ~280MB
+# download.
+CYPRESS_INSTALL_BINARY = "0"
 
 [tasks.lint_actionlint]
 description = "Lint GitHub Actions workflows for syntax/type errors"

--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -61,14 +61,9 @@ depends = ["corepack"]
 usage = '''
 flag "--release" help="Scope the install to the @tools/release closure (tag-job)"
 '''
-# --release scopes the install to the @tools/release closure (tag-job).
 run = 'pnpm install ${usage_release:+--filter @tools/release...}'
 
 [tasks.setup.env]
-# The base install never provisions the Cypress binary: the dedicated
-# //tools/build_and_test:cypress task (cache-restored in CI) installs it on
-# demand for the suites that need it, so every install skips the ~280MB
-# download.
 CYPRESS_INSTALL_BINARY = "0"
 
 [tasks.lint_actionlint]

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -59,8 +59,6 @@ jobs:
       - name: Setup mise
         uses: jdx/mise-action@v4
       - name: Install dependencies
-        # The setup task skips the Cypress binary (CYPRESS_INSTALL_BINARY=0);
-        # the Install Cypress step below cache-restores it for the e2e suites.
         run: mise run setup
       - name: Resolve Playwright version
         # Cache keys derive from the installed packages, so they bust exactly

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -59,11 +59,9 @@ jobs:
       - name: Setup mise
         uses: jdx/mise-action@v4
       - name: Install dependencies
+        # The setup task skips the Cypress binary (CYPRESS_INSTALL_BINARY=0);
+        # the Install Cypress step below cache-restores it for the e2e suites.
         run: mise run setup
-        env:
-          # The Install Cypress step below downloads the binary; skipping it
-          # here keeps download noise out of the pnpm postinstall output.
-          CYPRESS_INSTALL_BINARY: '0'
       - name: Resolve Playwright version
         # Cache keys derive from the installed packages, so they bust exactly
         # on a version bump and nothing else; one step per tool keeps the two

--- a/.github/workflows/publish-gh.yml
+++ b/.github/workflows/publish-gh.yml
@@ -79,6 +79,8 @@ jobs:
           # push credentials. Tools install fresh, checksum-verified against mise.lock.
           cache: false
       - name: Install dependencies
+        # --release scopes to the @tools/release closure; the setup task's env
+        # skips the Cypress binary (the tag path never runs Cypress).
         run: mise run setup --release
       - name: Setup Git user
         run: mise run //tools/release:git_user

--- a/.github/workflows/publish-gh.yml
+++ b/.github/workflows/publish-gh.yml
@@ -79,8 +79,6 @@ jobs:
           # push credentials. Tools install fresh, checksum-verified against mise.lock.
           cache: false
       - name: Install dependencies
-        # --release scopes to the @tools/release closure; the setup task's env
-        # skips the Cypress binary (the tag path never runs Cypress).
         run: mise run setup --release
       - name: Setup Git user
         run: mise run //tools/release:git_user

--- a/.github/workflows/release-signals.yml
+++ b/.github/workflows/release-signals.yml
@@ -56,10 +56,8 @@ jobs:
       - name: Setup mise
         uses: jdx/mise-action@v4
       - name: Install dependencies
+        # The setup task skips the Cypress binary; nothing here runs Cypress.
         run: mise run setup
-        env:
-          # Nothing here runs Cypress; skip the binary download.
-          CYPRESS_INSTALL_BINARY: '0'
       - name: Published diff
         run: mise run //tools/release:published_diff
         env:

--- a/.github/workflows/release-signals.yml
+++ b/.github/workflows/release-signals.yml
@@ -56,7 +56,6 @@ jobs:
       - name: Setup mise
         uses: jdx/mise-action@v4
       - name: Install dependencies
-        # The setup task skips the Cypress binary; nothing here runs Cypress.
         run: mise run setup
       - name: Published diff
         run: mise run //tools/release:published_diff


### PR DESCRIPTION
## What

Follow-up to #437. That PR scoped the tag-job install to the `@tools/release` closure, but the closure still pulls the `cypress` package (via `@tools/build_and_test`'s version-resolver task), and publish-gh's install step had no `CYPRESS_INSTALL_BINARY` guard — so all three `tag_push` legs **downloaded + unzipped the ~280MB Cypress binary** the tag path never runs:

```
tag_push (mobx): Downloading Cypress 06:57:05 → Finished 06:57:14  (~9s of a 22s install)
```
(run 29898279469)

## Change

Rather than add a third per-workflow `CYPRESS_INSTALL_BINARY: '0'`, the `setup` mise task **owns** the skip as task-level env:

```toml
[tasks.setup.env]
CYPRESS_INSTALL_BINARY = "0"
```

The base install never provisions the Cypress binary; the dedicated `//tools/build_and_test:cypress` task (cache-restored in CI) installs it on demand for the suites that need it. This lets the redundant workflow env go from **both** `build-test.yml` and `release-signals.yml` (build-test already set it; the task is now the single source of truth). `publish-gh.yml` gets the skip for free.

## Safety audit

All five `mise run setup` consumers checked:

| Workflow | Runs Cypress? | Binary source | Effect |
|---|---|---|---|
| build-test | yes (e2e) | dedicated Install Cypress + cache step | no change (already skipped at install; task env is scoped to the setup run, doesn't leak into the later cypress step) |
| publish-gh | no | — | ~9s/leg saved (the bug this fixes) |
| release-signals | no | — | binary no longer downloaded (was) |
| publish-npm | no | — | binary no longer downloaded (was) |
| bump-version | no | — | binary no longer downloaded (was) |

**Local dev change:** a fresh `mise run setup` no longer auto-downloads the Cypress binary — run the Cypress task before local e2e. (Intentional, per the "setup always skips it" decision.)

## Verification

- `mise run setup --release` → `Scope: 10 of 22`; bare `mise run setup` → `all 22`; both exit 0. `mise tasks info setup` shows `CYPRESS_INSTALL_BINARY=0`.
- `lint_workflows` (actionlint + zizmor) + `oxfmt --check` clean on all four files.
- Live payoff confirmed on the next main-push `tag_push` legs (install should drop ~20s → ~11s).