### PR TITLE
test(ui-router-server): upload native node:test coverage to codecov

### DIFF
--- a/.github/workflows/build-test-run.yml
+++ b/.github/workflows/build-test-run.yml
@@ -168,7 +168,7 @@ jobs:
         if: ${{ github.event_name != 'push' || github.ref == 'refs/heads/main' }}
         uses: codecov/codecov-action@v7
         with:
-          files: packages/lit-ui-router/coverage/lcov.info,packages/lit-ui-router/coverage/coverage-final.json,packages/lit-ui-router-mobx/coverage/lcov.info,packages/lit-ui-router-mobx/coverage/coverage-final.json,packages/navigation-location-plugin/coverage/lcov.info,packages/navigation-location-plugin/coverage/coverage-final.json
+          files: packages/lit-ui-router/coverage/lcov.info,packages/lit-ui-router/coverage/coverage-final.json,packages/lit-ui-router-mobx/coverage/lcov.info,packages/lit-ui-router-mobx/coverage/coverage-final.json,packages/navigation-location-plugin/coverage/lcov.info,packages/navigation-location-plugin/coverage/coverage-final.json,packages/ui-router-server/coverage/lcov.info
           disable_search: true
           plugins: noop
           fail_ci_if_error: false

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -302,6 +302,7 @@
       "files": [
         "scripts/**/*.test.ts",
         "tools/build_and_test/**/*.test.ts",
+        "tools/lcov-rebase/**/*.test.ts",
         "tools/release/**/*.test.ts",
         "tools/shared/**/*.test.ts",
         "tools/workers-builds/**/*.test.ts",

--- a/codecov.yml
+++ b/codecov.yml
@@ -38,3 +38,7 @@ component_management:
       name: lit-ui-router-mobx
       paths:
         - packages/lit-ui-router-mobx/src/**
+    - component_id: ui-router-server
+      name: ui-router-server
+      paths:
+        - packages/ui-router-server/src/**

--- a/packages/ui-router-server/package.json
+++ b/packages/ui-router-server/package.json
@@ -21,7 +21,7 @@
     "format:check": "oxfmt --check \"**/*.{ts,json,md}\"",
     "lint": "oxlint .",
     "test": "node --test \"test/**/*.test.ts\"",
-    "test:coverage": "mkdir -p coverage && node --test --experimental-test-coverage --test-coverage-include=\"src/**\" --test-reporter=spec --test-reporter-destination=stdout --test-reporter=lcov --test-reporter-destination=coverage/lcov.info \"test/**/*.test.ts\"",
+    "test:coverage": "mkdir -p coverage && node --test --experimental-test-coverage --test-coverage-include=\"src/**\" --test-reporter=spec --test-reporter-destination=stdout --test-reporter=lcov --test-reporter-destination=coverage/lcov.info \"test/**/*.test.ts\" && sed -e 's|^SF:|SF:packages/ui-router-server/|' coverage/lcov.info > coverage/lcov.tmp && mv coverage/lcov.tmp coverage/lcov.info",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "typecheck:tests": "tsc -p test/tsconfig.json --noEmit"
   },

--- a/packages/ui-router-server/package.json
+++ b/packages/ui-router-server/package.json
@@ -21,12 +21,13 @@
     "format:check": "oxfmt --check \"**/*.{ts,json,md}\"",
     "lint": "oxlint .",
     "test": "node --test \"test/**/*.test.ts\"",
-    "test:coverage": "mkdir -p coverage && node --test --experimental-test-coverage --test-coverage-include=\"src/**\" --test-reporter=spec --test-reporter-destination=stdout --test-reporter=lcov --test-reporter-destination=coverage/lcov.info \"test/**/*.test.ts\" && sed -e 's|^SF:|SF:packages/ui-router-server/|' coverage/lcov.info > coverage/lcov.tmp && mv coverage/lcov.tmp coverage/lcov.info",
+    "test:coverage": "mkdir -p coverage && node --test --experimental-test-coverage --test-coverage-include=\"src/**\" --test-reporter=spec --test-reporter-destination=stdout --test-reporter=lcov --test-reporter-destination=coverage/lcov.info \"test/**/*.test.ts\" && rebase-lcov coverage/lcov.info",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "typecheck:tests": "tsc -p test/tsconfig.json --noEmit"
   },
   "devDependencies": {
     "@tools/bundle-probe": "workspace:*",
+    "@tools/lcov-rebase": "workspace:*",
     "@types/node": "catalog:",
     "@uirouter/core": "catalog:",
     "hono": "catalog:",

--- a/packages/ui-router-server/package.json
+++ b/packages/ui-router-server/package.json
@@ -21,6 +21,7 @@
     "format:check": "oxfmt --check \"**/*.{ts,json,md}\"",
     "lint": "oxlint .",
     "test": "node --test \"test/**/*.test.ts\"",
+    "test:coverage": "mkdir -p coverage && node --test --experimental-test-coverage --test-coverage-include=\"src/**\" --test-reporter=spec --test-reporter-destination=stdout --test-reporter=lcov --test-reporter-destination=coverage/lcov.info \"test/**/*.test.ts\"",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "typecheck:tests": "tsc -p test/tsconfig.json --noEmit"
   },

