### PR TITLE
ci(build-test): split the run body out so check names are static

### DIFF
--- a/.github/workflows/build-test-branch.yml
+++ b/.github/workflows/build-test-branch.yml
@@ -1,0 +1,73 @@
+# Branch-head CI: the fallback for SHAs that no pull_request run covers.
+#
+# Split from build-test.yml by trigger so neither file instantiates the other's
+# jobs. That is what keeps the required context `build_and_test / run`
+# unforgeable: this workflow never contains a job that could emit it, and a
+# skipped job here can only report the names below.
+#
+# Required-check contexts are workflow-agnostic — the context is the job name
+# (or `caller / inner`), and the workflow name is display only. So these job
+# names share one namespace with build-test.yml's and must stay distinct.
+name: Build and Test (branch)
+
+on:
+  push:
+    branches:
+      # A CONFLICTING PR has no merge ref and a branch with no PR fires nothing
+      # at all; those are the SHAs this workflow exists for. main and PR runs
+      # belong to build-test.yml.
+      - '**'
+      - '!main'
+      # Dependabot push events get dependabot secrets (no TURBO_TOKEN); its
+      # PRs already get merge-head CI.
+      - '!dependabot/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  signal_gate:
+    # Answers whether a pull_request run will cover this SHA at all; its `run`
+    # output gates the job below. Imports nothing from node_modules, so no
+    # `mise run setup` step: paying for an install here would cost more than it
+    # saves on the pushes it can't skip. gh is preinstalled on the runner image.
+    name: build_and_test (signal gate)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      run: ${{ steps.gate.outputs.run }}
+    steps:
+      - name: 'Checkout code'
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+          # git merge-tree needs real merge bases; a shallow clone has none.
+          fetch-depth: 0
+      - name: Setup mise
+        uses: jdx/mise-action@v4
+      - name: Decide whether this push needs its own run
+        id: gate
+        run: mise run //tools/build_and_test:branch_ci_gate
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  build_and_test_branch:
+    # `signal_gate` is 'failure' if the gate itself broke — that means run,
+    # since the gate must never become a way to lose CI. `!cancelled()` is
+    # required for the `if` to evaluate at all once a `needs` job can skip.
+    # The dispatch-only debugging inputs are left at their defaults here.
+    name: build_and_test (branch)
+    needs: signal_gate
+    if: >-
+      ${{ !cancelled()
+      && (needs.signal_gate.result != 'success' || needs.signal_gate.outputs.run == 'true') }}
+    permissions:
+      contents: read
+    uses: ./.github/workflows/build-test-run.yml
+    secrets:
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/build-test-run.yml
+++ b/.github/workflows/build-test-run.yml
@@ -1,0 +1,160 @@
+# The build/test body shared by build-test.yml's two caller jobs.
+#
+# It lives here so those callers can carry STATIC names. A job's `name:` is
+# evaluated only when the job starts — a skipped job renders the expression
+# source verbatim — so the caller that serves pull requests and the caller that
+# serves branch-head pushes have to be two jobs rather than one job with a
+# conditional name.
+#
+# The `github` context here still describes the original triggering event, so
+# the step-level conditions below read the same as they did inline.
+name: Build and Test (run)
+
+on:
+  workflow_call:
+    inputs:
+      force:
+        description: 'Bypass turbo cache (deflake reproduction: rebuild/retest everything)'
+        type: boolean
+        default: false
+      mainGraph:
+        description: 'Run the ci:main superset (main-only guards included)'
+        type: boolean
+        default: false
+      cypressVideo:
+        description: 'Record Cypress videos and upload them as a run artifact'
+        type: boolean
+        default: false
+    secrets:
+      TURBO_TOKEN:
+        required: false
+      CODECOV_TOKEN:
+        required: false
+
+# Standard husky CI setup: skip the prepare-script git-hook install on CI
+# installs. Caller-level `env` does not reach a called workflow, so this is set
+# here rather than inherited from build-test.yml.
+env:
+  HUSKY: 0
+
+jobs:
+  # Named for the role the check plays, not the steps it runs: the composite
+  # `build_and_test / merge_gate` is the required status check for merging.
+  merge_gate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+
+    steps:
+      - name: 'Checkout code'
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - name: Setup mise
+        uses: jdx/mise-action@v4
+      - name: Install dependencies
+        run: mise run setup
+      - name: Resolve Playwright version
+        # Cache keys derive from the installed packages, so they bust exactly
+        # on a version bump and nothing else; one step per tool keeps the two
+        # caches independent.
+        id: playwright-version
+        run: mise run //tools/build_and_test:playwright_version
+      - name: Resolve Cypress version
+        id: cypress-version
+        run: mise run //tools/build_and_test:cypress_version
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v6
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.playwright }}
+      - name: Cache Cypress binary
+        uses: actions/cache@v6
+        with:
+          path: ~/.cache/Cypress
+          key: ${{ runner.os }}-cypress-${{ steps.cypress-version.outputs.cypress }}
+      - name: Install Playwright Browsers
+        if: ${{ steps.playwright-cache.outputs.cache-hit != 'true' }}
+        run: mise run //tools/build_and_test:playwright
+      - name: Install Playwright OS deps (firefox+webkit)
+        # Browsers came from the cache; only test:engines (main graph) needs
+        # the firefox+webkit apt libs — the PR graph is chromium-only, and
+        # chromium and Cypress ride the runner image's preinstalled set.
+        if: ${{ steps.playwright-cache.outputs.cache-hit == 'true' && ((github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'workflow_dispatch' && inputs.mainGraph)) }}
+        run: mise run //tools/build_and_test:playwright_deps_engines
+      - name: Install Cypress
+        # `cypress install` is a near-no-op when the binary is cached; verify
+        # still runs so the concurrent suites skip the first-use banner.
+        run: mise run //tools/build_and_test:cypress
+      - name: Start shared Xvfb display
+        # The vanilla and MobX Cypress suites run concurrently. Without a
+        # DISPLAY, each Cypress process spawns its own Xvfb and the spawns
+        # race ("Fatal server error"); one shared display serves both.
+        # https://docs.cypress.io/app/continuous-integration/overview#Xvfb
+        # The task captures Xvfb's stderr (routine xkbcomp keysym noise on
+        # the runner image) and prints it, filtered, only on startup failure.
+        run: mise run //tools/build_and_test:xvfb
+      - name: Build and Test
+        # TURBO_FORCE carries the deflake input through env (never `${{ }}`
+        # in run lines); turbo parses ""/"false" as cache-respecting.
+        # Exact complement of the ci_main step below: one of the two runs.
+        if: ${{ !((github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'workflow_dispatch' && inputs.mainGraph)) }}
+        run: mise run ci
+        env:
+          TURBO_FORCE: ${{ inputs.force }}
+          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+          TURBO_API: ${{ vars.TURBO_API }}
+          TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+          # Silence per-request [wrangler:info] logging from the e2e dev server.
+          WRANGLER_LOG: warn
+          # Cypress video off in CI (configs keep video:true for local runs);
+          # the cypressVideo dispatch input re-enables it for debugging.
+          CYPRESS_video: ${{ inputs.cypressVideo == true }}
+      - name: Build and Test (main)
+        # ci:main = the PR graph plus the main-only guards (check:pack,
+        # dts-backtest full TS matrix) in one parallel turbo invocation; a
+        # failure fails this job, so the tag_push call job never runs.
+        # Future main-only guards join ci:main's dependsOn, not new steps.
+        # mainGraph dispatches run this graph too; tag_push stays push-only.
+        if: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'workflow_dispatch' && inputs.mainGraph) }}
+        run: mise run ci_main
+        env:
+          TURBO_FORCE: ${{ inputs.force }}
+          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+          TURBO_API: ${{ vars.TURBO_API }}
+          TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+          # Silence per-request [wrangler:info] logging from the e2e dev server.
+          WRANGLER_LOG: warn
+          # Cypress video off in CI (configs keep video:true for local runs);
+          # the cypressVideo dispatch input re-enables it for debugging.
+          CYPRESS_video: ${{ inputs.cypressVideo == true }}
+      - name: Upload Codecov bundle stats
+        run: mise run codecov_bundle
+        env:
+          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+          TURBO_API: ${{ vars.TURBO_API }}
+          TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      - name: Upload Cypress videos
+        # Videos exist only when the dispatch input turned recording on;
+        # !cancelled() keeps videos from failed suites — the debugging case.
+        # An early failure before Cypress leaves no files, hence warn.
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.cypressVideo && !cancelled() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: cypress-videos
+          path: apps/sample-app-lit-e2e/cypress/videos*/
+          retention-days: 5
+          if-no-files-found: warn
+      - name: Upload to Codecov
+        # Branch-head runs skip upload; merge-head/main covers the same SHA.
+        if: ${{ github.event_name != 'push' || github.ref == 'refs/heads/main' }}
+        uses: codecov/codecov-action@v7
+        with:
+          files: packages/lit-ui-router/coverage/lcov.info,packages/lit-ui-router/coverage/coverage-final.json,packages/lit-ui-router-mobx/coverage/lcov.info,packages/lit-ui-router-mobx/coverage/coverage-final.json,packages/navigation-location-plugin/coverage/lcov.info,packages/navigation-location-plugin/coverage/coverage-final.json
+          disable_search: true
+          plugins: noop
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/build-test-run.yml
+++ b/.github/workflows/build-test-run.yml
@@ -38,9 +38,9 @@ env:
   HUSKY: 0
 
 jobs:
