### PR TITLE
chore(tooling): npm 12 pin, and move release tooling off the npm CLI

### DIFF
--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -30,7 +30,7 @@ idiomatic_version_file_enable_tools = ["node"]
 # mise-provided corepack: no npx per-invocation resolution, Node-25-proof
 "npm:corepack" = "0.35.0"
 # shadows node's bundled npm; OIDC trusted publishing needs npm >= 11.5.1
-"npm:npm" = "11.18.0"
+"npm:npm" = "12.0.1"
 
 # Provisioning tasks, not hooks: hooks warn-and-continue, task failures are
 # loud; and tool-only bumps (actionlint) skip the corepack ceremony.

--- a/.config/mise/mise.lock
+++ b/.config/mise/mise.lock
@@ -115,5 +115,5 @@ version = "0.35.0"
 backend = "npm:corepack"
 
 [[tools."npm:npm"]]
-version = "11.18.0"
+version = "12.0.1"
 backend = "npm:npm"

--- a/examples/hellogalaxy/package.json
+++ b/examples/hellogalaxy/package.json
@@ -22,8 +22,13 @@
   "overrides": {
     "d3-color": "3.1.0"
   },
+  "devEngines": {
+    "packageManager": {
+      "name": "npm",
+      "onFail": "warn"
+    }
+  },
   "allowScripts": {
-    "esbuild@0.27.2": true,
     "fsevents@2.3.3": true
   }
 }

--- a/examples/hellosolarsystem/package.json
+++ b/examples/hellosolarsystem/package.json
@@ -21,8 +21,13 @@
   "overrides": {
     "d3-color": "3.1.0"
   },
+  "devEngines": {
+    "packageManager": {
+      "name": "npm",
+      "onFail": "warn"
+    }
+  },
   "allowScripts": {
-    "fsevents@2.3.3": true,
-    "esbuild@0.27.2": true
+    "fsevents@2.3.3": true
   }
 }

--- a/examples/helloworld/package.json
+++ b/examples/helloworld/package.json
@@ -17,8 +17,13 @@
     "typescript": "^7.0.2",
     "vite": "^8.1.3"
   },