--- a/packages/ui-router-server/turbo.json
+++ b/packages/ui-router-server/turbo.json
@@ -6,6 +6,12 @@
       "dependsOn": ["^test", "transit"],
       "inputs": ["$TURBO_DEFAULT$"]
     },
+    // root task keys inputs on vitest configs; this suite is node --test
+    "test:coverage": {
+      "dependsOn": ["^test:coverage", "transit"],
+      "inputs": ["$TURBO_DEFAULT$"],
+      "outputs": ["coverage/**"]
+    },
     "typecheck": {
       "with": ["typecheck:tests"]
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -287,7 +287,7 @@ importers:
         version: 9.0.0
       eslint:
         specifier: 'catalog:'
-        version: 10.8.0(jiti@2.7.0)
+        version: 10.8.0(jiti@2.7.0)(supports-color@8.1.1)
       eslint-formatter-tap:
         specifier: 'catalog:'
         version: 9.0.1
@@ -296,13 +296,13 @@ importers:
         version: 1.76.0(oxlint@1.76.0(oxlint-tsgolint@7.0.2001))
       eslint-plugin-package-json:
         specifier: 'catalog:'
-        version: 1.6.2(eslint@10.8.0(jiti@2.7.0))
+        version: 1.6.2(eslint@10.8.0(jiti@2.7.0)(supports-color@8.1.1))
       eslint-plugin-pnpm:
         specifier: 'catalog:'
-        version: 1.7.0(eslint@10.8.0(jiti@2.7.0))
+        version: 1.7.0(eslint@10.8.0(jiti@2.7.0)(supports-color@8.1.1))
       eslint-plugin-turbo:
         specifier: 'catalog:'
-        version: 2.10.7(eslint@10.8.0(jiti@2.7.0))(turbo@2.10.7)
+        version: 2.10.7(eslint@10.8.0(jiti@2.7.0)(supports-color@8.1.1))(turbo@2.10.7)
       husky:
         specifier: 'catalog:'
         version: 9.1.7
@@ -351,7 +351,7 @@ importers:
         version: 0.61.0
       start-server-and-test:
         specifier: 'catalog:'
-        version: 3.0.11
+        version: 3.0.11(supports-color@8.1.1)
       typescript:
         specifier: catalog:typescript6-compat
         version: '@typescript/typescript6@6.0.2'
@@ -645,7 +645,7 @@ importers:
         version: 1.62.0
       release-it:
         specifier: 'catalog:'
-        version: 20.2.1(@types/node@24.13.3)(magicast@0.5.3)
+        version: 20.2.1(@types/node@24.13.3)(magicast@0.5.3)(supports-color@8.1.1)
       rimraf:
         specifier: 'catalog:'
         version: 6.1.3
@@ -711,7 +711,7 @@ importers:
         version: 0.61.0
       release-it:
         specifier: 'catalog:'
-        version: 20.2.1(@types/node@24.13.3)(magicast@0.5.3)
+        version: 20.2.1(@types/node@24.13.3)(magicast@0.5.3)(supports-color@8.1.1)
       rimraf:
         specifier: 'catalog:'
         version: 6.1.3
@@ -768,7 +768,7 @@ importers:
         version: 1.62.0
       release-it:
         specifier: 'catalog:'
-        version: 20.2.1(@types/node@24.13.3)(magicast@0.5.3)
+        version: 20.2.1(@types/node@24.13.3)(magicast@0.5.3)(supports-color@8.1.1)
       rimraf:
         specifier: 'catalog:'
         version: 6.1.3
@@ -921,7 +921,7 @@ importers:
         version: 24.13.3
       oxfmt:
         specifier: 'catalog:'
-        version: 0.59.0
+        version: 0.61.0
       typescript:
         specifier: 'catalog:'
         version: 7.0.2
@@ -973,7 +973,7 @@ importers:
         version: link:../../packages/lit-ui-router-mobx
       pacote:
         specifier: 'catalog:'
-        version: 22.0.0
+        version: 22.0.0(supports-color@8.1.1)
       publint:
         specifier: 'catalog:'
         version: 0.3.22
@@ -7018,14 +7018,20 @@ snapshots:
   '@esbuild/win32-x64@0.28.1':
     optional: true
 
+  '@eslint-community/eslint-utils@4.9.1(eslint@10.8.0(jiti@2.7.0)(supports-color@8.1.1))':
+    dependencies:
+      eslint: 10.8.0(jiti@2.7.0)(supports-color@8.1.1)
+      eslint-visitor-keys: 3.4.3
+
   '@eslint-community/eslint-utils@4.9.1(eslint@10.8.0(jiti@2.7.0))':
     dependencies:
       eslint: 10.8.0(jiti@2.7.0)
       eslint-visitor-keys: 3.4.3
+    optional: true
 
   '@eslint-community/regexpp@4.12.2': {}
 
-  '@eslint/config-array@0.23.5':
+  '@eslint/config-array@0.23.5(supports-color@8.1.1)':
     dependencies:
       '@eslint/object-schema': 3.0.5
       debug: 4.4.3(supports-color@8.1.1)
@@ -7989,7 +7995,7 @@ snapshots:
       conventional-changelog-angular: 8.3.1
       conventional-changelog-conventionalcommits: 9.3.1
       conventional-recommended-bump: 11.2.0
-      release-it: 20.2.1(@types/node@24.13.3)(magicast@0.5.3)
+      release-it: 20.2.1(@types/node@24.13.3)(magicast@0.5.3)(supports-color@8.1.1)
       semver: 7.8.5
     transitivePeerDependencies:
       - conventional-commits-filter
@@ -8180,10 +8186,10 @@ snapshots:
       - kerberos
       - supports-color
 
-  '@sigstore/tuf@5.0.0':
+  '@sigstore/tuf@5.0.0(supports-color@8.1.1)':
     dependencies:
       '@sigstore/protobuf-specs': 0.5.1
-      tuf-js: 6.0.0
+      tuf-js: 6.0.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -8664,7 +8670,7 @@ snapshots:
       '@vueuse/shared': 14.3.0(vue@3.5.40(typescript@7.0.2))
       vue: 3.5.40(typescript@7.0.2)
     optionalDependencies:
-      axios: 1.18.1(debug@4.4.3)
+      axios: 1.18.1(debug@4.4.3(supports-color@8.1.1))
       change-case: 5.4.4
       focus-trap: 8.2.2
 
@@ -8808,9 +8814,9 @@ snapshots:
 
   aws4@1.13.2: {}
 
-  axios@1.18.1(debug@4.4.3):
+  axios@1.18.1(debug@4.4.3(supports-color@8.1.1)):
     dependencies:
-      follow-redirects: 1.16.0(debug@4.4.3)
+      follow-redirects: 1.16.0(debug@4.4.3(supports-color@8.1.1))
       form-data: 4.0.6
       https-proxy-agent: 5.0.1
       proxy-from-env: 2.1.0
@@ -9382,9 +9388,9 @@ snapshots:
     optionalDependencies:
       source-map: 0.6.1
 
-  eslint-fix-utils@0.4.3(@types/estree@1.0.9)(eslint@10.8.0(jiti@2.7.0)):
+  eslint-fix-utils@0.4.3(@types/estree@1.0.9)(eslint@10.8.0(jiti@2.7.0)(supports-color@8.1.1)):
     dependencies:
-      eslint: 10.8.0(jiti@2.7.0)
+      eslint: 10.8.0(jiti@2.7.0)(supports-color@8.1.1)
     optionalDependencies:
       '@types/estree': 1.0.9
 
@@ -9392,9 +9398,9 @@ snapshots:
     dependencies:
       js-yaml: 4.3.0
 
-  eslint-json-compat-utils@0.2.3(eslint@10.8.0(jiti@2.7.0))(jsonc-eslint-parser@3.1.0):
+  eslint-json-compat-utils@0.2.3(eslint@10.8.0(jiti@2.7.0)(supports-color@8.1.1))(jsonc-eslint-parser@3.1.0):
     dependencies:
-      eslint: 10.8.0(jiti@2.7.0)
+      eslint: 10.8.0(jiti@2.7.0)(supports-color@8.1.1)
       esquery: 1.7.0
       jsonc-eslint-parser: 3.1.0
 
@@ -9403,26 +9409,26 @@ snapshots:
       jsonc-parser: 3.3.1
       oxlint: 1.76.0(oxlint-tsgolint@7.0.2001)
 
-  eslint-plugin-package-json@1.6.2(eslint@10.8.0(jiti@2.7.0)):
+  eslint-plugin-package-json@1.6.2(eslint@10.8.0(jiti@2.7.0)(supports-color@8.1.1)):
     dependencies:
       '@altano/repository-tools': 2.0.3
       '@types/estree': 1.0.9
       change-case: 5.4.4
       detect-indent: 7.0.2
       detect-newline: 4.0.1
-      eslint: 10.8.0(jiti@2.7.0)
-      eslint-fix-utils: 0.4.3(@types/estree@1.0.9)(eslint@10.8.0(jiti@2.7.0))
-      eslint-json-compat-utils: 0.2.3(eslint@10.8.0(jiti@2.7.0))(jsonc-eslint-parser@3.1.0)
+      eslint: 10.8.0(jiti@2.7.0)(supports-color@8.1.1)
+      eslint-fix-utils: 0.4.3(@types/estree@1.0.9)(eslint@10.8.0(jiti@2.7.0)(supports-color@8.1.1))
+      eslint-json-compat-utils: 0.2.3(eslint@10.8.0(jiti@2.7.0)(supports-color@8.1.1))(jsonc-eslint-parser@3.1.0)
       jsonc-eslint-parser: 3.1.0
       package-json-validator: 1.5.2
       semver: 7.8.5
       sort-object-keys: 2.1.0
       sort-package-json: 4.0.0
 
-  eslint-plugin-pnpm@1.7.0(eslint@10.8.0(jiti@2.7.0)):
+  eslint-plugin-pnpm@1.7.0(eslint@10.8.0(jiti@2.7.0)(supports-color@8.1.1)):
     dependencies:
       empathic: 2.0.1
-      eslint: 10.8.0(jiti@2.7.0)
+      eslint: 10.8.0(jiti@2.7.0)(supports-color@8.1.1)
       jsonc-eslint-parser: 3.1.0
       pathe: 2.0.3
       pnpm-workspace-yaml: 1.7.0
@@ -9430,10 +9436,10 @@ snapshots:
       yaml: 2.9.0
       yaml-eslint-parser: 2.1.0
 
-  eslint-plugin-turbo@2.10.7(eslint@10.8.0(jiti@2.7.0))(turbo@2.10.7):
+  eslint-plugin-turbo@2.10.7(eslint@10.8.0(jiti@2.7.0)(supports-color@8.1.1))(turbo@2.10.7):
     dependencies:
       dotenv: 16.0.3
-      eslint: 10.8.0(jiti@2.7.0)
+      eslint: 10.8.0(jiti@2.7.0)(supports-color@8.1.1)
       turbo: 2.10.7
 
   eslint-scope@9.1.2:
@@ -9451,7 +9457,45 @@ snapshots:
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@10.8.0(jiti@2.7.0))
       '@eslint-community/regexpp': 4.12.2
