### PR TITLE
ci(release): scope release-signals and bump-version installs to @tools/release

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -84,7 +84,7 @@ jobs:
           # push credentials. Tools install fresh, checksum-verified against mise.lock.
           cache: false
       - name: Install dependencies
-        run: mise run setup
+        run: mise run setup --release
       - name: Setup Git user
         run: mise run //tools/release:git_user
       # Tier-2 peer-floor gate: a package whose published peer floor no

--- a/.github/workflows/release-signals.yml
+++ b/.github/workflows/release-signals.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Setup mise
         uses: jdx/mise-action@v4
       - name: Install dependencies
-        run: mise run setup
+        run: mise run setup --release
       - name: Published diff
         run: mise run //tools/release:published_diff
         env:

--- a/tools/release/mise.toml
+++ b/tools/release/mise.toml
@@ -15,7 +15,7 @@
 # Keep this file [tasks]-only: root [env]/_.path and [tools] are inherited,
 # and a tasks-only config stays inert for shells that merely cd in here.
 # Tasks assume node_modules exists: every workflow runs `mise run setup` first
-# (the tag-only publish-gh job runs `setup --release` — its `--filter
+# (the release workflows run `setup --release` — its `--filter
 # @tools/release...` closure covers every task here), so tasks don't re-declare
 # `depends = ["//:setup"]` (which re-ran pnpm install per step). Run
 # `mise run setup` first when invoking a task standalone.


### PR DESCRIPTION
Follow-up to #437 (tag job) and #438 (Cypress skip). The tag job already installs the scoped `mise run setup --release`; the two other release workflows still ran a full-workspace install. Extends the scope to both.

## Why it's safe — everything they touch is in the `@tools/release...` closure

`@tools/release` devDepends on all three published packages (`workspace:*`), so the closure = the three published packages + their build tooling (10/22 projects).

**release-signals** runs `resolve:published`, `check:published-diff`, `typecheck:peer-floor`. Turbo's *executing* task graph (real commands, not no-op graph nodes) is exactly:
- `@tools/release#{resolve:published, check:published-diff}`
- `lit-ui-router#{build:custom-elements,build:js,build:types}`, mobx + nav-plugin `#build:*`, mobx `#typecheck:peer-floor`, `@tools/typedoc-plugin-lit-ui-router#build:*`

All in-closure. The docs/examples/sample-app/ui-router-server/dts-backtest entries in the dry plan are graph nodes with **no command** — they never execute.

**bump-version** runs the peer-floor gate + `release-it`, both scoped to the single target published package (same release-it-in-package mechanism the tag job already proves under `--release`).

## Payoff
Drops the `examples` postinstall (~5s) and the out-of-closure apps/tools from both installs — same ~20% install saving live-verified on the tag legs in #437.

## Verification
- `turbo run resolve:published check:published-diff typecheck:peer-floor --dry=json` → **0 executing tasks outside the closure**.
- `mise run setup --release` selects 10/22; bare `setup` selects 22/22.
- `lint_workflows` (actionlint + zizmor) + format check clean.

Live payoff confirmed on the next main-push release-signals run and the next Bump-version dispatch.

Note: `publish-gh.yml`'s install still carries its inline `--release`/Cypress comment from #437; left untouched (out of this diff) — say the word to strip it for three-way consistency.