### PR TITLE
chore(examples): lit-ui-router 1.7.2

### DIFF
--- a/examples/hellogalaxy/package-lock.json
+++ b/examples/hellogalaxy/package-lock.json
@@ -12,7 +12,7 @@
         "@uirouter/core": "^6.1.2",
         "@uirouter/visualizer": "^7.2.1",
         "lit": "^3.3.3",
-        "lit-ui-router": "^1.7.1"
+        "lit-ui-router": "^1.7.2"
       },
       "devDependencies": {
         "typescript": "^7.0.2",
@@ -1189,9 +1189,9 @@
       }
     },
     "node_modules/lit-ui-router": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/lit-ui-router/-/lit-ui-router-1.7.1.tgz",
-      "integrity": "sha512-M2EJ1i4WLJ+5kHAtwHPr4OTotTvpqyYmw/skwjKOZeWdNkKrKgG9RRmxwYO2r58ovJMdOOgxdljzjm8oF7NkNw==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/lit-ui-router/-/lit-ui-router-1.7.2.tgz",
+      "integrity": "sha512-DTIilRFUG45J2vND0X2yHLAcAtyRJQ0TQp+UOFe2/IPQIVS4QvOidlQewqaq7QDWDgeYnGj9ZuhpTJQH4HEhqA==",
       "license": "MIT",
       "dependencies": {
         "@oxc-project/runtime": "0.140.0",

--- a/examples/hellogalaxy/package.json
+++ b/examples/hellogalaxy/package.json
@@ -13,7 +13,7 @@
     "@uirouter/core": "^6.1.2",
     "@uirouter/visualizer": "^7.2.1",
     "lit": "^3.3.3",
-    "lit-ui-router": "^1.7.1"
+    "lit-ui-router": "^1.7.2"
   },
   "devDependencies": {
     "typescript": "^7.0.2",

--- a/examples/hellosolarsystem/package-lock.json
+++ b/examples/hellosolarsystem/package-lock.json
@@ -11,7 +11,7 @@
         "@uirouter/core": "^6.1.2",
         "@uirouter/visualizer": "^7.2.1",
         "lit": "^3.3.3",
-        "lit-ui-router": "^1.7.1"
+        "lit-ui-router": "^1.7.2"
       },
       "devDependencies": {
         "typescript": "^7.0.2",
@@ -1139,9 +1139,9 @@
       }
     },
     "node_modules/lit-ui-router": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/lit-ui-router/-/lit-ui-router-1.7.1.tgz",
-      "integrity": "sha512-M2EJ1i4WLJ+5kHAtwHPr4OTotTvpqyYmw/skwjKOZeWdNkKrKgG9RRmxwYO2r58ovJMdOOgxdljzjm8oF7NkNw==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/lit-ui-router/-/lit-ui-router-1.7.2.tgz",
+      "integrity": "sha512-DTIilRFUG45J2vND0X2yHLAcAtyRJQ0TQp+UOFe2/IPQIVS4QvOidlQewqaq7QDWDgeYnGj9ZuhpTJQH4HEhqA==",
       "license": "MIT",
       "dependencies": {
         "@oxc-project/runtime": "0.140.0",

--- a/examples/hellosolarsystem/package.json
+++ b/examples/hellosolarsystem/package.json
@@ -12,7 +12,7 @@
     "@uirouter/core": "^6.1.2",
     "@uirouter/visualizer": "^7.2.1",
     "lit": "^3.3.3",
-    "lit-ui-router": "^1.7.1"
+    "lit-ui-router": "^1.7.2"
   },
   "devDependencies": {
     "typescript": "^7.0.2",

--- a/examples/helloworld/package-lock.json
+++ b/examples/helloworld/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@uirouter/core": "^6.1.2",
         "lit": "^3.3.3",
-        "lit-ui-router": "^1.7.1"
+        "lit-ui-router": "^1.7.2"
       },
       "devDependencies": {
         "typescript": "^7.0.2",
@@ -1100,9 +1100,9 @@
       }
     },
     "node_modules/lit-ui-router": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/lit-ui-router/-/lit-ui-router-1.7.1.tgz",
-      "integrity": "sha512-M2EJ1i4WLJ+5kHAtwHPr4OTotTvpqyYmw/skwjKOZeWdNkKrKgG9RRmxwYO2r58ovJMdOOgxdljzjm8oF7NkNw==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/lit-ui-router/-/lit-ui-router-1.7.2.tgz",
+      "integrity": "sha512-DTIilRFUG45J2vND0X2yHLAcAtyRJQ0TQp+UOFe2/IPQIVS4QvOidlQewqaq7QDWDgeYnGj9ZuhpTJQH4HEhqA==",
       "license": "MIT",
       "dependencies": {
         "@oxc-project/runtime": "0.140.0",

--- a/examples/helloworld/package.json
+++ b/examples/helloworld/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@uirouter/core": "^6.1.2",
     "lit": "^3.3.3",
-    "lit-ui-router": "^1.7.1"
+    "lit-ui-router": "^1.7.2"
   },
   "devDependencies": {
     "typescript": "^7.0.2",


### PR DESCRIPTION
Bumps the three tutorial examples (`helloworld`, `hellosolarsystem`, `hellogalaxy`) from `lit-ui-router@^1.7.1` to `^1.7.2` and refreshes their standalone npm lockfiles.

1.7.2 (published today) is a **manifest-only** release — the `repository` field fix (shorthand → `{ type, url: git+…​.git, directory }`) that #445's check:exports surfaced. The dist and dependency tree are byte-identical to 1.7.1, so each lockfile diff is just the `lit-ui-router` node's `version`/`resolved`/`integrity` (8 lines apiece), no transitive churn.

Follows the prior bump convention (#385 for 1.7.1): pin + lockfile per example, nothing else.