+  "devEngines": {
+    "packageManager": {
+      "name": "npm",
+      "onFail": "warn"
+    }
+  },
   "allowScripts": {
-    "fsevents@2.3.3": true,
-    "esbuild@0.27.2": true
+    "fsevents@2.3.3": true
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,12 @@ catalogs:
     '@oxc-project/runtime':
       specifier: 0.140.0
       version: 0.140.0
+    '@pnpm/types':
+      specifier: 1101.4.0
+      version: 1101.4.0
+    '@pnpm/workspace.project-manifest-reader':
+      specifier: 1100.0.15
+      version: 1100.0.15
     '@pnpm/workspace.projects-reader':
       specifier: 1101.0.14
       version: 1101.0.14
@@ -909,6 +915,12 @@ importers:
 
   tools/release:
     devDependencies:
+      '@pnpm/types':
+        specifier: 'catalog:'
+        version: 1101.4.0
+      '@pnpm/workspace.project-manifest-reader':
+        specifier: 'catalog:'
+        version: 1100.0.15(@pnpm/logger@1001.0.1)
       '@tools/shared':
         specifier: workspace:*
         version: link:../shared

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -14,6 +14,8 @@ catalog:
   '@commitlint/config-conventional': ^21.2.0
   '@commitlint/types': ^21.2.0
   '@custom-elements-manifest/analyzer': ^0.11.0
+  '@pnpm/types': 1101.4.0
+  '@pnpm/workspace.project-manifest-reader': 1100.0.15
   '@pnpm/workspace.projects-reader': 1101.0.14
   '@pnpm/workspace.workspace-manifest-reader': 1100.1.0
   '@release-it/conventional-changelog': ^11.0.1

--- a/tools/release/package.json
+++ b/tools/release/package.json
@@ -15,6 +15,8 @@
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "devDependencies": {
+    "@pnpm/types": "catalog:",
+    "@pnpm/workspace.project-manifest-reader": "catalog:",
     "@tools/shared": "workspace:*",
     "@types/node": "catalog:",
     "@types/pacote": "catalog:",

--- a/tools/release/src/checks/check-pack.core.ts
+++ b/tools/release/src/checks/check-pack.core.ts
@@ -83,10 +83,10 @@ export function formatReport(results: PackResult[]): Report {
 
 /**
  * The manifest fields the Pack step (//tools/release:pack) drops before `pnpm
- * pack`. The single source of truth for the strip: the packed-manifest gate
- * fails when any of them survive, and anything reproducing the Pack step (e.g.
- * check-published-diff, which strips via `npm pkg delete`) derives from this
- * list rather than restating the fields.
+ * pack`, named here for the gate that enforces them: it fails when any of them
+ * survive into the tarball. The strip itself lives in release-pack.core.ts and
+ * is shared by everything reproducing the Pack step, so this list is the
+ * gate's statement of intent rather than a second implementation of it.
  */
 export const STRIPPED_MANIFEST_FIELDS = ['devDependencies', 'scripts'] as const;
 

--- a/tools/release/src/checks/check-pack.core.ts
+++ b/tools/release/src/checks/check-pack.core.ts
@@ -5,6 +5,7 @@
 
 import type { PackageManifest } from '@tools/shared/types.ts';
 
+import { STRIPPED_MANIFEST_FIELDS } from '../steps/release-pack.core.ts';
 import { DEP_FIELDS, type DepField, type Report } from './types.ts';
 
 // Specifier protocols pnpm must substitute at pack time. The npm registry
@@ -80,15 +81,6 @@ export function formatReport(results: PackResult[]): Report {
 // (dev-only metadata that leaks private workspace names and monorepo-only
 // commands into the published manifest), then re-checks the tarball it is
 // about to hand release-it. These checks are that gate.
-
-/**
- * The manifest fields the Pack step (//tools/release:pack) drops before `pnpm
- * pack`, named here for the gate that enforces them: it fails when any of them
- * survive into the tarball. The strip itself lives in release-pack.core.ts and
- * is shared by everything reproducing the Pack step, so this list is the
- * gate's statement of intent rather than a second implementation of it.
- */
-export const STRIPPED_MANIFEST_FIELDS = ['devDependencies', 'scripts'] as const;
 
 /**
  * Violations in the manifest npm would publish, as human-readable strings.

--- a/tools/release/src/checks/check-pack.core.ts
+++ b/tools/release/src/checks/check-pack.core.ts
@@ -76,17 +76,17 @@ export function formatReport(results: PackResult[]): Report {
 }
 
 // ── Packed-manifest gate (publish workflow) ─────────────────────────────────
-// The publish workflow strips devDependencies and scripts before `pnpm pack`
+// The Pack step strips devDependencies and scripts before `pnpm pack`
 // (dev-only metadata that leaks private workspace names and monorepo-only
 // commands into the published manifest), then re-checks the tarball it is
 // about to hand release-it. These checks are that gate.
 
 /**
- * The manifest fields publish-npm.yml's Pack step deletes before `pnpm pack`
- * (`npm pkg delete ...STRIPPED_MANIFEST_FIELDS`). The single source of truth
- * for the strip: the packed-manifest gate fails when any of them survive, and
- * anything reproducing the Pack step (e.g. check-published-diff) should build
- * its delete args from this list.
+ * The manifest fields the Pack step (//tools/release:pack) drops before `pnpm
+ * pack`. The single source of truth for the strip: the packed-manifest gate
+ * fails when any of them survive, and anything reproducing the Pack step (e.g.
+ * check-published-diff, which strips via `npm pkg delete`) derives from this
+ * list rather than restating the fields.
  */
 export const STRIPPED_MANIFEST_FIELDS = ['devDependencies', 'scripts'] as const;
 

--- a/tools/release/src/checks/check-pack.core.ts
+++ b/tools/release/src/checks/check-pack.core.ts
@@ -77,10 +77,9 @@ export function formatReport(results: PackResult[]): Report {
 }
 
 // ── Packed-manifest gate (publish workflow) ─────────────────────────────────
-// The Pack step strips devDependencies and scripts before `pnpm pack`
-// (dev-only metadata that leaks private workspace names and monorepo-only
-// commands into the published manifest), then re-checks the tarball it is
-// about to hand release-it. These checks are that gate.
+// The Pack step strips STRIPPED_MANIFEST_FIELDS before `pnpm pack`, then
+// re-checks the tarball it is about to hand release-it. These checks are that
+// gate.
 
 /**
  * Violations in the manifest npm would publish, as human-readable strings.

--- a/tools/release/src/checks/check-pack.test.ts
+++ b/tools/release/src/checks/check-pack.test.ts
@@ -190,9 +190,9 @@ describe('formatPackedManifestReport', () => {
 
 describe('STRIPPED_MANIFEST_FIELDS', () => {
   it('matches the Pack step strip list', () => {
-    // Consumers (the packed-manifest gate, //tools/release:pack, and
-    // check-published-diff's `npm pkg delete`) all derive from this list, so
-    // pinning it here is what keeps the strip in lockstep across them.
+    // The gate checks the tarball for exactly what strippedManifest removes.
+    // Pinning both ends here is what catches the two drifting apart — the gate
+    // is the only guard that would still pass if the strip quietly changed.
     assert.deepEqual(STRIPPED_MANIFEST_FIELDS, ['devDependencies', 'scripts']);
   });
 });

--- a/tools/release/src/checks/check-pack.test.ts
+++ b/tools/release/src/checks/check-pack.test.ts
@@ -6,7 +6,6 @@ import {
   findUnsubstitutedRefs,
   formatPackedManifestReport,
   formatReport,
-  STRIPPED_MANIFEST_FIELDS,
 } from './check-pack.core.ts';
 
 describe('findUnsubstitutedRefs', () => {
@@ -185,14 +184,5 @@ describe('formatPackedManifestReport', () => {
     assert.match(text, /✗ packed manifest check failed/);
     assert.match(text, /devDependencies leaked/);
     assert.match(text, /scripts leaked/);
-  });
-});
-
-describe('STRIPPED_MANIFEST_FIELDS', () => {
-  it('matches the Pack step strip list', () => {
-    // The gate checks the tarball for exactly what strippedManifest removes.
-    // Pinning both ends here is what catches the two drifting apart — the gate
-    // is the only guard that would still pass if the strip quietly changed.
-    assert.deepEqual(STRIPPED_MANIFEST_FIELDS, ['devDependencies', 'scripts']);
   });
 });

--- a/tools/release/src/checks/check-pack.test.ts
+++ b/tools/release/src/checks/check-pack.test.ts
@@ -189,10 +189,10 @@ describe('formatPackedManifestReport', () => {
 });
 
 describe('STRIPPED_MANIFEST_FIELDS', () => {
-  it("matches publish-npm.yml's `npm pkg delete` list", () => {
-    // The Pack step runs `npm pkg delete devDependencies scripts`; consumers
-    // (the packed-manifest gate, check-published-diff) derive from this list,
-    // so a change here must be mirrored in the workflow — and vice versa.
+  it('matches the Pack step strip list', () => {
+    // Consumers (the packed-manifest gate, //tools/release:pack, and
+    // check-published-diff's `npm pkg delete`) all derive from this list, so
+    // pinning it here is what keeps the strip in lockstep across them.
     assert.deepEqual(STRIPPED_MANIFEST_FIELDS, ['devDependencies', 'scripts']);
   });
 });

--- a/tools/release/src/checks/check-published-diff.ts
+++ b/tools/release/src/checks/check-published-diff.ts
@@ -7,11 +7,11 @@
 //
 // Method (validated against the 1.7.0 release, whose local rebuild reproduces
 // the registry tarball byte-for-byte): reproduce the publish workflow's Pack
-// step (//tools/release:pack) — drop the STRIPPED_MANIFEST_FIELDS, here via
-// `npm pkg delete`, then `pnpm pack` — and `npm diff` the tarball against the
-// published spec. The strip stays in lockstep with that step because both
-// derive from the same list in check-pack.core.ts, even though the Pack step
-// rewrites the manifest in TS. Comparing anything other than pack output (the source
+// step (//tools/release:pack) by running its own strip — strippedManifest
+// written back through pnpm's project-manifest writer — then `pnpm pack`, and
+// `npm diff` the tarball against the published spec. Sharing the strip itself,
+// rather than a second implementation that agrees with it today, is what keeps
+// the two in lockstep. Comparing anything other than pack output (the source
 // manifest, `npm view` fields) false-positives on catalog:/workspace:
 // substitution and registry-injected fields.
 //
@@ -36,8 +36,10 @@ import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { promisify } from 'node:util';
 
+import { readProjectManifest } from '@pnpm/workspace.project-manifest-reader';
+
 import { publishedDiffSummaryPath } from './cache-paths.ts';
-import { STRIPPED_MANIFEST_FIELDS } from './check-pack.core.ts';
+import { strippedManifest } from '../steps/release-pack.core.ts';
 import {
   changedFiles,
   classifyFiles,
@@ -78,9 +80,8 @@ async function diffAgainstPublished(
   const destination = await mkdtemp(join(tmpdir(), 'check-published-diff-'));
   const tarball = join(destination, 'package.tgz');
   try {
-    await run('npm', ['pkg', 'delete', ...STRIPPED_MANIFEST_FIELDS], {
-      cwd: dir,
-    });
+    const { manifest, writeProjectManifest } = await readProjectManifest(dir);
+    await writeProjectManifest(strippedManifest(manifest));
     await pnpmPack(dir, tarball);
     const { stdout } = await run(
       'npm',

--- a/tools/release/src/checks/check-published-diff.ts
+++ b/tools/release/src/checks/check-published-diff.ts
@@ -6,12 +6,11 @@
 // "cosmetic" refactor is caught even when the git log looks harmless.
 //
 // Method (validated against the 1.7.0 release, whose local rebuild reproduces
-// the registry tarball byte-for-byte): reproduce the publish workflow's Pack
-// step (//tools/release:pack) by running its own strip — strippedManifest
-// written back through pnpm's project-manifest writer — then `pnpm pack`, and
-// `npm diff` the tarball against the published spec. Sharing the strip itself,
-// rather than a second implementation that agrees with it today, is what keeps
-// the two in lockstep. Comparing anything other than pack output (the source
+// the registry tarball byte-for-byte): reproduce the Pack step
+// (//tools/release:pack) by running its own strippedManifest, then `pnpm pack`,
+// and `npm diff` the tarball against the published spec. Sharing the strip
+// itself is what keeps the two in lockstep.
+// Comparing anything other than pack output (the source
 // manifest, `npm view` fields) false-positives on catalog:/workspace:
 // substitution and registry-injected fields.
 //

--- a/tools/release/src/checks/check-published-diff.ts
+++ b/tools/release/src/checks/check-published-diff.ts
@@ -6,12 +6,12 @@
 // "cosmetic" refactor is caught even when the git log looks harmless.
 //
 // Method (validated against the 1.7.0 release, whose local rebuild reproduces
-// the registry tarball byte-for-byte): reproduce the Pack step of
-// .github/workflows/publish-npm.yml — `npm pkg delete` the
-// STRIPPED_MANIFEST_FIELDS then `pnpm pack` — and `npm diff` the tarball
-// against the published spec. The strip stays in lockstep with that workflow
-// because both build their delete args from the same list in
-// check-pack.core.ts. Comparing anything other than pack output (the source
+// the registry tarball byte-for-byte): reproduce the publish workflow's Pack
+// step (//tools/release:pack) — drop the STRIPPED_MANIFEST_FIELDS, here via
+// `npm pkg delete`, then `pnpm pack` — and `npm diff` the tarball against the
+// published spec. The strip stays in lockstep with that step because both
+// derive from the same list in check-pack.core.ts, even though the Pack step
+// rewrites the manifest in TS. Comparing anything other than pack output (the source
 // manifest, `npm view` fields) false-positives on catalog:/workspace:
 // substitution and registry-injected fields.
 //

--- a/tools/release/src/checks/resolve-published.ts
+++ b/tools/release/src/checks/resolve-published.ts
@@ -1,30 +1,32 @@
 #!/usr/bin/env node
 // Resolve each publishable package's `latest` dist-tag into
 // published-versions.json — the registry-reading half of check:published-diff,
-// split out so the diff itself can be a cached turbo task. npm enforces
+// split out so the diff itself can be a cached turbo task. Reads the registry
+// through pacote (as tarball.ts does) rather than shelling out to `npm view`:
+// one less subprocess, and an unpublished package arrives as a real E404 error
+// code instead of a string to match in stderr. npm enforces
 // per-version tarball immutability (and we practice it as publishers: a
 // published version is never mutated), so the only registry state that can
 // move is the dist-tag pointer captured here; with this file in the check
 // task's inputs, its cache key is sound.
 
-import { execFile } from 'node:child_process';
-import { promisify } from 'node:util';
+import pacote from 'pacote';
 
 import type { PublishedVersions } from './published-versions.core.ts';
 import { writePublishedVersions } from './published-versions.ts';
 import { loadWorkspace, workspaceRoot } from '@tools/shared/workspace.ts';
 
-const run = promisify(execFile);
-
 /** The `latest` dist-tag for `name`, or null when never published. */
 async function publishedLatest(name: string): Promise<string | null> {
   try {
-    const { stdout } = await run('npm', ['view', name, 'dist-tags.latest']);
-    return stdout.trim() || null;
+    const packument = await pacote.packument(name);
+    return packument['dist-tags'].latest ?? null;
   } catch (error) {
-    // promisified execFile rejects with the child's captured output attached.
-    const { stderr } = (error ?? {}) as { stderr?: string };
-    if (stderr?.includes('E404')) return null;
+    // pacote rejects with npm's own error code; an unpublished package is a
+    // real answer here, not a failure. Anything else (network, 5xx, auth) must
+    // still throw — a swallowed error would silently report "unpublished" and
+    // suppress the drift check for that package.
+    if ((error as { code?: string }).code === 'E404') return null;
     throw error;
   }
 }

--- a/tools/release/src/checks/resolve-published.ts
+++ b/tools/release/src/checks/resolve-published.ts
@@ -1,10 +1,7 @@
 #!/usr/bin/env node
 // Resolve each publishable package's `latest` dist-tag into
 // published-versions.json — the registry-reading half of check:published-diff,
-// split out so the diff itself can be a cached turbo task. Reads the registry
-// through pacote (as tarball.ts does) rather than shelling out to `npm view`:
-// one less subprocess, and an unpublished package arrives as a real E404 error
-// code instead of a string to match in stderr. npm enforces
+// split out so the diff itself can be a cached turbo task. npm enforces
 // per-version tarball immutability (and we practice it as publishers: a
 // published version is never mutated), so the only registry state that can
 // move is the dist-tag pointer captured here; with this file in the check
@@ -22,10 +19,8 @@ async function publishedLatest(name: string): Promise<string | null> {
     const packument = await pacote.packument(name);
     return packument['dist-tags'].latest ?? null;
   } catch (error) {
-    // pacote rejects with npm's own error code; an unpublished package is a
-    // real answer here, not a failure. Anything else (network, 5xx, auth) must
-    // still throw — a swallowed error would silently report "unpublished" and
-    // suppress the drift check for that package.
+    // An unpublished package is a real answer here; anything else (network,
+    // 5xx, auth) must throw rather than silently report "unpublished".
     if ((error as { code?: string }).code === 'E404') return null;
     throw error;
   }

--- a/tools/release/src/steps/release-pack.core.ts
+++ b/tools/release/src/steps/release-pack.core.ts
@@ -1,8 +1,12 @@
 // Pure logic for the publish Pack step: which manifest fields are stripped
 // before packing, and which file in the package directory is THE tarball.
-// The IO (writing the stripped manifest, running pnpm pack, restoring) lives
-// in release-pack.ts, where the mutate→restore invariant the workflow used
-// to encode as bash line order is a try/finally.
+// The IO (reading and writing the manifest through @pnpm/read-project-manifest,
+// running pnpm pack, restoring) lives in release-pack.ts, where the
+// mutate→restore invariant the workflow used to encode as bash line order is a
+// try/finally.
+
+// Type-only, so this file stays runtime-pure.
+import type { ProjectManifest } from '@pnpm/types';
 
 /**
  * The manifest with devDependencies and scripts removed (what `npm pkg
@@ -11,23 +15,16 @@
  * None of our scripts are lifecycle hooks; stripping happens before
  * `pnpm pack`, so a future prepack/prepare script would be silently
  * skipped — build via the turbo step instead.
+ *
+ * Takes and returns the parsed manifest rather than JSON text: the caller
+ * writes it back through pnpm's project-manifest writer, which reproduces the
+ * file's own indentation instead of imposing this function's.
  */
-export function strippedManifestJson(source: string): string {
-  const manifest: unknown = JSON.parse(source);
-  if (
-    typeof manifest !== 'object' ||
-    manifest === null ||
-    Array.isArray(manifest)
-  ) {
-    throw new Error('package.json does not contain a JSON object');
-  }
-  const { devDependencies, scripts, ...rest } = manifest as Record<
-    string,
-    unknown
-  >;
+export function strippedManifest(manifest: ProjectManifest): ProjectManifest {
+  const { devDependencies, scripts, ...rest } = manifest;
   void devDependencies;
   void scripts;
-  return `${JSON.stringify(rest, null, 2)}\n`;
+  return rest;
 }
 
 /**

--- a/tools/release/src/steps/release-pack.core.ts
+++ b/tools/release/src/steps/release-pack.core.ts
@@ -26,10 +26,8 @@ export function strippedManifest(manifest: ProjectManifest): ProjectManifest {
 }
 
 /**
- * The single packed tarball among a directory's entries. The old
- * `realpath "$PACKAGE_DIR"/*.tgz` glob silently mangled 0 or 2+ matches
- * into a broken TARBALL value; a CI checkout has exactly one, so anything
- * else is an error worth naming.
+ * The single packed tarball among a directory's entries — anything other than
+ * exactly one is a broken pack worth naming rather than silently mishandling.
  */
 export function pickTarball(entries: readonly string[]): string {
   const tarballs = entries.filter((entry) => entry.endsWith('.tgz'));

--- a/tools/release/src/steps/release-pack.core.ts
+++ b/tools/release/src/steps/release-pack.core.ts
@@ -11,7 +11,10 @@ import type { ProjectManifest } from '@pnpm/types';
  * The strip runs before `pnpm pack`, so a lifecycle hook added to `scripts`
  * (prepack/prepare) would be silently skipped — build via the turbo step.
  */
-export const STRIPPED_MANIFEST_FIELDS = ['devDependencies', 'scripts'] as const;
+export const STRIPPED_MANIFEST_FIELDS = [
+  'devDependencies',
+  'scripts',
+] as const satisfies readonly (keyof ProjectManifest)[];
 
 /** A copy of `manifest` without {@link STRIPPED_MANIFEST_FIELDS}. */
 export function strippedManifest(manifest: ProjectManifest): ProjectManifest {

--- a/tools/release/src/steps/release-pack.core.ts
+++ b/tools/release/src/steps/release-pack.core.ts
@@ -9,22 +9,33 @@
 import type { ProjectManifest } from '@pnpm/types';
 
 /**
- * The manifest with devDependencies and scripts removed (what `npm pkg
- * delete devDependencies scripts` did): dev-only metadata that leaks private
- * workspace names and monorepo-only commands into the published manifest.
- * None of our scripts are lifecycle hooks; stripping happens before
- * `pnpm pack`, so a future prepack/prepare script would be silently
- * skipped — build via the turbo step instead.
+ * Dev-only metadata that leaks private workspace names and monorepo-only
+ * commands into the published manifest. None of our scripts are lifecycle
+ * hooks; stripping happens before `pnpm pack`, so a future prepack/prepare
+ * script would be silently skipped — build via the turbo step instead.
+ *
+ * The strip below removes these, and the packed-manifest gate
+ * (findPackedManifestViolations) fails the tarball when any of them survive.
+ * Both read this one list, so the guard cannot drift from what it guards.
+ */
+export const STRIPPED_MANIFEST_FIELDS = ['devDependencies', 'scripts'] as const;
+
+/**
+ * The manifest with {@link STRIPPED_MANIFEST_FIELDS} removed (what `npm pkg
+ * delete devDependencies scripts` did).
  *
  * Takes and returns the parsed manifest rather than JSON text: the caller
  * writes it back through pnpm's project-manifest writer, which reproduces the
- * file's own indentation instead of imposing this function's.
+ * file's own indentation instead of imposing this function's. Copies rather
+ * than mutating — the caller holds the original across the pack and restores
+ * from it.
  */
 export function strippedManifest(manifest: ProjectManifest): ProjectManifest {
-  const { devDependencies, scripts, ...rest } = manifest;
-  void devDependencies;
-  void scripts;
-  return rest;
+  const stripped = { ...manifest };
+  for (const field of STRIPPED_MANIFEST_FIELDS) {
+    delete stripped[field];
+  }
+  return stripped;
 }
 
 /**

--- a/tools/release/src/steps/release-pack.core.ts
+++ b/tools/release/src/steps/release-pack.core.ts
@@ -1,35 +1,19 @@
 // Pure logic for the publish Pack step: which manifest fields are stripped
 // before packing, and which file in the package directory is THE tarball.
-// The IO (reading and writing the manifest through @pnpm/read-project-manifest,
-// running pnpm pack, restoring) lives in release-pack.ts, where the
-// mutate→restore invariant the workflow used to encode as bash line order is a
-// try/finally.
+// The IO (manifest read/write, pnpm pack, restore) lives in release-pack.ts.
 
-// Type-only, so this file stays runtime-pure.
 import type { ProjectManifest } from '@pnpm/types';
 
 /**
- * Dev-only metadata that leaks private workspace names and monorepo-only
- * commands into the published manifest. None of our scripts are lifecycle
- * hooks; stripping happens before `pnpm pack`, so a future prepack/prepare
- * script would be silently skipped — build via the turbo step instead.
+ * Dev-only metadata that must not reach the published manifest. Read by both
+ * the strip below and the packed-manifest gate (findPackedManifestViolations).
  *
- * The strip below removes these, and the packed-manifest gate
- * (findPackedManifestViolations) fails the tarball when any of them survive.
- * Both read this one list, so the guard cannot drift from what it guards.
+ * The strip runs before `pnpm pack`, so a lifecycle hook added to `scripts`
+ * (prepack/prepare) would be silently skipped — build via the turbo step.
  */
 export const STRIPPED_MANIFEST_FIELDS = ['devDependencies', 'scripts'] as const;
 
-/**
- * The manifest with {@link STRIPPED_MANIFEST_FIELDS} removed (what `npm pkg
- * delete devDependencies scripts` did).
- *
- * Takes and returns the parsed manifest rather than JSON text: the caller
- * writes it back through pnpm's project-manifest writer, which reproduces the
- * file's own indentation instead of imposing this function's. Copies rather
- * than mutating — the caller holds the original across the pack and restores
- * from it.
- */
+/** A copy of `manifest` without {@link STRIPPED_MANIFEST_FIELDS}. */
 export function strippedManifest(manifest: ProjectManifest): ProjectManifest {
   const stripped = { ...manifest };
   for (const field of STRIPPED_MANIFEST_FIELDS) {

--- a/tools/release/src/steps/release-pack.test.ts
+++ b/tools/release/src/steps/release-pack.test.ts
@@ -13,7 +13,7 @@ describe('strippedManifest', () => {
     peerDependencies: { '@uirouter/core': '^6.0.0' },
   };
 
-  it('drops exactly devDependencies and scripts, like npm pkg delete did', () => {
+  it('drops exactly devDependencies and scripts', () => {
     assert.deepEqual(strippedManifest(manifest), {
       name: 'lit-ui-router',
       version: '1.8.0',
@@ -37,8 +37,7 @@ describe('strippedManifest', () => {
   });
 
   it('does not mutate the manifest it was handed', () => {
-    // release-pack restores from the original bytes, but the caller also holds
-    // this object across the pack — stripping must not reach back into it.
+    // release-pack restores from this same object after the pack.
     const source = { ...manifest };
     strippedManifest(source);
     assert.deepEqual(source, manifest);

--- a/tools/release/src/steps/release-pack.test.ts
+++ b/tools/release/src/steps/release-pack.test.ts
@@ -1,9 +1,9 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
-import { pickTarball, strippedManifestJson } from './release-pack.core.ts';
+import { pickTarball, strippedManifest } from './release-pack.core.ts';
 
-describe('strippedManifestJson', () => {
+describe('strippedManifest', () => {
   const manifest = {
     name: 'lit-ui-router',
     version: '1.8.0',
@@ -14,10 +14,7 @@ describe('strippedManifestJson', () => {
   };
 
   it('drops exactly devDependencies and scripts, like npm pkg delete did', () => {
-    const stripped: unknown = JSON.parse(
-      strippedManifestJson(JSON.stringify(manifest)),
-    );
-    assert.deepEqual(stripped, {
+    assert.deepEqual(strippedManifest(manifest), {
       name: 'lit-ui-router',
       version: '1.8.0',
       dependencies: { lit: '^3.0.0' },
@@ -26,9 +23,7 @@ describe('strippedManifestJson', () => {
   });
 
   it('preserves key order of the surviving fields', () => {
-    const stripped = strippedManifestJson(JSON.stringify(manifest));
-    const keys = Object.keys(JSON.parse(stripped) as Record<string, unknown>);
-    assert.deepEqual(keys, [
+    assert.deepEqual(Object.keys(strippedManifest(manifest)), [
       'name',
       'version',
       'dependencies',
@@ -38,20 +33,15 @@ describe('strippedManifestJson', () => {
 
   it('is a no-op shape-wise when the fields are already absent', () => {
     const bare = { name: 'x', version: '1.0.0' };
-    assert.deepEqual(
-      JSON.parse(strippedManifestJson(JSON.stringify(bare))),
-      bare,
-    );
+    assert.deepEqual(strippedManifest(bare), bare);
   });
 
-  it('ends with a newline (a manifest is a text file)', () => {
-    assert.ok(strippedManifestJson('{}').endsWith('\n'));
-  });
-
-  it('rejects non-object manifests', () => {
-    assert.throws(() => strippedManifestJson('[]'), /JSON object/);
-    assert.throws(() => strippedManifestJson('"str"'), /JSON object/);
-    assert.throws(() => strippedManifestJson('null'), /JSON object/);
+  it('does not mutate the manifest it was handed', () => {
+    // release-pack restores from the original bytes, but the caller also holds
+    // this object across the pack — stripping must not reach back into it.
+    const source = { ...manifest };
+    strippedManifest(source);
+    assert.deepEqual(source, manifest);
   });
 });
 

--- a/tools/release/src/steps/release-pack.ts
+++ b/tools/release/src/steps/release-pack.ts
@@ -2,31 +2,35 @@
 // Pack the publish tarball — publish-npm.yml's Pack step as a tool:
 //   env in:  PACKAGE_NAME, PACKAGE_DIR (workspace-relative)
 //   outputs: tarball (absolute path, for the attest + check + publish steps)
-// Strip dev-only manifest fields, `pnpm pack`, restore. The restore is a
-// try/finally over the original file contents (the workflow restored with
-// `git checkout -- package.json`, which the try/finally is byte-equivalent
+// Strip dev-only manifest fields, `pnpm pack`, restore. Read and write both go
+// through pnpm's own project-manifest reader — the one `pnpm pack` itself reads
+// with — so the stripped file keeps the source manifest's indentation instead
+// of whatever a re-serialize would pick, and the restore is just the manifest
+// the reader handed back. The restore is a try/finally (the workflow restored
+// with `git checkout -- package.json`, which the try/finally is byte-equivalent
 // to on CI's clean checkout — and unlike the bash, it also restores when the
 // pack itself fails). Field decisions live in ./release-pack.core.ts.
 
-import { readFile, readdir, writeFile } from 'node:fs/promises';
+import { readdir } from 'node:fs/promises';
 import { join } from 'node:path';
+
+import { readProjectManifest } from '@pnpm/workspace.project-manifest-reader';
 
 import { defaultStream } from '@tools/shared/exec.ts';
 import { group, runMain, setOutput } from '@tools/shared/gha.ts';
 import { requireEnv } from '@tools/shared/env.core.ts';
-import { pickTarball, strippedManifestJson } from './release-pack.core.ts';
+import { pickTarball, strippedManifest } from './release-pack.core.ts';
 import { workspaceRoot } from '@tools/shared/workspace.ts';
 
 runMain(async () => {
   const packageName = requireEnv(process.env, 'PACKAGE_NAME');
   const packageDir = requireEnv(process.env, 'PACKAGE_DIR');
   const dir = join(workspaceRoot, packageDir);
-  const manifestPath = join(dir, 'package.json');
 
-  const original = await readFile(manifestPath, 'utf8');
+  const { manifest, writeProjectManifest } = await readProjectManifest(dir);
   await group(`pack ${packageName} with stripped manifest`, async () => {
     try {
-      await writeFile(manifestPath, strippedManifestJson(original));
+      await writeProjectManifest(strippedManifest(manifest));
       await defaultStream(
         'pnpm',
         ['--filter', packageName, 'pack', '--pack-destination', dir],
@@ -35,7 +39,7 @@ runMain(async () => {
     } finally {
       // release-it later requires a clean working dir — and a failed pack
       // must not leave a stripped manifest behind either.
-      await writeFile(manifestPath, original);
+      await writeProjectManifest(manifest);
     }
   });
 

--- a/tools/release/src/steps/release-pack.ts
+++ b/tools/release/src/steps/release-pack.ts
@@ -2,14 +2,9 @@
 // Pack the publish tarball — publish-npm.yml's Pack step as a tool:
 //   env in:  PACKAGE_NAME, PACKAGE_DIR (workspace-relative)
 //   outputs: tarball (absolute path, for the attest + check + publish steps)
-// Strip dev-only manifest fields, `pnpm pack`, restore. Read and write both go
-// through pnpm's own project-manifest reader — the one `pnpm pack` itself reads
-// with — so the stripped file keeps the source manifest's indentation instead
-// of whatever a re-serialize would pick, and the restore is just the manifest
-// the reader handed back. The restore is a try/finally (the workflow restored
-// with `git checkout -- package.json`, which the try/finally is byte-equivalent
-// to on CI's clean checkout — and unlike the bash, it also restores when the
-// pack itself fails). Field decisions live in ./release-pack.core.ts.
+// Strip dev-only manifest fields, `pnpm pack`, restore. Manifest read/write
+// goes through pnpm's own project-manifest reader, so the rewrite preserves the
+// file's formatting. Field decisions live in ./release-pack.core.ts.
 
 import { readdir } from 'node:fs/promises';
 import { join } from 'node:path';


### PR DESCRIPTION
Closes #326. The npm 12 roll-forward, then a cluster of release-tooling refactors that fell out of auditing npm's surface under 12: pack and dist-tag resolution move off the npm CLI, and the manifest strip is unified with the gate that guards it.

## 1. npm pin 11.18.0 → 12.0.1

Bumps the single version authority — `"npm:npm"` in `.config/mise/config.toml`, with `mise.lock` regenerated via `mise install`.

npm 12's headline change is that dependency lifecycle scripts no longer run unless covered by an `allowScripts` allowlist. That was already handled here: all three examples commit one, `npm approve-scripts --allow-scripts-pending` reports no unreviewed scripts in any of them, and `fsevents@2.3.3` is the only package with `hasInstallScript` across the three lockfiles. A clean-`node_modules` reinstall under 12 still lands `fsevents.node`, so the entry is load-bearing and the approval is honored. The `esbuild@0.27.2` entries are dropped — vite 8 dropped esbuild and it is in none of the lockfiles.

`examples/*` now declare their package manager, since they are standalone `npm ci` projects inside a pnpm workspace:

```json
"devEngines": { "packageManager": { "name": "npm", "onFail": "warn" } }
```

`devEngines` is npm-native, validated before `install`/`ci`/`run`. The corepack `packageManager` field [does not support npm](https://github.com/nodejs/node/issues/51888), so it would have been inert. No version floor: the mise pin is the one npm authority, and StackBlitz ships its own npm (10.8.2 today), so `onFail: "warn"` keeps that expected drift quiet rather than breaking the live demos.

## 2. Pack through pnpm's project-manifest reader

The Pack step re-serialized the manifest itself (`JSON.stringify(rest, null, 2)`), hardcoding two-space indent and silently reformatting any manifest that used something else. It now reads and writes through `@pnpm/workspace.project-manifest-reader`, which reproduces the file's own formatting — and is the reader `pnpm pack` itself uses. The restore is just the manifest the reader handed back, so the step no longer keeps its own copy of the original bytes to write over the top.

`strippedManifest` takes and returns the parsed `ProjectManifest` (from `@pnpm/types`) instead of JSON text.

## 3. Resolve dist-tags through pacote, not `npm view`

`resolve-published.ts` read each package's `latest` dist-tag by shelling out to `npm view <pkg> dist-tags.latest` and matching `E404` in stderr. It now calls `pacote.packument(name)` — the same registry client `tarball.ts` already uses — and reads `dist-tags.latest` directly. One less subprocess, and an unpublished package arrives as a real `E404` error **code** rather than a substring to grep out of stderr; any other error (network, 5xx, auth) still throws instead of being misreported as "unpublished".

## 4. One field list, shared by the strip and its gate

The two manifest fields stripped before pack (`devDependencies`, `scripts`) were stated twice: a `STRIPPED_MANIFEST_FIELDS` constant in `check-pack.core.ts`, and an independent destructure in `strippedManifest`. A change-detector test asserted the constant equalled its own literal — it caught edits to that line, not drift between the two ends.

The list now lives once in `release-pack.core.ts` next to the strip; the strip iterates it, and the packed-manifest gate (`findPackedManifestViolations`) imports it. Drift is unrepresentable, so the change-detector test is deleted rather than relocated — `strippedManifest`'s behavioural tests (drops exactly these fields, preserves key order, no-op when absent, doesn't mutate its input) cover the semantics.

The list is also `as const satisfies readonly (keyof ProjectManifest)[]`, so a typo fails at the declaration (TS2820, "did you mean 'scripts'?") instead of silently stripping and guarding nothing. `satisfies` rather than an annotation keeps the inferred type the literal tuple, which `check-pack.core.ts` needs to index `PackageManifest`.

**check-published-diff reuses that same strip**, replacing its `npm pkg delete`. That check answers "would a publish ship different bytes", which is only sound if the local side is packed from byte-identical input — sharing the strip guarantees it, where a second implementation could only agree until one of them changed.

### npm is now read-only across the repo

With `npm pkg delete` and `npm view` both gone, no release-tooling code path **writes** through npm anymore. Every remaining npm touch is a read or examples-only: `npm ci --prefix` in `examples/*` (StackBlitz parity), and `npm diff` in check-published-diff (the only `npm diff` replacement, `libnpmdiff`, was prototyped and declined — it pulls npm's arborist installer + audit machinery for 29 marginal packages, and the subprocess is the same binary the check's fidelity rests on).

## Pinned SDK versions

pnpm's release workflow stopped verifying packed payloads around 2026-07-16, so a run of `@pnpm/*` versions shipped **only `lib/index.js`** — no relative-import targets, no `.d.ts` — failing at import with `ERR_MODULE_NOT_FOUND`. The reader and its closure are exact-pinned below the break:

| package | pin | payload |
| --- | --- | --- |
| `@pnpm/workspace.project-manifest-reader` | 1100.0.15 | complete ✅ (1100.0.16+ are index-only ❌) |
| `@pnpm/types` | 1101.4.0 | complete ✅ (1101.5.0 index-only ❌) |

Every `@pnpm/*` dependency of the reader is itself exact-pinned upstream, so the single pin determines the whole pnpm closure — no `overrides` needed. The fix, [pnpm/pnpm#13185](https://github.com/pnpm/pnpm/pull/13185) ("verify internal package payloads before publish"), **merged 2026-07-23**. It's a publish-time guard in pnpm's own pipeline, so the dividing line is the publish timestamp, not the version — any `@pnpm/*` released after the merge is sound. As of this PR only `@pnpm/types@1101.6.0` has a post-fix release (verified: 20 files, 8 `lib/*.js`, imports clean); the other pins have no post-fix release yet, so they're held. Bump all together once each republishes.

## Comment pass

The refactors' comments were trimmed to code-level facts, with rationale moved to commit bodies: several described the strip as `publish-npm.yml` running `npm pkg delete` (that step is TS now, and `npm pkg` appears nowhere in the repo), one named the wrong reader package (`@pnpm/read-project-manifest` — we use the workspace reader), and `pickTarball`'s bash-glob backstory was dropped for the invariant it enforces.

## Verification

| Surface | Result |
| --- | --- |
| `npm ci --prefix` × 3 — standalone, clean `node_modules`, and via workspace `postinstall` | green, zero warnings, no lockfile churn |
| `resolve:published` (pacote) dist-tags | same values as the old `npm view` path; unpublished → `null` via `E404` code |
| pack `lit-ui-router` before vs after the whole refactor | **byte-identical tarball**, every packed file incl. `package.json` — no release owed |
| `check:published-diff` | same verdicts (3 packages, no ship-affecting drift, 3 ship-inert) — the npm-vs-pnpm differential agreeing |
| packing each publishable package | `package.json` sha **unchanged**, git clean — the reader round-trip restores exactly what the raw-bytes copy did |
| `check:pack`, `@tools/release` tests, typecheck, lint, format | green |
| root `.npmrc` under npm 12 | plain scoped-registry line, accepted (unknown `NPM_CONFIG_*` only warns under 12, doesn't throw) |

The 3 ship-inert `package.json` drifts are pre-existing (`workspace:*` peer normalization, publish being the only normalizer). Full `turbo run ci` / `ci:main` is left to CI on this PR.

### Note on `mise.lock`

The `npm:` backend records only `version` + `backend` — no per-platform checksums, unlike `node` / `actionlint` / `zizmor`, which carry all 7 platform blocks. So the pin bump is a one-line lock diff with no checksum-restoration hazard. It also means npm/corepack integrity rests on the registry rather than a hash in `mise.lock`, which slightly overstates publish-npm.yml's "checksum-verified against mise.lock" comment. Not addressed here.
