### PR TITLE
docs(api): stand up the ui-router-server typedoc reference

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -3,4 +3,5 @@ dist
 api/reference
 api/lit-ui-router-mobx
 api/navigation-location-plugin
+api/ui-router-server
 worker/worker-configuration.d.ts

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -4,6 +4,7 @@ import { defineConfig, HeadConfig, type DefaultTheme } from 'vitepress';
 import typedocSidebarItemsJson from '../api/reference/typedoc-sidebar.json';
 import mobxSidebarItemsJson from '../api/lit-ui-router-mobx/typedoc-sidebar.json';
 import navigationSidebarItemsJson from '../api/navigation-location-plugin/typedoc-sidebar.json';
+import serverSidebarItemsJson from '../api/ui-router-server/typedoc-sidebar.json';
 
 const typedocSidebarItems =
   typedocSidebarItemsJson as DefaultTheme.SidebarItem[];
@@ -26,6 +27,21 @@ const navigationSidebarItemsRaw =
   navigationSidebarItemsJson as DefaultTheme.SidebarItem[];
 const mobxSidebarItems = flattenGroups(mobxSidebarItemsRaw);
 const navigationSidebarItems = flattenGroups(navigationSidebarItemsRaw);
+
+// ui-router-server is multi-entry: typedoc emits one module per subpath
+// export, so the module level is the import surface — keep it, retitle each
+// module to its import specifier, and flatten only the kind groups within.
+const serverSidebarItemsRaw =
+  serverSidebarItemsJson as DefaultTheme.SidebarItem[];
+const serverSidebarItems = serverSidebarItemsRaw.map((module) => ({
+  ...module,
+  text:
+    module.text === 'index'
+      ? 'ui-router-server'
+      : `ui-router-server/${module.text}`,
+  collapsed: true,
+  items: module.items && flattenGroups(module.items),
+}));
 
 const baseUrl = 'https://lit-ui-router.dev';
 
@@ -94,7 +110,19 @@ function makeSidebar() {
             },
           ],
         },
