### PR TITLE
build(turbo): exclude mid-graph mutable dirs from lint/format hashes

### DIFF
--- a/packages/lit-ui-router/turbo.json
+++ b/packages/lit-ui-router/turbo.json
@@ -3,7 +3,10 @@
   "extends": ["//"],
   "tasks": {
     "build": {
-      "with": ["build:custom-elements"]
+      "with": ["build:custom-elements"],
+      // `with` is unordered: without the negation, build's archive captures
+      // custom-elements.json only when the manifest task finishes first
+      "outputs": ["dist/**", "!dist/custom-elements.json"]
     },
     "build:custom-elements": {
       "inputs": ["src/**/*.ts", "custom-elements-manifest.config.js"],

--- a/tools/release/package.json
+++ b/tools/release/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "check:exports": "node src/checks/check-exports.ts",
     "check:pack": "node src/checks/check-pack.ts",
-    "check:published-diff": "node src/checks/check-published-diff.ts",
+    "check:published-diff": "node src/checks/check-published-diff.ts --no-build",
     "format": "oxfmt \"**/*.{ts,js,json,jsonc,md}\"",
     "format:check": "oxfmt --check \"**/*.{ts,js,json,jsonc,md}\"",
     "lint": "oxlint .",

--- a/turbo.json
+++ b/turbo.json
@@ -65,9 +65,13 @@
       ],
       // type-aware oxlint resolves cross-package imports to dist d.ts only
       "dependsOn": ["^build:types"],
+      // explicit globs hash gitignored files too; dist/ and .cache/ mutate
+      // mid-graph (build:js, pack:all staging) and oxlint never reads them
       "inputs": [
         "**/*.ts",
         "**/*.js",
+        "!dist/**",
+        "!.cache/**",
         "$TURBO_ROOT$/.oxlintrc.json",
         "$TURBO_DEFAULT$"
       ]
@@ -210,8 +214,12 @@
     },
     "format": {
       "with": ["//#format:root", "//#format:toml"],
+      // explicit globs hash gitignored files too; dist/ and .cache/ mutate
+      // mid-graph and oxfmt (gitignore-aware) never reads them
       "inputs": [
         "**/*.{ts,js,mjs,cjs,json,jsonc,md,yml,yaml,html,vue}",
+        "!dist/**",
+        "!.cache/**",
         ".oxfmtrc.json",
         "$TURBO_ROOT$/.oxfmtrc.json"
       ]
@@ -220,6 +228,8 @@
       "with": ["//#format:check:root", "//#format:check:toml"],
       "inputs": [
         "**/*.{ts,js,mjs,cjs,json,jsonc,md,yml,yaml,html,vue}",
+        "!dist/**",
+        "!.cache/**",
         ".oxfmtrc.json",
         "$TURBO_ROOT$/.oxfmtrc.json"
       ]


### PR DESCRIPTION
Three low-grade graph-hygiene items from the post-#464 cache-poisoner audit — none are active poisoners, all are hash-coherence or determinism holes.

## 1. `lint` / `format` / `format:check` input negations (root turbo.json)

Explicit input globs hash gitignored files too (the repo relies on exactly this for `.cache/published-versions.json`). The bare `**/*.ts` / `**/*.{ts,js,...}` globs therefore folded `dist/**` and `.cache/**` into these tasks' hashes — directories that mutate mid-graph (`build:js` output, `pack:all` staging) while oxlint/oxfmt, both gitignore-aware, never read them. Result was bimodal keys and spurious misses. Negations restore hash ⊇ tool coverage without touching what the tools see.

Known residual (out of scope): `docs#format:check` still hashes gitignored `docs/api/reference/**` markdown that `docs:api` regenerates mid-graph; `docs/api/index.md` is tracked, so a bare `!api/**` would under-approximate.

## 2. `lit-ui-router#build` outputs vs `build:custom-elements`

`with` is unordered, so build's `dist/**` archive captured `custom-elements.json` only when the manifest task finished first — a nondeterministic cache entry. `!dist/custom-elements.json` makes the two outputs disjoint; the dedicated task's own cache restores the manifest (replay verified: rm dist → cache hit → both artifacts present).

## 3. `check:published-diff` script passes `--no-build`

The turbo task `dependsOn: pack:all`, so the script's nested `turbo run @tools/release#pack:all` self-provision is pure ceremony in-graph — and a rewrite-tarballs-mid-graph footgun under a force env. The package script (turbo's entry) now passes `--no-build`; direct `node src/checks/check-published-diff.ts` keeps self-provisioning.

## Verification

- `pnpm run check:published-diff` green end-to-end with the new script (pack:all provisioned by the task edge)
- `--dry=json` shows `lit-ui-router#build` outputs `["!dist/custom-elements.json","dist/**"]`; cold build + cache-replay both leave `custom-elements.json` + `index.js` in place
- full `turbo run lint format:check` sweep green (56 tasks)