### PR TITLE
ci(build-test): opt into the main graph by branch prefix

### DIFF
--- a/.github/workflows/build-test-branch.yml
+++ b/.github/workflows/build-test-branch.yml
@@ -1,4 +1,6 @@
-# Branch-head CI: the fallback for SHAs that no pull_request run covers.
+# Branch-head CI: the fallback for SHAs that no pull_request run covers, and
+# the opt-in path for the main graph — a `ci-main/` branch builds `ci:main` on
+# every push, smoke-testing the main-only guards before merge rather than after.
 #
 # Split from build-test.yml by trigger so neither file instantiates the other's
 # jobs. That is what keeps the required context `build_and_test / run`
@@ -40,6 +42,7 @@ jobs:
       pull-requests: read
     outputs:
       run: ${{ steps.gate.outputs.run }}
+      mainGraph: ${{ steps.gate.outputs.mainGraph }}
     steps:
       - name: 'Checkout code'
         uses: actions/checkout@v7
@@ -60,6 +63,9 @@ jobs:
     # since the gate must never become a way to lose CI. `!cancelled()` is
     # required for the `if` to evaluate at all once a `needs` job can skip.
     # The dispatch-only debugging inputs are left at their defaults here.
+    #
+    # A `ci-main/` branch needs no extra term here: the gate answers `run=true`
+    # for the opt-in itself, so the prefix lives in exactly one place.
     name: build_and_test (branch)
     needs: signal_gate
     if: >-
@@ -68,6 +74,11 @@ jobs:
     permissions:
       contents: read
     uses: ./.github/workflows/build-test-run.yml
+    with:
+      # Only a `ci-main/` branch sets this. A job-level failure that never
+      # reached the gate leaves it empty, i.e. the PR graph — the run still
+      # happens, it is just the smaller one.
+      mainGraph: ${{ needs.signal_gate.outputs.mainGraph == 'true' }}
     secrets:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/build-test-run.yml
+++ b/.github/workflows/build-test-run.yml
@@ -17,8 +17,11 @@ on:
         description: 'Bypass turbo cache (deflake reproduction: rebuild/retest everything)'
         type: boolean
         default: false
+      # Which graph to build. Callers decide: each knows its own event, and a
+      # branch push can opt in too (see build-test-branch.yml), so sniffing the
+      # event here would be answering a question only the caller can.
       mainGraph:
-        description: 'Run the ci:main superset (main-only guards included)'
+        description: 'Run the ci:main superset (main-only guards included) instead of the PR graph'
         type: boolean
         default: false
       cypressVideo:
@@ -82,7 +85,7 @@ jobs:
         # Browsers came from the cache; only test:engines (main graph) needs
         # the firefox+webkit apt libs — the PR graph is chromium-only, and
         # chromium and Cypress ride the runner image's preinstalled set.
-        if: ${{ steps.playwright-cache.outputs.cache-hit == 'true' && ((github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'workflow_dispatch' && inputs.mainGraph)) }}
+        if: ${{ steps.playwright-cache.outputs.cache-hit == 'true' && inputs.mainGraph }}
         run: mise run //tools/build_and_test:playwright_deps_engines
       - name: Install Cypress
         # `cypress install` is a near-no-op when the binary is cached; verify
@@ -100,7 +103,7 @@ jobs:
         # TURBO_FORCE carries the deflake input through env (never `${{ }}`
         # in run lines); turbo parses ""/"false" as cache-respecting.
         # Exact complement of the ci_main step below: one of the two runs.
-        if: ${{ !((github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'workflow_dispatch' && inputs.mainGraph)) }}
+        if: ${{ !inputs.mainGraph }}
         run: mise run ci
         env:
           TURBO_FORCE: ${{ inputs.force }}
@@ -117,8 +120,9 @@ jobs:
         # dts-backtest full TS matrix) in one parallel turbo invocation; a
         # failure fails this job, so the tag_push call job never runs.
         # Future main-only guards join ci:main's dependsOn, not new steps.