-      '@eslint/config-array': 0.23.5
+      '@eslint/config-array': 0.23.5(supports-color@8.1.1)
+      '@eslint/config-helpers': 0.7.0
+      '@eslint/core': 1.2.1
+      '@eslint/plugin-kit': 0.7.2
+      '@humanfs/node': 0.16.8
+      '@humanwhocodes/module-importer': 1.0.1
+      '@humanwhocodes/retry': 0.4.3
+      '@types/estree': 1.0.9
+      ajv: 6.15.0
+      cross-spawn: 7.0.6
+      debug: 4.4.3(supports-color@8.1.1)
+      escape-string-regexp: 4.0.0
+      eslint-scope: 9.1.2
+      eslint-visitor-keys: 5.0.1
+      espree: 11.2.0
+      esquery: 1.7.0
+      esutils: 2.0.3
+      fast-deep-equal: 3.1.3
+      file-entry-cache: 8.0.0
+      find-up: 5.0.0
+      glob-parent: 6.0.2
+      ignore: 5.3.2
+      imurmurhash: 0.1.4
+      is-glob: 4.0.3
+      json-stable-stringify-without-jsonify: 1.0.1
+      minimatch: 10.2.5
+      natural-compare: 1.4.0
+      optionator: 0.9.4
+    optionalDependencies:
+      jiti: 2.7.0
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
+  eslint@10.8.0(jiti@2.7.0)(supports-color@8.1.1):
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.8.0(jiti@2.7.0)(supports-color@8.1.1))
+      '@eslint-community/regexpp': 4.12.2
+      '@eslint/config-array': 0.23.5(supports-color@8.1.1)
       '@eslint/config-helpers': 0.7.0
       '@eslint/core': 1.2.1
       '@eslint/plugin-kit': 0.7.2
