### PR TITLE
feat(release): add check:exports (publint + attw) to the PR graph

### DIFF
--- a/packages/lit-ui-router/package.json
+++ b/packages/lit-ui-router/package.json
@@ -7,7 +7,8 @@
   "author": "Shane Daniel",
   "repository": {
     "type": "git",
-    "url": "https://github.com/simshanith/lit-ui-router"
+    "url": "git+https://github.com/simshanith/lit-ui-router.git",
+    "directory": "packages/lit-ui-router"
   },
   "files": [
     "dist/**",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,9 @@ catalogs:
     '@api-viewer/docs':
       specifier: 1.0.0-pre.10
       version: 1.0.0-pre.10
+    '@arethetypeswrong/core':
+      specifier: ^0.18.5
+      version: 0.18.5
     '@codecov/bundle-analyzer':
       specifier: ^2.0.1
       version: 2.0.1
@@ -153,6 +156,9 @@ catalogs:
     playwright:
       specifier: ^1.61.1
       version: 1.61.1
+    publint:
+      specifier: ^0.3.21
+      version: 0.3.21
     release-it:
       specifier: ^20.2.1
       version: 20.2.1
@@ -918,6 +924,9 @@ importers:
 
   tools/release:
     devDependencies:
+      '@arethetypeswrong/core':
+        specifier: 'catalog:'
+        version: 0.18.5
       '@pnpm/types':
         specifier: 'catalog:'
         version: 1101.4.0
@@ -942,6 +951,9 @@ importers:
       pacote:
         specifier: 'catalog:'
         version: 22.0.0(supports-color@8.1.1)
+      publint:
+        specifier: 'catalog:'
+        version: 0.3.21
       typescript:
         specifier: 'catalog:'
         version: 7.0.2
@@ -1031,6 +1043,9 @@ packages:
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
 
+  '@andrewbranch/untar.js@1.0.3':
+    resolution: {integrity: sha512-Jh15/qVmrLGhkKJBdXlK1+9tY4lZruYjsgkDFj08ZmDiWVBLJcqkok7Z0/R0In+i1rScBpJlSvrTS2Lm41Pbnw==}
+
   '@api-viewer/common@1.0.0-pre.10':
     resolution: {integrity: sha512-6quixfdtbQ0oF3QIfm20+Fj+ODusYrssjBNQsCiXj3qwFsRmNVGfwdKvBXuH3y022NYgq0dgwADVPOm8SXLj7A==}
 
@@ -1039,6 +1054,10 @@ packages:
 
   '@api-viewer/tabs@1.0.0-pre.10':
     resolution: {integrity: sha512-yLjUvGfg64S0BANfZuA0buBoK2WStiGQnsqvTuAge0zuzWGT6+Qoh4SSyKQwfPRJOAqPvVkuPSVqZFqN2itLug==}
+
+  '@arethetypeswrong/core@0.18.5':
+    resolution: {integrity: sha512-9ytjzGwxjm9Uz7I9avfbt5vlQt6uk9uRRESzJjqrznl6WKvI6dwYTo+vJ3U02Wrq/mR3iql/PzhvHhKdJIAjDQ==}
+    engines: {node: '>=20'}
 
   '@babel/code-frame@7.29.7':
     resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
@@ -1067,6 +1086,9 @@ packages:
 
   '@blazediff/core@1.9.1':
     resolution: {integrity: sha512-ehg3jIkYKulZh+8om/O25vkvSsXXwC+skXmyA87FFx6A/45eqOkZsBltMw/TVteb0mloiGT8oGRTcjRAz66zaA==}
+
+  '@braidai/lang@1.1.2':
+    resolution: {integrity: sha512-qBcknbBufNHlui137Hft8xauQMTZDKdophmLFv05r2eNmdIv/MlPuP4TdUknHG68UdWLgVZwgxVe735HzJNIwA==}
 
   '@cloudflare/kv-asset-handler@0.5.0':
     resolution: {integrity: sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==}
@@ -1829,6 +1851,9 @@ packages:
 
   '@lit/reactive-element@2.1.2':
     resolution: {integrity: sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==}
+
+  '@loaderkit/resolve@1.0.6':
+    resolution: {integrity: sha512-G8FdIoF5CypfwmD9rl8BXod5HDn8JqB0CCNBXDTaRZ+yRYhARrrSToX1zg1zy9jX3zLqigsELwhT4gNtkdQAUg==}
 
   '@napi-rs/wasm-runtime@1.1.6':
     resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
@@ -2677,6 +2702,10 @@ packages:
 
   '@poppinss/exception@1.2.3':
     resolution: {integrity: sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==}
+
+  '@publint/pack@0.1.5':
+    resolution: {integrity: sha512-edgyN2pP07uXiP4tJs0s8KVmU8M8i60YPbbI0/WDeok1mIJHRXz+CgD8I0nelwDkoCh3EWL/G5kGfbuHjsdbvw==}
+    engines: {node: '>=18'}
 
   '@release-it/conventional-changelog@11.0.1':
     resolution: {integrity: sha512-SHAnHfOFhazpDeYuQSqH8Qm8RJa2oREn2ILSod+9s8dqiA18mBgpPyYlpvRaqISCVerSmLzEZghQBKphkrf4IQ==}
@@ -3787,6 +3816,9 @@ packages:
   citty@0.2.2:
     resolution: {integrity: sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w==}
 
+  cjs-module-lexer@1.4.3:
+    resolution: {integrity: sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==}
+
   cli-cursor@5.0.0:
     resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
     engines: {node: '>=18'}
@@ -4357,6 +4389,9 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  fflate@0.8.3:
+    resolution: {integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==}
 
   figures@6.1.0:
     resolution: {integrity: sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==}
@@ -5185,6 +5220,10 @@ packages:
   mobx@6.16.1:
     resolution: {integrity: sha512-syNcDdX3KT+Jq3je6eGjBhuc24Z68td2VG0zNFqRswaE433D9SNH5VRy/xrGbJsUixfppLLccXhAW9JSf6n+SQ==}
 
+  mri@1.2.0:
+    resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
+    engines: {node: '>=4'}
+
   mrmime@2.0.1:
     resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
     engines: {node: '>=10'}
@@ -5418,6 +5457,9 @@ packages:
     resolution: {integrity: sha512-eHXskJQU4aCiSfjhRfTVtCJ+22/EzLHgYgZv5Gj3teb3NJrnTMzq5BnKAWKvR+PLpknCO1PmOCImDuO+dX4Vaw==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
+  package-manager-detector@1.8.0:
+    resolution: {integrity: sha512-yQA4H19AmPEoMUeavPMDIe1higySl/gH/yaQrkT/s07Qp+7pp2hYz30N3z2l5BkjVkF9Ow6o0wjJamm2y7Sn0A==}
+
   pacote@22.0.0:
     resolution: {integrity: sha512-++VqeOZeL03uGM2MFLk96jGCSt1owBGkyFKoPr+trwNlZhCpjN2RrvwYxt8nTbs1wNMqSFYurq0TafVWkAIHig==}
     engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
@@ -5597,6 +5639,11 @@ packages:
     resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
     engines: {node: '>=10'}
 
+  publint@0.3.21:
+    resolution: {integrity: sha512-OqejcnMV6E9zel2oCrUOJEiiFkGiAAni0A6ibfQNh1k9Gu5z4F+Yso8lllam7AzmV6Do0vp7u3UpZNRBwuXaHQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
 
@@ -5717,6 +5764,10 @@ packages:
 
   rxjs@7.8.2:
     resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
+
+  sade@1.8.1:
+    resolution: {integrity: sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==}
+    engines: {node: '>=6'}
 
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
@@ -6082,6 +6133,11 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  typescript@5.6.1-rc:
+    resolution: {integrity: sha512-E3b2+1zEFu84jB0YQi9BORDjz9+jGbwwy1Zi3G0LUNw7a7cePUrHMRNy8aPh53nXpkFGVHSxIZo5vKTfYaFiBQ==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
@@ -6176,6 +6232,10 @@ packages:
 
   validate-npm-package-license@3.0.4:
     resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
+
+  validate-npm-package-name@5.0.1:
+    resolution: {integrity: sha512-OljLrQ9SQdOUqTaQxqL5dEfZWrXExyyWsozYlAWFawPVNuD83igl7uJD2RTkNMbniIYgt8l81eCJGIdQF7avLQ==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
   validate-npm-package-name@7.0.2:
     resolution: {integrity: sha512-hVDIBwsRruT73PbK7uP5ebUt+ezEtCmzZz3F59BSr2F6OVFnJ/6h8liuvdLrQ88Xmnk6/+xGGuq+pG9WwTuy3A==}
@@ -6544,6 +6604,8 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
 
+  '@andrewbranch/untar.js@1.0.3': {}
+
   '@api-viewer/common@1.0.0-pre.10':
     dependencies:
       custom-elements-manifest: 2.1.0
@@ -6564,6 +6626,17 @@ snapshots:
   '@api-viewer/tabs@1.0.0-pre.10':
     dependencies:
       '@api-viewer/common': 1.0.0-pre.10
+
+  '@arethetypeswrong/core@0.18.5':
+    dependencies:
+      '@andrewbranch/untar.js': 1.0.3
+      '@loaderkit/resolve': 1.0.6
+      cjs-module-lexer: 1.4.3
+      fflate: 0.8.3
+      lru-cache: 11.5.1
+      semver: 7.8.5
+      typescript: 5.6.1-rc
+      validate-npm-package-name: 5.0.1
 
   '@babel/code-frame@7.29.7':
     dependencies:
@@ -6587,6 +6660,8 @@ snapshots:
   '@bcoe/v8-coverage@1.0.2': {}
 
   '@blazediff/core@1.9.1': {}
+
+  '@braidai/lang@1.1.2': {}
 
   '@cloudflare/kv-asset-handler@0.5.0': {}
 
@@ -7262,6 +7337,10 @@ snapshots:
     dependencies:
       '@lit-labs/ssr-dom-shim': 1.6.0
 
+  '@loaderkit/resolve@1.0.6':
+    dependencies:
+      '@braidai/lang': 1.1.2
+
   '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
     dependencies:
       '@emnapi/core': 1.11.1
@@ -7872,6 +7951,10 @@ snapshots:
       supports-color: 10.2.2
 
   '@poppinss/exception@1.2.3': {}
+
+  '@publint/pack@0.1.5':
+    dependencies:
+      tinyexec: 1.2.4
 
   '@release-it/conventional-changelog@11.0.1(conventional-commits-filter@5.0.0)(conventional-commits-parser@6.4.0)(release-it@20.2.1(@types/node@24.13.3)(magicast@0.5.3))':
     dependencies:
@@ -8865,6 +8948,8 @@ snapshots:
 
   citty@0.2.2: {}
 
+  cjs-module-lexer@1.4.3: {}
+
   cli-cursor@5.0.0:
     dependencies:
       restore-cursor: 5.1.0
@@ -9537,6 +9622,8 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.5):
     optionalDependencies:
       picomatch: 4.0.5
+
+  fflate@0.8.3: {}
 
   figures@6.1.0:
     dependencies:
@@ -10360,6 +10447,8 @@ snapshots:
 
   mobx@6.16.1: {}
 
+  mri@1.2.0: {}
+
   mrmime@2.0.1: {}
 
   ms@2.1.3: {}
@@ -10709,6 +10798,8 @@ snapshots:
       validate-npm-package-license: 3.0.4
       validate-npm-package-name: 7.0.2
 
+  package-manager-detector@1.8.0: {}
+
   pacote@22.0.0(supports-color@8.1.1):
     dependencies:
       '@gar/promise-retry': 1.0.3
@@ -10877,6 +10968,13 @@ snapshots:
   proxy-from-env@1.1.0: {}
 
   proxy-from-env@2.1.0: {}
+
+  publint@0.3.21:
+    dependencies:
+      '@publint/pack': 0.1.5
+      package-manager-detector: 1.8.0
+      picocolors: 1.1.1
+      sade: 1.8.1
 
   pump@3.0.4:
     dependencies:
@@ -11051,6 +11149,10 @@ snapshots:
   rxjs@7.8.2:
     dependencies:
       tslib: 2.8.1
+
+  sade@1.8.1:
+    dependencies:
+      mri: 1.2.0
 
   safe-buffer@5.2.1: {}
 
@@ -11449,6 +11551,8 @@ snapshots:
 
   typescript@5.4.5: {}
 
+  typescript@5.6.1-rc: {}
+
   typescript@5.9.3: {}
 
   typescript@6.0.3: {}
@@ -11545,6 +11649,8 @@ snapshots:
     dependencies:
       spdx-correct: 3.2.0
       spdx-expression-parse: 3.0.1
+
+  validate-npm-package-name@5.0.1: {}
 
   validate-npm-package-name@7.0.2: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,6 +8,7 @@ packages:
 catalog:
   '@ampproject/remapping': ^2.3.0
   '@api-viewer/docs': 1.0.0-pre.10
+  '@arethetypeswrong/core': ^0.18.5
   '@codecov/bundle-analyzer': ^2.0.1
   '@oxc-project/runtime': 0.140.0
   '@commitlint/cli': ^21.2.0
@@ -55,6 +56,7 @@ catalog:
   oxlint-tsgolint: 0.25.0
   pacote: ^22.0.0
   playwright: ^1.61.1
+  publint: ^0.3.21
   release-it: ^20.2.1
   rimraf: ^6.1.3
   rolldown: ^1.2.0

--- a/tools/release/package.json
+++ b/tools/release/package.json
@@ -5,6 +5,7 @@
   "description": "Owns the release-pipeline logic: the tested entries the publish and bump-version workflows invoke",
   "type": "module",
   "scripts": {
+    "check:exports": "node src/checks/check-exports.ts",
     "check:pack": "node src/checks/check-pack.ts",
     "check:published-diff": "node src/checks/check-published-diff.ts",
     "format": "oxfmt \"**/*.{ts,js,json,jsonc,md}\"",
@@ -15,6 +16,7 @@
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "devDependencies": {
+    "@arethetypeswrong/core": "catalog:",
     "@pnpm/types": "catalog:",
     "@pnpm/workspace.project-manifest-reader": "catalog:",
     "@tools/shared": "workspace:*",
@@ -23,6 +25,7 @@
     "lit-ui-router": "workspace:*",
     "lit-ui-router-mobx": "workspace:*",
     "pacote": "catalog:",
+    "publint": "catalog:",
     "typescript": "catalog:",
     "ui-router-navigation-location-plugin": "workspace:*"
   }

--- a/tools/release/src/checks/check-exports.core.ts
+++ b/tools/release/src/checks/check-exports.core.ts
@@ -1,0 +1,117 @@
+// Pure logic for the packed exports/types check — no filesystem, pnpm, attw, or
+// publint here (structural inputs only), so every unit is directly testable with
+// plain fixtures (see check-exports.test.ts). The IO (packing each publishable
+// package and running attw + publint over the tarball) lives in check-exports.ts.
+
+import type { Report } from './types.ts';
+
+// The @arethetypeswrong/cli `esm-only` profile: these packages are ESM-only
+// forever, so node10 (no exports-map support) and require-from-CJS resolutions
+// never gate; a broken node16-esm/bundler resolution still does.
+const IGNORED_RESOLUTIONS = new Set(['node10', 'node16-cjs']);
+
+/** A gating attw problem, reduced to the fields the report renders. */
+export type AttwProblem = {
+  kind: string;
+  entrypoint?: string;
+  resolutionKind?: string;
+};
+
+// checkPackage returns `types: false` for a package shipping no declarations,
+// which attw exits 0 on; every publishable package here is typed, so absent
+// types is a gating failure instead.
+const NO_TYPE_DECLARATIONS: AttwProblem = { kind: 'NoTypeDeclarations' };
+
+// The subset of @arethetypeswrong/core's CheckResult this predicate reads; the
+// real Analysis | UntypedResult is assignable to it.
+type AttwAnalysis = {
+  types: unknown;
+  problems?: readonly AttwProblem[];
+};
+
+/**
+ * attw problems that gate under the esm-only profile — the port of the CLI's
+ * getExitCode: a problem gates unless it carries an ignored resolutionKind.
+ */
+export function attwGatingProblems(analysis: AttwAnalysis): AttwProblem[] {
+  if (!analysis.types) return [NO_TYPE_DECLARATIONS];
+  return (analysis.problems ?? []).filter(
+    (problem) =>
+      problem.resolutionKind === undefined ||
+      !IGNORED_RESOLUTIONS.has(problem.resolutionKind),
+  );
+}
+
+/** publint messages that gate: `error` and `warning`; `suggestion` is reported. */
+export function publintGatingMessages<T extends { type: string }>(
+  messages: readonly T[],
+): T[] {
+  return messages.filter((m) => m.type === 'error' || m.type === 'warning');
+}
+
+/** One package's verdict, ready to render. publint messages arrive formatted. */
+export type PackageExportsCheck = {
+  name: string;
+  dir: string;
+  attw: AttwProblem[];
+  publint: string[];
+  suggestions: string[];
+};
+
+function formatAttwProblem(problem: AttwProblem): string {
+  const entrypoint = problem.entrypoint ? ` — ${problem.entrypoint}` : '';
+  const resolution = problem.resolutionKind
+    ? ` (${problem.resolutionKind})`
+    : '';
+  return `${problem.kind}${entrypoint}${resolution}`;
+}
+
+function suggestionLines(results: PackageExportsCheck[]): string[] {
+  const withSuggestions = results.filter((r) => r.suggestions.length > 0);
+  if (withSuggestions.length === 0) return [];
+  const lines = ['', 'publint suggestions (not gating):'];
+  for (const { name, suggestions } of withSuggestions) {
+    lines.push(`  ${name}`);
+    for (const message of suggestions) lines.push(`      • ${message}`);
+  }
+  return lines;
+}
+
+/** Render the human-readable report. */
+export function formatExportsReport(results: PackageExportsCheck[]): Report {
+  if (results.length === 0) {
+    return {
+      ok: false,
+      text: '✗ exports check failed — no publishable workspace packages found (broken workspace globs?).',
+    };
+  }
+
+  const suggestions = suggestionLines(results);
+  const bad = results.filter((r) => r.attw.length > 0 || r.publint.length > 0);
+  if (bad.length === 0) {
+    return {
+      ok: true,
+      text: [
+        `✓ exports check passed — ${results.length} publishable packages, ` +
+          `publint + attw clean (esm-only profile).`,
+        ...suggestions,
+      ].join('\n'),
+    };
+  }
+
+  const lines = [
+    '✗ exports check failed — packed exports/types do not resolve ' +
+      '(publishing would break consumers):',
+    '',
+  ];
+  for (const { name, dir, attw, publint } of bad) {
+    lines.push(`  ${name} (${dir})`);
+    for (const problem of attw) {
+      lines.push(`      • attw: ${formatAttwProblem(problem)}`);
+    }
+    for (const message of publint) lines.push(`      • publint: ${message}`);
+    lines.push('');
+  }
+  lines.push(...suggestions);
+  return { ok: false, text: lines.join('\n').trimEnd() };
+}

--- a/tools/release/src/checks/check-exports.test.ts
+++ b/tools/release/src/checks/check-exports.test.ts
@@ -1,0 +1,183 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+  attwGatingProblems,
+  formatExportsReport,
+  type PackageExportsCheck,
+  publintGatingMessages,
+} from './check-exports.core.ts';
+
+describe('attwGatingProblems', () => {
+  it('ignores node10 and node16-cjs resolutions (esm-only profile)', () => {
+    const analysis = {
+      types: {},
+      problems: [
+        { kind: 'NoResolution', entrypoint: '.', resolutionKind: 'node10' },
+        {
+          kind: 'CJSResolvesToESM',
+          entrypoint: '.',
+          resolutionKind: 'node16-cjs',
+        },
+      ],
+    };
+    assert.deepEqual(attwGatingProblems(analysis), []);
+  });
+
+  it('gates a broken node16-esm resolution', () => {
+    const analysis = {
+      types: {},
+      problems: [
+        {
+          kind: 'NoResolution',
+          entrypoint: './pure',
+          resolutionKind: 'node16-esm',
+        },
+      ],
+    };
+    assert.deepEqual(attwGatingProblems(analysis), [
+      {
+        kind: 'NoResolution',
+        entrypoint: './pure',
+        resolutionKind: 'node16-esm',
+      },
+    ]);
+  });
+
+  it('gates a broken bundler resolution', () => {
+    const analysis = {
+      types: {},
+      problems: [
+        { kind: 'FalseESM', entrypoint: '.', resolutionKind: 'bundler' },
+      ],
+    };
+    assert.equal(attwGatingProblems(analysis).length, 1);
+  });
+
+  it('gates a problem with no resolutionKind', () => {
+    const analysis = {
+      types: {},
+      problems: [{ kind: 'InternalResolutionError' }],
+    };
+    assert.deepEqual(attwGatingProblems(analysis), [
+      { kind: 'InternalResolutionError' },
+    ]);
+  });
+
+  it('gates when the package ships no type declarations', () => {
+    assert.deepEqual(attwGatingProblems({ types: false }), [
+      { kind: 'NoTypeDeclarations' },
+    ]);
+  });
+
+  it('passes a clean analysis', () => {
+    assert.deepEqual(attwGatingProblems({ types: {}, problems: [] }), []);
+  });
+});
+
+describe('publintGatingMessages', () => {
+  it('passes when only suggestions are present', () => {
+    assert.deepEqual(
+      publintGatingMessages([{ type: 'suggestion', code: 'USE_LICENSE' }]),
+      [],
+    );
+  });
+
+  it('gates a warning', () => {
+    const messages = [{ type: 'warning', code: 'EXPORTS_VALUE_INVALID' }];
+    assert.deepEqual(publintGatingMessages(messages), messages);
+  });
+
+  it('gates an error', () => {
+    const messages = [{ type: 'error', code: 'FILE_DOES_NOT_EXIST' }];
+    assert.deepEqual(publintGatingMessages(messages), messages);
+  });
+
+  it('keeps only the gating messages from a mixed list', () => {
+    const messages = [
+      { type: 'suggestion', code: 'USE_LICENSE' },
+      { type: 'warning', code: 'EXPORTS_VALUE_INVALID' },
+      { type: 'error', code: 'FILE_DOES_NOT_EXIST' },
+    ];
+    assert.deepEqual(publintGatingMessages(messages), [
+      { type: 'warning', code: 'EXPORTS_VALUE_INVALID' },
+      { type: 'error', code: 'FILE_DOES_NOT_EXIST' },
+    ]);
+  });
+});
+
+describe('formatExportsReport', () => {
+  const clean = (name: string, dir: string): PackageExportsCheck => ({
+    name,
+    dir,
+    attw: [],
+    publint: [],
+    suggestions: [],
+  });
+
+  it('passes when every package is clean', () => {
+    const { ok, text } = formatExportsReport([
+      clean('lit-ui-router', 'packages/lit-ui-router'),
+      clean('lit-ui-router-mobx', 'packages/lit-ui-router-mobx'),
+    ]);
+    assert.equal(ok, true);
+    assert.match(text, /✓ exports check passed — 2 publishable packages/);
+  });
+
+  it('reports suggestions without gating', () => {
+    const { ok, text } = formatExportsReport([
+      {
+        ...clean('lit-ui-router', 'packages/lit-ui-router'),
+        suggestions: ['use "license"'],
+      },
+    ]);
+    assert.equal(ok, true);
+    assert.match(text, /✓ exports check passed/);
+    assert.match(text, /publint suggestions \(not gating\)/);
+    assert.match(text, /use "license"/);
+  });
+
+  it('fails and names the offending package for an attw problem', () => {
+    const { ok, text } = formatExportsReport([
+      clean('lit-ui-router', 'packages/lit-ui-router'),
+      {
+        name: 'lit-ui-router-mobx',
+        dir: 'packages/lit-ui-router-mobx',
+        attw: [
+          {
+            kind: 'NoResolution',
+            entrypoint: './pure',
+            resolutionKind: 'node16-esm',
+          },
+        ],
+        publint: [],
+        suggestions: [],
+      },
+    ]);
+    assert.equal(ok, false);
+    assert.match(text, /✗ exports check failed/);
+    assert.match(text, /lit-ui-router-mobx \(packages\/lit-ui-router-mobx\)/);
+    assert.match(text, /attw: NoResolution — \.\/pure \(node16-esm\)/);
+    assert.doesNotMatch(text, /lit-ui-router \(packages\/lit-ui-router\)/);
+  });
+
+  it('fails and lists a publint violation', () => {
+    const { ok, text } = formatExportsReport([
+      {
+        name: 'lit-ui-router',
+        dir: 'packages/lit-ui-router',
+        attw: [],
+        publint: ['pkg.exports["."] is invalid'],
+        suggestions: [],
+      },
+    ]);
+    assert.equal(ok, false);
+    assert.match(text, /publint: pkg\.exports\["\."\] is invalid/);
+  });
+
+  it('fails when no publishable packages were found', () => {
+    const { ok, text } = formatExportsReport([]);
+    assert.equal(ok, false);
+    assert.match(text, /no publishable workspace packages/);
+  });
+});

--- a/tools/release/src/checks/check-exports.ts
+++ b/tools/release/src/checks/check-exports.ts
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+// Guard publishable packages against shipping an exports/types map that does
+// not resolve in the packed tarball — the payload/exports-map class that the
+// field-level check:pack and the baseline-comparing check:published-diff cannot
+// see. publint lints the packed file set + manifest; @arethetypeswrong/core
+// resolves every entrypoint's types under an esm-only profile.
+//
+// This file is the IO shell: it packs each non-private workspace package with a
+// raw `pnpm pack` (the publish strip only removes devDependencies + scripts,
+// neither in attw's nor publint's analysis scope, so the verdicts are identical
+// to the stripped tarball), runs both validators over the bytes, and delegates
+// every gating decision to the pure, unit-tested ./check-exports.core.ts.
+
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  checkPackage,
+  createPackageFromTarballData,
+} from '@arethetypeswrong/core';
+import { publint } from 'publint';
+import { formatMessage } from 'publint/utils';
+
+import {
+  attwGatingProblems,
+  formatExportsReport,
+  type PackageExportsCheck,
+  publintGatingMessages,
+} from './check-exports.core.ts';
+import { pnpmPack } from './pack.ts';
+import { assertSelfDeclaredDeps } from './self-deps.ts';
+import { loadWorkspace, workspaceRoot } from '@tools/shared/workspace.ts';
+
+/** Pack one package raw and run attw + publint over the tarball. */
+async function checkExports(
+  name: string,
+  dir: string,
+  packageDir: string,
+): Promise<PackageExportsCheck> {
+  const destination = await mkdtemp(join(tmpdir(), 'check-exports-'));
+  const tarball = join(destination, 'package.tgz');
+  try {
+    await pnpmPack(packageDir, tarball);
+    const data = await readFile(tarball);
+
+    // Offline — resolves the tarball's own types, no registry fetch.
+    const analysis = await checkPackage(
+      createPackageFromTarballData(new Uint8Array(data)),
+    );
+
+    // Lint the packed tarball's own file set + manifest (its substituted deps),
+    // never the working dir. pkgDir is omitted on purpose: with `{ tarball }`
+    // publint roots the vfs at the tarball's own package dir, and passing a
+    // real path would override that and miss the manifest.
+    const { messages, pkg } = await publint({
+      pack: {
+        tarball: data.buffer.slice(
+          data.byteOffset,
+          data.byteOffset + data.byteLength,
+        ),
+      },
+      level: 'suggestion',
+    });
+    const gating = publintGatingMessages(messages);
+    const suggestions = messages.filter((m) => m.type === 'suggestion');
+
+    return {
+      name,
+      dir,
+      attw: attwGatingProblems(analysis),
+      publint: gating.map((m) => formatMessage(m, pkg) ?? m.code),
+      suggestions: suggestions.map((m) => formatMessage(m, pkg) ?? m.code),
+    };
+  } finally {
+    await rm(destination, { recursive: true, force: true });
+  }
+}
+
+async function main() {
+  const { members } = await loadWorkspace(workspaceRoot);
+  const publishable = members.filter(
+    (member) =>
+      member.dir !== '<root>' &&
+      member.manifest &&
+      member.manifest.private !== true,
+  );
+  await assertSelfDeclaredDeps(publishable.map(({ name }) => name));
+  const results: PackageExportsCheck[] = [];
+  for (const { name, dir } of publishable) {
+    results.push(await checkExports(name, dir, join(workspaceRoot, dir)));
+  }
+  const { ok, text } = formatExportsReport(results);
+  (ok ? console.log : console.error)(text);
+  if (!ok) process.exitCode = 1;
+}
+
+main().catch((error: unknown) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/tools/release/src/checks/check-exports.ts
+++ b/tools/release/src/checks/check-exports.ts
@@ -49,10 +49,8 @@ async function checkExports(
       createPackageFromTarballData(new Uint8Array(data)),
     );
 
-    // Lint the packed tarball's own file set + manifest (its substituted deps),
-    // never the working dir. pkgDir is omitted on purpose: with `{ tarball }`
-    // publint roots the vfs at the tarball's own package dir, and passing a
-    // real path would override that and miss the manifest.
+    // No pkgDir: `{ tarball }` roots publint at the archive's own dir; a real
+    // path overrides that and throws.
     const { messages, pkg } = await publint({
       pack: {
         tarball: data.buffer.slice(

--- a/turbo.json
+++ b/turbo.json
@@ -135,8 +135,14 @@
         "lint",
         "typecheck",
         "format:check",
-        "check:bundle"
+        "check:bundle",
+        "@tools/release#check:exports"
       ]
+    },
+    "@tools/release#check:exports": {
+      // packed exports/types resolve; needs shipped dist, re-run on any manifest edit
+      "dependsOn": ["^build"],
+      "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/packages/*/package.json"]
     },
     "check:bundle": {
       "dependsOn": ["transit"],


### PR DESCRIPTION
## What

A new release check, `@tools/release#check:exports`, that statically validates every publishable package's **packed** exports/types with two registry-citizen validators and gates the **PR graph** on genuine breakage:

- **[publint](https://publint.dev)** lints the packed file set + substituted manifest.
- **[@arethetypeswrong/core](https://github.com/arethetypeswrong/arethetypeswrong.github.io)** (attw) resolves every entrypoint's types.

## The gap it closes

This is the guard for the payload / exports-map class — "the manifest references a file or condition that is absent or mis-resolves in the tarball" (the pnpm-payload regression class, and this repo's own `sideEffects` / DSR `exports` history). The existing checks don't cover it:

- `check:pack` validates manifest *fields* (no `catalog:` / `workspace:` leaks), not whether `exports` / `types` targets resolve.
- `check:published-diff` compares against the *previous published* version — a first-publish or an already-broken export has no baseline.

## The attw policy — esm-only, forever

`@arethetypeswrong/core` doesn't export the CLI's `getExitCode` / profiles, so the 3-line `esm-only` predicate (`ignoreResolutions: ['node10', 'node16-cjs']`) is ported into the pure, unit-tested core. node10 (no exports-map support) and require-from-CJS resolutions never gate; a genuinely broken `node16-esm` / `bundler` resolution, an internal-resolution error, or missing types still gates. A package that ships no types (attw exits 0) is treated as a gating failure here, since every publishable package is typed.

## The publint policy

Gate on `error` / `warning`; **report** (print, don't gate) `suggestion`.

## Raw pack suffices

Packs **raw** `pnpm pack` — no manifest strip, no in-place mutation, no restore. The publish strip removes only `devDependencies` + `scripts`, neither in attw's nor publint's analysis scope (they resolve `exports` / `main` / `module` / `types` / `files` against the packed `dist`), so raw and stripped tarballs produce **identical** verdicts. Runtime deps are already substituted by `pnpm pack`, so publint's workspace-protocol rule stays clean.

## Placement & cost

`@tools/release#check:exports` `dependsOn: ["^build"]` (release devDepends on every publishable package, enforced by `assertSelfDeclaredDeps`, so `^build` gives fresh `dist` and invalidates on `dist` changes) with an over-approximating `packages/*/package.json` input glob so an exports-map edit that leaves `dist` untouched still re-runs it. Added to `ci:pull_request`; cache-hit ~0, off the critical path.

## The one metadata fix

publint's only current finding: `lit-ui-router`'s `repository.url` shorthand now matches the sibling `git+https://…/.git` + `directory` form (mobx / nav already use it). All three packages then land **green**.

## Non-goals (deferred)

- No shared publish-shape pack target / manifest-strip refactor of `check:pack` / `check:published-diff`.
- No GH check-run / README badge — plain PR gate, parity with how `check:pack` sits in the graph.
- No other metadata changes (`engines`, `keywords`, `bugs`, `funding`).

## Verification

- `pnpm --filter @tools/release test` — 157 pass (new suites: `attwGatingProblems`, `publintGatingMessages`, `formatExportsReport`).
- Built all three packages, then `check:exports` → green for lit-ui-router, lit-ui-router-mobx, ui-router-navigation-location-plugin.
- `turbo run check:exports --dry` → `^build` resolves to all publishable builds; present in the `ci:pull_request` closure; **FULL TURBO** (10/10 cached) on rerun.
- `typecheck` / `lint` / `format:check` green (`@tools/release` and root).
- Sanity: pointing one package's `.` types at a nonexistent file makes the check fail with a clear attw + publint message; reverted.

## Note on the publint pin

The catalog pins `publint: ^0.3.21` (mature) rather than `0.3.22`; `0.3.22` was published today and is blocked by the repo's own `minimumReleaseAge` gate.