-        { text: 'Server', link: '/packages/server' },
+        {
+          text: 'Server',
+          link: '/packages/server',
+          collapsed: true,
+          items: [
+            {
+              text: 'ui-router-server API',
+              link: '/api/ui-router-server/',
+              collapsed: false,
+              items: serverSidebarItems,
+            },
+          ],
+        },
       ],
     },
     {

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -33,15 +33,22 @@ const navigationSidebarItems = flattenGroups(navigationSidebarItemsRaw);
 // module to its import specifier, and flatten only the kind groups within.
 const serverSidebarItemsRaw =
   serverSidebarItemsJson as DefaultTheme.SidebarItem[];
-const serverSidebarItems = serverSidebarItemsRaw.map((module) => ({
-  ...module,
-  text:
-    module.text === 'index'
-      ? 'ui-router-server'
-      : `ui-router-server/${module.text}`,
-  collapsed: true,
-  items: module.items && flattenGroups(module.items),
-}));
+const serverSidebarItems = serverSidebarItemsRaw
+  .map((module) => ({
+    ...module,
+    text:
+      module.text === 'index'
+        ? 'ui-router-server'
+        : `ui-router-server/${module.text}`,
+    collapsed: true,
+    items: module.items && flattenGroups(module.items),
+  }))
+  // root module first; stable sort keeps the subpaths in typedoc order
+  .sort(
+    (a, b) =>
+      Number(b.text === 'ui-router-server') -
+      Number(a.text === 'ui-router-server'),
+  );
 
 const baseUrl = 'https://lit-ui-router.dev';
 

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -160,7 +160,7 @@ See the [@uirouter/core location plugins documentation](https://ui-router.github
 
 ## Companion Packages
 
-`lit-ui-router` is the core package; optional **companion packages** layer on extra integrations — [MobX bindings](/packages/mobx) and the [Navigation API location plugin](/packages/navigation-plugin), each independently versioned with its own guide and API reference; [`ui-router-server`](/packages/server), server-side routing verdicts at the edge, is in development. See [Companion Packages](/packages/).
+`lit-ui-router` is the core package; optional **companion packages** layer on extra integrations — [MobX bindings](/packages/mobx), the [Navigation API location plugin](/packages/navigation-plugin), and [server-side routing verdicts](/packages/server) with [`ui-router-server`](/api/ui-router-server/) (in development), each independently versioned with its own guide and API reference. See [Companion Packages](/packages/).
 
 ## Further Reading
 

--- a/docs/packages/server.md
+++ b/docs/packages/server.md
@@ -316,6 +316,8 @@ as the mount's `config`.
 
 ## Further reading
 
+- [API reference](/api/ui-router-server/) — every entry point, one module
+  per subpath import
 - [Server-Side Routing guide](/guides/server-route-matching) — the spectrum,
   the projection, and the live mounts
 - [Unmatched URLs](/guides/unmatched-urls) — the client-side 404 state this

--- a/packages/ui-router-server/package.json
+++ b/packages/ui-router-server/package.json
@@ -17,6 +17,7 @@
   },
   "scripts": {
     "codecov:bundle": "upload-entry-bundles",
+    "docs:api": "rimraf ../../docs/api/ui-router-server && typedoc",
     "format": "oxfmt \"**/*.{ts,json,md}\"",
     "format:check": "oxfmt --check \"**/*.{ts,json,md}\"",
     "lint": "oxlint .",
@@ -26,11 +27,16 @@
   },
   "devDependencies": {
     "@tools/bundle-probe": "workspace:*",
+    "@tools/typedoc-plugin-lit-ui-router": "workspace:*",
     "@types/node": "catalog:",
     "@uirouter/core": "catalog:",
     "hono": "catalog:",
     "oxfmt": "catalog:",
-    "typescript": "catalog:",
+    "rimraf": "catalog:",
+    "typedoc": "catalog:",
+    "typedoc-plugin-markdown": "catalog:",
+    "typedoc-vitepress-theme": "catalog:",
+    "typescript": "catalog:typescript6-compat",
     "vite": "catalog:"
   },
   "peerDependencies": {

--- a/packages/ui-router-server/src/connect.ts
+++ b/packages/ui-router-server/src/connect.ts
@@ -7,13 +7,13 @@
  * mount-owned misses answer 404, and only real routes reach the shell.
  *
  * The adapter owns verdict → response mechanics (status mapping,
- * [[mergeSearch]] on redirect Locations, validator stripping and status
+ * {@link mergeSearch} on redirect Locations, validator stripping and status
  * relabeling on status'd shells); the HOST supplies asset IO. The default
  * host is the downstream stack itself: shells rewrite `req.url` to the
  * mount's shell path and `next()` into `express.static`/`sirv`/Vite —
  * which is why this middleware mounts BEFORE the static layer, exactly
- * where `connect-history-api-fallback` sits. Override [[serveShell]] /
- * [[serveNotFound]] to take asset IO in hand.
+ * where `connect-history-api-fallback` sits. Override {@link ConnectAdapterOptions.serveShell | serveShell} /
+ * {@link ConnectAdapterOptions.serveNotFound | serveNotFound} to take asset IO in hand.
  *
  * Dependency-free, like the tiers it fronts: the request/response types
  * below declare the minimal structural surface the adapter touches (the
@@ -54,14 +54,14 @@ export type ConnectMiddleware = (
 
 export interface ConnectAdapterOptions {
   /**
-   * Maps a shell verdict's mount to the path the default [[serveShell]]
+   * Maps a shell verdict's mount to the path the default {@link ConnectAdapterOptions.serveShell | serveShell}
    * rewrites `req.url` to (default: the mount base itself). The hook for
    * aliased mounts whose shell lives under another prefix.
    */
   shellPath?: (mount: string) => string;
   /**
    * Serve the mount's shell. The default rewrites `req.url` to
-   * [[shellPath]] and `next()`s into the downstream static layer. By the
+   * {@link ConnectAdapterOptions.shellPath | shellPath} and `next()`s into the downstream static layer. By the
    * time this runs the adapter has already done the status'd-shell
    * mechanics: request validators stripped and the response relabeled to
    * the verdict's status — a host override only owns the asset IO.
@@ -134,21 +134,21 @@ const defaultServeNotFound = (
 };
 
 /**
- * Wraps a [[ServerRouter]] as Connect middleware. Mount it BEFORE the
+ * Wraps a {@link ServerRouter} as Connect middleware. Mount it BEFORE the
  * static layer; the default host serves shells by rewriting `req.url` and
  * `next()`ing into it. `resolve()` is always async (the simulate tier's
  * lazy boundary), which Connect absorbs naturally — with matcher-tier
  * mounts nothing async ever actually runs.
  *
  * - `redirect` → `writeHead(302, { Location })`, the request's search
- *   MERGED into the verdict's location via [[mergeSearch]] (targets that
+ *   MERGED into the verdict's location via {@link mergeSearch} (targets that
  *   declare their own query keep it — never `?a=1?b=2`).
  * - `shell` → `Link: <mount>; rel="canonical"` (the shell is the same
- *   representation at every route path), then [[serveShell]].
+ *   representation at every route path), then {@link ConnectAdapterOptions.serveShell | serveShell}.
  * - `shell` with status (the otherwise projection) → validators stripped,
  *   downstream status relabeled, no canonical Link (a 404 is not an
- *   alternate representation of the mount root), then [[serveShell]].
- * - `notFound` with a mount → [[serveNotFound]] (honest 404).
+ *   alternate representation of the mount root), then {@link ConnectAdapterOptions.serveShell | serveShell}.
+ * - `notFound` with a mount → {@link ConnectAdapterOptions.serveNotFound | serveNotFound} (honest 404).
  * - `notFound` without a mount, or a non-navigation request → `next()`.
  */
 export function createConnectMiddleware(

--- a/packages/ui-router-server/src/fetch.ts
+++ b/packages/ui-router-server/src/fetch.ts
@@ -9,12 +9,12 @@
  *
  * The division of labor is the Connect adapter's, adapted to fetch's
  * immutable objects: the adapter owns verdict -> response mechanics (status
- * mapping, [[mergeSearch]] on redirect Locations, validator stripping and
+ * mapping, {@link mergeSearch} on redirect Locations, validator stripping and
  * status relabeling on status'd shells, the canonical Link header), the HOST
- * supplies asset IO through [[serveShell]]. Because a fetch Request is
+ * supplies asset IO through {@link FetchAdapterOptions.serveShell | serveShell}. Because a fetch Request is
  * immutable and served from a DIFFERENT url than the route path, the adapter
- * hands [[serveShell]] a fully-prepared shell Request — url rewritten to the
- * mount's [[shellPath]], conditional validators already stripped on a status'd
+ * hands {@link FetchAdapterOptions.serveShell | serveShell} a fully-prepared shell Request — url rewritten to the
+ * mount's {@link FetchAdapterOptions.shellPath | shellPath}, conditional validators already stripped on a status'd
  * shell — so the host's job is the pure one-liner `(_m, req) => ASSETS.fetch(req)`.
  * The adapter then wraps the raw asset Response with the verdict's status and
  * headers. `null` is the pass-through: a mountless miss or a non-navigation
@@ -52,7 +52,7 @@ export interface FetchAdapterOptions {
   shellPath?: (mount: string) => string;
   /**
    * Serve the mount's shell asset. The adapter hands over a shell Request
-   * already rewritten to [[shellPath]] and, for a status'd shell, already
+   * already rewritten to {@link FetchAdapterOptions.shellPath | shellPath} and, for a status'd shell, already
    * stripped of conditional validators — so the host returns the RAW asset
    * Response (`(mount, request) => env.ASSETS.fetch(request)`) and the adapter
    * owns the status relabel and Link header on the way out. REQUIRED: asset IO
@@ -127,20 +127,20 @@ const defaultServeNotFound = (mount: string, request: Request): Response =>
   );
 
 /**
- * Wraps a [[ServerRouter]] as a WinterCG fetch handler. `resolve()` is always
+ * Wraps a {@link ServerRouter} as a WinterCG fetch handler. `resolve()` is always
  * async (the simulate tier's lazy boundary), which fetch absorbs naturally —
  * with matcher-tier mounts nothing async ever actually runs.
  *
  * - `redirect` -> `Response(null, { status, Location })`, the request's search
- *   MERGED into the location via [[mergeSearch]] (targets that declare their
+ *   MERGED into the location via {@link mergeSearch} (targets that declare their
  *   own query keep it — never `?a=1?b=2`).
- * - `shell` -> [[serveShell]] on a Request rewritten to [[shellPath]], the raw
+ * - `shell` -> {@link FetchAdapterOptions.serveShell | serveShell} on a Request rewritten to {@link FetchAdapterOptions.shellPath | shellPath}, the raw
  *   asset Response wrapped with a `Link: <mount>; rel="canonical"` header (the
  *   shell is the same representation at every route path).
  * - `shell` with status (the otherwise projection) -> validators stripped, the
  *   asset Response's status relabeled to the verdict's, no canonical Link (a
  *   404 is not an alternate representation of the mount root).
- * - `notFound` with a mount -> [[serveNotFound]] (honest 404).
+ * - `notFound` with a mount -> {@link FetchAdapterOptions.serveNotFound | serveNotFound} (honest 404).
  * - `notFound` without a mount, or a non-navigation request -> `null` (the
  *   host serves it however it would have).
  */

--- a/packages/ui-router-server/src/hono.ts
+++ b/packages/ui-router-server/src/hono.ts
@@ -16,7 +16,7 @@
  * adapter's `null` pass-through assumes: a redirect or mount-owned 404 is
  * answered here, and everything else (`null`) falls through to `next()` and
  * Hono's own asset serving. The host still supplies asset IO through
- * [[FetchAdapterOptions.serveShell]] — `(mount, request) => c.env.ASSETS.fetch(request)`
+ * {@link FetchAdapterOptions.serveShell} — `(mount, request) => c.env.ASSETS.fetch(request)`
  * on Cloudflare, a `serveStatic` fetch elsewhere.
  */
 
@@ -27,7 +27,7 @@ import type { ServerRouter } from './index.ts';
 import type { MiddlewareHandler } from 'hono';
 
 /**
- * Wraps a [[ServerRouter]] as Hono middleware. The returned handler resolves
+ * Wraps a {@link ServerRouter} as Hono middleware. The returned handler resolves
  * the request to a verdict and either answers it (`return`ing the verdict
  * Response) or passes it on (`await next()`), exactly the fetch adapter's
  * `Response | null` contract expressed in Hono's continuation.

--- a/packages/ui-router-server/src/index.ts
+++ b/packages/ui-router-server/src/index.ts
@@ -38,7 +38,7 @@ export type {
 const SETTLE_TIMEOUT_MS = 100;
 
 export interface MountConfig {
-  /** The mount's state tree; dotted names nest, urls append (see [[RouteDeclaration]]). */
+  /** The mount's state tree; dotted names nest, urls append (see {@link RouteDeclaration}). */
   routes: RouteDeclaration[];
   /** when()-style pattern rules, evaluated before per-state redirectTo entries. */
   redirects?: RedirectRule[];
@@ -47,7 +47,7 @@ export interface MountConfig {
    * redirects. 'simulate': replay through a headless @uirouter/core router —
    * the tier where routing that data cannot express (hooks, resolves,
    * redirectTo functions) will live. Those are NOT yet reachable through
-   * MountConfig: both strategies consume the same [[RouteDeclaration]] data
+   * MountConfig: both strategies consume the same {@link RouteDeclaration} data
    * subset today, deliberately, so strategy stays a pure cost knob; the
    * config widens later (e.g. an auth tier).
    */

--- a/packages/ui-router-server/src/redirects.ts
+++ b/packages/ui-router-server/src/redirects.ts
@@ -22,12 +22,12 @@ export interface RouteDeclaration {
   name: string;
   /** Url segment appended to the ancestors' segments; a url-less state is structural only (never matched, never a redirect target). */
   url?: string;
-  /** Param declarations for this state's own placeholders (shorthand defaults or [[ParamDeclaration]]s). */
+  /** Param declarations for this state's own placeholders (shorthand defaults or {@link matcher!ParamDeclaration | ParamDeclaration}s). */
   params?: Record<string, unknown>;
   /**
    * Data redirect, mirroring ui-router's redirectTo subset: a url landing on
    * this state goes to the target state instead. A string target keeps the
-   * matched params; a [[RedirectTarget]] with `params` replaces them
+   * matched params; a {@link RedirectTarget} with `params` replaces them
    * (core's `result.params || trans.params()`). Chains are followed;
    * cycles are rejected at compile.
    */
@@ -132,7 +132,7 @@ export interface RouteMatch {
 
 /**
  * Returns which route's pattern the pathname matched, with the extracted
- * params. The most specific match wins ([[compare]]); ties go to
+ * params. The most specific match wins ({@link compare}); ties go to
  * declaration order.
  */
 export function matchRoute(
@@ -245,7 +245,7 @@ export function compileRedirects(
   };
 }
 
-/** One-shot convenience over [[compileRedirects]]. */
+/** One-shot convenience over {@link compileRedirects}. */
 export function evaluateRedirects(
   table: RedirectTable,
   pathname: string,

--- a/packages/ui-router-server/src/url-matcher.ts
+++ b/packages/ui-router-server/src/url-matcher.ts
@@ -138,13 +138,13 @@ const unsupportedTypes = new Set(['hash', 'json', 'any']);
 /**
  * A per-param configuration: core's ParamDeclaration members that matching
  * honors. Relaxation vs core: `type` also accepts a plain-object
- * [[ParamType]], and `value` must be static (functions are rejected).
+ * {@link ParamType}, and `value` must be static (functions are rejected).
  */
 export interface ParamDeclaration extends Pick<
   CoreParamDeclaration,
   'value' | 'squash'
 > {
-  /** Type for params not already typed inline (`{id:int}`) — a built-in name or a [[ParamType]]. */
+  /** Type for params not already typed inline (`{id:int}`) — a built-in name or a {@link ParamType}. */
   type?: string | ParamType;
 }
 
@@ -361,9 +361,9 @@ export interface UrlMatcherCompileOptions<M = undefined> extends Pick<
   UrlMatcherCompileConfig,
   'strict' | 'caseInsensitive'
 > {
-  /** Relaxation vs core: `state.params` flattened to `params` (no StateDeclaration here) — a [[ParamDeclaration]] or a shorthand static default per name. */
+  /** Relaxation vs core: `state.params` flattened to `params` (no StateDeclaration here) — a {@link ParamDeclaration} or a shorthand static default per name. */
   params?: Record<string, unknown>;
-  /** Passenger field: rides the compiled matcher as [[CompiledMatcher.meta]], untouched by compilation. */
+  /** Passenger field: rides the compiled matcher as {@link CompiledMatcher.meta}, untouched by compilation. */
   meta?: M;
 }
 
@@ -382,9 +382,9 @@ interface ResolvedConfig extends Required<UrlMatcherCompilerConfig> {
 }
 
 /**
- * A compiled url pattern: inert data produced by [[urlMatcherFactory]]'s
- * `compile` and consumed by [[exec]], [[format]], and [[compare]].
- * Frozen — treat as immutable: [[compare]] memoizes per object identity,
+ * A compiled url pattern: inert data produced by {@link urlMatcherFactory}'s
+ * `compile` and consumed by {@link exec}, {@link format}, and {@link compare}.
+ * Frozen — treat as immutable: {@link compare} memoizes per object identity,
  * and the functions/regexps inside make it not structuredClone-able.
  * Two data channels: compile's `options.meta` rides compile-time data on
  * the matcher, and a consumer-owned identity-keyed WeakMap (frozen keys
@@ -399,7 +399,7 @@ export interface CompiledMatcher<M = undefined> {
   readonly segments: readonly string[];
   readonly pathParams: readonly CompiledParam[];
   readonly searchParams: readonly CompiledParam[];
-  /** Whether [[exec]] percent-decodes captured values (the factory's decodeParams). */
+  /** Whether {@link exec} percent-decodes captured values (the factory's decodeParams). */
   readonly decodeParams: boolean;
   /** Compile-time data riding the matcher (e.g. a build-time route id); the reference is frozen in, the object stays consumer-owned. */
   readonly meta: M;
@@ -567,7 +567,7 @@ export function exec(
 
 /**
  * Builds a url from a compiled matcher by substituting parameter values —
- * the inverse of [[exec]], mirroring core's UrlMatcher.format for the
+ * the inverse of {@link exec}, mirroring core's UrlMatcher.format for the
  * supported subset (no parent-matcher composition: matchers here never
  * append). Default values honor the squash policy, search params render
  * as a query string, and `values['#']` appends a hash fragment.

--- a/packages/ui-router-server/src/url-matcher.ts
+++ b/packages/ui-router-server/src/url-matcher.ts
@@ -1,3 +1,4 @@
+/** @module matcher */
 // Derived from @uirouter/core (MIT, Copyright (c) 2013-2015 The AngularUI Team, Karsten Sperling) — UrlMatcher/Param/ParamTypes, https://github.com/ui-router/core
 
 /**

--- a/packages/ui-router-server/src/vite.ts
+++ b/packages/ui-router-server/src/vite.ts
@@ -30,7 +30,7 @@ export interface ServerRouterPlugin {
 }
 
 /**
- * Wraps a [[ServerRouter]] as a Vite plugin. The middleware installs in the
+ * Wraps a {@link ServerRouter} as a Vite plugin. The middleware installs in the
  * PRE position — synchronously inside `configureServer`, before Vite adds
  * its own middlewares — which is exactly where `connect-history-api-fallback`
  * sits and the only position that beats Vite's always-200 HTML fallback: a
@@ -41,7 +41,7 @@ export interface ServerRouterPlugin {
  *
  * `serveShell` defaults to rewriting `req.url` to the mount base and
  * `next()`ing into Vite's HTML/transform layer (dev) or `sirv` (preview);
- * point [[ConnectAdapterOptions.shellPath]] at the mount's actual HTML entry
+ * point {@link ConnectAdapterOptions.shellPath} at the mount's actual HTML entry
  * when it isn't served at the base.
  */
 export function serverRouterPlugin(

--- a/packages/ui-router-server/turbo.json
+++ b/packages/ui-router-server/turbo.json
@@ -2,6 +2,9 @@
   "$schema": "https://turborepo.com/schema.json",
   "extends": ["//"],
   "tasks": {
+    "docs:api": {
+      "outputs": ["../../docs/api/ui-router-server/**"]
+    },
     "test": {
       "dependsOn": ["^test", "transit"],
       "inputs": ["$TURBO_DEFAULT$"]

--- a/packages/ui-router-server/typedoc.json
+++ b/packages/ui-router-server/typedoc.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://typedoc.org/schema.json",
+  "entryPoints": [
+    "src/index.ts",
+    "src/url-matcher.ts",
+    "src/redirects.ts",
+    "src/simulate.ts",
+    "src/connect.ts",
+    "src/fetch.ts",
+    "src/hono.ts",
+    "src/vite.ts"
+  ],
+  "out": "../../docs/api/ui-router-server",
+  "docsRoot": "../../docs",
+  "plugin": [
+    "typedoc-plugin-markdown",
+    "typedoc-vitepress-theme",
+    "@tools/typedoc-plugin-lit-ui-router/kind-indexes"
+  ],
+  "excludeExternals": true,
+  "excludeInternal": true,
+  "excludePrivate": true,
+  "readme": "none",
+  "githubPages": false,
+  "entryFileName": "index",
+  "useCodeBlocks": true,
+  "expandObjects": true,
+  "parametersFormat": "table",
+  "propertiesFormat": "table",
+  "enumMembersFormat": "table",
+  "typeDeclarationFormat": "table",
+  "sort": ["alphabetical", "source-order"],
+  "externalSymbolLinkMappings": {
+    "@uirouter/core": {
+      "UIRouter": "https://ui-router.github.io/core/docs/latest/classes/_router_.uirouter.html",
+      "UrlMatcher": "https://ui-router.github.io/core/docs/latest/classes/_url_urlmatcher_.urlmatcher.html",
+      "StateDeclaration": "https://ui-router.github.io/core/docs/latest/interfaces/_state_interface_.statedeclaration.html",
+      "RawParams": "https://ui-router.github.io/core/docs/latest/interfaces/_params_interface_.rawparams.html",
+      "Transition": "https://ui-router.github.io/core/docs/latest/classes/_transition_transition_.transition.html",
+      "TargetState": "https://ui-router.github.io/core/docs/latest/classes/_state_targetstate_.targetstate.html"
+    }
+  },
+  "sidebar": {
+    "pretty": true
+  }
+}

--- a/packages/ui-router-server/typedoc.json
+++ b/packages/ui-router-server/typedoc.json
@@ -31,6 +31,11 @@
   "typeDeclarationFormat": "table",
   "sort": ["alphabetical", "source-order"],
   "externalSymbolLinkMappings": {
+    "ui-router-server": {
+      "Request": "https://developer.mozilla.org/en-US/docs/Web/API/Request",
+      "Response": "https://developer.mozilla.org/en-US/docs/Web/API/Response",
+      "Headers": "https://developer.mozilla.org/en-US/docs/Web/API/Headers"
+    },
     "@uirouter/core": {
       "UIRouter": "https://ui-router.github.io/core/docs/latest/classes/_router_.uirouter.html",
       "UrlMatcher": "https://ui-router.github.io/core/docs/latest/classes/_url_urlmatcher_.urlmatcher.html",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -790,6 +790,9 @@ importers:
       '@tools/bundle-probe':
         specifier: workspace:*
         version: link:../../tools/bundle-probe
+      '@tools/typedoc-plugin-lit-ui-router':
+        specifier: workspace:*
+        version: link:../../tools/typedoc-plugin-lit-ui-router
       '@types/node':
         specifier: 'catalog:'
         version: 24.13.3
@@ -802,9 +805,21 @@ importers:
       oxfmt:
         specifier: 'catalog:'
         version: 0.59.0
-      typescript:
+      rimraf:
         specifier: 'catalog:'
-        version: 7.0.2
+        version: 6.1.3
+      typedoc:
+        specifier: 'catalog:'
+        version: 0.28.20(@typescript/typescript6@6.0.2)
+      typedoc-plugin-markdown:
+        specifier: 'catalog:'
+        version: 4.12.0(typedoc@0.28.20(@typescript/typescript6@6.0.2))
+      typedoc-vitepress-theme:
+        specifier: 'catalog:'
+        version: 1.1.3(typedoc-plugin-markdown@4.12.0(typedoc@0.28.20(@typescript/typescript6@6.0.2)))
+      typescript:
+        specifier: catalog:typescript6-compat
+        version: '@typescript/typescript6@6.0.2'
       vite:
         specifier: 'catalog:'
         version: 8.1.3(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)

--- a/tools/typedoc-plugin-lit-ui-router/src/kind-indexes.ts
+++ b/tools/typedoc-plugin-lit-ui-router/src/kind-indexes.ts
@@ -41,6 +41,7 @@ export function load(app: Application): void {
     const baseLink = resolveBaseLink(outDir, app);
     generateKindIndexFiles(outDir, baseLink, app);
     linkSidebarGroups(outDir, baseLink, app);
+    retitleRootModule(outDir, app);
   });
 }
 
@@ -100,6 +101,61 @@ ${items}
     fs.writeFileSync(path.join(kindDir, 'index.md'), indexContent);
     app.logger.verbose(`[lit-ui-router] Generated ${folder}/index.md`);
   }
+}
+
+/**
+ * Retitle a multi-entry package's root module from typedoc's filename
+ * default ("index") to the package name and lift it to the top of the
+ * root Modules list. Text-only: URLs keep the `index/` folder, and the
+ * typedoc-sidebar.json entry stays "index" for the site config to map.
+ */
+function retitleRootModule(outDir: string, app: Application): void {
+  const packageName = path.basename(outDir);
+  const moduleDir = path.join(outDir, 'index');
+  const modulePage = path.join(moduleDir, 'index.md');
+  const rootPage = path.join(outDir, 'index.md');
+  // Single-entry packages have no `index/` module folder.
+  if (!fs.existsSync(modulePage) || !fs.existsSync(rootPage)) return;
+
+  const entry = `- [index](index/index.md)\n`;
+  const root = fs.readFileSync(rootPage, 'utf-8');
+  if (root.includes(entry)) {
+    fs.writeFileSync(
+      rootPage,
+      root
+        .replace(entry, '')
+        .replace(
+          '## Modules\n\n',
+          `## Modules\n\n- [${packageName}](index/index.md)\n`,
+        ),
+    );
+  }
+
+  const page = fs.readFileSync(modulePage, 'utf-8');
+  fs.writeFileSync(
+    modulePage,
+    page
+      .replace(/^(\[.+\]\(\.\.\/index\.md\)) \/ index$/m, `$1 / ${packageName}`)
+      .replace(/^# index$/m, `# ${packageName}`),
+  );
+
+  for (const kindFolder of fs.readdirSync(moduleDir)) {
+    const kindDir = path.join(moduleDir, kindFolder);
+    if (!fs.statSync(kindDir).isDirectory()) continue;
+    for (const file of fs.readdirSync(kindDir)) {
+      if (!file.endsWith('.md')) continue;
+      const memberPage = path.join(kindDir, file);
+      const content = fs.readFileSync(memberPage, 'utf-8');
+      fs.writeFileSync(
+        memberPage,
+        content.replace(
+          /^(\[.+\]\(\.\.\/\.\.\/index\.md\)) \/ \[index\]\(\.\.\/index\.md\)/m,
+          `$1 / [${packageName}](../index.md)`,
+        ),
+      );
+    }
+  }
+  app.logger.verbose(`[lit-ui-router] Retitled root module to ${packageName}`);
 }
 
 /**


### PR DESCRIPTION
Stacked on #473 (base = `docs/packages-server-page`; rebase onto main after it merges). Checks off the "API reference (typedoc)" item on #354's publish-machinery list.

Stands up the typedoc API reference for `ui-router-server` on the exact sibling pattern (typedoc-plugin-markdown + typedoc-vitepress-theme + `@tools/typedoc-plugin-lit-ui-router/kind-indexes`, `docs:api` script + per-package turbo task, generated output gitignored under `docs/api/ui-router-server/`, `typescript` devDep on the `typescript6-compat` catalog since typedoc needs the TS6 JS API — the compat package's bin is `tsc6`, so bare `tsc` in scripts still resolves to the root TS 7; build/typecheck are unaffected, same as the siblings).

## The one structural difference: multi-entry

The siblings are single-entry; this package's import surface is eight subpath exports, so `entryPoints` lists all eight src files and the module tier is deliberately **kept** — one typedoc module per export, URLs matching imports (`/api/ui-router-server/matcher/` etc.). Details:

- `src/url-matcher.ts` gains a one-line `/** @module matcher */` so the module name equals the `./matcher` export (typedoc only honors `@module` in the file's first comment). The other seven filenames already match.
- `entryModule: "index"` was tried and reverted: it silently drops the root module's members from `typedoc-sidebar.json`.
- The root module keeps typedoc's filename-default name `index` internally, but the kind-indexes plugin now retitles it to `ui-router-server` post-render — modules list (lifted to the top), breadcrumbs, and page heading — matching the vitepress sidebar. Text-only: URLs keep `index/`, and `typedoc-sidebar.json` keeps `"index"` for the site config's mapping. Single-entry packages are untouched.
- The vitepress sidebar retitles each module to its literal import specifier and reuses the existing `flattenGroups` helper one level down; the 'Server' entry gets the siblings' collapsed sub-sidebar shape.
- `docs/api/index.md` and the `/packages/server` page now link the reference (in-development caveat kept).

## Doc-comment link cleanup

The package's doc comments used TypeDoc's pre-0.23 `[[Symbol]]` link syntax, which now renders as literal text (the full flagship plugin rewrites it, but the companions load only `kind-indexes` — and its regex is uppercase-only anyway). All 38 occurrences converted to standard `{@link}`, with three shapes needing qualification: option-callback references become interface-member links with pipe labels (`{@link ConnectAdapterOptions.serveShell | serveShell}`), and the cross-module `ParamDeclaration` in redirects uses a declaration reference (`{@link matcher!ParamDeclaration | ParamDeclaration}`).

The last two typedoc warnings (ambient `Request`/`Response` from the deliberate `src/fetch.globals.d.ts` WinterCG shims, referenced-but-not-exported) are resolved via `externalSymbolLinkMappings` keyed by the package's own name — this both satisfies the validator and renders those types as MDN links. `docs:api` is now warning-free.

## Verification

- `turbo run docs:api` — 19/19 successful, zero typedoc warnings
- `turbo run format:check lint typecheck build --filter=docs` — 34/34; VitePress dead-link check passes and the reference renders into `docs/dist`
- `turbo run format:check lint typecheck test --filter=ui-router-server` — 16/16 (the typescript6-compat swap doesn't break the package's own typecheck)
- `turbo run format:check lint typecheck --filter=@tools/typedoc-plugin-lit-ui-router` — 14/14
- Generated output spot-checked: no `[index]` / `[[...]]` labels remain anywhere under `docs/api/`; companion references byte-identical
