### PR TITLE
docs(readme): swap escape-hatch badge for Publish to NPM; link bump-version dispatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Main Branch CI](https://github.com/simshanith/lit-ui-router/actions/workflows/build-test.yml/badge.svg?branch=main)](https://github.com/simshanith/lit-ui-router/actions/workflows/build-test.yml?query=branch%3Amain)
 [![codecov](https://codecov.io/gh/simshanith/lit-ui-router/branch/main/graph/badge.svg)](https://codecov.io/gh/simshanith/lit-ui-router)
-[![Publish Pipeline](https://img.shields.io/github/actions/workflow/status/simshanith/lit-ui-router/publish-npm.yml?label=Publish%20Pipeline)](https://github.com/simshanith/lit-ui-router/actions/workflows/publish-npm.yml)
+[![Publish Pipeline](https://github.com/simshanith/lit-ui-router/actions/workflows/publish-npm.yml/badge.svg?event=push)](https://github.com/simshanith/lit-ui-router/actions/workflows/publish-npm.yml)
 [![Website](https://img.shields.io/website?url=https%3A%2F%2Flit-ui-router.dev)](https://lit-ui-router.dev)
 
 #### Published packages

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Main Branch CI](https://github.com/simshanith/lit-ui-router/actions/workflows/build-test.yml/badge.svg?branch=main)](https://github.com/simshanith/lit-ui-router/actions/workflows/build-test.yml?query=branch%3Amain)
-[![Publish to NPM](https://github.com/simshanith/lit-ui-router/actions/workflows/publish-npm.yml/badge.svg)](https://github.com/simshanith/lit-ui-router/actions/workflows/publish-npm.yml)
 [![codecov](https://codecov.io/gh/simshanith/lit-ui-router/branch/main/graph/badge.svg)](https://codecov.io/gh/simshanith/lit-ui-router)
+[![Publish Pipeline](https://img.shields.io/github/actions/workflow/status/simshanith/lit-ui-router/publish-npm.yml?label=Publish%20Pipeline)](https://github.com/simshanith/lit-ui-router/actions/workflows/publish-npm.yml)
 [![Website](https://img.shields.io/website?url=https%3A%2F%2Flit-ui-router.dev)](https://lit-ui-router.dev)
 
 #### Published packages

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Main Branch CI](https://github.com/simshanith/lit-ui-router/actions/workflows/build-test.yml/badge.svg?branch=main)](https://github.com/simshanith/lit-ui-router/actions/workflows/build-test.yml?query=branch%3Amain)
-[![Tag & push (escape hatch)](https://github.com/simshanith/lit-ui-router/actions/workflows/publish-gh.yml/badge.svg?branch=main&event=workflow_dispatch)](https://github.com/simshanith/lit-ui-router/actions/workflows/publish-gh.yml?query=branch%3Amain+event%3Aworkflow_dispatch)
+[![Publish to NPM](https://github.com/simshanith/lit-ui-router/actions/workflows/publish-npm.yml/badge.svg)](https://github.com/simshanith/lit-ui-router/actions/workflows/publish-npm.yml)
 [![codecov](https://codecov.io/gh/simshanith/lit-ui-router/branch/main/graph/badge.svg)](https://codecov.io/gh/simshanith/lit-ui-router)
 [![Website](https://img.shields.io/website?url=https%3A%2F%2Flit-ui-router.dev)](https://lit-ui-router.dev)
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -66,6 +66,8 @@ These are consumed by `build-test.yml` and `publish-npm.yml` to enable remote ca
 
 **Triggers:** Pull requests, branch and `main` pushes, manual dispatch
 
+[Actions ▸ Build and Test ▸ **Run workflow**](https://github.com/simshanith/lit-ui-router/actions/workflows/build-test.yml)
+
 Runs the CI pipeline including:
 
 - Build verification
@@ -109,6 +111,8 @@ Creates a release PR by:
 
 **Triggers:** Called by Build and Test after a green `main` run (`workflow_call`); manual dispatch is the CI-bypass escape hatch
 
+[Actions ▸ Tag & push ▸ **Run workflow**](https://github.com/simshanith/lit-ui-router/actions/workflows/publish-gh.yml)
+
 When a release PR merges and main CI is green:
 
 1. Uses release-it to create a git tag per package (`<package>@X.Y.Z`)
@@ -120,6 +124,8 @@ When a release PR merges and main CI is green:
 ### 4. Publish to NPM (`publish-npm.yml`)
 
 **Triggers:** Tag push matching a published package tag (`lit-ui-router@*`, `lit-ui-router-mobx@*`, `ui-router-navigation-location-plugin@*`); manual dispatch for dry runs
+
+[Actions ▸ Publish to NPM ▸ **Run workflow**](https://github.com/simshanith/lit-ui-router/actions/workflows/publish-npm.yml)
 
 The final release stage:
 
@@ -133,6 +139,8 @@ The final release stage:
 ### 5. Release signals (`release-signals.yml`)
 
 **Triggers:** Pushes to `main`; called by Publish to NPM after a publish; manual dispatch
+
+[Actions ▸ Release signals ▸ **Run workflow**](https://github.com/simshanith/lit-ui-router/actions/workflows/release-signals.yml)
 
 Non-gating per-package check runs on main's head — `published-diff (<pkg>)`
 (does the pack surface differ from the published `latest`?) and

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -87,7 +87,9 @@ to deflake the full main graph); tagging stays push-only.
 
 ### 2. Bump Version (`bump-version.yml`)
 
-**Triggers:** Manual dispatch only — [Actions ▸ Bump version ▸ **Run workflow**](https://github.com/simshanith/lit-ui-router/actions/workflows/bump-version.yml)
+**Triggers:** Manual dispatch only
+
+[Actions ▸ Bump version ▸ **Run workflow**](https://github.com/simshanith/lit-ui-router/actions/workflows/bump-version.yml)
 
 Creates a release PR by:
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -87,7 +87,7 @@ to deflake the full main graph); tagging stays push-only.
 
 ### 2. Bump Version (`bump-version.yml`)
 
-**Triggers:** Manual dispatch only
+**Triggers:** Manual dispatch only — [Actions ▸ Bump version ▸ **Run workflow**](https://github.com/simshanith/lit-ui-router/actions/workflows/bump-version.yml)
 
 Creates a release PR by:
 


### PR DESCRIPTION
## Why

Root README header review. Two badge/link findings:

1. **The `Tag & push (escape hatch)` header badge is stale-by-design.** It filtered on `event=workflow_dispatch`, but tagging is now driven by **Build and Test** via `workflow_call` (`build-test.yml` `tag_push` job → `publish-gh.yml`). `workflow_call` runs don't appear under that query, so the badge only reflected the rare manual hotfix path and rendered *no status* the rest of the time — advertising the bypass, not the pipeline.
2. **Publish to NPM — the actual release action, and the one still-standalone workflow (tag-triggered) — had no badge.** Better header fit.
3. **No click-to-run entry point for `Bump version`,** the human start of a release.

## Changes

- **README.md** — replace the `Tag & push (escape hatch)` header badge with an unfiltered **Publish to NPM** badge (tag-triggered, so no `branch=main` filter). The Tag & push / escape-hatch detail already lives in `RELEASE.md §3`.
- **RELEASE.md §2** — add a click-to-dispatch link to the Bump version workflow.

Header now: `License · Main Branch CI · Publish to NPM · codecov · Website`.

Docs-only. No workflow or code changes.