### PR TITLE
refactor(tooling): extract shared sample-app vite config and tsconfig base

### DIFF
--- a/apps/sample-app-lit-mobx/package.json
+++ b/apps/sample-app-lit-mobx/package.json
@@ -28,8 +28,6 @@
     "oxfmt": "catalog:",
     "typescript": "catalog:typescript6-compat",
     "vite": "catalog:",
-    "vite-plugin-checker": "catalog:",
-    "vite-plugin-static-copy": "catalog:",
     "wrangler": "catalog:"
   }
 }

--- a/apps/sample-app-lit-mobx/tsconfig.json
+++ b/apps/sample-app-lit-mobx/tsconfig.json
@@ -1,10 +1,5 @@
 {
-  "extends": "../../tsconfig.base.json",
-  "compilerOptions": {
-    "allowJs": true,
-    "types": ["vite/client", "dom-navigation"],
-    "noEmit": true
-  },
+  "extends": "../sample-app-shared/tooling/tsconfig.app.json",
   "include": ["src/**/*", "vite.config.ts"],
   "exclude": ["node_modules", "dist"]
 }

--- a/apps/sample-app-lit-mobx/turbo.json
+++ b/apps/sample-app-lit-mobx/turbo.json
@@ -9,6 +9,15 @@
         "VITE_SAMPLE_APP_PUSH_STATE"
       ],
       "dependsOn": ["^build", "^transit"]
+    },
+    "typecheck": {
+      // tsconfig extends + the vite factory live in sample-app-shared/tooling,
+      // outside this package's default inputs; ^build:types doesn't hash it
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "$TURBO_ROOT$/tsconfig.base.json",
+        "$TURBO_ROOT$/apps/sample-app-shared/tooling/**"
+      ]
     }
   }
 }

--- a/apps/sample-app-lit-mobx/turbo.json
+++ b/apps/sample-app-lit-mobx/turbo.json
@@ -11,13 +11,9 @@
       "dependsOn": ["^build", "^transit"]
     },
     "typecheck": {
-      // tsconfig extends + the vite factory live in sample-app-shared/tooling,
-      // outside this package's default inputs; ^build:types doesn't hash it
-      "inputs": [
-        "$TURBO_DEFAULT$",
-        "$TURBO_ROOT$/tsconfig.base.json",
-        "$TURBO_ROOT$/apps/sample-app-shared/tooling/**"
-      ]
+      // tsc follows imports and the tsconfig extends chain into the buildless
+      // app-layer packages' raw .ts; ^transit hashes them, ^build:types can't
+      "dependsOn": ["^build:types", "^transit"]
     }
   }
 }

--- a/apps/sample-app-lit-mobx/vite.config.ts
+++ b/apps/sample-app-lit-mobx/vite.config.ts
@@ -1,65 +1,7 @@
-import { createRequire } from 'node:module';
-import path from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { sampleAppViteConfig } from 'sample-app-shared/tooling/vite.config.shared.js';
 
