### PR TITLE
chore(examples): bump lit-ui-router to ^1.8.0

### DIFF
--- a/examples/hellogalaxy/package-lock.json
+++ b/examples/hellogalaxy/package-lock.json
@@ -12,7 +12,7 @@
         "@uirouter/core": "^6.1.2",
         "@uirouter/visualizer": "^7.2.1",
         "lit": "^3.3.3",
-        "lit-ui-router": "^1.7.2"
+        "lit-ui-router": "^1.8.0"
       },
       "devDependencies": {
         "typescript": "^7.0.2",
@@ -1189,12 +1189,14 @@
       }
     },
     "node_modules/lit-ui-router": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/lit-ui-router/-/lit-ui-router-1.7.2.tgz",
-      "integrity": "sha512-DTIilRFUG45J2vND0X2yHLAcAtyRJQ0TQp+UOFe2/IPQIVS4QvOidlQewqaq7QDWDgeYnGj9ZuhpTJQH4HEhqA==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/lit-ui-router/-/lit-ui-router-1.8.0.tgz",
+      "integrity": "sha512-gl0XBgnvLo4SAYwBmS9LCqqdvzG2l6DlUURVzjilQIHz548kvDYWIK4GBamUqD0hVu+qWpc17y1lD+YU+GR8TA==",
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/runtime": "0.140.0",
+        "@oxc-project/runtime": ">=0.50.0"
+      },
+      "peerDependencies": {
         "@uirouter/core": "^6.0.8",
         "lit": "^3.0.0"
       }

--- a/examples/hellogalaxy/package.json
+++ b/examples/hellogalaxy/package.json
@@ -13,7 +13,7 @@
     "@uirouter/core": "^6.1.2",
     "@uirouter/visualizer": "^7.2.1",
     "lit": "^3.3.3",
-    "lit-ui-router": "^1.7.2"
+    "lit-ui-router": "^1.8.0"
   },
   "devDependencies": {
     "typescript": "^7.0.2",

--- a/examples/hellosolarsystem/package-lock.json
+++ b/examples/hellosolarsystem/package-lock.json
@@ -11,7 +11,7 @@
         "@uirouter/core": "^6.1.2",
         "@uirouter/visualizer": "^7.2.1",
         "lit": "^3.3.3",
-        "lit-ui-router": "^1.7.2"
+        "lit-ui-router": "^1.8.0"
       },
       "devDependencies": {
         "typescript": "^7.0.2",
@@ -1139,12 +1139,14 @@
       }
     },
     "node_modules/lit-ui-router": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/lit-ui-router/-/lit-ui-router-1.7.2.tgz",
-      "integrity": "sha512-DTIilRFUG45J2vND0X2yHLAcAtyRJQ0TQp+UOFe2/IPQIVS4QvOidlQewqaq7QDWDgeYnGj9ZuhpTJQH4HEhqA==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/lit-ui-router/-/lit-ui-router-1.8.0.tgz",
+      "integrity": "sha512-gl0XBgnvLo4SAYwBmS9LCqqdvzG2l6DlUURVzjilQIHz548kvDYWIK4GBamUqD0hVu+qWpc17y1lD+YU+GR8TA==",
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/runtime": "0.140.0",
+        "@oxc-project/runtime": ">=0.50.0"
+      },
+      "peerDependencies": {
         "@uirouter/core": "^6.0.8",
         "lit": "^3.0.0"
       }

--- a/examples/hellosolarsystem/package.json
+++ b/examples/hellosolarsystem/package.json
@@ -12,7 +12,7 @@
     "@uirouter/core": "^6.1.2",
     "@uirouter/visualizer": "^7.2.1",
     "lit": "^3.3.3",
-    "lit-ui-router": "^1.7.2"
+    "lit-ui-router": "^1.8.0"
   },
   "devDependencies": {
     "typescript": "^7.0.2",

--- a/examples/helloworld/package-lock.json
+++ b/examples/helloworld/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@uirouter/core": "^6.1.2",
         "lit": "^3.3.3",
-        "lit-ui-router": "^1.7.2"
+        "lit-ui-router": "^1.8.0"
       },
       "devDependencies": {
         "typescript": "^7.0.2",
@@ -1100,12 +1100,14 @@
       }
     },
     "node_modules/lit-ui-router": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/lit-ui-router/-/lit-ui-router-1.7.2.tgz",
-      "integrity": "sha512-DTIilRFUG45J2vND0X2yHLAcAtyRJQ0TQp+UOFe2/IPQIVS4QvOidlQewqaq7QDWDgeYnGj9ZuhpTJQH4HEhqA==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/lit-ui-router/-/lit-ui-router-1.8.0.tgz",
+      "integrity": "sha512-gl0XBgnvLo4SAYwBmS9LCqqdvzG2l6DlUURVzjilQIHz548kvDYWIK4GBamUqD0hVu+qWpc17y1lD+YU+GR8TA==",
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/runtime": "0.140.0",
+        "@oxc-project/runtime": ">=0.50.0"
+      },
+      "peerDependencies": {
         "@uirouter/core": "^6.0.8",
         "lit": "^3.0.0"
       }

--- a/examples/helloworld/package.json
+++ b/examples/helloworld/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@uirouter/core": "^6.1.2",
     "lit": "^3.3.3",
-    "lit-ui-router": "^1.7.2"
+    "lit-ui-router": "^1.8.0"
   },
   "devDependencies": {
     "typescript": "^7.0.2",


### PR DESCRIPTION
Bumps the three tutorial examples to the released 1.8.0.

- `lit-ui-router` `^1.7.2` → `^1.8.0` in each example's `package.json`, npm lockfiles regenerated against the live registry (all resolve 1.8.0).
- **No peer additions needed**: every example already declares `lit ^3.3.3` and `@uirouter/core ^6.1.2` as direct dependencies, which satisfy 1.8.0's new peer ranges (`^3.0.0`, `^6.0.8`).
- Lockfile delta is exactly the version/integrity bump plus the manifest changes 1.8.0 ships (runtime dep `0.140.0` → `>=0.50.0`, new `peerDependencies` block).

Verified: `turbo run typecheck lint format:check --filter=examples` — 13 tasks green.
