### PR TITLE
build(release): upload the packed tarball as the GitHub release asset

### DIFF
--- a/tools/release/src/steps/release-it.core.test.ts
+++ b/tools/release/src/steps/release-it.core.test.ts
@@ -104,7 +104,7 @@ describe('publishArgs', () => {
       '--github.release',
       'true',
       '--github.assets',
-      '*.tgz',
+      '/w/packages/lit-ui-router/lit-ui-router-1.8.0.tgz',
       '--git.tagExclude',
       '${npm.name}@1.8.0',
       '--plugins.@release-it/conventional-changelog.gitRawCommitsOpts.from=lit-ui-router@1.7.0',

--- a/tools/release/src/steps/release-it.core.test.ts
+++ b/tools/release/src/steps/release-it.core.test.ts
@@ -88,7 +88,7 @@ describe('bumpArgs', () => {
 describe('publishArgs', () => {
   const base = {
     releaseVersion: '1.8.0',
-    tarballPath: '/w/packages/lit-ui-router/lit-ui-router-1.8.0.tgz',
+    tarballPath: '/w/tools/release/.cache/publish/lit-ui-router.tgz',
     dryRun: false,
   };
 
@@ -100,11 +100,11 @@ describe('publishArgs', () => {
       '--npm.skipChecks',
       'true',
       '--npm.publishPath',
-      '/w/packages/lit-ui-router/lit-ui-router-1.8.0.tgz',
+      '/w/tools/release/.cache/publish/lit-ui-router.tgz',
       '--github.release',
       'true',
       '--github.assets',
-      '/w/packages/lit-ui-router/lit-ui-router-1.8.0.tgz',
+      '/w/tools/release/.cache/publish/lit-ui-router.tgz',
       '--git.tagExclude',
       '${npm.name}@1.8.0',
       '--plugins.@release-it/conventional-changelog.gitRawCommitsOpts.from=lit-ui-router@1.7.0',

--- a/tools/release/src/steps/release-it.core.ts
+++ b/tools/release/src/steps/release-it.core.ts
@@ -61,6 +61,8 @@ export function bumpArgs(options: {
  * - `--npm.publishPath`: publish the pnpm-packed (and attested) tarball; a
  *   bare `npm publish` re-packs from source and ships raw catalog:/workspace:
  *   refs npm can't resolve (broke 1.3.0–1.5.0)
+ * - `--github.assets`: the explicit tarball path; release-it globs assets
+ *   relative to the package dir, which stopped holding the tarball in #449
  * - `--git.tagExclude '${npm.name}@<version>'`: literal release-it template,
  *   never shell-expanded here
  * - `gitRawCommitsOpts.from=<prevTag>`: pins the conventional-changelog range
@@ -90,7 +92,7 @@ export function publishArgs(options: {
     '--github.release',
     'true',
     '--github.assets',
-    '*.tgz',
+    tarballPath,
     '--git.tagExclude',
     `\${npm.name}@${releaseVersion}`,
     ...(prevTag !== undefined


### PR DESCRIPTION
## Problem

`release-it` resolves `--github.assets` globs relative to the package dir. #449 moved packing to `tools/release/.cache/publish/`, so the `'*.tgz'` glob matches nothing:

```
WARNING octokit repos.uploadReleaseAssets: did not find "*.tgz" relative to /home/runner/work/lit-ui-router/lit-ui-router/packages/lit-ui-router
```

The warning doesn't fail the run — `lit-ui-router@1.8.0-canary.0` and `lit-ui-router@1.8.0` both shipped GitHub releases with **no tarball asset** (`1.7.2` has one). npm was unaffected: `--npm.publishPath` gets the explicit path and the registry tarball sha matches the attestation (`aa8cb366…`).

## Fix

Pass the explicit `TARBALL` path to `--github.assets` — the same value `npm.publishPath` already publishes. Test expectation updated to pin the argv.

## Verification

`turbo run test lint format:check typecheck --filter=@tools/release` — 24 tasks green.

Note: releases are immutable, so 1.8.0/canary can't be repaired retroactively; this fixes the next release forward.
