### PR TITLE
feat(mise): inherit remote-cache creds in worktrees via a setup-time symlink

### DIFF
--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -25,6 +25,8 @@ TAPLO_CONFIG = "{{config_root}}/.config/taplo.toml"
 # `mise run turbo_login`. A dotenv, not [env] here, so the sensitive worker
 # domain never lands in a checked-in file; a missing file is fine (mise loads
 # nothing, no error) since the cache is maintainer-only.
+# config_root-scoped, so a git worktree starts with no creds; `mise run setup`
+# links it at the owning checkout's file (see the turbo_link_worktree task).
 # NOT `{ …, redact = true }`: redaction wraps the task's stdio to mask secrets,
 # which clobbers a task reading its own stdin — it silently breaks
 # `printf … | mise run turbo_login --token-file -`. Verified on this mise.
@@ -76,7 +78,10 @@ depends = ["corepack_enable", "corepack_install"]
 # pnpm auto-enables --frozen-lockfile when CI is set (ci-info detection),
 # so one task serves local (plain) and CI (frozen) alike.
 description = "Install workspace dependencies with the pnpm on PATH"
-depends = ["corepack"]
+# turbo_link_worktree is independent of corepack and no-ops everywhere but a
+# fresh worktree; it rides setup because that is the one step every new
+# checkout already runs.
+depends = ["corepack", "turbo_link_worktree"]
 usage = '''
 flag "--release" help="Scope the install to the @tools/release closure (tag-job)"
 '''
@@ -138,9 +143,9 @@ run = "mise run taplo fmt --check"
 # invocation, not release logic, and at the root config_root turbo already
 # runs from the workspace root.
 
-# turbo_login + read_secret are file-based tasks under .config/mise/tasks/ —
-# their shell bodies were too large to sit inline. Every other task here is a
-# one- or two-liner and stays inline.
+# turbo_login, read_secret and turbo_link_worktree are file-based tasks under
+# .config/mise/tasks/ — their shell bodies were too large to sit inline. Every
+# other task here is a one- or two-liner and stays inline.
 
 [tasks.build]
 # env: TURBO_TOKEN/TURBO_API/TURBO_TEAM for remote cache (ambient turbo

--- a/.config/mise/tasks/turbo_link_worktree
+++ b/.config/mise/tasks/turbo_link_worktree
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+#MISE description="Point a git worktree's turbo.local.env at the owning checkout's copy (symlink)"
+#
+# The creds dotenv is gitignored, so `git worktree add` produces a checkout with
+# no remote-cache config at all: turbo warns "TURBO_TOKEN set without TURBO_TEAM"
+# and silently falls back to local-only. config.toml's [env] _.file is
+# {{config_root}}-scoped and cannot reach out of the worktree by itself.
+#
+# So link, once, at setup time: `--git-common-dir` resolves to the SAME absolute
+# path from a worktree and from the checkout that owns it, which names that
+# checkout with nothing machine-specific in the committed config. A symlink and
+# not a copy — rotating creds in the main checkout has to reach every worktree.
+#
+# The resolution deliberately does not live in _.file as {{ exec(...) }}: mise
+# runs template exec under `sh -c -o errexit`, so a copy of the tree without a
+# .git would fail template parsing and take the whole config down (rc=1), not
+# just the cache. It is also not a perf measure — either shape costs ~50ms.
+set -eu
+
+# File-based tasks are raw scripts: {{config_root}} does not render here.
+env="${MISE_CONFIG_ROOT}/.config/mise/turbo.local.env"
+
+# -L as well as -e: a dangling link (owning checkout deleted) is not -e, and
+# relinking it would still point nowhere. Leave whatever is there alone; a real
+# file wins, which is how a worktree overrides one key while inheriting the rest.
+if [ -e "$env" ] || [ -L "$env" ]; then
+  exit 0
+fi
+
+# No .git at all (source tarball, vendored copy): nothing to inherit from.
+common_dir="$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null)" || exit 0
+owner="$(cd "$common_dir/.." && pwd)"
+
+# The owning checkout writes its own file; only worktrees borrow.
+[ "$owner" != "$MISE_CONFIG_ROOT" ] || exit 0
+[ -f "$owner/.config/mise/turbo.local.env" ] || exit 0
+
+ln -s "$owner/.config/mise/turbo.local.env" "$env"
+echo "turbo_link_worktree: linked remote-cache creds from $owner" >&2