-import { defineConfig } from 'vite';
-import checker from 'vite-plugin-checker';
-import { viteStaticCopy } from 'vite-plugin-static-copy';
-
-// @uirouter/visualizer is a dep of sample-app-shared, so resolve it from there;
-// require.resolve yields a realpath, avoiding globs through pnpm symlinks.
-const sharedRequire = createRequire(
-  new URL('../sample-app-shared/package.json', import.meta.url),
-);
-const visualizerImages = path
-  .join(
-    path.dirname(sharedRequire.resolve('@uirouter/visualizer/package.json')),
-    'images',
-  )
-  .replaceAll('\\', '/'); // glob patterns need posix separators
-
-// path segments static-copy prepends to dest for sources outside the vite root
-const stripBase = path
-  .relative(path.dirname(fileURLToPath(import.meta.url)), visualizerImages)
-  .replaceAll('\\', '/')
-  .replace(/^(?:\.\.\/)+/, '')
-  .split('/').length;
-
-export default defineConfig({
-  // Static data (favicon, simulated REST fixtures) lives in the shared
-  // sample-app package; the apps differ only in their reactivity idiom.
-  publicDir: '../sample-app-shared/public',
-  build: {
-    // Provenance for scripts/upload-bundle-stats.ts: the manifest tells
-    // rollup-emitted assets apart from publicDir/static-copy files.
-    manifest: true,
-  },
-  plugins: [
-    checker({ typescript: true }),
-    viteStaticCopy({
-      targets: [
-        {
-          src: `${visualizerImages}/**`,
-          dest: 'images',
-          rename: { stripBase },
-        },
-        // Per-mount 404 page; the docs worker serves it for unmatched paths.
-        {
-          src: '404.html',
-          dest: '',
-        },
-      ],
-    }),
-  ],
-  // Pinned ports (vanilla 5173/4173, mobx 5174/4174): strictPort fails loudly
-  // instead of drifting, and open stays off so `turbo dev` spawns no browsers.
-  server: {
-    port: 5174,
-    strictPort: true,
-    open: false,
-  },
-  preview: {
-    port: 4174,
-    strictPort: true,
-  },
+export default sampleAppViteConfig({
+  configUrl: import.meta.url,
+  serverPort: 5174,
+  previewPort: 4174,
 });

--- a/apps/sample-app-lit-vanilla/package.json
+++ b/apps/sample-app-lit-vanilla/package.json
@@ -27,8 +27,6 @@
     "oxfmt": "catalog:",
     "typescript": "catalog:typescript6-compat",
     "vite": "catalog:",
-    "vite-plugin-checker": "catalog:",
-    "vite-plugin-static-copy": "catalog:",
     "wrangler": "catalog:"
   }
 }

--- a/apps/sample-app-lit-vanilla/tsconfig.json
+++ b/apps/sample-app-lit-vanilla/tsconfig.json
@@ -1,10 +1,5 @@
 {
-  "extends": "../../tsconfig.base.json",
-  "compilerOptions": {
-    "allowJs": true,
-    "types": ["vite/client", "dom-navigation"],
-    "noEmit": true
-  },
+  "extends": "../sample-app-shared/tooling/tsconfig.app.json",
   "include": ["src/**/*", "vite.config.ts"],
   "exclude": ["node_modules", "dist"]
 }

--- a/apps/sample-app-lit-vanilla/turbo.json
+++ b/apps/sample-app-lit-vanilla/turbo.json
@@ -20,6 +20,15 @@
       ],
       "dependsOn": ["^build", "^transit"],
       "outputs": ["dist/hash/**"]
+    },
+    "typecheck": {
+      // tsconfig extends + the vite factory live in sample-app-shared/tooling,
+      // outside this package's default inputs; ^build:types doesn't hash it
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "$TURBO_ROOT$/tsconfig.base.json",
+        "$TURBO_ROOT$/apps/sample-app-shared/tooling/**"
+      ]
     }
   }
 }

--- a/apps/sample-app-lit-vanilla/turbo.json
+++ b/apps/sample-app-lit-vanilla/turbo.json
@@ -22,13 +22,9 @@
       "outputs": ["dist/hash/**"]
     },
     "typecheck": {
-      // tsconfig extends + the vite factory live in sample-app-shared/tooling,
-      // outside this package's default inputs; ^build:types doesn't hash it
-      "inputs": [
-        "$TURBO_DEFAULT$",
-        "$TURBO_ROOT$/tsconfig.base.json",
-        "$TURBO_ROOT$/apps/sample-app-shared/tooling/**"
-      ]
+      // tsc follows imports and the tsconfig extends chain into the buildless
+      // app-layer packages' raw .ts; ^transit hashes them, ^build:types can't
+      "dependsOn": ["^build:types", "^transit"]
     }
   }
 }

