### PR TITLE
build(bundle-probe): emit entry stats to .cache/bundle-stats, not dist/.stats

### DIFF
--- a/TURBO.md
+++ b/TURBO.md
@@ -87,7 +87,7 @@ docs
 - `outputs` defines cacheable artifacts
 - `inputs` scopes cache invalidation
 - Every build output lives under a `dist/` dir, so every traversal ignore is one `**/dist/**` glob (no sibling `dist-*` patterns): single-output packages use plain `dist/`; multi-output packages namespace each variant as `dist/<variant>/` (disjoint outputs globs, each vite build empties only its own subdir)
-- Dot-dirs under `dist/` (e.g. `dist/.stats/`, uncached codecov probe output) are machinery, not artifact — packers include dot-dirs under `files: ["dist/**"]`, so shipped packages carry an explicit `!dist/.*/**` negation; `check:published-diff` backstops the boundary
+- Nothing writes machinery under `dist/` — probe/scratch output lives in gitignored `.cache/` dirs (e.g. `.cache/bundle-stats/`), because anything under a `dist/` can be captured by build caching or pack staging mid-graph; shipped packages keep the `!dist/.*/**` files negation as a backstop, and `check:published-diff` backstops the boundary
 
 Exceptions: `docs/api/**` (generated VitePress content, not a bundle output) and `tools/release/.cache/**` (turbo-hashed input cache).
 

--- a/tools/bundle-probe/src/upload-entry-bundles.ts
+++ b/tools/bundle-probe/src/upload-entry-bundles.ts
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 // Codecov bundle series per exported entry: rolldown (the vite-8-era
 // consumer bundler) emits each entry minified with declared dependencies and
-// peers external into dist/.stats/ (dot-dir: machinery, not artifact — the
-// packages' files negation keeps it out of the tarball), then the shared uploader ships one
+// peers external into .cache/bundle-stats/ (gitignored, outside dist/ — build
+// outputs must never carry probe machinery), then the shared uploader ships one
 // <prefix>-<label>-esm series per entry. Entries and labels derive from the
 // exports map (see entries.ts); the optional prefix argument overrides the
 // package name (series continuity). CODECOV_TOKEN unset stays the uploader's
@@ -24,7 +24,7 @@ const uploader = fileURLToPath(
   import.meta.resolve('@tools/build_and_test/src/upload-bundle-stats.ts'),
 );
 
-const statsRoot = path.join(packageDir, 'dist', '.stats');
+const statsRoot = path.join(packageDir, '.cache', 'bundle-stats');
 await rm(statsRoot, { recursive: true, force: true });
 
 console.log(


### PR DESCRIPTION
## What

`upload-entry-bundles` wrote its minified probe chunks to `<package>/dist/.stats/` for the four `codecov:bundle` packages. That is inside every `build` task's declared `dist/**` outputs: the chunks persist after the CI step, so any subsequent `build` in that working copy archives them into the (remote-shared) cache entry, and only the `!dist/.*/**` files negation keeps them out of shipped tarballs.

Stats now go to `<package>/.cache/bundle-stats/` — the repo's gitignored scratch convention (`.cache/` is ignored repo-wide), outside build outputs and pack staging entirely. The `!dist/.*/**` negation stays as a backstop. TURBO.md's dot-dir bullet updated to the new invariant: nothing writes machinery under `dist/`.

Flagged by the post-#464 audit for writers of the dts-backtest poisoning class — this was the only other cross-package `dist/` writer.

## Verification

- `turbo run codecov:bundle --filter=lit-ui-router` (token unset → uploader's clean skip): all five entry series written under `.cache/bundle-stats/`, `dist/.stats` not created
- bundle-probe lint / format:check / typecheck green