### PR TITLE
chore(deps): move the pnpm workspace SDK onto the pnpm 11 line

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,9 +30,9 @@ catalogs:
     '@oxc-project/runtime':
       specifier: 0.140.0
       version: 0.140.0
-    '@pnpm/fs.find-packages':
-      specifier: ^1000.0.24
-      version: 1000.0.24
+    '@pnpm/workspace.projects-reader':
+      specifier: 1101.0.14
+      version: 1101.0.14
     '@pnpm/workspace.workspace-manifest-reader':
       specifier: 1100.1.0
       version: 1100.1.0
@@ -936,9 +936,9 @@ importers:
 
   tools/shared:
     devDependencies:
-      '@pnpm/fs.find-packages':
+      '@pnpm/workspace.projects-reader':
         specifier: 'catalog:'
-        version: 1000.0.24(@pnpm/logger@1001.0.1)
+        version: 1101.0.14(@pnpm/logger@1001.0.1)
       '@pnpm/workspace.workspace-manifest-reader':
         specifier: 'catalog:'
         version: 1100.1.0
@@ -1440,10 +1440,6 @@ packages:
 
   '@github/catalyst@1.8.1':
     resolution: {integrity: sha512-dnN4WWpbeuQvA17LvsGdlXEueJdBk9y+I+WO5pdNpoHNOXPsFcz3hJrq1iRmdsNgQOf4S8e83axtwIxvG62eWA==}
-
-  '@gwhitney/detect-indent@7.0.1':
-    resolution: {integrity: sha512-7bQW+gkKa2kKZPeJf6+c6gFK9ARxQfn+FKy9ScTBppyKRWH2KzsmweXUoklqeEiHiNVWaeP5csIdsNq6w7QhzA==}
-    engines: {node: '>=12.20'}
 
   '@hapi/address@5.1.1':
     resolution: {integrity: sha512-A+po2d/dVoY7cYajycYI43ZbYMXukuopIsqCjh5QzsBCipDtdofHntljDlpccMjIfTy6UOkg+5KPriwYch2bXA==}
@@ -2562,79 +2558,89 @@ packages:
     resolution: {integrity: sha512-oeQJs1aa8Ghke8JIK9yuq/+KjMiaYeDZ38jx7MhkXncXlUKjqQ3wEm2X3qCKyjo+ZZofZj+WsEEiqkTtRuE2xQ==}
     engines: {node: ^20.9.0 || >=22.0.0, npm: '>=10.8.2'}
 
-  '@pnpm/constants@1001.3.1':
-    resolution: {integrity: sha512-2hf0s4pVrVEH8RvdJJ7YRKjQdiG8m0iAT26TTqXnCbK30kKwJW69VLmP5tED5zstmDRXcOeH5eRcrpkdwczQ9g==}
-    engines: {node: '>=18.12'}
+  '@pnpm/cli.meta@1100.0.9':
+    resolution: {integrity: sha512-8diUgtJ4HzU5CFy4Il5XE57ds7G9vuLu6Spf64yWF+/YvEpe5Z2NjhlrDssRpujdeJBvM68AM/222sxzM00Cpw==}
+    engines: {node: '>=22.13'}
+
+  '@pnpm/cli.utils@1101.0.14':
+    resolution: {integrity: sha512-AM6OXJNL1ulBsKvdhyHMFqeVCJ62YSqkoTPDG1WZLU2rlA62j2M4l8sVhHVV9uCNoO9Rtdqr5b3tuYweGbAZqg==}
+    engines: {node: '>=22.13'}
+    peerDependencies:
+      '@pnpm/logger': ^1100.0.0
+
+  '@pnpm/config.package-is-installable@1100.0.13':
+    resolution: {integrity: sha512-vvu39XGSRL0LK+CGjn8yXPYkLmgyz+6HI/y66CIq/4m6EhVF/bGc83gBQI3tKsSM0wBez5rToGG795/ZoswWWw==}
+    engines: {node: '>=22.13'}
+    peerDependencies:
+      '@pnpm/logger': ^1100.0.0
 
   '@pnpm/constants@1100.0.0':
     resolution: {integrity: sha512-CSJ5fKSUgqXrON5J2zQd1LwttU4gdqffJ3zYyHGAEhZ8u22fhQEVfCnc4+3aczDHbBNU0pNRX2ajiioPj46YtA==}
     engines: {node: '>=22.13'}
 
-  '@pnpm/core-loggers@1001.0.9':
-    resolution: {integrity: sha512-pW58m3ssrwVjwhlmTXDW1dh1sv2y6R2Gl5YvQInjM2d01/5mre/sYAY4MK3XfgEShZJQxv6wVXDUvyHHJ0oizg==}
-    engines: {node: '>=18.12'}
+  '@pnpm/core-loggers@1100.2.2':
+    resolution: {integrity: sha512-/TU7WIIXXMzXbOeUn78fihNIMDpBMgoCEEVhaL/HNXzt4thJugF/SAxORqXNJZMvFzkvcCLIYb+lr6OamZUokQ==}
+    engines: {node: '>=22.13'}
     peerDependencies:
-      '@pnpm/logger': '>=1001.0.0 <1002.0.0'
+      '@pnpm/logger': ^1100.0.0
 
-  '@pnpm/error@1000.1.0':
-    resolution: {integrity: sha512-Dqc2IJJPjUatwc9Letw+vG29rnaMrDGi5g6WCx1HiZYm0obXbTmLygeRafMbgf+sLKXrWE1shOeiayQuczBdoA==}
-    engines: {node: '>=18.12'}
+  '@pnpm/deps.peer-range@1100.0.2':
+    resolution: {integrity: sha512-kiPFbLNdasVrJohn5jnQ0evnTdLWzHWBpnMaCGqJmz0GwQQ5S/TqQLuLhnBYGnnUkEiN3sCaSGr2TFXcL3xrig==}
+    engines: {node: '>=22.13'}
+
+  '@pnpm/engine.runtime.system-version@1100.0.4':
+    resolution: {integrity: sha512-VKtKsFSFMc4xBhcWpucQqmt8UUKeTaqECsVAQW9u1Ot/cZQC1PMLPB1A30Lbl1o3Bwb0F9P32xQ4IUQriL0nEQ==}
+    engines: {node: '>=22.13'}
 
   '@pnpm/error@1100.0.1':
     resolution: {integrity: sha512-+SRTHRx9/etv+6AYMv6RX/uGW6CEQbV/o2Ojtjk4aHkmdVMe1Q9LekOV6gKmlEmeWOzv6zTzH/soFcuOWxIxTA==}
     engines: {node: '>=22.13'}
 