@@ -9645,7 +9689,7 @@ snapshots:
 
   focus-visible@5.2.1: {}
 
-  follow-redirects@1.16.0(debug@4.4.3):
+  follow-redirects@1.16.0(debug@4.4.3(supports-color@8.1.1)):
     optionalDependencies:
       debug: 4.4.3(supports-color@8.1.1)
 
@@ -9711,7 +9755,7 @@ snapshots:
       '@sec-ant/readable-stream': 0.4.1
       is-stream: 4.0.1
 
-  get-uri@7.0.0:
+  get-uri@7.0.0(supports-color@8.1.1):
     dependencies:
       basic-ftp: 5.3.1
       data-uri-to-buffer: 7.0.0
@@ -10754,11 +10798,11 @@ snapshots:
 
   p-map@7.0.5: {}
 
-  pac-proxy-agent@8.0.0:
+  pac-proxy-agent@8.0.0(supports-color@8.1.1):
     dependencies:
       agent-base: 8.0.0
       debug: 4.4.3(supports-color@8.1.1)
-      get-uri: 7.0.0
+      get-uri: 7.0.0(supports-color@8.1.1)
       http-proxy-agent: 8.0.0
       https-proxy-agent: 8.0.0
       pac-resolver: 8.0.0(quickjs-wasi@0.0.1)