--- a/apps/sample-app-lit-vanilla/vite.config.ts
+++ b/apps/sample-app-lit-vanilla/vite.config.ts
@@ -1,65 +1,7 @@
-import { createRequire } from 'node:module';
-import path from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { sampleAppViteConfig } from 'sample-app-shared/tooling/vite.config.shared.js';
 
-import { defineConfig } from 'vite';
-import checker from 'vite-plugin-checker';
-import { viteStaticCopy } from 'vite-plugin-static-copy';
-
-// @uirouter/visualizer is a dep of sample-app-shared, so resolve it from there;
-// require.resolve yields a realpath, avoiding globs through pnpm symlinks.
-const sharedRequire = createRequire(
-  new URL('../sample-app-shared/package.json', import.meta.url),
-);
-const visualizerImages = path
-  .join(
-    path.dirname(sharedRequire.resolve('@uirouter/visualizer/package.json')),
-    'images',
-  )
-  .replaceAll('\\', '/'); // glob patterns need posix separators
-
-// path segments static-copy prepends to dest for sources outside the vite root
-const stripBase = path
-  .relative(path.dirname(fileURLToPath(import.meta.url)), visualizerImages)
-  .replaceAll('\\', '/')
-  .replace(/^(?:\.\.\/)+/, '')
-  .split('/').length;
-
-export default defineConfig({
-  // Static data (favicon, simulated REST fixtures) lives in the shared
-  // sample-app package; the apps differ only in their reactivity idiom.
-  publicDir: '../sample-app-shared/public',
-  build: {
-    // Provenance for scripts/upload-bundle-stats.ts: the manifest tells
-    // rollup-emitted assets apart from publicDir/static-copy files.
-    manifest: true,
-  },
-  plugins: [
-    checker({ typescript: true }),
-    viteStaticCopy({
-      targets: [
-        {
-          src: `${visualizerImages}/**`,
-          dest: 'images',
-          rename: { stripBase },
-        },
-        // Per-mount 404 page; the docs worker serves it for unmatched paths.
-        {
-          src: '404.html',
-          dest: '',
-        },
-      ],
-    }),
-  ],
-  // Pinned ports (vanilla 5173/4173, mobx 5174/4174): strictPort fails loudly
-  // instead of drifting, and open stays off so `turbo dev` spawns no browsers.
-  server: {
-    port: 5173,
-    strictPort: true,
-    open: false,
-  },
-  preview: {
-    port: 4173,
-    strictPort: true,
-  },
+export default sampleAppViteConfig({
+  configUrl: import.meta.url,
+  serverPort: 5173,
+  previewPort: 4173,
 });

--- a/apps/sample-app-shared/package.json
+++ b/apps/sample-app-shared/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "exports": {
     "./*": "./src/*",
-    "./*.js": "./src/*.ts"
+    "./*.js": "./src/*.ts",
+    "./tooling/*.js": "./tooling/*.ts"
   },
   "scripts": {
     "format": "oxfmt \"**/*.{js,ts,json,md,css}\"",
@@ -37,6 +38,8 @@
     "playwright": "catalog:",
     "typescript": "catalog:",
     "vite": "catalog:",
+    "vite-plugin-checker": "catalog:",
+    "vite-plugin-static-copy": "catalog:",
     "vitest": "catalog:"
   }
 }

--- a/apps/sample-app-shared/tooling/tsconfig.app.json
+++ b/apps/sample-app-shared/tooling/tsconfig.app.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "allowJs": true,
+    "types": ["vite/client", "dom-navigation"],
+    "noEmit": true
+  }
+}