-  # Named for the role the check plays, not the steps it runs: the composite
-  # `build_and_test / merge_gate` is the required status check for merging.
-  merge_gate:
+  # Named for what it does, not for the role one of its callers plays: the
+  # UI's own "Required" badge already says which composite gates merging.
+  run:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,24 +1,19 @@
-# CI pipeline for pull requests and branch/main pushes.
+# CI pipeline for pull requests, main pushes and dispatches.
 # Runs build, tests (Vitest + Playwright + Cypress), and Codecov upload.
 #
-# The body lives in build-test-run.yml; this file is the trigger surface, the
-# branch-head gate, and two caller jobs. Two callers rather than one job with a
-# conditional name: a skipped job renders its `name:` expression source
-# verbatim, and the branch caller's normal outcome is to skip.
+# Branch-head pushes are handled by build-test-branch.yml instead. Splitting by
+# trigger keeps each event from instantiating the other's jobs, and it is what
+# makes the required context `build_and_test / run` trustworthy: no push to a
+# topic branch ever runs this file, so no push can emit that name. GitHub counts
+# a SKIPPED required check as PASSING, so a shared file that merely suppressed
+# this job on branch pushes would not be enough.
 name: Build and Test
 
 on:
   pull_request:
   push:
     branches:
-      # Branch-head runs are the fallback for SHAs no pull_request run covers:
-      # a CONFLICTING PR has no merge ref, and a branch with no PR yet fires
-      # nothing at all. The branch_gate job below decides which pushes those
-      # are; the rest skip as a duplicate of the merge-head run.
-      - '**'
-      # Dependabot push events get dependabot secrets (no TURBO_TOKEN); its
-      # PRs already get merge-head CI.
-      - '!dependabot/**'
+      - main
   workflow_dispatch:
     inputs:
       force:
@@ -35,83 +30,20 @@ on:
         type: boolean
         default: false
 
-# Standard husky CI setup: skip the prepare-script git-hook install on CI installs.
-env:
-  HUSKY: 0
-
 # Cancel superseded runs per event per ref; never cancel main runs.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
-  branch_gate:
-    # Branch-head pushes duplicate the merge-head pull_request run whenever the
-    # PR is mergeable — both race for the same turbo cache entries. This job
-    # runs only for those pushes and answers whether pull_request will cover
-    # this SHA at all; its `run` output gates build_and_test_branch below.
-    # Imports nothing from node_modules, so no `mise run setup` step: paying
-    # for an install here would cost more than it saves on the pushes it can't
-    # skip. gh is preinstalled on the runner image.
-    # "signal gate", not "branch gate": it decides whether this push emits a
-    # signal at all, and no longer sits one word from build_and_test (branch).
-    name: build_and_test (signal gate)
-    if: ${{ github.event_name == 'push' && github.ref != 'refs/heads/main' }}
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    permissions:
-      contents: read
-      pull-requests: read
-    outputs:
-      run: ${{ steps.gate.outputs.run }}
-    steps:
-      - name: 'Checkout code'
-        uses: actions/checkout@v7
-        with:
-          persist-credentials: false
-          # git merge-tree needs real merge bases; a shallow clone has none.
-          fetch-depth: 0
-      - name: Setup mise
-        uses: jdx/mise-action@v4
-      - name: Decide whether this push needs its own run
-        id: gate
-        run: mise run //tools/build_and_test:branch_ci_gate
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
   build_and_test:
-    # Serves pull requests, main pushes and dispatches. Reports the composite
-    # check `build_and_test / run`, which is the required status check for
-    # merging — a name branch-head pushes can never emit, because they run
-    # build_and_test_branch instead. That exclusivity is the whole guard:
-    # GitHub counts a SKIPPED required check as passing, so merely suppressing
-    # a job on push events would not be enough.
+    # Reports the composite `build_and_test / run` — the required status check.
+    # A caller emits its composite name ONLY when it runs; skipping collapses it
+    # to the bare caller name, so the required context cannot be satisfied by a
+    # skip. That also blocks fork PRs, which skip below to protect secrets:
+    # they report a bare `build_and_test` and the required context stays absent.
     name: build_and_test
-    if: >-
-      ${{ (github.event_name != 'push' || github.ref == 'refs/heads/main')
-      && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
-    permissions:
-      contents: read
-    uses: ./.github/workflows/build-test-run.yml
-    with:
-      force: ${{ inputs.force || false }}
-      mainGraph: ${{ inputs.mainGraph || false }}
-      cypressVideo: ${{ inputs.cypressVideo || false }}
-    secrets:
-      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-
-  build_and_test_branch:
-    # The branch-head fallback, running the same body under a distinct check
-    # name. `branch_gate` is 'failure' if the gate itself broke — that means
-    # run, since the gate must never become a way to lose CI. `!cancelled()`
-    # is required for the `if` to evaluate at all once a `needs` job can skip.
-    name: build_and_test (branch)
-    needs: branch_gate
-    if: >-
-      ${{ !cancelled()
-      && github.event_name == 'push' && github.ref != 'refs/heads/main'
-      && (needs.branch_gate.result != 'success' || needs.branch_gate.outputs.run == 'true') }}
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     permissions:
       contents: read
     uses: ./.github/workflows/build-test-run.yml

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -53,7 +53,9 @@ jobs:
     # Imports nothing from node_modules, so no `mise run setup` step: paying
     # for an install here would cost more than it saves on the pushes it can't
     # skip. gh is preinstalled on the runner image.
-    name: build_and_test (branch gate)
+    # "signal gate", not "branch gate": it decides whether this push emits a
+    # signal at all, and reads as a distinct verb next to merge_gate below.
+    name: build_and_test (signal gate)
     if: ${{ github.event_name == 'push' && github.ref != 'refs/heads/main' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -54,7 +54,7 @@ jobs:
     # for an install here would cost more than it saves on the pushes it can't
     # skip. gh is preinstalled on the runner image.
     # "signal gate", not "branch gate": it decides whether this push emits a
-    # signal at all, and reads as a distinct verb next to merge_gate below.
+    # signal at all, and no longer sits one word from build_and_test (branch).
     name: build_and_test (signal gate)
     if: ${{ github.event_name == 'push' && github.ref != 'refs/heads/main' }}
     runs-on: ubuntu-latest
@@ -81,8 +81,8 @@ jobs:
 
   build_and_test:
     # Serves pull requests, main pushes and dispatches. Reports the composite
-    # check `build_and_test / merge_gate`, which is the required status check
-    # for merging — a name branch-head pushes can never emit, because they run
+    # check `build_and_test / run`, which is the required status check for
+    # merging — a name branch-head pushes can never emit, because they run
     # build_and_test_branch instead. That exclusivity is the whole guard:
     # GitHub counts a SKIPPED required check as passing, so merely suppressing
     # a job on push events would not be enough.

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,5 +1,10 @@
 # CI pipeline for pull requests and branch/main pushes.
 # Runs build, tests (Vitest + Playwright + Cypress), and Codecov upload.
+#
+# The body lives in build-test-run.yml; this file is the trigger surface, the
+# branch-head gate, and two caller jobs. Two callers rather than one job with a
+# conditional name: a skipped job renders its `name:` expression source
+# verbatim, and the branch caller's normal outcome is to skip.
 name: Build and Test
 
 on:
@@ -44,7 +49,7 @@ jobs:
     # Branch-head pushes duplicate the merge-head pull_request run whenever the
     # PR is mergeable — both race for the same turbo cache entries. This job
     # runs only for those pushes and answers whether pull_request will cover
-    # this SHA at all; its `run` output gates build_and_test below.
+    # this SHA at all; its `run` output gates build_and_test_branch below.
     # Imports nothing from node_modules, so no `mise run setup` step: paying
     # for an install here would cost more than it saves on the pushes it can't
     # skip. gh is preinstalled on the runner image.
@@ -57,12 +62,6 @@ jobs:
       pull-requests: read
     outputs:
       run: ${{ steps.gate.outputs.run }}
-      # The check-name suffix for the runs this job guards. GitHub evaluates a
-      # job's `name:` only when the job starts and prints the expression source
-      # verbatim when it skips — which is now the common case — so the name is
-      # sourced from here to keep that printed form short and to keep it
-      # starting with the real job name.
-      suffix: ' (branch)'
     steps:
       - name: 'Checkout code'
         uses: actions/checkout@v7
@@ -79,142 +78,48 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   build_and_test:
-    needs: branch_gate
-    # Branch-head (push) runs report under a distinct check name so they can
-    # never satisfy the required "build_and_test" merge gate. That gate can only
-    # be trusted if a push run never emits the name at all: GitHub counts a
-    # SKIPPED required check as passing, so suppressing the job is not enough.
-    # branch_gate is skipped on every other path, leaving the suffix empty.
-    name: build_and_test${{ needs.branch_gate.outputs.suffix }}
-    # First clause: branch_gate is 'skipped' on every path it doesn't guard
-    # (pull_request, main pushes, dispatch) and 'failure' if the gate itself
-    # broke — both mean run. Only a successful gate saying `run=false` skips.
-    # `!cancelled()` is required for the `if` to evaluate at all once a `needs`
-    # job can be skipped.
-    # Second clause: only run on first-party PRs (not forks) to protect
-    # secrets. Fork PRs don't have access to secrets, so they would fail
-    # anyway. Maintainers should review fork PRs and run CI manually.
+    # Serves pull requests, main pushes and dispatches. Reports the composite
+    # check `build_and_test / merge_gate`, which is the required status check
+    # for merging — a name branch-head pushes can never emit, because they run
+    # build_and_test_branch instead. That exclusivity is the whole guard:
+    # GitHub counts a SKIPPED required check as passing, so merely suppressing
+    # a job on push events would not be enough.
+    name: build_and_test
     if: >-
-      ${{ !cancelled()
-      && (needs.branch_gate.result != 'success' || needs.branch_gate.outputs.run == 'true')
+      ${{ (github.event_name != 'push' || github.ref == 'refs/heads/main')
       && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
     permissions:
       contents: read
+    uses: ./.github/workflows/build-test-run.yml
+    with:
+      force: ${{ inputs.force || false }}
+      mainGraph: ${{ inputs.mainGraph || false }}
+      cypressVideo: ${{ inputs.cypressVideo || false }}
+    secrets:
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
-    steps:
-      - name: 'Checkout code'
-        uses: actions/checkout@v7
-        with:
-          persist-credentials: false
-      - name: Setup mise
-        uses: jdx/mise-action@v4
-      - name: Install dependencies
-        run: mise run setup
-      - name: Resolve Playwright version
-        # Cache keys derive from the installed packages, so they bust exactly
-        # on a version bump and nothing else; one step per tool keeps the two
-        # caches independent.
-        id: playwright-version
-        run: mise run //tools/build_and_test:playwright_version
-      - name: Resolve Cypress version
-        id: cypress-version
-        run: mise run //tools/build_and_test:cypress_version
-      - name: Cache Playwright browsers
-        id: playwright-cache
-        uses: actions/cache@v6
-        with:
-          path: ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.playwright }}
-      - name: Cache Cypress binary
-        uses: actions/cache@v6
-        with:
-          path: ~/.cache/Cypress
-          key: ${{ runner.os }}-cypress-${{ steps.cypress-version.outputs.cypress }}
-      - name: Install Playwright Browsers
-        if: ${{ steps.playwright-cache.outputs.cache-hit != 'true' }}
-        run: mise run //tools/build_and_test:playwright
-      - name: Install Playwright OS deps (firefox+webkit)
-        # Browsers came from the cache; only test:engines (main graph) needs
-        # the firefox+webkit apt libs — the PR graph is chromium-only, and
-        # chromium and Cypress ride the runner image's preinstalled set.
-        if: ${{ steps.playwright-cache.outputs.cache-hit == 'true' && ((github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'workflow_dispatch' && inputs.mainGraph)) }}
-        run: mise run //tools/build_and_test:playwright_deps_engines
-      - name: Install Cypress
-        # `cypress install` is a near-no-op when the binary is cached; verify
-        # still runs so the concurrent suites skip the first-use banner.
-        run: mise run //tools/build_and_test:cypress
-      - name: Start shared Xvfb display
-        # The vanilla and MobX Cypress suites run concurrently. Without a
-        # DISPLAY, each Cypress process spawns its own Xvfb and the spawns
-        # race ("Fatal server error"); one shared display serves both.
-        # https://docs.cypress.io/app/continuous-integration/overview#Xvfb
-        # The task captures Xvfb's stderr (routine xkbcomp keysym noise on
-        # the runner image) and prints it, filtered, only on startup failure.
-        run: mise run //tools/build_and_test:xvfb
-      - name: Build and Test
-        # TURBO_FORCE carries the deflake input through env (never `${{ }}`
-        # in run lines); turbo parses ""/"false" as cache-respecting.
-        # Exact complement of the ci_main step below: one of the two runs.
-        if: ${{ !((github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'workflow_dispatch' && inputs.mainGraph)) }}
-        run: mise run ci
-        env:
-          TURBO_FORCE: ${{ inputs.force }}
-          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-          TURBO_API: ${{ vars.TURBO_API }}
-          TURBO_TEAM: ${{ vars.TURBO_TEAM }}
-          # Silence per-request [wrangler:info] logging from the e2e dev server.
-          WRANGLER_LOG: warn
-          # Cypress video off in CI (configs keep video:true for local runs);
-          # the cypressVideo dispatch input re-enables it for debugging.
-          CYPRESS_video: ${{ inputs.cypressVideo == true }}
-      - name: Build and Test (main)
-        # ci:main = the PR graph plus the main-only guards (check:pack,
-        # dts-backtest full TS matrix) in one parallel turbo invocation; a
-        # failure fails build_and_test, so the tag_push call job never runs.
-        # Future main-only guards join ci:main's dependsOn, not new steps.
-        # mainGraph dispatches run this graph too; tag_push stays push-only.
-        if: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'workflow_dispatch' && inputs.mainGraph) }}
-        run: mise run ci_main
-        env:
-          TURBO_FORCE: ${{ inputs.force }}
-          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-          TURBO_API: ${{ vars.TURBO_API }}
-          TURBO_TEAM: ${{ vars.TURBO_TEAM }}
-          # Silence per-request [wrangler:info] logging from the e2e dev server.
-          WRANGLER_LOG: warn
-          # Cypress video off in CI (configs keep video:true for local runs);
-          # the cypressVideo dispatch input re-enables it for debugging.
-          CYPRESS_video: ${{ inputs.cypressVideo == true }}
-      - name: Upload Codecov bundle stats
-        run: mise run codecov_bundle
-        env:
-          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-          TURBO_API: ${{ vars.TURBO_API }}
-          TURBO_TEAM: ${{ vars.TURBO_TEAM }}
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-      - name: Upload Cypress videos
-        # Videos exist only when the dispatch input turned recording on;
-        # !cancelled() keeps videos from failed suites — the debugging case.
-        # An early failure before Cypress leaves no files, hence warn.
-        if: ${{ github.event_name == 'workflow_dispatch' && inputs.cypressVideo && !cancelled() }}
-        uses: actions/upload-artifact@v7
-        with:
-          name: cypress-videos
-          path: apps/sample-app-lit-e2e/cypress/videos*/
-          retention-days: 5
-          if-no-files-found: warn
-      - name: Upload to Codecov
-        # Branch-head runs skip upload; merge-head/main covers the same SHA.
-        if: ${{ github.event_name != 'push' || github.ref == 'refs/heads/main' }}
-        uses: codecov/codecov-action@v7
-        with:
-          files: packages/lit-ui-router/coverage/lcov.info,packages/lit-ui-router/coverage/coverage-final.json,packages/lit-ui-router-mobx/coverage/lcov.info,packages/lit-ui-router-mobx/coverage/coverage-final.json,packages/navigation-location-plugin/coverage/lcov.info,packages/navigation-location-plugin/coverage/coverage-final.json
-          disable_search: true
-          plugins: noop
-          fail_ci_if_error: false
-          token: ${{ secrets.CODECOV_TOKEN }}
+  build_and_test_branch:
+    # The branch-head fallback, running the same body under a distinct check
+    # name. `branch_gate` is 'failure' if the gate itself broke — that means
+    # run, since the gate must never become a way to lose CI. `!cancelled()`
+    # is required for the `if` to evaluate at all once a `needs` job can skip.
+    name: build_and_test (branch)
+    needs: branch_gate
+    if: >-
+      ${{ !cancelled()
+      && github.event_name == 'push' && github.ref != 'refs/heads/main'
+      && (needs.branch_gate.result != 'success' || needs.branch_gate.outputs.run == 'true') }}
+    permissions:
+      contents: read
+    uses: ./.github/workflows/build-test-run.yml
+    with:
+      force: ${{ inputs.force || false }}
+      mainGraph: ${{ inputs.mainGraph || false }}
+      cypressVideo: ${{ inputs.cypressVideo || false }}
+    secrets:
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   tag_push:
     # Gated tagging: rides the same run as main CI, so a red build_and_test


### PR DESCRIPTION
Stacked on #458 — base is that branch, so this can merge separately or as a unit with it.

## Why

A job's `name:` is evaluated only when the job *starts*. A skipped job renders the expression source verbatim. #458's gate makes skipping the normal outcome for branch-head pushes, so the conditional name started surfacing in every PR's check list as a truncated `github.event_name == 'push' && github.ref != ...` row. Check runs are keyed to the head SHA, so a push run's checks appear on the PR — there is no view that hides them.

Two static names require two jobs, and two jobs can't share a body inside one file. Hence the split.

## What

- `build-test-run.yml` — the build/test steps, as `workflow_call`. The `github` context in a called workflow still describes the original triggering event, so every step-level `if` is unchanged. `HUSKY=0` is re-declared here because caller-level `env` does not reach a called workflow.
- `build-test.yml` — trigger surface, `branch_gate`, `tag_push`, and two caller jobs with static names: `build_and_test` (pull requests, main pushes, dispatches) and `build_and_test (branch)` (the gated branch-head fallback).

The dynamic name and the comment explaining it are both gone.

## Required status check must be repointed (ruleset, not branch protection)

`build_and_test` → **`build_and_test / run`**

Classic branch protection is not in use here (`/branches/main/protection` 404s). The gate lives in ruleset **`main`** (id `6938828`), whose required contexts are currently `["build_and_test", "Workers Builds: lit-ui-router"]`.

```bash
gh api repos/simshanith/lit-ui-router/rulesets/6938828 > /tmp/rs.json
jq '{rules: (.rules | map(
      if .type == "required_status_checks"
      then .parameters.required_status_checks |= map(
             if .context == "build_and_test"
             then .context = "build_and_test / run" else . end)
      else . end))}' /tmp/rs.json > /tmp/rs-patch.json
gh api -X PUT repos/simshanith/lit-ui-router/rulesets/6938828 --input /tmp/rs-patch.json \
  --jq '[.rules[] | select(.type=="required_status_checks") | .parameters.required_status_checks[].context]'
```

This is required for correctness, not cosmetics. Verified on `298ca5f` (push, no PR):

```
build_and_test                          skipped
build_and_test (branch gate)            success
build_and_test (branch) / run    success
tag_push                                skipped
```

A skipped caller emits only `build_and_test` — never the composite. So `build_and_test / run` cannot be emitted by a push run, which is what makes it a real gate: GitHub counts a **skipped** required check as passing, so suppressing a job on push events is not sufficient protection.

The corollary is the merge hazard. That skipped `build_and_test` row is new; today branch pushes never emit the bare name. Merging while the ruleset still requires `build_and_test` would let a push run satisfy the gate having run no CI. The two requirements also cannot overlap — after merge, PR runs emit only the composite, so leaving the old name required blocks every PR. **Merge and repoint in the same sitting.**

## Verification

- `mise run lint_workflows` clean (actionlint, zizmor, taplo, shellcheck).
- Branch-push-without-PR path exercised live: gate chose RUN, `build_and_test (branch) / run` went green, all names rendered statically.

## Closes a pre-existing fork-PR hole

Fork PRs skip the build job to protect secrets. Today that job's name evaluates to plain `build_and_test`, so the fork PR emits a **skipped check under the required context** — and GitHub counts skipped as passing. A fork PR can therefore satisfy the required check having run no CI at all.

After this change a fork PR emits only skipped `build_and_test`, never the composite, so `build_and_test / run` is simply absent and the PR is correctly blocked until a maintainer runs CI.

This follows from two separately verified facts — skipped jobs do emit check runs, and skipped required checks count as passing — rather than from an attempted fork merge.

## Job / check name matrix

| check name | PR (same-repo) | PR (fork) | push branch, gate=RUN | push branch, gate=SKIP | push main | dispatch |
| --- | --- | --- | --- | --- | --- | --- |
| `build_and_test (signal gate)` | skip | skip | ✅ | ✅ | skip | skip |
| `build_and_test / run` | ✅ | — | — | — | ✅ | ✅ |
| `build_and_test` | — | skip | skip | skip | — | — |
| `build_and_test (branch) / run` | — | — | ✅ | — | — | — |
| `build_and_test (branch)` | skip | skip | — | skip | skip | skip |
| `tag_push / publish_gh` | — | — | — | — | ✅ | — |
| `tag_push` | skip | skip | skip | skip | — | skip |

A dash means the name is not emitted at all — the row is absent, not gray. A caller emits its composite name only when it runs; skipping collapses it to the bare caller name, which is what makes the required context unforgeable by a push run.

The gate job is named `build_and_test (signal gate)`: it decides whether this push emits a signal at all, a distinct verb from `run`, and it no longer sits one word from `build_and_test (branch)`.