@@ -10784,7 +10828,7 @@ snapshots:
 
   package-manager-detector@1.8.0: {}
 
-  pacote@22.0.0:
+  pacote@22.0.0(supports-color@8.1.1):
     dependencies:
       '@gar/promise-retry': 1.0.3
       '@npmcli/git': 8.0.0
@@ -10800,7 +10844,7 @@ snapshots:
       npm-pick-manifest: 12.0.0
       npm-registry-fetch: 20.0.1
       proc-log: 7.0.0
-      sigstore: 5.0.0
+      sigstore: 5.0.0(supports-color@8.1.1)
       ssri: 14.0.0
       tar: 7.5.22
     transitivePeerDependencies:
@@ -10928,14 +10972,14 @@ snapshots:
 
   proxy-agent-negotiate@1.1.0: {}
 
-  proxy-agent@7.0.0:
+  proxy-agent@7.0.0(supports-color@8.1.1):
     dependencies:
       agent-base: 8.0.0
       debug: 4.4.3(supports-color@8.1.1)
       http-proxy-agent: 8.0.0
       https-proxy-agent: 8.0.0
       lru-cache: 7.18.3
-      pac-proxy-agent: 8.0.0
+      pac-proxy-agent: 8.0.0(supports-color@8.1.1)
       proxy-from-env: 1.1.0
       socks-proxy-agent: 9.0.0
     transitivePeerDependencies:
@@ -11004,7 +11048,7 @@ snapshots:
     dependencies:
       regex-utilities: 2.3.0
 
-  release-it@20.2.1(@types/node@24.13.3)(magicast@0.5.3):
+  release-it@20.2.1(@types/node@24.13.3)(magicast@0.5.3)(supports-color@8.1.1):
     dependencies:
       '@inquirer/prompts': 8.4.2(@types/node@24.13.3)
       '@octokit/rest': 22.0.1