-        # mainGraph dispatches run this graph too; tag_push stays push-only.
-        if: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'workflow_dispatch' && inputs.mainGraph) }}
+        # Main pushes, mainGraph dispatches and ci-main/ branches all land here;
+        # tag_push stays push-only, so none of the others can tag.
+        if: ${{ inputs.mainGraph }}
         run: mise run ci_main
         env:
           TURBO_FORCE: ${{ inputs.force }}
@@ -138,10 +142,11 @@ jobs:
           TURBO_TEAM: ${{ vars.TURBO_TEAM }}
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       - name: Upload Cypress videos
-        # Videos exist only when the dispatch input turned recording on;
+        # Videos exist only when the dispatch input turned recording on — no
+        # other caller passes cypressVideo, so the input alone is the condition.
         # !cancelled() keeps videos from failed suites — the debugging case.
         # An early failure before Cypress leaves no files, hence warn.
-        if: ${{ github.event_name == 'workflow_dispatch' && inputs.cypressVideo && !cancelled() }}
+        if: ${{ inputs.cypressVideo && !cancelled() }}
         uses: actions/upload-artifact@v7
         with:
           name: cypress-videos

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -49,7 +49,9 @@ jobs:
     uses: ./.github/workflows/build-test-run.yml
     with:
       force: ${{ inputs.force || false }}
