### PR TITLE
test(dts-backtest): compile selftest probes from a scratch file, not the shipped dist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,6 @@ coverage
 
 # bv (beads viewer) local config and caches
 .bv/
+
+# dts-backtest per-process selftest probes (cleaned in-run; belt for crashes)
+tools/dts-backtest/.probe-scratch/

--- a/.gitignore
+++ b/.gitignore
@@ -64,5 +64,5 @@ coverage
 # bv (beads viewer) local config and caches
 .bv/
 
-# dts-backtest per-process selftest probes (cleaned in-run; belt for crashes)
+# dts-backtest selftest scratch (cleaned in-run)
 tools/dts-backtest/.probe-scratch/

--- a/tools/dts-backtest/run.ts
+++ b/tools/dts-backtest/run.ts
@@ -261,11 +261,9 @@ function run(specifier: string, configFile: string) {
 // third-party and stay green forever. If the floor is ever raised past 5.4,
 // this fails loudly — pick a newer-syntax probe.
 //
-// The probe lives in a per-process scratch dir under this package — NEVER in
-// packages/*/dist. The `test` and `test:matrix` tasks run this script
-// concurrently, and pack:all stages copies of the packages in the same graph:
-// any mutation of a shared build output races them (it has corrupted a run
-// and poisoned a remote-cache tarball).
+// Probes live in a scratch dir, never in packages/*/dist — concurrent tasks
+// in the same graph (test × test:matrix, pack:all staging) race any mutation
+// of shared build outputs.
 const PROBE = 'export type __dtsBacktestProbe = NoInfer<string>;\n';
 
 // The native leg has its own ownership filter, so it needs its own proof. An
@@ -273,11 +271,9 @@ const PROBE = 'export type __dtsBacktestProbe = NoInfer<string>;\n';
 const NATIVE_PROBE =
   'export type __dtsBacktestNativeProbe = __NoSuchTypeExists__;\n';
 
-// Scratch dir under `here` (not os.tmpdir()) so ownsPath() owns the probe
-// diagnostics and the scratch tsconfig's relative paths resolve; outside the
-// task's turbo `inputs` (fixtures/**, run.ts, tsconfig.fixture*.json) so its
-// lifecycle never dirties the cache hash. mkdtemp keeps the two concurrent
-// tasks from sharing it.
+// Under `here` (not os.tmpdir()) so ownsPath() owns the probe diagnostics and
+// relative tsconfig paths resolve; outside this task's turbo `inputs` so the
+// scratch lifecycle never dirties the cache hash.
 async function withProbeFile<T>(
   probe: string,
   body: (probePath: string, scratchDir: string) => T | Promise<T>,
@@ -325,9 +321,8 @@ function selftest() {
 }
 
 async function selftestNative() {
-  // The native API takes only a tsconfig, so the scratch dir gets one that
-  // extends the fixture config and re-includes the fixtures plus the probe.
-  // Relative `include` paths resolve against the config that declares them.
+  // The native API takes only a tsconfig; relative `include` paths resolve
+  // against the declaring config, so the scratch dir gets its own.
   const { version, owned } = await withProbeFile(
     NATIVE_PROBE,
     (_probePath, scratchDir) => {

--- a/tools/dts-backtest/run.ts
+++ b/tools/dts-backtest/run.ts
@@ -16,8 +16,13 @@
 // `typescript/unstable/sync` — a different, still-unstable surface that 7.1 is
 // expected to replace.
 
-import { randomUUID } from 'node:crypto';
-import { mkdirSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
+import {
+  mkdirSync,
+  mkdtempSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 import { createRequire } from 'node:module';
 import { dirname, join, resolve, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -268,20 +273,17 @@ const PROBE = 'export type __dtsBacktestProbe = NoInfer<string>;\n';
 const NATIVE_PROBE =
   'export type __dtsBacktestNativeProbe = __NoSuchTypeExists__;\n';
 
-// Scratch dir under `here` so ownsPath() owns the probe diagnostics; outside
-// the task's turbo `inputs` (fixtures/**, run.ts, tsconfig.fixture*.json) so
-// its lifecycle never dirties the cache hash. Unique per process — the two
-// concurrent tasks must not share it.
+// Scratch dir under `here` (not os.tmpdir()) so ownsPath() owns the probe
+// diagnostics and the scratch tsconfig's relative paths resolve; outside the
+// task's turbo `inputs` (fixtures/**, run.ts, tsconfig.fixture*.json) so its
+// lifecycle never dirties the cache hash. mkdtemp keeps the two concurrent
+// tasks from sharing it.
 async function withProbeFile<T>(
   probe: string,
   body: (probePath: string, scratchDir: string) => T | Promise<T>,
 ): Promise<T> {
-  const scratchDir = join(
-    here,
-    '.probe-scratch',
-    `${process.pid}-${randomUUID().slice(0, 8)}`,
-  );
-  mkdirSync(scratchDir, { recursive: true });
+  mkdirSync(join(here, '.probe-scratch'), { recursive: true });
+  const scratchDir = mkdtempSync(join(here, '.probe-scratch', 'run-'));
   const probePath = join(scratchDir, 'probe.d.ts');
   writeFileSync(probePath, probe);
   try {

--- a/tools/dts-backtest/run.ts
+++ b/tools/dts-backtest/run.ts
@@ -328,7 +328,7 @@ async function selftestNative() {
   // Relative `include` paths resolve against the config that declares them.
   const { version, owned } = await withProbeFile(
     NATIVE_PROBE,
-    (probePath, scratchDir) => {
+    (_probePath, scratchDir) => {
       const scratchConfig = join(scratchDir, 'tsconfig.json');
       writeFileSync(
         scratchConfig,

--- a/tools/dts-backtest/run.ts
+++ b/tools/dts-backtest/run.ts
@@ -16,7 +16,8 @@
 // `typescript/unstable/sync` — a different, still-unstable surface that 7.1 is
 // expected to replace.
 
-import { readFileSync, realpathSync, writeFileSync } from 'node:fs';
+import { randomUUID } from 'node:crypto';
+import { mkdirSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import { dirname, join, resolve, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -117,11 +118,15 @@ function loadConfig(ts: ClassicApi, configFile: string): TS.ParsedCommandLine {
   return parsed;
 }
 
-function check(specifier: string, configFile: string) {
+function check(
+  specifier: string,
+  configFile: string,
+  extraRootNames: string[] = [],
+) {
   const ts = require(specifier) as ClassicApi;
   const parsed = loadConfig(ts, configFile);
   const program = ts.createProgram({
-    rootNames: parsed.fileNames,
+    rootNames: [...parsed.fileNames, ...extraRootNames],
     options: parsed.options,
   });
 
@@ -162,7 +167,7 @@ async function checkNative(specifier: string, configFile: string) {
   ])) as [NativeSyncModule, NativeModule];
 
   const api = new API({ cwd: here });
-  const configPath = join(here, configFile);
+  const configPath = resolve(here, configFile);
   const snapshot = api.updateSnapshot({ openProjects: [configPath] });
   try {
     const project = snapshot.getProject(configPath);
@@ -245,49 +250,65 @@ function run(specifier: string, configFile: string) {
   return true;
 }
 
-// Self-test: prove the harness can fail. Injects a NoInfer<> probe (TS 5.4+
-// syntax) into a dist .d.ts, then asserts the floor leg rejects it and the
-// current leg accepts it. Guards against a filter/ownership bug that would
-// classify everything as third-party and stay green forever. If the floor is
-// ever raised past 5.4, this fails loudly — pick a newer-syntax probe.
-const PROBE = '\nexport type __dtsBacktestProbe = NoInfer<string>;\n';
+// Self-test: prove the harness can fail. Compiles a probe .d.ts alongside the
+// fixtures, then asserts the floor leg rejects it and the current leg accepts
+// it. Guards against a filter/ownership bug that would classify everything as
+// third-party and stay green forever. If the floor is ever raised past 5.4,
+// this fails loudly — pick a newer-syntax probe.
+//
+// The probe lives in a per-process scratch dir under this package — NEVER in
+// packages/*/dist. The `test` and `test:matrix` tasks run this script
+// concurrently, and pack:all stages copies of the packages in the same graph:
+// any mutation of a shared build output races them (it has corrupted a run
+// and poisoned a remote-cache tarball).
+const PROBE = 'export type __dtsBacktestProbe = NoInfer<string>;\n';
 
 // The native leg has its own ownership filter, so it needs its own proof. An
 // unresolvable name must surface as an owned diagnostic, not a tolerated one.
 const NATIVE_PROBE =
-  '\nexport type __dtsBacktestNativeProbe = __NoSuchTypeExists__;\n';
+  'export type __dtsBacktestNativeProbe = __NoSuchTypeExists__;\n';
 
-// async: the native leg reads the probe after an await, so the restore must not
-// run until the body has fully resolved.
-async function withProbe<T>(
+// Scratch dir under `here` so ownsPath() owns the probe diagnostics; outside
+// the task's turbo `inputs` (fixtures/**, run.ts, tsconfig.fixture*.json) so
+// its lifecycle never dirties the cache hash. Unique per process — the two
+// concurrent tasks must not share it.
+async function withProbeFile<T>(
   probe: string,
-  body: (target: string) => T | Promise<T>,
+  body: (probePath: string, scratchDir: string) => T | Promise<T>,
 ): Promise<T> {
-  const target = join(PACKAGE_DIRS[0], 'index.d.ts');
-  const original = readFileSync(target, 'utf8');
-  writeFileSync(target, original + probe);
+  const scratchDir = join(
+    here,
+    '.probe-scratch',
+    `${process.pid}-${randomUUID().slice(0, 8)}`,
+  );
+  mkdirSync(scratchDir, { recursive: true });
+  const probePath = join(scratchDir, 'probe.d.ts');
+  writeFileSync(probePath, probe);
   try {
-    return await body(target);
+    return await body(probePath, scratchDir);
   } finally {
-    writeFileSync(target, original);
+    rmSync(scratchDir, { recursive: true, force: true });
   }
 }
+
+const probeDiagnostic = (fileName: string | undefined) =>
+  fileName?.endsWith('probe.d.ts') ?? false;
 
 function selftest() {
   const floor = API_VERSIONS[0];
   const current = API_VERSIONS[API_VERSIONS.length - 1];
-  return withProbe(PROBE, (target) => {
-    const floorRun = check(floor, CONFIGS[0]);
+  return withProbeFile(PROBE, (probePath) => {
+    const floorRun = check(floor, CONFIGS[0], [probePath]);
     const probeCaught = floorRun.owned.some((diagnostic) =>
-      diagnostic.file?.fileName.endsWith('index.d.ts'),
+      probeDiagnostic(diagnostic.file?.fileName),
     );
     if (!probeCaught) {
       console.error(
-        `✖ selftest — TS ${floorRun.ts.version} did not reject the NoInfer probe in ${target}`,
+        `✖ selftest — TS ${floorRun.ts.version} did not reject the NoInfer probe in ${probePath}`,
       );
       return false;
     }
-    const currentRun = check(current, CONFIGS[0]);
+    const currentRun = check(current, CONFIGS[0], [probePath]);
     if (currentRun.owned.length > 0) {
       console.error(
         `✖ selftest — TS ${currentRun.ts.version} unexpectedly rejected the NoInfer probe`,
@@ -302,11 +323,25 @@ function selftest() {
 }
 
 async function selftestNative() {
-  const { version, owned } = await withProbe(NATIVE_PROBE, () =>
-    checkNative(NATIVE_VERSION, CONFIGS[0]),
+  // The native API takes only a tsconfig, so the scratch dir gets one that
+  // extends the fixture config and re-includes the fixtures plus the probe.
+  // Relative `include` paths resolve against the config that declares them.
+  const { version, owned } = await withProbeFile(
+    NATIVE_PROBE,
+    (probePath, scratchDir) => {
+      const scratchConfig = join(scratchDir, 'tsconfig.json');
+      writeFileSync(
+        scratchConfig,
+        JSON.stringify({
+          extends: `../../${CONFIGS[0]}`,
+          include: ['../../fixtures/**/*.ts', './probe.d.ts'],
+        }),
+      );
+      return checkNative(NATIVE_VERSION, scratchConfig);
+    },
   );
   const caught = owned.some((diagnostic) =>
-    diagnostic.fileName?.endsWith('index.d.ts'),
+    probeDiagnostic(diagnostic.fileName),
   );
   if (!caught) {
     console.error(`✖ selftest native — TS ${version} did not reject the probe`);


### PR DESCRIPTION
## The bug — one root cause, three faces

`withProbe` mutated the real `packages/lit-ui-router/dist/index.d.ts` (read → append probe → try/finally restore). Three concurrent readers/writers share that file in one `ci:main` graph:

1. **`test` × `test:matrix` race** — both run `run.ts` concurrently (no edge between them). Interleaved probe windows: one process's restore erases the other's freshly-injected probe → `✖ selftest — TS 5.0.4 did not reject the NoInfer probe`; the other process's restore then writes back its captured "original" **with the first probe embedded** → `__dtsBacktestNativeProbe` stranded at line 5 → every later leg fails TS2304. Failed main runs 30189253383 attempts 1 and 2 (post-#452 merge push) are both this.
2. **Cache poisoning** — a cold `pack:all` staged its package copy during a probe window and uploaded the probe-bearing tarball under the clean-input hash (turbo hashes inputs, not outputs). That was the `published-diff (lit-ui-router)` false "unreleased changes vs 1.7.2 — dist/index.d.ts" on main (appeared at 635ca2a, cleared by the R2 flush).
3. Any future consumer of dist in the same graph inherits the same window.

## The fix

Probes never touch `packages/*/dist`. Each selftest compiles a probe `.d.ts` from a **per-process scratch dir** (`tools/dts-backtest/.probe-scratch/<pid>-<uuid>/`, gitignored, removed in `finally`):

- **Classic legs**: `check()` takes extra root names; the probe file rides the fixture program.
- **Native leg**: takes only a tsconfig, so the scratch dir gets one — `extends` the fixture config and re-includes the fixtures plus the probe (relative `include` resolves against the declaring config).
- Scratch dir lives under the tool so `ownsPath()` owns the probe diagnostics; it is outside the task's turbo `inputs`, so the cache hash is untouched.

## Verification

- `--versions=full` and `--versions=current` both pass; selftests still prove the harness can fail (floor rejects, current accepts; native rejects).
- **3 rounds of full+current running concurrently: 0 failures**, `dist/index.d.ts` byte-identical before/after, no scratch residue.
- `lint`, `format:check`, `test` green via turbo.