@@ -11022,7 +11066,7 @@ snapshots:
       open: 11.0.0
       ora: 9.3.0
       os-name: 7.0.0
-      proxy-agent: 7.0.0
+      proxy-agent: 7.0.0(supports-color@8.1.1)
       semver: 7.7.4
       tinyglobby: 0.2.15
       undici: 7.28.0
@@ -11233,13 +11277,13 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
-  sigstore@5.0.0:
+  sigstore@5.0.0(supports-color@8.1.1):
     dependencies:
       '@sigstore/bundle': 5.0.0
       '@sigstore/core': 4.0.1
       '@sigstore/protobuf-specs': 0.5.1
       '@sigstore/sign': 5.0.0
-      '@sigstore/tuf': 5.0.0
+      '@sigstore/tuf': 5.0.0(supports-color@8.1.1)
       '@sigstore/verify': 4.1.0
     transitivePeerDependencies:
       - kerberos
@@ -11343,7 +11387,7 @@ snapshots:
 
   stackback@0.0.2: {}
 
-  start-server-and-test@3.0.11:
+  start-server-and-test@3.0.11(supports-color@8.1.1):
     dependencies:
       arg: 5.0.2
       check-more-types: 2.24.0
@@ -11351,7 +11395,7 @@ snapshots:
       execa: 5.1.1
       lazy-ass: 2.0.3
       tree-kill: 1.2.2