-  '@pnpm/fs.find-packages@1000.0.24':
-    resolution: {integrity: sha512-6r2lpvoljgTvQ+CiJYz3jCunzO1PM6g1Cqc3xon49he8sgg8BatMsNxcGnuZWK//du80+ylS/uBXKxwuHMuHUw==}
-    engines: {node: '>=18.12'}
-
-  '@pnpm/graceful-fs@1000.1.0':
-    resolution: {integrity: sha512-EsMX4slK0qJN2AR0/AYohY5m0HQNYGMNe+jhN74O994zp22/WbX+PbkIKyw3UQn39yQm2+z6SgwklDxbeapsmQ==}
-    engines: {node: '>=18.12'}
+  '@pnpm/fs.graceful-fs@1100.1.0':
+    resolution: {integrity: sha512-sqz/s9GmCpMdTL1CP7lteu6EzV2FpAB2xBTztWh7ZCZUoM2MFQZlQI1OuCqdkn6VI3WRnhkUgV0pIOlbqFTCSw==}
+    engines: {node: '>=22.13'}
 
   '@pnpm/logger@1001.0.1':
     resolution: {integrity: sha512-gdwlAMXC4Wc0s7Dmg/4wNybMEd/4lSd9LsXQxeg/piWY0PPXjgz1IXJWnVScx6dZRaaodWP3c1ornrw8mZdFZw==}
     engines: {node: '>=18.12'}
 
-  '@pnpm/manifest-utils@1002.0.5':
-    resolution: {integrity: sha512-2DSwQ6pP73IuJS5mCCtPd5fibJwuAdufXKuSL/Oq1n6AggCqy8616Xea1X3RH3z5dL4mn7Z4EZ+vnX8jX3Wrfw==}
-    engines: {node: '>=18.12'}
+  '@pnpm/pkg-manifest.utils@1100.2.7':
+    resolution: {integrity: sha512-+VNfp7Jh+9WvkJ6A0v2Jb4YEEi1qwxbltWFWOZFrOd347nwRre6hbsCfgeV4cu8HsJPfEQlNCTXi2wrfDKH3vA==}
+    engines: {node: '>=22.13'}
     peerDependencies:
-      '@pnpm/logger': ^1001.0.1
+      '@pnpm/logger': ^1100.0.0
 
-  '@pnpm/read-project-manifest@1001.2.6':
-    resolution: {integrity: sha512-BcNO50lAkE4m9JaJ0WmG3m/DH/qLSvMgZywtmb/dfyyLVu5nDZfDqmOd8U+f1NhLcLMbBK6AnS3hyUqZYvw9Vg==}
-    engines: {node: '>=18.12'}
-    peerDependencies:
-      '@pnpm/logger': ^1001.0.1
-
-  '@pnpm/semver.peer-range@1000.0.0':
-    resolution: {integrity: sha512-r6VzkrdH7ZKjPmAogTNvxuV/UyS/xwHNme+ZuEFiG0UthZgqudDftYtKmG20fcfrjG1lgJbbWICA8KvZy7mmbw==}
-    engines: {node: '>=18.12'}
-
-  '@pnpm/text.comments-parser@1000.0.0':
-    resolution: {integrity: sha512-ivv/esrETOq9uMiKOC0ddVZ1BktEGsfsMQ9RWmrDpwPiqFSqWsIspnquxTBmm5GflC5N06fbqjGOpulZVYo3vQ==}
-    engines: {node: '>=18.12'}
-
-  '@pnpm/types@1001.3.0':
-    resolution: {integrity: sha512-NLTXheat/u7OEGg5M5vF6Z85zx8uKUZE0+whtX/sbFV2XL48RdnOWGPTKYuVVkv8M+launaLUTgGEXNs/ess2w==}
-    engines: {node: '>=18.12'}
+  '@pnpm/text.comments-parser@1100.0.0':
+    resolution: {integrity: sha512-POntpaKUaDXaRBYLKZTnd0uxYZSMGLwpS3BqENlH4SEyz/8OK409573XtJgOQgtpmLM3DHZ6iJaRcr8ig6qSnw==}
+    engines: {node: '>=22.13'}
 
   '@pnpm/types@1101.4.0':
     resolution: {integrity: sha512-s03f87SySGMvjOE16dWXmUOsXt+5Ic/DabWaB4/+L13l4q/tMjOusIu3t2plazCK0gCY9wYOIw2p9CQ9+CHbcA==}
     engines: {node: '>=22.13'}
 
-  '@pnpm/util.lex-comparator@3.0.2':
-    resolution: {integrity: sha512-blFO4Ws97tWv/SNE6N39ZdGmZBrocXnBOfVp0ln4kELmns4pGPZizqyRtR8EjfOLMLstbmNCTReBoDvLz1isVg==}
-    engines: {node: '>=18.12'}
+  '@pnpm/util.lex-comparator@4.0.1':
+    resolution: {integrity: sha512-EZ3aWU7ThppE3Xgq7/ftxq8J/nit6z8I2/wZbC/acea2Zw7KJ1k/fLkGBgyyVAE37CULFsOSmPl3EjYM18cB2Q==}
+    engines: {node: '>=22.13'}
+
+  '@pnpm/workspace.project-manifest-reader@1100.0.15':
+    resolution: {integrity: sha512-dEvDXnAVTnBw1/eQ1mvUzXB8gmAbdD6VmbJZhoTW4x9Y8zVGYH2/vS4wZiTz40TPM92BXxSEpSR7aE7uxk6oIQ==}
+    engines: {node: '>=22.13'}
+    peerDependencies:
+      '@pnpm/logger': ^1100.0.0
+
+  '@pnpm/workspace.project-manifest-writer@1100.0.9':
+    resolution: {integrity: sha512-QJh894R8HxUyp/FKPG6AbHihMRoLiMza8SI8B/BfqzRAz7eMo3KtqDULdooy16WZAtjk3nr76PNu+vrYy+QjVA==}
+    engines: {node: '>=22.13'}
+
+  '@pnpm/workspace.projects-reader@1101.0.14':
+    resolution: {integrity: sha512-YLUFTIQPFdUgoCghJpDkardlujs4ResfGKJtovxLIreSzDiPTpE1SSWkzruGbpxGj2qaZNohJVceqdvlS2QxQA==}
+    engines: {node: '>=22.13'}
+    peerDependencies:
+      '@pnpm/logger': ^1100.0.0
 
   '@pnpm/workspace.workspace-manifest-reader@1100.1.0':
     resolution: {integrity: sha512-c2NgP8evfZ2i3SYecfhIwLGiMl++jYidyY95q3xHf8ItjGBk8eXbW6RFCubG26YltGO+OB4diUqGPb0jOwwB2Q==}
     engines: {node: '>=22.13'}
-
-  '@pnpm/write-project-manifest@1000.0.16':
-    resolution: {integrity: sha512-zG68fk03ryot7TWUl9S/ShQ91uHWzIL9sVr2aQCuNHJo8G9kjsG6S0p58Zj/voahdDQeakZYYBSJ0mjNZeiJnw==}
-    engines: {node: '>=18.12'}
 
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
@@ -2847,6 +2853,9 @@ packages:
   '@rolldown/pluginutils@1.0.1':
     resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
+  '@sec-ant/readable-stream@0.4.1':
+    resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
+
   '@shikijs/core@4.3.1':
     resolution: {integrity: sha512-ANMDxuaPsNMdDC1m4vfvhlDmJweMwkE5XitTwrq2rWHx5jM+dlm4MmHt2PP6t0uejfR77SuhrhJ0zEijIF/uhA==}
     engines: {node: '>=20'}
@@ -2940,6 +2949,10 @@ packages:
 
   '@sindresorhus/is@7.2.0':
     resolution: {integrity: sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==}
+    engines: {node: '>=18'}
+
+  '@sindresorhus/merge-streams@4.0.0':
+    resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
 
   '@spectrum-web-components/base@1.12.2':
@@ -3474,6 +3487,11 @@ packages:
     engines: {node: '>=14'}
     cpu: [x64]
     os: [win32]
+
+  '@zkochan/which@2.0.3':
+    resolution: {integrity: sha512-C1ReN7vt2/2O0fyTsx5xnbQuxBrmG5NMSbcIkPKCCfCTJgpZBsuRYzFXHj3nVq8vTfK7vxHUmzfCpSHgO7j4rg==}
+    engines: {node: '>= 8'}
+    hasBin: true
 
   abbrev@5.0.0:
     resolution: {integrity: sha512-/XrFJgzQQQHpti1raDJC6m4ws6aNktmjBlhk8Fdlk7LwCEuDoieEJJY9OFHjfiFJFFRM2tK+Ky/IsfbbmlMu1w==}
@@ -4248,6 +4266,10 @@ packages:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
     engines: {node: '>=10'}
 
+  execa@9.6.1:
+    resolution: {integrity: sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==}
+    engines: {node: ^18.19.0 || >=20.5.0}
+
   executable@4.1.1:
     resolution: {integrity: sha512-8iA79xD3uAch729dUG8xaaBBFGaEa0wdD2VkYLFHwlqosEj/jT66AzcreRDSgV7ehnNLBW2WR5jIXwGKjVdTLg==}
     engines: {node: '>=4'}
@@ -4311,6 +4333,10 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  figures@6.1.0:
+    resolution: {integrity: sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==}
+    engines: {node: '>=18'}
 
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
@@ -4401,6 +4427,10 @@ packages:
   get-stream@6.0.1:
     resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
     engines: {node: '>=10'}
+
+  get-stream@9.0.1:
+    resolution: {integrity: sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==}
+    engines: {node: '>=18'}
 
   get-uri@7.0.0:
     resolution: {integrity: sha512-ZsC7KQxm1Hra8yO0RvMZ4lGJT7vnBtSNpEHKq39MPN7vjuvCiu1aQ8rkXUaIXG1y/TSDez97Gmv04ibnYqCp/A==}
@@ -4548,6 +4578,10 @@ packages:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
     engines: {node: '>=10.17.0'}
 
+  human-signals@8.0.1:
+    resolution: {integrity: sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==}
+    engines: {node: '>=18.18.0'}
+
   husky@9.1.7:
     resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
     engines: {node: '>=18'}
@@ -4575,6 +4609,10 @@ packages:
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
+
+  index-to-position@1.2.0:
+    resolution: {integrity: sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw==}
+    engines: {node: '>=18'}
 
   individual@3.0.0:
     resolution: {integrity: sha512-rUY5vtT748NMRbEMrTNiFfy29BgGZwGXUi2NFUVMWQrogSLzlJvQV9eeMWi+g1aVaQ53tpyLAQtd5x/JH0Nh1g==}
@@ -4665,6 +4703,10 @@ packages:
   is-stream@2.0.1:
     resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
     engines: {node: '>=8'}
+
+  is-stream@4.0.1:
+    resolution: {integrity: sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==}
+    engines: {node: '>=18'}
 
   is-typedarray@1.0.0:
     resolution: {integrity: sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==}
@@ -4910,6 +4952,10 @@ packages:
   lit@3.3.3:
     resolution: {integrity: sha512-fycuvZg/hkpozL00lm1pEJH5nN/lr9ZXd6mJI2HSN4+Bzc+LDNdEApJ6HFbPkdFNHLvOplIIuJvxkS4XUxqirw==}
 
+  load-json-file@7.0.1:
+    resolution: {integrity: sha512-Gnxj3ev3mB5TkVBGad0JM6dmLiQL+o0t23JPBZ9sd+yvSLk05mFoqKBw5N8gbbkU4TNXyqCgIrl/VM17OgUIgQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
@@ -5006,6 +5052,10 @@ packages:
 
   mdurl@2.0.0:
     resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
+
+  memoize@11.0.0:
+    resolution: {integrity: sha512-cjsfZaC9b1clqPeIVMbb5dLHSXgdgGWGxdAU3oTUUkHiwWTKTBNnSmcqWJncNjYtBi3S8Rp0c5GIiyGztR8TRA==}
+    engines: {node: '>=22'}
 
   meow@13.2.0:
     resolution: {integrity: sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==}
@@ -5307,21 +5357,21 @@ packages:
       vite-plus:
         optional: true
 
-  p-filter@2.1.0:
-    resolution: {integrity: sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw==}
-    engines: {node: '>=8'}
+  p-filter@4.1.0:
+    resolution: {integrity: sha512-37/tPdZ3oJwHaS3gNJdenCDB3Tz26i9sjhnguBtvN0vYlRIiDNnvTWkuh+0hETV9rLPdJ3rlL3yVOYPIAnM8rw==}
+    engines: {node: '>=18'}
 
   p-limit@3.1.0:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
     engines: {node: '>=10'}
 
+  p-limit@7.3.1:
+    resolution: {integrity: sha512-0trZaiG7Y7kN/Egy9a8j47t9osC0Tch4PaIWd9yGF6bvmlk7muExRvGNYb8sXBwEKMoNKsbNN9P8EefuQekE4Q==}
+    engines: {node: '>=20'}
+
   p-locate@5.0.0:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
-
-  p-map@2.1.0:
-    resolution: {integrity: sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==}
-    engines: {node: '>=6'}
 
   p-map@7.0.5:
     resolution: {integrity: sha512-e8vJF4XdVkzqqSHguEMz41mQO1wKwxKm5ENrUJQUu9kLDCtn83cxbyHZcszr4QC5zEA7WffRRC4gsTecC7J9oA==}
@@ -5357,6 +5407,14 @@ packages:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
     engines: {node: '>=8'}
 
+  parse-json@8.3.0:
+    resolution: {integrity: sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==}
+    engines: {node: '>=18'}
+
+  parse-ms@4.0.0:
+    resolution: {integrity: sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==}
+    engines: {node: '>=18'}
+
   parse-path@7.1.0:
     resolution: {integrity: sha512-EuCycjZtfPcjWk7KTksnJ5xPMvWGA/6i4zrLYhRG0hGvC3GPU/jGUj3Cy+ZR0v30duV3e23R95T1lE2+lsndSw==}
 
@@ -5378,6 +5436,9 @@ packages:
   path-key@4.0.0:
     resolution: {integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==}
     engines: {node: '>=12'}
+
+  path-name@1.0.0:
+    resolution: {integrity: sha512-/dcAb5vMXH0f51yvMuSUqFpxUcA8JelbRmE5mW/p4CUJxrNgK24IkstnV7ENtg2IDGBOu6izKTG6eilbnbNKWQ==}
 
   path-scurry@2.0.2:
     resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
@@ -5464,6 +5525,10 @@ packages:
     resolution: {integrity: sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==}
     engines: {node: '>=6'}
 
+  pretty-ms@9.3.0:
+    resolution: {integrity: sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==}
+    engines: {node: '>=18'}
+
   proc-log@6.1.0:
     resolution: {integrity: sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==}
     engines: {node: ^20.17.0 || >=22.9.0}
@@ -5531,10 +5596,6 @@ packages:
 
   rc9@2.1.2:
     resolution: {integrity: sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg==}
-
-  read-yaml-file@2.1.0:
-    resolution: {integrity: sha512-UkRNRIwnhG+y7hpqnycCL/xbTk7+ia9VuVTC0S+zVbwd65DI9eUpRMfsWIGrCWxTU/mi+JW8cHQCrv+zfCbEPQ==}
-    engines: {node: '>=10.13'}
 
   read-yaml-file@3.0.0:
     resolution: {integrity: sha512-7urDNDyx3oJt9NGkymzT3qudju76BoJhT6ICWclx6274zxMeSUOhyiceHscSBk4Lfbs0IYpjOjUwLkaOzrsJdQ==}
@@ -5635,6 +5696,10 @@ packages:
 
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
+  safe-execa@0.3.0:
+    resolution: {integrity: sha512-LMzgcWXnnL60sDuAzlmGehx7OHa4ajy0R/3djFOfnZwj4aksZUcdHfZgIIWLNcqverOAQJ2qOe7BDFm7Qpxd6Q==}
+    engines: {node: '>=22.13'}
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
@@ -5823,10 +5888,6 @@ packages:
     resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
     engines: {node: '>=12'}
 
-  strip-bom@4.0.0:
-    resolution: {integrity: sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==}
-    engines: {node: '>=8'}
-
   strip-bom@5.0.0:
     resolution: {integrity: sha512-p+byADHF7SzEcVnLvc/r3uognM1hUhObuHXxJcgLCfD194XAkaLbjq3Wzb0N5G2tgIjH0dgT708Z51QxMeu60A==}
     engines: {node: '>=12'}
@@ -5837,6 +5898,10 @@ packages:
   strip-final-newline@2.0.0:
     resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
     engines: {node: '>=6'}
+
+  strip-final-newline@4.0.0:
+    resolution: {integrity: sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==}
+    engines: {node: '>=18'}
 
   supports-color@10.2.2:
     resolution: {integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==}
@@ -5957,6 +6022,10 @@ packages:
   type-fest@2.19.0:
     resolution: {integrity: sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==}
     engines: {node: '>=12.20'}
+
+  type-fest@4.41.0:
+    resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
+    engines: {node: '>=16'}
 
   typedarray@0.0.6:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
@@ -6323,13 +6392,13 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
-  write-file-atomic@5.0.1:
-    resolution: {integrity: sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==}
-    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+  write-file-atomic@7.0.1:
+    resolution: {integrity: sha512-OTIk8iR8/aCRWBqvxrzxR0hgxWpnYBblY1S5hDWBQfk/VFmJwzmJgQFN3WsoUKHISv2eAwe+PpbUzyL1CKTLXg==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
-  write-yaml-file@5.0.0:
-    resolution: {integrity: sha512-FdNA4RyH1L43TlvGG8qOMIfcEczwA5ij+zLXUy3Z83CjxhLvcV7/Q/8pk22wnCgYw7PJhtK+7lhO+qqyT4NdvQ==}
-    engines: {node: '>=16.14'}
+  write-yaml-file@6.0.0:
+    resolution: {integrity: sha512-WG6oDbTuNkiDr0sjYiuV715ZBUYOZVf838wu+7M0WAbkCmv5z2P7OW9gCfgEclXPwP08r5CvBtEyqV7vht070A==}
+    engines: {node: '>=22.13'}
 
   ws@8.21.0:
     resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
@@ -6390,6 +6459,10 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  yocto-queue@1.2.2:
+    resolution: {integrity: sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==}
+    engines: {node: '>=12.20'}
 
   yoctocolors@2.1.2:
     resolution: {integrity: sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==}
@@ -6864,8 +6937,6 @@ snapshots:
       '@shikijs/vscode-textmate': 10.0.2
 
   '@github/catalyst@1.8.1': {}
-
-  '@gwhitney/detect-indent@7.0.1': {}
 
   '@hapi/address@5.1.1':
     dependencies:
@@ -7632,34 +7703,59 @@ snapshots:
 
   '@phun-ky/typeof@2.0.3': {}
 
-  '@pnpm/constants@1001.3.1': {}
+  '@pnpm/cli.meta@1100.0.9':
+    dependencies:
+      '@pnpm/types': 1101.4.0
+      load-json-file: 7.0.1
+
+  '@pnpm/cli.utils@1101.0.14(@pnpm/logger@1001.0.1)':
+    dependencies:
+      '@pnpm/cli.meta': 1100.0.9
+      '@pnpm/config.package-is-installable': 1100.0.13(@pnpm/logger@1001.0.1)
+      '@pnpm/error': 1100.0.1
+      '@pnpm/logger': 1001.0.1
+      '@pnpm/pkg-manifest.utils': 1100.2.7(@pnpm/logger@1001.0.1)
+      '@pnpm/types': 1101.4.0
+      '@pnpm/workspace.project-manifest-reader': 1100.0.15(@pnpm/logger@1001.0.1)
+      chalk: 5.6.2
+      load-json-file: 7.0.1
+
+  '@pnpm/config.package-is-installable@1100.0.13(@pnpm/logger@1001.0.1)':
+    dependencies:
+      '@pnpm/cli.meta': 1100.0.9
+      '@pnpm/core-loggers': 1100.2.2(@pnpm/logger@1001.0.1)
+      '@pnpm/engine.runtime.system-version': 1100.0.4
+      '@pnpm/error': 1100.0.1
+      '@pnpm/logger': 1001.0.1
+      '@pnpm/types': 1101.4.0
+      detect-libc: 2.1.2
+      execa: safe-execa@0.3.0
+      memoize: 11.0.0
+      semver: 7.8.5
 
   '@pnpm/constants@1100.0.0': {}
 
-  '@pnpm/core-loggers@1001.0.9(@pnpm/logger@1001.0.1)':
+  '@pnpm/core-loggers@1100.2.2(@pnpm/logger@1001.0.1)':
     dependencies:
       '@pnpm/logger': 1001.0.1
-      '@pnpm/types': 1001.3.0
+      '@pnpm/types': 1101.4.0
 
-  '@pnpm/error@1000.1.0':
+  '@pnpm/deps.peer-range@1100.0.2':
     dependencies:
-      '@pnpm/constants': 1001.3.1
+      semver: 7.8.5
+
+  '@pnpm/engine.runtime.system-version@1100.0.4':
+    dependencies:
+      '@pnpm/cli.meta': 1100.0.9
+      '@pnpm/types': 1101.4.0
+      execa: safe-execa@0.3.0
+      memoize: 11.0.0
 
   '@pnpm/error@1100.0.1':
     dependencies:
       '@pnpm/constants': 1100.0.0
 
-  '@pnpm/fs.find-packages@1000.0.24(@pnpm/logger@1001.0.1)':
-    dependencies:
-      '@pnpm/read-project-manifest': 1001.2.6(@pnpm/logger@1001.0.1)
-      '@pnpm/types': 1001.3.0
-      '@pnpm/util.lex-comparator': 3.0.2
-      p-filter: 2.1.0
-      tinyglobby: 0.2.17
-    transitivePeerDependencies:
-      - '@pnpm/logger'
-
-  '@pnpm/graceful-fs@1000.1.0':
+  '@pnpm/fs.graceful-fs@1100.1.0':
     dependencies:
       graceful-fs: 4.2.11
 
@@ -7668,45 +7764,59 @@ snapshots:
       bole: 5.0.29
       split2: 4.2.0
 
-  '@pnpm/manifest-utils@1002.0.5(@pnpm/logger@1001.0.1)':
+  '@pnpm/pkg-manifest.utils@1100.2.7(@pnpm/logger@1001.0.1)':
     dependencies:
-      '@pnpm/core-loggers': 1001.0.9(@pnpm/logger@1001.0.1)
-      '@pnpm/error': 1000.1.0
+      '@pnpm/core-loggers': 1100.2.2(@pnpm/logger@1001.0.1)
+      '@pnpm/deps.peer-range': 1100.0.2
+      '@pnpm/error': 1100.0.1
       '@pnpm/logger': 1001.0.1
-      '@pnpm/semver.peer-range': 1000.0.0
-      '@pnpm/types': 1001.3.0
+      '@pnpm/types': 1101.4.0
       semver: 7.8.5
 
-  '@pnpm/read-project-manifest@1001.2.6(@pnpm/logger@1001.0.1)':
-    dependencies:
-      '@gwhitney/detect-indent': 7.0.1
-      '@pnpm/error': 1000.1.0
-      '@pnpm/graceful-fs': 1000.1.0
-      '@pnpm/logger': 1001.0.1
-      '@pnpm/manifest-utils': 1002.0.5(@pnpm/logger@1001.0.1)
-      '@pnpm/text.comments-parser': 1000.0.0
-      '@pnpm/types': 1001.3.0
-      '@pnpm/write-project-manifest': 1000.0.16
-      fast-deep-equal: 3.1.3
-      is-windows: 1.0.2
-      json5: 2.2.3
-      parse-json: 5.2.0
-      read-yaml-file: 2.1.0
-      strip-bom: 4.0.0
-
-  '@pnpm/semver.peer-range@1000.0.0':
-    dependencies:
-      semver: 7.8.5
-
-  '@pnpm/text.comments-parser@1000.0.0':
+  '@pnpm/text.comments-parser@1100.0.0':
     dependencies:
       strip-comments-strings: 1.2.0
 
-  '@pnpm/types@1001.3.0': {}
-
   '@pnpm/types@1101.4.0': {}
 
-  '@pnpm/util.lex-comparator@3.0.2': {}
+  '@pnpm/util.lex-comparator@4.0.1': {}
+
+  '@pnpm/workspace.project-manifest-reader@1100.0.15(@pnpm/logger@1001.0.1)':
+    dependencies:
+      '@pnpm/error': 1100.0.1
+      '@pnpm/fs.graceful-fs': 1100.1.0
+      '@pnpm/logger': 1001.0.1
+      '@pnpm/pkg-manifest.utils': 1100.2.7(@pnpm/logger@1001.0.1)
+      '@pnpm/text.comments-parser': 1100.0.0
+      '@pnpm/types': 1101.4.0
+      '@pnpm/workspace.project-manifest-writer': 1100.0.9
+      detect-indent: 7.0.2
+      fast-deep-equal: 3.1.3
+      is-windows: 1.0.2
+      json5: 2.2.3
+      p-limit: 7.3.1
+      parse-json: 8.3.0
+      read-yaml-file: 3.0.0
+      strip-bom: 5.0.0
+
+  '@pnpm/workspace.project-manifest-writer@1100.0.9':
+    dependencies:
+      '@pnpm/text.comments-parser': 1100.0.0
+      '@pnpm/types': 1101.4.0
+      json5: 2.2.3
+      write-file-atomic: 7.0.1
+      write-yaml-file: 6.0.0
+
+  '@pnpm/workspace.projects-reader@1101.0.14(@pnpm/logger@1001.0.1)':
+    dependencies:
+      '@pnpm/cli.utils': 1101.0.14(@pnpm/logger@1001.0.1)
+      '@pnpm/constants': 1100.0.0
+      '@pnpm/logger': 1001.0.1
+      '@pnpm/types': 1101.4.0
+      '@pnpm/util.lex-comparator': 4.0.1
+      '@pnpm/workspace.project-manifest-reader': 1100.0.15(@pnpm/logger@1001.0.1)
+      p-filter: 4.1.0
+      tinyglobby: 0.2.17
 
   '@pnpm/workspace.workspace-manifest-reader@1100.1.0':
     dependencies:
@@ -7714,14 +7824,6 @@ snapshots:
       '@pnpm/error': 1100.0.1
       '@pnpm/types': 1101.4.0
       read-yaml-file: 3.0.0
-
-  '@pnpm/write-project-manifest@1000.0.16':
-    dependencies:
-      '@pnpm/text.comments-parser': 1000.0.0
-      '@pnpm/types': 1001.3.0
-      json5: 2.2.3
-      write-file-atomic: 5.0.1
-      write-yaml-file: 5.0.0
 
   '@polka/url@1.0.0-next.29': {}
 
@@ -7851,6 +7953,8 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.1': {}
 
+  '@sec-ant/readable-stream@0.4.1': {}
+
   '@shikijs/core@4.3.1':
     dependencies:
       '@shikijs/primitive': 4.3.1
@@ -7962,6 +8066,8 @@ snapshots:
   '@simple-libs/stream-utils@2.0.0': {}
 
   '@sindresorhus/is@7.2.0': {}
+
+  '@sindresorhus/merge-streams@4.0.0': {}
 
   '@spectrum-web-components/base@1.12.2':
     dependencies:
@@ -8456,6 +8562,10 @@ snapshots:
 
   '@xn-sakina/rml-win32-x64-msvc@2.8.0':
     optional: true
+
+  '@zkochan/which@2.0.3':
+    dependencies:
+      isexe: 2.0.0
 
   abbrev@5.0.0: {}
 
@@ -9325,6 +9435,21 @@ snapshots:
       signal-exit: 3.0.7
       strip-final-newline: 2.0.0
 
+  execa@9.6.1:
+    dependencies:
+      '@sindresorhus/merge-streams': 4.0.0
+      cross-spawn: 7.0.6
+      figures: 6.1.0
+      get-stream: 9.0.1
+      human-signals: 8.0.1
+      is-plain-obj: 4.1.0
+      is-stream: 4.0.1
+      npm-run-path: 6.0.0
+      pretty-ms: 9.3.0
+      signal-exit: 4.1.0
+      strip-final-newline: 4.0.0
+      yoctocolors: 2.1.2
+
   executable@4.1.1:
     dependencies:
       pify: 2.3.0
@@ -9378,6 +9503,10 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.5):
     optionalDependencies:
       picomatch: 4.0.5
+
+  figures@6.1.0:
+    dependencies:
+      is-unicode-supported: 2.1.0
 
   file-entry-cache@8.0.0:
     dependencies:
@@ -9469,6 +9598,11 @@ snapshots:
       pump: 3.0.4
 
   get-stream@6.0.1: {}
+
+  get-stream@9.0.1:
+    dependencies:
+      '@sec-ant/readable-stream': 0.4.1
+      is-stream: 4.0.1
 
   get-uri@7.0.0(supports-color@8.1.1):
     dependencies:
@@ -9665,6 +9799,8 @@ snapshots:
 
   human-signals@2.1.0: {}
 
+  human-signals@8.0.1: {}
+
   husky@9.1.7: {}
 
   iconv-lite@0.7.3:
@@ -9685,6 +9821,8 @@ snapshots:
       resolve-from: 4.0.0
 
   imurmurhash@0.1.4: {}
+
+  index-to-position@1.2.0: {}
 
   individual@3.0.0: {}
 
@@ -9744,6 +9882,8 @@ snapshots:
       protocols: 2.0.2
 
   is-stream@2.0.1: {}
+
+  is-stream@4.0.1: {}
 
   is-typedarray@1.0.0: {}
 
@@ -9969,6 +10109,8 @@ snapshots:
       lit-element: 4.2.2
       lit-html: 3.3.3
 
+  load-json-file@7.0.1: {}
+
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
@@ -10079,6 +10221,10 @@ snapshots:
       vfile: 6.0.3
 
   mdurl@2.0.0: {}
+
+  memoize@11.0.0:
+    dependencies:
+      mimic-function: 5.0.1
 
   meow@13.2.0: {}
 
@@ -10483,19 +10629,21 @@ snapshots:
       '@oxlint/binding-win32-x64-msvc': 1.74.0
       oxlint-tsgolint: 0.25.0
 
-  p-filter@2.1.0:
+  p-filter@4.1.0:
     dependencies:
-      p-map: 2.1.0
+      p-map: 7.0.5
 
   p-limit@3.1.0:
     dependencies:
       yocto-queue: 0.1.0
 
+  p-limit@7.3.1:
+    dependencies:
+      yocto-queue: 1.2.2
+
   p-locate@5.0.0:
     dependencies:
       p-limit: 3.1.0
-
-  p-map@2.1.0: {}
 
   p-map@7.0.5: {}
 
@@ -10561,6 +10709,14 @@ snapshots:
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
 
+  parse-json@8.3.0:
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      index-to-position: 1.2.0
+      type-fest: 4.41.0
+
+  parse-ms@4.0.0: {}
+
   parse-path@7.1.0:
     dependencies:
       protocols: 2.0.2
@@ -10577,6 +10733,8 @@ snapshots:
   path-key@3.1.1: {}
 
   path-key@4.0.0: {}
+
+  path-name@1.0.0: {}
 
   path-scurry@2.0.2:
     dependencies:
@@ -10645,6 +10803,10 @@ snapshots:
 
   pretty-bytes@5.6.0: {}
 
+  pretty-ms@9.3.0:
+    dependencies:
+      parse-ms: 4.0.0
+
   proc-log@6.1.0: {}
 
   proc-log@7.0.0: {}
@@ -10704,11 +10866,6 @@ snapshots:
     dependencies:
       defu: 6.1.7
       destr: 2.0.5
-
-  read-yaml-file@2.1.0:
-    dependencies:
-      js-yaml: 4.3.0
-      strip-bom: 4.0.0
 
   read-yaml-file@3.0.0:
     dependencies:
@@ -10862,6 +11019,12 @@ snapshots:
       tslib: 2.8.1
 
   safe-buffer@5.2.1: {}
+
+  safe-execa@0.3.0:
+    dependencies:
+      '@zkochan/which': 2.0.3
+      execa: 9.6.1
+      path-name: 1.0.0
 
   safer-buffer@2.1.2: {}
 
@@ -11115,13 +11278,13 @@ snapshots:
     dependencies:
       ansi-regex: 6.2.2
 
-  strip-bom@4.0.0: {}
-
   strip-bom@5.0.0: {}
 
   strip-comments-strings@1.2.0: {}
 
   strip-final-newline@2.0.0: {}
+
+  strip-final-newline@4.0.0: {}
 
   supports-color@10.2.2: {}
 
@@ -11225,6 +11388,8 @@ snapshots:
   type-fest@0.8.1: {}
 
   type-fest@2.19.0: {}
+
+  type-fest@4.41.0: {}
 
   typedarray@0.0.6: {}
 
@@ -11610,15 +11775,14 @@ snapshots:
 
   wrappy@1.0.2: {}
 
-  write-file-atomic@5.0.1:
+  write-file-atomic@7.0.1:
     dependencies:
-      imurmurhash: 0.1.4
       signal-exit: 4.1.0
 
-  write-yaml-file@5.0.0:
+  write-yaml-file@6.0.0:
     dependencies:
       js-yaml: 4.3.0
-      write-file-atomic: 5.0.1
+      write-file-atomic: 7.0.1
 
   ws@8.21.0: {}
 
@@ -11668,6 +11832,8 @@ snapshots:
       pend: 1.2.0
 
   yocto-queue@0.1.0: {}
+
+  yocto-queue@1.2.2: {}
 
   yoctocolors@2.1.2: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,9 +33,9 @@ catalogs:
     '@pnpm/fs.find-packages':
       specifier: ^1000.0.24
       version: 1000.0.24
-    '@pnpm/workspace.read-manifest':
-      specifier: ^1000.3.1
-      version: 1000.3.1
+    '@pnpm/workspace.workspace-manifest-reader':
+      specifier: 1100.1.0
+      version: 1100.1.0
     '@release-it/conventional-changelog':
       specifier: ^11.0.1
       version: 11.0.1
@@ -939,9 +939,9 @@ importers:
       '@pnpm/fs.find-packages':
         specifier: 'catalog:'
         version: 1000.0.24(@pnpm/logger@1001.0.1)
-      '@pnpm/workspace.read-manifest':
+      '@pnpm/workspace.workspace-manifest-reader':
         specifier: 'catalog:'
-        version: 1000.3.1
+        version: 1100.1.0
       '@types/node':
         specifier: 'catalog:'
         version: 24.13.3
@@ -2566,6 +2566,10 @@ packages:
     resolution: {integrity: sha512-2hf0s4pVrVEH8RvdJJ7YRKjQdiG8m0iAT26TTqXnCbK30kKwJW69VLmP5tED5zstmDRXcOeH5eRcrpkdwczQ9g==}
     engines: {node: '>=18.12'}
 
+  '@pnpm/constants@1100.0.0':
+    resolution: {integrity: sha512-CSJ5fKSUgqXrON5J2zQd1LwttU4gdqffJ3zYyHGAEhZ8u22fhQEVfCnc4+3aczDHbBNU0pNRX2ajiioPj46YtA==}
+    engines: {node: '>=22.13'}
+
   '@pnpm/core-loggers@1001.0.9':
     resolution: {integrity: sha512-pW58m3ssrwVjwhlmTXDW1dh1sv2y6R2Gl5YvQInjM2d01/5mre/sYAY4MK3XfgEShZJQxv6wVXDUvyHHJ0oizg==}
     engines: {node: '>=18.12'}
@@ -2575,6 +2579,10 @@ packages:
   '@pnpm/error@1000.1.0':
     resolution: {integrity: sha512-Dqc2IJJPjUatwc9Letw+vG29rnaMrDGi5g6WCx1HiZYm0obXbTmLygeRafMbgf+sLKXrWE1shOeiayQuczBdoA==}
     engines: {node: '>=18.12'}
+
+  '@pnpm/error@1100.0.1':
+    resolution: {integrity: sha512-+SRTHRx9/etv+6AYMv6RX/uGW6CEQbV/o2Ojtjk4aHkmdVMe1Q9LekOV6gKmlEmeWOzv6zTzH/soFcuOWxIxTA==}
+    engines: {node: '>=22.13'}
 
   '@pnpm/fs.find-packages@1000.0.24':
     resolution: {integrity: sha512-6r2lpvoljgTvQ+CiJYz3jCunzO1PM6g1Cqc3xon49he8sgg8BatMsNxcGnuZWK//du80+ylS/uBXKxwuHMuHUw==}
@@ -2612,13 +2620,17 @@ packages:
     resolution: {integrity: sha512-NLTXheat/u7OEGg5M5vF6Z85zx8uKUZE0+whtX/sbFV2XL48RdnOWGPTKYuVVkv8M+launaLUTgGEXNs/ess2w==}
     engines: {node: '>=18.12'}
 
+  '@pnpm/types@1101.4.0':
+    resolution: {integrity: sha512-s03f87SySGMvjOE16dWXmUOsXt+5Ic/DabWaB4/+L13l4q/tMjOusIu3t2plazCK0gCY9wYOIw2p9CQ9+CHbcA==}
+    engines: {node: '>=22.13'}
+
   '@pnpm/util.lex-comparator@3.0.2':
     resolution: {integrity: sha512-blFO4Ws97tWv/SNE6N39ZdGmZBrocXnBOfVp0ln4kELmns4pGPZizqyRtR8EjfOLMLstbmNCTReBoDvLz1isVg==}
     engines: {node: '>=18.12'}
 
-  '@pnpm/workspace.read-manifest@1000.3.1':
-    resolution: {integrity: sha512-ojO1Anf4ITL7OskuUYoLI3bldQ36XNLpG2cYQZ4F6LZbBZnRY8umW6TeWzb9h/aX8UFwYp9vWbQ8R/FaMtMEeg==}
-    engines: {node: '>=18.12'}
+  '@pnpm/workspace.workspace-manifest-reader@1100.1.0':
+    resolution: {integrity: sha512-c2NgP8evfZ2i3SYecfhIwLGiMl++jYidyY95q3xHf8ItjGBk8eXbW6RFCubG26YltGO+OB4diUqGPb0jOwwB2Q==}
+    engines: {node: '>=22.13'}
 
   '@pnpm/write-project-manifest@1000.0.16':
     resolution: {integrity: sha512-zG68fk03ryot7TWUl9S/ShQ91uHWzIL9sVr2aQCuNHJo8G9kjsG6S0p58Zj/voahdDQeakZYYBSJ0mjNZeiJnw==}
@@ -3308,14 +3320,8 @@ packages:
   '@volar/typescript@2.4.28':
     resolution: {integrity: sha512-Ja6yvWrbis2QtN4ClAKreeUZPVYMARDYZl9LMEv1iQ1QdepB6wn0jTRxA9MftYmYa4DQ4k/DaSZpFPUfxl8giw==}
 
-  '@vue/compiler-core@3.5.39':
-    resolution: {integrity: sha512-16KBTEXAJCpDr0mwlw+AZyhu8iyC7R3S2vBwsI7QnWJU6X3WKc9VKeNEZpiMdZ569qWhz9574L3vV55qRL0Vtw==}
-
   '@vue/compiler-core@3.5.40':
     resolution: {integrity: sha512-39E8IgOhTbVDnoJFMKc2DvYnypcZwUqgUhQkccva/0m6FUwtIKSGV7n1hpVmYcFaoRAwf9pBcwnKlCEsN63ZEQ==}
-
-  '@vue/compiler-dom@3.5.39':
-    resolution: {integrity: sha512-oQPigALqYbNxTNPvNgSOe+czwVExfbVF02lz8jP0S3AXJiu3jxYDygNUiqSep4ezzW8XgnubqH63My2A7JR/vg==}
 
   '@vue/compiler-dom@3.5.40':
     resolution: {integrity: sha512-pwkx4vqlqOspFstrcmzwkKLePVMD3PT65imRzLhanU2V1Fj4K13g6OXjanOyzw3aTAuRk84BOmY8f3rEHqPaVA==}
@@ -5530,6 +5536,10 @@ packages:
     resolution: {integrity: sha512-UkRNRIwnhG+y7hpqnycCL/xbTk7+ia9VuVTC0S+zVbwd65DI9eUpRMfsWIGrCWxTU/mi+JW8cHQCrv+zfCbEPQ==}
     engines: {node: '>=10.13'}
 
+  read-yaml-file@3.0.0:
+    resolution: {integrity: sha512-7urDNDyx3oJt9NGkymzT3qudju76BoJhT6ICWclx6274zxMeSUOhyiceHscSBk4Lfbs0IYpjOjUwLkaOzrsJdQ==}
+    engines: {node: '>=22.13'}
+
   readable-stream@3.6.2:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
     engines: {node: '>= 6'}
@@ -5816,6 +5826,10 @@ packages:
   strip-bom@4.0.0:
     resolution: {integrity: sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==}
     engines: {node: '>=8'}
+
+  strip-bom@5.0.0:
+    resolution: {integrity: sha512-p+byADHF7SzEcVnLvc/r3uognM1hUhObuHXxJcgLCfD194XAkaLbjq3Wzb0N5G2tgIjH0dgT708Z51QxMeu60A==}
+    engines: {node: '>=12'}
 
   strip-comments-strings@1.2.0:
     resolution: {integrity: sha512-zwF4bmnyEjZwRhaak9jUWNxc0DoeKBJ7lwSN/LEc8dQXZcUFG6auaaTQJokQWXopLdM3iTx01nQT8E4aL29DAQ==}
@@ -7620,6 +7634,8 @@ snapshots:
 
   '@pnpm/constants@1001.3.1': {}
 
+  '@pnpm/constants@1100.0.0': {}
+
   '@pnpm/core-loggers@1001.0.9(@pnpm/logger@1001.0.1)':
     dependencies:
       '@pnpm/logger': 1001.0.1
@@ -7628,6 +7644,10 @@ snapshots:
   '@pnpm/error@1000.1.0':
     dependencies:
       '@pnpm/constants': 1001.3.1
+
+  '@pnpm/error@1100.0.1':
+    dependencies:
+      '@pnpm/constants': 1100.0.0
 
   '@pnpm/fs.find-packages@1000.0.24(@pnpm/logger@1001.0.1)':
     dependencies:
@@ -7684,14 +7704,16 @@ snapshots:
 
   '@pnpm/types@1001.3.0': {}
 
+  '@pnpm/types@1101.4.0': {}
+
   '@pnpm/util.lex-comparator@3.0.2': {}
 
-  '@pnpm/workspace.read-manifest@1000.3.1':
+  '@pnpm/workspace.workspace-manifest-reader@1100.1.0':
     dependencies:
-      '@pnpm/constants': 1001.3.1
-      '@pnpm/error': 1000.1.0
-      '@pnpm/types': 1001.3.0
-      read-yaml-file: 2.1.0
+      '@pnpm/constants': 1100.0.0
+      '@pnpm/error': 1100.0.1
+      '@pnpm/types': 1101.4.0
+      read-yaml-file: 3.0.0
 
   '@pnpm/write-project-manifest@1000.0.16':
     dependencies:
@@ -8302,14 +8324,6 @@ snapshots:
       path-browserify: 1.0.1
       vscode-uri: 3.1.0
 
-  '@vue/compiler-core@3.5.39':
-    dependencies:
-      '@babel/parser': 7.29.7
-      '@vue/shared': 3.5.39
-      entities: 7.0.1
-      estree-walker: 2.0.2
-      source-map-js: 1.2.1
-
   '@vue/compiler-core@3.5.40':
     dependencies:
       '@babel/parser': 7.29.7
@@ -8317,11 +8331,6 @@ snapshots:
       entities: 7.0.1
       estree-walker: 2.0.2
       source-map-js: 1.2.1
-
-  '@vue/compiler-dom@3.5.39':
-    dependencies:
-      '@vue/compiler-core': 3.5.39
-      '@vue/shared': 3.5.39
 
   '@vue/compiler-dom@3.5.40':
     dependencies:
@@ -8361,8 +8370,8 @@ snapshots:
   '@vue/language-core@3.3.7':
     dependencies:
       '@volar/language-core': 2.4.28
-      '@vue/compiler-dom': 3.5.39
-      '@vue/shared': 3.5.39
+      '@vue/compiler-dom': 3.5.40
+      '@vue/shared': 3.5.40
       alien-signals: 3.2.1
       muggle-string: 0.4.1
       path-browserify: 1.0.1
@@ -10701,6 +10710,11 @@ snapshots:
       js-yaml: 4.3.0
       strip-bom: 4.0.0
 
+  read-yaml-file@3.0.0:
+    dependencies:
+      js-yaml: 4.3.0
+      strip-bom: 5.0.0
+
   readable-stream@3.6.2:
     dependencies:
       inherits: 2.0.4
@@ -11102,6 +11116,8 @@ snapshots:
       ansi-regex: 6.2.2
 
   strip-bom@4.0.0: {}
+
+  strip-bom@5.0.0: {}
 
   strip-comments-strings@1.2.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -14,7 +14,7 @@ catalog:
   '@commitlint/config-conventional': ^21.2.0
   '@commitlint/types': ^21.2.0
   '@custom-elements-manifest/analyzer': ^0.11.0
-  '@pnpm/fs.find-packages': ^1000.0.24
+  '@pnpm/workspace.projects-reader': 1101.0.14
   '@pnpm/workspace.workspace-manifest-reader': 1100.1.0
   '@release-it/conventional-changelog': ^11.0.1
   '@spectrum-web-components/icons-workflow': ^1.12.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -15,7 +15,7 @@ catalog:
   '@commitlint/types': ^21.2.0
   '@custom-elements-manifest/analyzer': ^0.11.0
   '@pnpm/fs.find-packages': ^1000.0.24
-  '@pnpm/workspace.read-manifest': ^1000.3.1
+  '@pnpm/workspace.workspace-manifest-reader': 1100.1.0
   '@release-it/conventional-changelog': ^11.0.1
   '@spectrum-web-components/icons-workflow': ^1.12.2
   '@types/dom-navigation': ^1.0.7

--- a/tools/shared/package.json
+++ b/tools/shared/package.json
@@ -22,7 +22,7 @@
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "devDependencies": {
-    "@pnpm/fs.find-packages": "catalog:",
+    "@pnpm/workspace.projects-reader": "catalog:",
     "@pnpm/workspace.workspace-manifest-reader": "catalog:",
     "@types/node": "catalog:",
     "typescript": "catalog:"

--- a/tools/shared/package.json
+++ b/tools/shared/package.json
@@ -23,7 +23,7 @@
   },
   "devDependencies": {
     "@pnpm/fs.find-packages": "catalog:",
-    "@pnpm/workspace.read-manifest": "catalog:",
+    "@pnpm/workspace.workspace-manifest-reader": "catalog:",
     "@types/node": "catalog:",
     "typescript": "catalog:"
   }

--- a/tools/shared/src/workspace.ts
+++ b/tools/shared/src/workspace.ts
@@ -14,7 +14,7 @@
 import { dirname, join, relative } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import type { WorkspaceManifest } from '@pnpm/workspace.read-manifest';
+import type { WorkspaceManifest } from '@pnpm/workspace.workspace-manifest-reader';
 
 import type { PackageManifest } from './types.ts';
 
@@ -40,7 +40,7 @@ export async function loadWorkspace(root: string): Promise<{
 }> {
   const [{ findPackages }, { readWorkspaceManifest }] = await Promise.all([
     import('@pnpm/fs.find-packages'),
-    import('@pnpm/workspace.read-manifest'),
+    import('@pnpm/workspace.workspace-manifest-reader'),
   ]);
   const workspaceManifest = await readWorkspaceManifest(root);
   const projects = await findPackages(root, {
@@ -63,7 +63,7 @@ export async function loadPatchedDependencies(
   root: string,
 ): Promise<Record<string, string>> {
   const { readWorkspaceManifest } =
-    await import('@pnpm/workspace.read-manifest');
+    await import('@pnpm/workspace.workspace-manifest-reader');
   const workspaceManifest = await readWorkspaceManifest(root);
   return workspaceManifest?.patchedDependencies ?? {};
 }

--- a/tools/shared/src/workspace.ts
+++ b/tools/shared/src/workspace.ts
@@ -8,7 +8,7 @@
 // members (the glob is `examples`, not `examples/*`).
 //
 // The SDK is imported lazily so that `workspaceRoot` costs nothing to import:
-// consumers that only need the path don't load ~60ms of pnpm internals, and
+// consumers that only need the path don't load ~100ms of pnpm internals, and
 // don't depend on the root's devDependencies being installed.
 
 import { dirname, join, relative } from 'node:path';
@@ -39,7 +39,7 @@ export async function loadWorkspace(root: string): Promise<{
   workspaceManifest: WorkspaceManifest | undefined;
 }> {
   const [{ findPackages }, { readWorkspaceManifest }] = await Promise.all([
-    import('@pnpm/fs.find-packages'),
+    import('@pnpm/workspace.projects-reader'),
     import('@pnpm/workspace.workspace-manifest-reader'),
   ]);
   const workspaceManifest = await readWorkspaceManifest(root);


### PR DESCRIPTION
We moved to pnpm 11 a while back, but `tools/shared` was still reading the workspace through pnpm 10's packages (the 1000 line). This moves both SDK imports onto the pnpm 11 line.

| old (pnpm 10) | new (pnpm 11) |
|---|---|
| `@pnpm/workspace.read-manifest` `^1000.3.1` | [`@pnpm/workspace.workspace-manifest-reader`](https://github.com/pnpm/pnpm/tree/main/pnpm11/workspace/workspace-manifest-reader) `1100.1.0` |
| `@pnpm/fs.find-packages` `^1000.0.24` | [`@pnpm/workspace.projects-reader`](https://github.com/pnpm/pnpm/tree/main/pnpm11/workspace/projects-reader) `1101.0.14` |

Both are drop-ins — only the specifier changes:

- `readWorkspaceManifest(dir, cfgFileName?)` and the exported `WorkspaceManifest` type are unchanged.
- `projects-reader` absorbed `findPackages` ([`src/findPackages.ts`](https://github.com/pnpm/pnpm/blob/v11.16.0/pnpm11/workspace/projects-reader/src/findPackages.ts)); `findPackages(root, { patterns, includeRoot })` still returns `Project[]` with `rootDir` and `manifest`.

## Why #177 didn't catch this

The pnpm 11 migration was #177 (last deferred toolchain item from #157); there was no tracking issue. It upgraded the **package manager** but never revisited the **SDK we consume**, and nothing was watching the difference:

- Both catalog entries were introduced on 2026-06-03 by #145, a month before the migration.
- #177 touched five files, and its only `pnpm-workspace.yaml` edit was relocating `overrides` out of `package.json` — it never looked at the `@pnpm/*` catalog entries.
- Neither #177's "Needs verification" checklist nor its "Heads-up for future dependency work" section mentions them.

`git log -S` on both specifiers confirms they sat untouched at `^1000.x` from 2026-06-03 until this PR. So this is leftover migration scope, not a deliberate deferral coming due.

## Why both versions are pinned exact

pnpm has a live publishing regression: past a certain release, tarballs ship **only `lib/index.js`** — every sibling module and every `.d.ts` is missing, so importing throws `ERR_MODULE_NOT_FOUND`. File counts from the published tarballs:

| `workspace-manifest-reader` | `.js` | `.d.ts` |     | `workspace.projects-reader` | `.js` | `.d.ts` |
|---|---|---|---|---|---|---|
| 1100.0.9 | 3 | 3 | | 1101.0.13 | 2 | 2 |
| **1100.1.0** | **4** | **4** | | **1101.0.14** | **2** | **2** |
| 1100.1.1 | 1 | 0 | | 1101.0.15 | 1 | 0 |
| | | | | 1101.0.18 (latest) | 1 | 0 |

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '.../lib/catalogs.js'
imported from .../lib/index.js
```

So the catalog pins the last intact release of each, exactly. A caret would resolve straight into a broken one. Restore carets once fixed versions ship.

## Cost

`projects-reader` pulls `@pnpm/cli.utils`, so importing it costs about 2x what `fs.find-packages` did (47ms → 91ms measured). That's paid only by callers that actually enumerate members — the SDK import is already lazy so `workspaceRoot` stays free — and the stale `~60ms` note on that lazy import is updated to match.

## Verification

Run against the real workspace, not just mocks:

- `loadWorkspace` — 22 members, identical set before and after, `packages` glob preserved (`examples` still not expanded to `examples/*`), every member manifest resolved, 68 catalog entries plus all 4 named catalogs (`peerFloor`, `publishedPeer`, `typescript6-compat`, `typescript6`) parsed
- `loadPatchedDependencies` — all 3 patch entries returned; `check:patches` verifies them against installs
- `check:pack` — passes, 3 publishable packages, all packed manifests fully substituted
- `@tools/shared` typecheck + 19 tests, `@tools/release` typecheck + 144 tests
- `lint:package-json` (26 ok), `lint:root`, `format:check` — all clean
