### PR TITLE
Release 1.8.0

### DIFF
--- a/packages/lit-ui-router/package.json
+++ b/packages/lit-ui-router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lit-ui-router",
-  "version": "1.7.2",
+  "version": "1.8.0",
   "description": "State-based routing for Lit",
   "homepage": "https://lit-ui-router.dev",
   "license": "MIT",


### PR DESCRIPTION
### Features

* **lit-ui-router:** declare lit and @uirouter/core as peers ([#455](https://github.com/simshanith/lit-ui-router/issues/455)) ([7828ac7](https://github.com/simshanith/lit-ui-router/commit/7828ac7124f61743bc147822187b35a3c3c7370f))

### Build System

* **turbo:** exclude mid-graph mutable dirs from lint/format hashes ([#466](https://github.com/simshanith/lit-ui-router/issues/466)) ([1dd2980](https://github.com/simshanith/lit-ui-router/commit/1dd298063bea092032ca9bdb5308b17f0833e978)), closes [lit-ui-router#build](https://github.com/simshanith/lit-ui-router/issues/build)