--- a/REMOTE_CACHE.md
+++ b/REMOTE_CACHE.md
@@ -78,6 +78,22 @@ Never commit a blank placeholder for these: an empty value in a mise config
 wins over an ambient `export`, silently disabling the remote cache for anyone
 who already has a token.
 
+### Worktrees
+
+`_.file` is scoped to the config root, and the dotenv is gitignored, so a fresh
+`git worktree add` starts with no credentials — turbo warns
+`Remote caching disabled (TURBO_TOKEN set without TURBO_TEAM)` and quietly falls
+back to local-only. `mise run setup` fixes that: the `turbo_link_worktree` leg
+symlinks the worktree's `.config/mise/turbo.local.env` at the owning checkout's
+file, found via `git rev-parse --git-common-dir` (the same absolute path from
+either side).
+
+A symlink and not a copy, so rotating creds in the main checkout reaches every
+worktree at once. The task never overwrites: run `turbo_login` inside a worktree
+and that real file wins, which is how a worktree under test can override
+`TURBO_API` while inheriting the rest. Worktrees created before the main
+checkout had credentials just need `mise run setup` again.
+
 ### Rotation
 
 Both secrets live in the same places — rotate every row together:


### PR DESCRIPTION
Stacked on #452 (base is `worktree-turbo-token-local-toml`, not `main`).

## The hole

`[env] _.file` is `{{config_root}}`-scoped and the dotenv is gitignored, so a
fresh `git worktree add` starts with no remote-cache config at all. turbo warns

```
Remote caching disabled (TURBO_TOKEN set without TURBO_TEAM)
```

and quietly falls back to local-only — the `TURBO_TOKEN` in that message is just
a stray export inherited from the launching shell. This was equally true of the
`.turbo/config.json` #452 replaces (also gitignored, also never copied), so
moving the file does not close it.

## The fix

Resolve the owning checkout once, at setup, and materialize a symlink.
`git rev-parse --path-format=absolute --git-common-dir` returns the **same**
absolute path from a worktree and from the checkout that owns it, so the owning
checkout is nameable with nothing machine-specific in the committed config.

A symlink and not a copy: rotating creds in the main checkout has to reach every
worktree, which is the whole thesis of #452's rotation story.

- new file task `.config/mise/tasks/turbo_link_worktree`
- `setup` gains it as a second `depends` leg — the one step every new checkout
  already runs; it no-ops everywhere else, including CI
- `REMOTE_CACHE.md` gets a short **Worktrees** section

Committed `_.file` is unchanged from what this branch already has.

## Why not `{{ exec(...) }}` in `_.file`

It works, but mise runs template exec under `sh -c -o errexit`: a copy of the
tree with no `.git` fails template *parsing* and takes the whole config down
(rc=1) — not just the cache — unless guarded. The symlink also survives
`mise env` on a broken owner. It is **not** a perf win: measured ~50ms either
way, startup-dominated. Failure modes and live rotation are the argument.

## Verification

Ran on a real `git worktree add` in a scratch repo:

| Case | Result |
| --- | --- |
| fresh worktree, owner has creds | link created, all keys exported |
| rotate the owner's file | worktree picks up new values live |
| rerun the task | rc=0, no change (idempotent) |
| dangling link (owner deleted) | left alone; task **and** `mise env` rc=0 |
| real file written in the worktree | wins, never clobbered (per-key override) |
| checkout with no `.git` | rc=0 no-op |
| the owning checkout itself | rc=0 no-op, no self-link |

`mise run lint_workflows` green (shellcheck sees the new file task; the
`${usage_*}`-free body has no SC2154 surface), `taplo fmt --check` clean,
`mise tasks deps setup` shows the leg wired.

Also harmless if `MISE_CONFIG_ROOT` and the physical path ever disagree
(symlinked homes): the `-e`/`-L` guard has already exited by then.