--- a/apps/sample-app-shared/tooling/vite.config.shared.ts
+++ b/apps/sample-app-shared/tooling/vite.config.shared.ts
@@ -1,0 +1,78 @@
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { defineConfig } from 'vite';
+import checker from 'vite-plugin-checker';
+import { viteStaticCopy } from 'vite-plugin-static-copy';
+
+// @uirouter/visualizer is a dep of this package; require.resolve yields a
+// realpath, avoiding globs through pnpm symlinks.
+const sharedRequire = createRequire(
+  new URL('../package.json', import.meta.url),
+);
+const visualizerImages = path
+  .join(
+    path.dirname(sharedRequire.resolve('@uirouter/visualizer/package.json')),
+    'images',
+  )
+  .replaceAll('\\', '/'); // glob patterns need posix separators
+
+export interface SampleAppViteConfigOptions {
+  /** the app's `import.meta.url` — anchors stripBase to that app's vite root */
+  configUrl: string;
+  serverPort: number;
+  previewPort: number;
+}
+
+export const sampleAppViteConfig = ({
+  configUrl,
+  serverPort,
+  previewPort,
+}: SampleAppViteConfigOptions) => {
+  // path segments static-copy prepends to dest for sources outside the vite root
+  const stripBase = path
+    .relative(path.dirname(fileURLToPath(configUrl)), visualizerImages)
+    .replaceAll('\\', '/')
+    .replace(/^(?:\.\.\/)+/, '')
+    .split('/').length;
+
+  return defineConfig({
+    // Static data (favicon, simulated REST fixtures) lives in the shared
+    // sample-app package; the apps differ only in their reactivity idiom.
+    publicDir: '../sample-app-shared/public',
+    build: {
+      // Provenance for scripts/upload-bundle-stats.ts: the manifest tells
+      // rollup-emitted assets apart from publicDir/static-copy files.
+      manifest: true,
+    },
+    plugins: [
+      checker({ typescript: true }),
+      viteStaticCopy({
+        targets: [
+          {
+            src: `${visualizerImages}/**`,
+            dest: 'images',
+            rename: { stripBase },
+          },
+          // Per-mount 404 page; the docs worker serves it for unmatched paths.
+          {
+            src: '404.html',
+            dest: '',
+          },
+        ],
+      }),
+    ],
+    // Pinned per-app ports: strictPort fails loudly instead of drifting, and
+    // open stays off so `turbo dev` spawns no browsers.
+    server: {
+      port: serverPort,
+      strictPort: true,
+      open: false,
+    },
+    preview: {
+      port: previewPort,
+      strictPort: true,
+    },
+  });
+};