-      wait-on: 9.0.10(debug@4.4.3)
+      wait-on: 9.0.10(debug@4.4.3(supports-color@8.1.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -11471,7 +11515,7 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tuf-js@6.0.0:
+  tuf-js@6.0.0(supports-color@8.1.1):
     dependencies:
       '@gar/promise-retry': 1.0.3
       '@tufjs/models': 5.0.0
@@ -11812,9 +11856,9 @@ snapshots:
     optionalDependencies:
       typescript: 7.0.2
 
-  wait-on@9.0.10(debug@4.4.3):
+  wait-on@9.0.10(debug@4.4.3(supports-color@8.1.1)):
     dependencies:
-      axios: 1.18.1(debug@4.4.3)
+      axios: 1.18.1(debug@4.4.3(supports-color@8.1.1))
       joi: 18.2.3
       lodash: 4.18.1
       minimist: 1.2.8

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -910,6 +910,9 @@ importers:
 
   tools/lcov-rebase:
     devDependencies:
+      '@tools/shared':
+        specifier: workspace:*
+        version: link:../shared
       '@types/node':
         specifier: 'catalog:'
         version: 24.13.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -790,6 +790,9 @@ importers:
       '@tools/bundle-probe':
         specifier: workspace:*
         version: link:../../tools/bundle-probe
+      '@tools/lcov-rebase':
+        specifier: workspace:*
+        version: link:../../tools/lcov-rebase
       '@types/node':
         specifier: 'catalog:'
         version: 24.13.3
@@ -904,6 +907,18 @@ importers:
       vitest:
         specifier: 'catalog:'
         version: 4.1.10(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.0)(vite@8.1.3(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
+
+  tools/lcov-rebase:
+    devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.13.3
+      oxfmt:
+        specifier: 'catalog:'
+        version: 0.59.0
+      typescript:
+        specifier: 'catalog:'
+        version: 7.0.2
 
   tools/oxc-emit:
     dependencies:

--- a/tools/lcov-rebase/package.json
+++ b/tools/lcov-rebase/package.json
@@ -18,6 +18,7 @@
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "devDependencies": {
+    "@tools/shared": "workspace:*",
     "@types/node": "catalog:",
     "oxfmt": "catalog:",
     "typescript": "catalog:"

--- a/tools/lcov-rebase/package.json
+++ b/tools/lcov-rebase/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@tools/lcov-rebase",
+  "version": "0.0.1",
+  "private": true,
+  "description": "Rewrite lcov SF paths to repo-relative form so codecov can disambiguate same-named files across packages",
+  "bin": {
+    "rebase-lcov": "./src/rebase-lcov.ts"
+  },
+  "type": "module",
+  "exports": {
+    ".": "./src/rebase.ts"
+  },
+  "scripts": {
+    "format": "oxfmt \"**/*.{ts,json,md}\"",
+    "format:check": "oxfmt --check \"**/*.{ts,json,md}\"",
+    "lint": "oxlint .",
+    "test": "node --test \"src/**/*.test.ts\"",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:",
+    "oxfmt": "catalog:",
+    "typescript": "catalog:"
+  }
+}

--- a/tools/lcov-rebase/src/rebase-lcov.ts
+++ b/tools/lcov-rebase/src/rebase-lcov.ts
@@ -6,7 +6,9 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
-import { findRepoRoot, rebaseLcov } from './rebase.ts';
+import { workspaceRoot } from '@tools/shared/workspace.ts';
+
+import { rebaseLcov } from './rebase.ts';
 
 const files = process.argv.slice(2);
 if (files.length === 0) {
@@ -15,7 +17,7 @@ if (files.length === 0) {
 }
 
 const packageDir = path
-  .relative(findRepoRoot(process.cwd()), process.cwd())
+  .relative(workspaceRoot, process.cwd())
   .split(path.sep)
   .join('/');
 

--- a/tools/lcov-rebase/src/rebase-lcov.ts
+++ b/tools/lcov-rebase/src/rebase-lcov.ts
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+// Rewrite each lcov file's relative SF paths to repo-relative, in place.
+// Run from the package that produced the report — the package dir is the
+// base the reporter's relative paths mean.
+// Usage (from the package dir): rebase-lcov <lcov-file> [...]
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { findRepoRoot, rebaseLcov } from './rebase.ts';
+
+const files = process.argv.slice(2);
+if (files.length === 0) {
+  console.error('usage: rebase-lcov <lcov-file> [...]');
+  process.exit(1);
+}
+
+const packageDir = path
+  .relative(findRepoRoot(process.cwd()), process.cwd())
+  .split(path.sep)
+  .join('/');
+
+for (const file of files) {
+  fs.writeFileSync(file, rebaseLcov(fs.readFileSync(file, 'utf8'), packageDir));
+}

--- a/tools/lcov-rebase/src/rebase.test.ts
+++ b/tools/lcov-rebase/src/rebase.test.ts
@@ -1,0 +1,36 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { rebaseLcov } from './rebase.ts';
+
+const record = (sf: string) => `TN:\nSF:${sf}\nDA:1,1\nend_of_record\n`;
+
+test('prefixes package-relative SF paths', () => {
+  assert.equal(
+    rebaseLcov(record('src/index.ts'), 'packages/ui-router-server'),
+    record('packages/ui-router-server/src/index.ts'),
+  );
+});
+
+test('resolves cross-package .. escapes onto the real package', () => {
+  assert.equal(
+    rebaseLcov(
+      record('../../tools/bundle-probe/src/bundle.ts'),
+      'packages/ui-router-server',
+    ),
+    record('tools/bundle-probe/src/bundle.ts'),
+  );
+});
+
+test('leaves absolute SF paths untouched', () => {
+  const absolute = record('/repo/packages/x/src/index.ts');
+  assert.equal(rebaseLcov(absolute, 'packages/x'), absolute);
+});
+
+test('touches only SF records', () => {
+  const report = 'TN:\nSF:src/a.ts\nDA:1,1\nLF:1\nLH:1\nend_of_record\n';
+  const rebased = rebaseLcov(report, 'packages/x');
+  assert.match(rebased, /^DA:1,1$/m);
+  assert.match(rebased, /^LF:1$/m);
+  assert.equal(rebased.match(/packages\/x/g)?.length, 1);
+});

--- a/tools/lcov-rebase/src/rebase.ts
+++ b/tools/lcov-rebase/src/rebase.ts
@@ -1,0 +1,33 @@
+// Package-relative SF paths (node --test's lcov reporter, vitest's lcov)
+// are ambiguous at repo root — four packages own a src/index.ts — and an
+// lcov-only upload has no absolute-path sibling report to break the tie,
+// so codecov silently drops the ambiguous entry. Repo-relative SF paths
+// are the canonical unambiguous form.
+import fs from 'node:fs';
+import path from 'node:path';
+
+/** Walk up from dir to the workspace root (the pnpm-workspace.yaml holder). */
+export const findRepoRoot = (dir: string): string => {
+  let current = path.resolve(dir);
+  while (true) {
+    if (fs.existsSync(path.join(current, 'pnpm-workspace.yaml')))
+      return current;
+    const parent = path.dirname(current);
+    if (parent === current) {
+      throw new Error(`no pnpm-workspace.yaml above ${dir}`);
+    }
+    current = parent;
+  }
+};
+
+/**
+ * Rewrite relative SF records to repo-relative form. `packageDir` is the
+ * repo-relative directory the report's paths are relative to (the cwd of
+ * the test run). Absolute SF paths and non-SF records pass through; `..`
+ * segments resolve, so cross-package entries land on their real package.
+ */
+export const rebaseLcov = (content: string, packageDir: string): string =>
+  content.replace(/^SF:(.+)$/gm, (record, sf: string) => {
+    if (path.posix.isAbsolute(sf) || path.win32.isAbsolute(sf)) return record;
+    return `SF:${path.posix.normalize(path.posix.join(packageDir, sf))}`;
+  });

--- a/tools/lcov-rebase/src/rebase.ts
+++ b/tools/lcov-rebase/src/rebase.ts
@@ -3,22 +3,7 @@
 // lcov-only upload has no absolute-path sibling report to break the tie,
 // so codecov silently drops the ambiguous entry. Repo-relative SF paths
 // are the canonical unambiguous form.
-import fs from 'node:fs';
 import path from 'node:path';
-
-/** Walk up from dir to the workspace root (the pnpm-workspace.yaml holder). */
-export const findRepoRoot = (dir: string): string => {
-  let current = path.resolve(dir);
-  while (true) {
-    if (fs.existsSync(path.join(current, 'pnpm-workspace.yaml')))
-      return current;
-    const parent = path.dirname(current);
-    if (parent === current) {
-      throw new Error(`no pnpm-workspace.yaml above ${dir}`);
-    }
-    current = parent;
-  }
-};
 
 /**
  * Rewrite relative SF records to repo-relative form. `packageDir` is the

--- a/tools/lcov-rebase/tsconfig.json
+++ b/tools/lcov-rebase/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  // Node runs these files directly via type stripping — same constraints as
+  // the root scripts tsconfig: .ts import extensions, nothing emitted.
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "allowImportingTsExtensions": true,
+    "erasableSyntaxOnly": true,
+    "verbatimModuleSyntax": true,
+    "types": ["node"],
+    "lib": ["ES2022"]
+  },
+  "include": ["**/*.ts"]
+}


### PR DESCRIPTION
## Summary

Closes the ui-router-server slice of the coverage gap tracked in #330 — on the **native runner**, no vitest conversion. `node --test --experimental-test-coverage` runs the type-stripped `.ts` sources directly and emits standard LCOV attributing to real `src/*.ts` paths.

Four plumbing spots, mirroring the vitest packages' `test`/`test:coverage` split:

- **`package.json`**: new `test:coverage` script. `--test-coverage-include="src/**"` scopes the report to the 8 shipped entry files — it drops both the test files and the cross-package `@tools/bundle-probe` `.ts` imports, keeping the project gate's shipped-code-only semantics intact.
- **package `turbo.json`**: `test:coverage` override — the root task keys inputs on vitest configs, this suite is buildless `node --test` (`transit` + `$TURBO_DEFAULT$`, like its `test` task). Since root `ci:pull_request` already depends on `test:coverage`, the package joins the PR graph with no workflow change.
- **`build-test-run.yml`**: appended `packages/ui-router-server/coverage/lcov.info` to the codecov-action `files:` list (`disable_search: true` means nothing uploads otherwise). LCOV only — the node reporter produces no `coverage-final.json`.
- **`codecov.yml`**: new `ui-router-server` component (`packages/ui-router-server/src/**`). Validated against `api.codecov.io/validate`.

## Verification

- `turbo run test:coverage --filter=ui-router-server` green; all 8 src files in lcov, ~99% lines.
- **Line-map spot check** (the historical type-strip worry): lcov's uncovered lines 127–128/186 in `url-matcher.ts` land exactly on the calendar-day `equals` comparator body and a return tail — mapping is 1:1.
- SF paths are package-relative (`SF:src/…`), the same shape the three working vitest lcov uploads use.
- `format:check`, `lint_workflows` (actionlint/zizmor/shellcheck/taplo) green.

## Out of scope

The other 6 node:test suites (tools/*, sample-app-routes, docs worker) stay uncovered pending the policy call in #330 about whether internal tooling belongs in the coverage gate — this PR only adds shipped code, so the meaning of the project % gate is unchanged.

Refs #330