### PR TITLE
chore(mise): move npm audit/fund opt-out to setup task env

### DIFF
--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -65,6 +65,10 @@ run = 'pnpm install ${usage_release:+--filter @tools/release...}'
 
 [tasks.setup.env]
 CYPRESS_INSTALL_BINARY = "0"
+# npm config for the examples/* `npm ci --prefix` postinstall legs; env beats
+# per-call flags, so the example manifests stay flag-free.
+NPM_CONFIG_AUDIT = "false"
+NPM_CONFIG_FUND = "false"
 
 [tasks.lint_actionlint]
 description = "Lint GitHub Actions workflows for syntax/type errors"

--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -65,8 +65,7 @@ run = 'pnpm install ${usage_release:+--filter @tools/release...}'
 
 [tasks.setup.env]
 CYPRESS_INSTALL_BINARY = "0"
-# npm config for the examples/* `npm ci --prefix` postinstall legs; env beats
-# per-call flags, so the example manifests stay flag-free.
+# npm config for the examples/*
 NPM_CONFIG_AUDIT = "false"
 NPM_CONFIG_FUND = "false"
 

--- a/examples/package.json
+++ b/examples/package.json
@@ -5,9 +5,9 @@
   "type": "module",
   "scripts": {
     "build:embeds": "node build-embeds.ts",
-    "example:install:hellogalaxy": "npm ci --no-audit --no-fund --prefix hellogalaxy",
-    "example:install:hellosolarsystem": "npm ci --no-audit --no-fund --prefix hellosolarsystem",
-    "example:install:helloworld": "npm ci --no-audit --no-fund --prefix helloworld",
+    "example:install:hellogalaxy": "npm ci --prefix hellogalaxy",
+    "example:install:hellosolarsystem": "npm ci --prefix hellosolarsystem",
+    "example:install:helloworld": "npm ci --prefix helloworld",
     "format": "oxfmt \"**/*.{ts,js,json,md,html}\"",
     "format:check": "oxfmt --check \"**/*.{ts,js,json,md,html}\"",
     "postinstall": "concurrently \"npm:example:install:*\"",


### PR DESCRIPTION
`examples/package.json` repeated `--no-audit --no-fund` on each of the three `npm ci --prefix` legs. Those run from pnpm's `postinstall`, which only ever runs under `mise run setup` (every CI workflow and the CONTRIBUTING flow), so the setup task's env reaches them.

```toml
[tasks.setup.env]
CYPRESS_INSTALL_BINARY = "0"
NPM_CONFIG_AUDIT = "false"
NPM_CONFIG_FUND = "false"
```

Verified locally, both directions:

- `mise run setup` → `added 27 packages in 2s` (no audit/funding lines) with the flags removed.
- Same `npm ci` with `env -u NPM_CONFIG_AUDIT -u NPM_CONFIG_FUND` → `added 27 packages, and audited 28 packages` + `8 packages are looking for funding`.

Note: values are TOML strings (`"false"`), matching the existing `CYPRESS_INSTALL_BINARY = "0"`; npm parses the env value itself.