--- a/apps/sample-app-shared/tsconfig.json
+++ b/apps/sample-app-shared/tsconfig.json
@@ -1,10 +1,5 @@
 {
-  "extends": "../../tsconfig.base.json",
-  "compilerOptions": {
-    "allowJs": true,
-    "types": ["vite/client", "dom-navigation"],
-    "noEmit": true
-  },
-  "include": ["src/**/*"],
+  "extends": "./tooling/tsconfig.app.json",
+  "include": ["src/**/*", "tooling/**/*"],
   "exclude": ["node_modules"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -398,12 +398,6 @@ importers:
       vite:
         specifier: 'catalog:'
         version: 8.1.3(@types/node@25.0.9)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)
-      vite-plugin-checker:
-        specifier: 'catalog:'
-        version: 0.14.4(@typescript/typescript6@6.0.2)(eslint@10.7.0(jiti@2.7.0))(meow@13.2.0)(optionator@0.9.4)(oxlint@1.74.0(oxlint-tsgolint@0.25.0))(vite@8.1.3(@types/node@25.0.9)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(vue-tsc@3.3.7(@typescript/typescript6@6.0.2))
-      vite-plugin-static-copy:
-        specifier: 'catalog:'
-        version: 4.1.1(vite@8.1.3(@types/node@25.0.9)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
       wrangler:
         specifier: 'catalog:'
         version: 4.112.0
@@ -444,12 +438,6 @@ importers:
       vite:
         specifier: 'catalog:'
         version: 8.1.3(@types/node@25.0.9)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)
-      vite-plugin-checker:
-        specifier: 'catalog:'
-        version: 0.14.4(@typescript/typescript6@6.0.2)(eslint@10.7.0(jiti@2.7.0))(meow@13.2.0)(optionator@0.9.4)(oxlint@1.74.0(oxlint-tsgolint@0.25.0))(vite@8.1.3(@types/node@25.0.9)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(vue-tsc@3.3.7(@typescript/typescript6@6.0.2))
-      vite-plugin-static-copy:
-        specifier: 'catalog:'
-        version: 4.1.1(vite@8.1.3(@types/node@25.0.9)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
       wrangler:
         specifier: 'catalog:'
         version: 4.112.0
@@ -530,6 +518,12 @@ importers:
       vite:
         specifier: 'catalog:'
         version: 8.1.3(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)
+      vite-plugin-checker:
+        specifier: 'catalog:'
+        version: 0.14.4(eslint@10.7.0(jiti@2.7.0))(meow@13.2.0)(optionator@0.9.4)(oxlint@1.74.0(oxlint-tsgolint@0.25.0))(typescript@7.0.2)(vite@8.1.3(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(vue-tsc@3.3.7(typescript@7.0.2))
+      vite-plugin-static-copy:
+        specifier: 'catalog:'
+        version: 4.1.1(vite@8.1.3(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
       vitest:
         specifier: 'catalog:'
         version: 4.1.10(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.0)(vite@8.1.3(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
@@ -11663,7 +11657,7 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite-plugin-checker@0.14.4(@typescript/typescript6@6.0.2)(eslint@10.7.0(jiti@2.7.0))(meow@13.2.0)(optionator@0.9.4)(oxlint@1.74.0(oxlint-tsgolint@0.25.0))(vite@8.1.3(@types/node@25.0.9)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(vue-tsc@3.3.7(@typescript/typescript6@6.0.2)):
+  vite-plugin-checker@0.14.4(eslint@10.7.0(jiti@2.7.0))(meow@13.2.0)(optionator@0.9.4)(oxlint@1.74.0(oxlint-tsgolint@0.25.0))(typescript@7.0.2)(vite@8.1.3(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(vue-tsc@3.3.7(typescript@7.0.2)):
     dependencies:
       '@babel/code-frame': 7.29.7
       chokidar: 5.0.0
@@ -11672,14 +11666,14 @@ snapshots:
       picomatch: 4.0.5
       proper-lockfile: 4.1.2
       tiny-invariant: 1.3.3
-      vite: 8.1.3(@types/node@25.0.9)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)
+      vite: 8.1.3(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)
     optionalDependencies:
       eslint: 10.7.0(jiti@2.7.0)
       meow: 13.2.0
       optionator: 0.9.4
       oxlint: 1.74.0(oxlint-tsgolint@0.25.0)
-      typescript: '@typescript/typescript6@6.0.2'
-      vue-tsc: 3.3.7(@typescript/typescript6@6.0.2)
+      typescript: 7.0.2
+      vue-tsc: 3.3.7(typescript@7.0.2)
 
   vite-plugin-static-copy@4.1.1(vite@8.1.3(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)):
     dependencies:
@@ -11688,14 +11682,6 @@ snapshots:
       picocolors: 1.1.1
       tinyglobby: 0.2.17
       vite: 8.1.3(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)
-
-  vite-plugin-static-copy@4.1.1(vite@8.1.3(@types/node@25.0.9)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)):
-    dependencies:
-      chokidar: 3.6.0
-      p-map: 7.0.5
-      picocolors: 1.1.1
-      tinyglobby: 0.2.17
-      vite: 8.1.3(@types/node@25.0.9)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)
 
   vite@8.1.3(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0):
     dependencies:
@@ -11806,18 +11792,18 @@ snapshots:
 
   vscode-uri@3.1.0: {}
 
-  vue-tsc@3.3.7(@typescript/typescript6@6.0.2):
-    dependencies:
-      '@volar/typescript': 2.4.28
-      '@vue/language-core': 3.3.7
-      typescript: '@typescript/typescript6@6.0.2'
-    optional: true
-
   vue-tsc@3.3.7(typescript@6.0.3):
     dependencies:
       '@volar/typescript': 2.4.28
       '@vue/language-core': 3.3.7
       typescript: 6.0.3
+
+  vue-tsc@3.3.7(typescript@7.0.2):
+    dependencies:
+      '@volar/typescript': 2.4.28
+      '@vue/language-core': 3.3.7
+      typescript: 7.0.2
+    optional: true
 
   vue@3.5.40(typescript@7.0.2):
     dependencies:


### PR DESCRIPTION
Extracts the duplicated per-app tooling flagged in #288 into `sample-app-shared/tooling/`, so each app directory reads as "what's unique about this integration."

## What moved

- **`vite.config.ts`** — the two apps carried a 65-line config identical except ports. Both now call a `sampleAppViteConfig({ configUrl, serverPort, previewPort })` factory. `configUrl` is the app's `import.meta.url`: static-copy's `stripBase` must be computed relative to the consuming app's vite root, not the shared file's location. Per-app config is now 7 lines, and only the ports differ.
- **`tsconfig.json`** — the apps' files were byte-identical. Both now extend `tooling/tsconfig.app.json`, keeping only `include`/`exclude` per-app (`include` can't live in the base: TS resolves a base's `include` relative to the *base* file). `sample-app-shared`'s own tsconfig extends the same base.
- `vite-plugin-checker` / `vite-plugin-static-copy` devDeps move from the apps to `sample-app-shared` (node resolves the factory's imports from the shared package).

Kept per-app on purpose: `index.html`/`404.html` (title + mount-path differences), the vanilla-only `build:hash` variant, and `package.json` deps — those *are* the comparison.

## Cache placement: `sample-app-shared` vs a new `@tools/*` package

Weighed and settled in favor of `sample-app-shared`:

- `sample-app-shared`'s only dependents are the two apps, and turbo's `^transit` edge hashes buildless workspace deps whole-package. So the invalidation blast radius of a tooling edit is **exactly the two apps under either home** — a new `@tools` package would buy zero cache scoping while costing another manifest and transit edge.
- No `build:types` for `sample-app-shared` either: the app layer is deliberately buildless (raw-`.ts` exports), and `transit` is the repo's mechanism for hashing exactly that. Emitting d.ts would add dist artifacts and exports surgery for a private package with no consumer wanting declarations.
- The one real cache hazard was internal: `sample-app-shared#test`/`test:engines` (the expensive 3-browser suites) key on `src/**`. The tooling lives in `tooling/`, *outside* `src/`, so a port tweak never busts the browser-test caches.
- The apps' `typecheck` task gains `^transit` alongside `^build:types`: tsc follows imports and the tsconfig `extends` chain into the buildless packages' raw `.ts`, which `^build:types` hashes none of. This also closes a pre-existing staleness hole — app typecheck already read `sample-app-shared/src` and (transitively) `sample-app-routes/src` unhashed, masked only by vite's checker in `build`.

`build` needs no input changes — it already depends on `^transit`.

## Verification

- `turbo run build typecheck lint format:check` across all three packages: 31/31 tasks pass.
- Built `dist/` static layout (visualizer `images/` tree + `404.html`) diffed **identical** against the pre-change build for the vanilla app — `stripBase` resolves correctly from the shared factory; hash-mode build output verified present.
- Cache-invalidation probes: from a fully-cached state, an edit under `sample-app-shared/tooling/` cache-misses both apps' `typecheck`; so does an edit in `sample-app-routes/src` (the transitive transit leg).
- Node loads the factory fine at vite-config time: vite externalizes the bare specifier, pnpm's symlink realpath escapes `node_modules`, and node 24 type-strips the `.ts` (same mechanism `@tools/shared` already relies on).

Closes #288 (the remaining audit found nothing else genuinely shareable: test setup already lives in `sample-app-routes`/`sample-app-shared`).