-      mainGraph: ${{ inputs.mainGraph || false }}
+      # Main pushes build the superset; the dispatch input asks for it against
+      # any ref. `inputs` is null on pull_request, so PRs get the PR graph.
+      mainGraph: ${{ inputs.mainGraph || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
       cypressVideo: ${{ inputs.cypressVideo || false }}
     secrets:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -82,8 +82,11 @@ Pushes to `main` run the same graph plus the main-only guards (turbo
 pack-surface manifest check (`check:pack`), and the full dts-backtest
 TypeScript matrix. A green main run then calls the Tag & push workflow — a
 red run means no tag, hence no publish. Manual dispatch can run the
-`ci:main` graph on demand via the `mainGraph` input (combine with `force`
-to deflake the full main graph); tagging stays push-only.
+`ci:main` graph on demand against any ref via the `mainGraph` input
+(combine with `force` to deflake the full main graph), and a branch named
+`ci-main/<topic>` builds it on every push — so the guards that gate a
+release can be smoke-tested before merge. Tagging stays push-to-`main`
+only, so neither path can release.
 
 **Security:** Only runs on first-party PRs (not forks) to protect secrets.
 

--- a/TURBO.md
+++ b/TURBO.md
@@ -198,11 +198,20 @@ The GitHub Actions workflow (`.github/workflows/build-test.yml`) runs the CI pip
 1. **Checkout** - Clone repository
 2. **Setup** - mise installs Node.js (version pinned in `.nvmrc`) and corepack; `mise run setup` corepack-installs the `packageManager`-pinned pnpm, then installs dependencies
 3. **Install browsers** - Playwright and Cypress for e2e tests, restored from `actions/cache` keyed on the installed package versions
-4. **Build and Test** - PRs and branch pushes run `mise run ci` (turbo `ci:pull_request`); main pushes run `mise run ci_main` (turbo `ci:main`, adding the main-only guards)
+4. **Build and Test** - PRs and branch pushes run `mise run ci` (turbo `ci:pull_request`); main pushes, `mainGraph` dispatches and `ci-main/` branches run `mise run ci_main` (turbo `ci:main`, adding the main-only guards)
 5. **Coverage reports** - Vitest coverage for PR comments, Codecov upload
 6. **Tag** (main pushes only) - a green run calls the Tag & push workflow, so release tags fire only after green main CI
 
-Manual dispatch of the workflow has two deflake inputs: `force` (`TURBO_FORCE`) bypasses the turbo cache, and `mainGraph` runs the `ci:main` superset on demand — combine them to deflake the full main graph without pushing a commit (tagging stays push-only). CI also sets `CYPRESS_video: 'false'` (passed through un-hashed, so it never affects cache validity); local runs keep video recording.
+Manual dispatch of the workflow has two deflake inputs: `force` (`TURBO_FORCE`) bypasses the turbo cache, and `mainGraph` runs the `ci:main` superset on demand — combine them to deflake the full main graph without pushing a commit (tagging stays push-only). Dispatch takes a ref, so this is also how you run the main graph against an arbitrary branch. CI also sets `CYPRESS_video: 'false'` (passed through un-hashed, so it never affects cache validity); local runs keep video recording.
+
+#### Smoke-testing the main graph before merge
+
+The main-only guards (`test:engines`, `check:pack`, the full `dts-backtest` matrix) run after merge, so a break in them surfaces on main rather than on the PR. Two ways to pull that signal forward:
+
+- **Per run** — dispatch **Build and Test** with `mainGraph: true` and pick the branch as the ref. Nothing needs to be pushed, and the branch needs no PR.
+- **Per branch** — name the branch `ci-main/<topic>`. Every push to it builds `ci:main` instead of the PR graph, and it runs even when the branch merges cleanly (a `pull_request` run would only cover the PR graph). The prefix is the whole opt-in; there is no other flag.
+
+The prefix affects the graph only. Tagging and publishing stay bound to pushes to `main`, so a `ci-main/` branch can never release.
 
 ### CI Environment Variables
 
@@ -224,7 +233,7 @@ TURBO_TEAM: ${{ vars.TURBO_TEAM }} # Team identifier
 | `format:check`                    | `ci:pull_request`                                                                         |
 | `check:bundle`, `codecov:bundle`  | `ci:pull_request`                                                                         |
 | `test:engines`                    | `ci:main` only — Firefox + WebKit vitest pass (lit-ui-router, navigation-location-plugin) |
-| `@tools/release#check:pack`       | `ci:main` only (main pushes)                                                              |
+| `@tools/release#check:pack`       | `ci:main` only                                                                            |
 | `@tools/dts-backtest#test:matrix` | `ci:main` only; PRs run the current-TS `#test` leg                                        |
 | `typecheck:peer-floor`            | Neither ci graph — Release signals check runs + bump gate                                 |
 

--- a/tools/build_and_test/src/branch-ci-gate.core.ts
+++ b/tools/build_and_test/src/branch-ci-gate.core.ts
@@ -22,7 +22,19 @@ export type BaseVerdict = {
   detail?: string;
 };
 
-export type Decision = { run: boolean; reason: string };
+export type Decision = { run: boolean; reason: string; mainGraph: boolean };
+
+/**
+ * Branch-name prefix that opts a push into the `ci:main` superset — the
+ * main-only guards a pull_request run never covers, smoke-tested before merge
+ * rather than after. Named for the task it selects (`mise run ci_main`).
+ */
+export const MAIN_GRAPH_PREFIX = 'ci-main/';
+
+/** Whether this branch name opts into the main graph. */
+export function wantsMainGraph(branch: string): boolean {
+  return branch.startsWith(MAIN_GRAPH_PREFIX);
+}
 
 /**
  * Validate `gh pr list --json number,baseRefName` output. Throws on any shape
@@ -95,10 +107,22 @@ function listBases(verdicts: readonly BaseVerdict[]): string {
 export function decide(
   prs: readonly OpenPr[],
   verdicts: readonly BaseVerdict[],
+  mainGraph = false,
 ): Decision {
+  // Checked before mergeability, because this is the one case where a branch a
+  // pull_request run *does* cover still needs its own: that run builds the PR
+  // graph, and the main-only guards are exactly what the opt-in asked for.
+  if (mainGraph) {
+    return {
+      run: true,
+      mainGraph,
+      reason: `\`${MAIN_GRAPH_PREFIX}\` branch prefix — running ci:main`,
+    };
+  }
   if (prs.length === 0) {
     return {
       run: true,
+      mainGraph,
       reason:
         'no open PR has this branch as its head — no pull_request run will cover this push',
     };
@@ -106,6 +130,7 @@ export function decide(
   if (verdicts.length === 0) {
     return {
       run: true,
+      mainGraph,
       reason: `${prs.length} open PR(s) but no merge probe ran — running rather than assume coverage`,
     };
   }
@@ -115,6 +140,7 @@ export function decide(
   if (conflicting.length > 0) {
     return {
       run: true,
+      mainGraph,
       reason: `conflicts with ${listBases(conflicting)} — GitHub builds no merge ref, so the pull_request run is skipped`,
     };
   }
@@ -124,11 +150,13 @@ export function decide(
   if (indeterminate.length > 0) {
     return {
       run: true,
+      mainGraph,
       reason: `mergeability with ${listBases(indeterminate)} is indeterminate — running rather than risk dropping the only signal`,
     };
   }
   return {
     run: false,
+    mainGraph,
     reason: `mergeable with ${listBases(verdicts)} — the merge-head pull_request run already covers this SHA`,
   };
 }
@@ -167,6 +195,12 @@ export function summaryMarkdown({
     decision.reason,
     '',
   ];
+  if (decision.run) {
+    lines.push(
+      `Graph: \`${decision.mainGraph ? 'ci:main' : 'ci:pull_request'}\``,
+      '',
+    );
+  }
   if (prs.length === 0) {
     lines.push('No open pull requests have this branch as their head.');
   } else {

--- a/tools/build_and_test/src/branch-ci-gate.test.ts
+++ b/tools/build_and_test/src/branch-ci-gate.test.ts
@@ -10,6 +10,7 @@ import {
   mergeStateFromExit,
   parseOpenPrs,
   summaryMarkdown,
+  wantsMainGraph,
 } from './branch-ci-gate.core.ts';
 
 const PR_ONE: OpenPr = { number: 1, baseRefName: 'main' };
@@ -99,6 +100,24 @@ describe('mergeStateFromExit', () => {
   });
 });
 
+describe('wantsMainGraph', () => {
+  it('opts in on the ci-main/ prefix', () => {
+    assert.equal(wantsMainGraph('ci-main/smoke-the-guards'), true);
+    assert.equal(wantsMainGraph('ci-main/nested/topic'), true);
+  });
+
+  it('requires the separator, so ci-main-ish names do not opt in', () => {
+    assert.equal(wantsMainGraph('ci-main'), false);
+    assert.equal(wantsMainGraph('ci-maintenance'), false);
+  });
+
+  it('anchors at the start — the prefix is not a substring match', () => {
+    assert.equal(wantsMainGraph('feat/ci-main/thing'), false);
+    assert.equal(wantsMainGraph('main'), false);
+    assert.equal(wantsMainGraph(''), false);
+  });
+});
+
 describe('decide', () => {
   it('runs when no open PR has this branch as its head', () => {
     const decision = decide([], []);
@@ -158,6 +177,36 @@ describe('decide', () => {
     assert.equal(decision.run, true);
     assert.match(decision.reason, /no merge probe ran/);
   });
+
+  it('reports the PR graph unless the opt-in asked otherwise', () => {
+    assert.equal(decide([], []).mainGraph, false);
+    assert.equal(decide([PR_ONE], [verdict('main', 'clean')]).mainGraph, false);
+  });
+
+  it('runs the main graph on opt-in even when every base is mergeable', () => {
+    // The case the gate would otherwise skip: a pull_request run covers this
+    // SHA, but only with the PR graph, which is not what was asked for.
+    const decision = decide([PR_ONE], [verdict('main', 'clean')], true);
+    assert.equal(decision.run, true);
+    assert.equal(decision.mainGraph, true);
+    assert.match(decision.reason, /ci-main\//);
+    assert.match(decision.reason, /running ci:main/);
+  });
+
+  it('keeps the opt-in graph through every other run reason', () => {
+    for (const verdicts of [
+      [],
+      [verdict('main', 'conflict')],
+      [verdict('main', 'unknown')],
+    ]) {
+      const decision = decide([PR_ONE], verdicts, true);
+      assert.equal(decision.run, true);
+      assert.equal(decision.mainGraph, true);
+    }
+    const noPr = decide([], [], true);
+    assert.equal(noPr.run, true);
+    assert.equal(noPr.mainGraph, true);
+  });
 });
 
 describe('summaryMarkdown', () => {
@@ -167,8 +216,15 @@ describe('summaryMarkdown', () => {
     branch: string,
     prs: readonly OpenPr[],
     verdicts: readonly BaseVerdict[],
+    mainGraph = false,
   ): GateRun {
-    return { branch, sha, prs, verdicts, decision: decide(prs, verdicts) };
+    return {
+      branch,
+      sha,
+      prs,
+      verdicts,
+      decision: decide(prs, verdicts, mainGraph),
+    };
   }
 
   it('explains a skip with the bases it cleared', () => {
@@ -186,6 +242,26 @@ describe('summaryMarkdown', () => {
     );
     assert.match(markdown, /running/);
     assert.match(markdown, /CONFLICTS/);
+  });
+
+  it('names the graph a run will build', () => {
+    assert.match(
+      summaryMarkdown(gateRun('topic', [], [])),
+      /Graph: `ci:pull_request`/,
+    );
+    assert.match(
+      summaryMarkdown(
+        gateRun('ci-main/topic', [PR_ONE], [verdict('main', 'clean')], true),
+      ),
+      /Graph: `ci:main`/,
+    );
+  });
+
+  it('omits the graph on a skip — nothing gets built', () => {
+    assert.doesNotMatch(
+      summaryMarkdown(gateRun('topic', [PR_ONE], [verdict('main', 'clean')])),
+      /Graph:/,
+    );
   });
 
   it('states the no-PR case instead of an empty table', () => {

--- a/tools/build_and_test/src/branch-ci-gate.ts
+++ b/tools/build_and_test/src/branch-ci-gate.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
-// Decides whether a branch-head push needs its own CI run, exporting
-// `run=true|false` to GITHUB_OUTPUT for build-test.yml's build_and_test `if`.
+// Decides whether a branch-head push needs its own CI run, and which graph it
+// should build. Exports `run` and `mainGraph` to GITHUB_OUTPUT, which
+// build-test-branch.yml reads as its build job's `if` and `mainGraph` input.
 //
 // A mergeable branch with an open PR gets a merge-head pull_request run on the
 // same content, so the push run is a duplicate racing it for the same turbo
@@ -33,6 +34,7 @@ import {
   mergeStateFromExit,
   parseOpenPrs,
   summaryMarkdown,
+  wantsMainGraph,
 } from './branch-ci-gate.core.ts';
 
 const run = promisify(execFile);
@@ -125,7 +127,7 @@ async function main(): Promise<void> {
     sha: head,
     prs,
     verdicts,
-    decision: decide(prs, verdicts),
+    decision: decide(prs, verdicts, wantsMainGraph(branch)),
   });
 }
 
@@ -136,9 +138,9 @@ async function report(gate: GateRun): Promise<void> {
   // Both runner files are absent on a local `mise run`; print instead so a dry
   // local invocation still shows exactly what CI would export.
   const output = process.env.GITHUB_OUTPUT;
-  const line = `run=${decision.run}`;
-  if (output) await appendFile(output, `${line}\n`);
-  else console.log(line);
+  const lines = `run=${decision.run}\nmainGraph=${decision.mainGraph}\n`;
+  if (output) await appendFile(output, lines);
+  else process.stdout.write(lines);
 
   const summary = process.env.GITHUB_STEP_SUMMARY;
   const markdown = summaryMarkdown(gate);
@@ -153,7 +155,11 @@ main().catch(async (error: unknown) => {
   console.log(
     `::warning::branch CI gate failed, running CI anyway: ${message}`,
   );
+  // The opt-in survives here too: it is a string test on the ref name, so it
+  // cannot be what broke, and degrading it would silently run the smaller graph.
+  const mainGraph = wantsMainGraph(process.env.GITHUB_REF_NAME?.trim() ?? '');
   const output = process.env.GITHUB_OUTPUT;
-  if (output) await appendFile(output, 'run=true\n');
-  else console.log('run=true');
+  const lines = `run=true\nmainGraph=${mainGraph}\n`;
+  if (output) await appendFile(output, lines);
+  else process.stdout.write(lines);
 });


### PR DESCRIPTION
Stacked on #458 (base is its branch, not `main`).

## Why

The main-only guards — `test:engines`, `@tools/release#check:pack`, the full `dts-backtest` TypeScript matrix — run in `ci:main`, which only fires on pushes to `main`. So a break in them surfaces *after* merge, on main, rather than on the PR that caused it. This adds a way to pull that signal forward.

## Two paths

**Per run — already worked, now documented.** `workflow_dispatch` takes a ref, so **Build and Test** with `mainGraph: true` has always been able to run the main graph against an arbitrary branch. Nothing needed to change; it just wasn't written down. Verified live before touching anything (see below).

**Per branch — new.** A branch named `ci-main/<topic>` builds `ci:main` on every push. It runs *even when the branch merges cleanly*: the `pull_request` run that covers that SHA covers only the PR graph, which is precisely what the opt-in is asking past. The prefix is the entire opt-in — no input, no label, no commit trailer.

Tagging and publishing stay bound to pushes to `main`, so neither path can release.

## The refactor this required

`build-test-run.yml` was inferring the graph from `github.event_name`/`github.ref`. With a third caller that inference is no longer possible — and it was never really its question to answer, since each caller knows its own event. The graph choice moves to the callers and the shared body now keys purely on `inputs.mainGraph`:

| caller | `mainGraph` |
| --- | --- |
| `build-test.yml` (PR) | `false` |
| `build-test.yml` (push to `main`) | `true` |
| `build-test.yml` (dispatch) | the input |
| `build-test-branch.yml` | the gate's output |

**This fixes a latent hole rather than only enabling the feature.** The "Install Playwright OS deps (firefox+webkit)" step keyed on that same event predicate. Any non-main caller running `ci:main` would have run `test:engines` *without* its OS deps — so the branch opt-in would have been broken on a cache hit if the predicate had been left alone. Same for the Cypress-video upload, which now keys on its input alone.

## Where the prefix lives

One place: `decide()` in `branch-ci-gate.core.ts`, checked *before* mergeability since it is the one case where a covered SHA still needs its own run. Consequences:

- `build-test-branch.yml` needs no extra `if` term — the gate already answers `run=true` for the opt-in, so the build job's existing condition covers it.
- The fail-open path re-derives it from `GITHUB_REF_NAME`. A `startsWith` cannot be what broke the gate, and degrading it would silently run the smaller graph — the opposite of what was asked for.
- `ci-main` and `ci-maintenance` do **not** opt in; the separator is required.

## Verification

Live, against real runs:

| case | evidence |
| --- | --- |
| dispatch runs the main graph on an arbitrary branch | run [30169092107](https://github.com/simshanith/lit-ui-router/actions/runs/30169092107) — ref `throwaway/no-pr-trigger-split`, `success`, executed `mise run ci_main`. This is the *pre-change* behaviour, confirmed before editing. |
| `ci-main/` branch push builds `ci:main` | `ci-main/verify-optin` @ `7e6d70f`, run [30169324417](https://github.com/simshanith/lit-ui-router/actions/runs/30169324417) — `success`. Gate logged `RUN: `ci-main/` branch prefix — running the ci:main superset`; the build job executed `mise run ci_main` and ran `test:engines` + `check:pack`, i.e. the main-only guards, on a branch push. |
| trigger isolation holds | only **Build and Test (branch)** fired on that push — two rows, `build_and_test (signal gate)` and `build_and_test (branch) / run`. |

Unit-tested (`node --test`, 30 cases in the gate suite, 0 fail):

- opt-in wins over a clean-mergeable verdict — the case a live no-PR branch cannot demonstrate, since "no open PR" would run it anyway
- the opt-in graph survives every other run reason (conflict, indeterminate, no probe, no PR)
- prefix anchoring and the separator requirement

Also green locally: `tsc --noEmit`, `oxlint`, `oxfmt --check`, `actionlint`, `zizmor`, `taplo`.

## Docs

`TURBO.md` gains a "Smoke-testing the main graph before merge" section; `RELEASE.md` notes both paths where it describes the guards that gate a release.

## Merge notes

- Merge #458 first — this is stacked on it and inherits its ruleset repoint (`build_and_test` → `build_and_test / run`).
- Throwaway branches to delete after merge: `ci-main/verify-optin`, `throwaway/no-pr-trigger-split` (the latter is #458's evidence ref).
