### PR TITLE
refactor(tooling): validate workers-builds config with valibot schemas

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -198,6 +198,9 @@ catalogs:
     typescript-7:
       specifier: npm:typescript@^7.0.2
       version: 7.0.2
+    valibot:
+      specifier: ^1.4.2
+      version: 1.4.2
     vite:
       specifier: ^8.1.3
       version: 8.1.3
@@ -1017,6 +1020,9 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 7.0.2
+      valibot:
+        specifier: 'catalog:'
+        version: 1.4.2(typescript@7.0.2)
 
 packages:
 
@@ -6222,6 +6228,14 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  valibot@1.4.2:
+    resolution: {integrity: sha512-gjdCvJ6d3RyHAneqxMYMW9QMCwYMb3jpOO0IyHZV1bnRHFBHrX3VkIILt5XYR0WhwHiH7Mty8ovuPZ/O3gamrg==}
+    peerDependencies:
+      typescript: '>=5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   validate-npm-package-license@3.0.4:
     resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
@@ -11629,6 +11643,10 @@ snapshots:
   url-join@5.0.0: {}
 
   util-deprecate@1.0.2: {}
+
+  valibot@1.4.2(typescript@7.0.2):
+    optionalDependencies:
+      typescript: 7.0.2
 
   validate-npm-package-license@3.0.4:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -71,6 +71,7 @@ catalog:
   typescript-5.0: npm:typescript@5.0.4
   typescript-5.9: npm:typescript@^5.9.3
   typescript-7: npm:typescript@^7.0.2
+  valibot: ^1.4.2
   vite: ^8.1.3
   vite-plugin-checker: ^0.14.4
   vite-plugin-static-copy: ^4.1.1

--- a/tools/workers-builds/package.json
+++ b/tools/workers-builds/package.json
@@ -15,6 +15,7 @@
   "devDependencies": {
     "@types/node": "catalog:",
     "jsonc-parser": "catalog:",
-    "typescript": "catalog:"
+    "typescript": "catalog:",
+    "valibot": "catalog:"
   }
 }

--- a/tools/workers-builds/workers-builds-triggers.core.ts
+++ b/tools/workers-builds/workers-builds-triggers.core.ts
@@ -4,6 +4,7 @@
 // reading wrangler.jsonc) lives in workers-builds-triggers.ts.
 
 import { type ParseError, parse, printParseErrorCode } from 'jsonc-parser';
+import * as v from 'valibot';
 
 // What the shell prints and exits on.
 export type Report = { ok: boolean; text: string };
@@ -27,12 +28,25 @@ export const PINNABLE_FIELDS = [
   'root_directory',
 ] as const;
 export type PinnableField = (typeof PINNABLE_FIELDS)[number];
-export type DesiredTrigger = Partial<Record<PinnableField, string>>;
-export type DesiredState = {
-  productionBranch: string;
-  production: DesiredTrigger;
-  preview: DesiredTrigger;
-};
+
+const nonEmptyString = v.pipe(v.string(), v.nonEmpty());
+
+// strictObject: an unknown or typoed key throws rather than silently
+// un-pinning a field, since --apply writes this state to production.
+const DesiredTriggerSchema = v.strictObject({
+  build_command: v.optional(nonEmptyString),
+  deploy_command: v.optional(nonEmptyString),
+  root_directory: v.optional(nonEmptyString),
+} satisfies Record<PinnableField, unknown>);
+
+const DesiredStateSchema = v.strictObject({
+  productionBranch: nonEmptyString,
+  production: DesiredTriggerSchema,
+  preview: DesiredTriggerSchema,
+});
+
+export type DesiredTrigger = v.InferOutput<typeof DesiredTriggerSchema>;
+export type DesiredState = v.InferOutput<typeof DesiredStateSchema>;
 
 export type TriggerKind = 'production' | 'preview';
 
@@ -50,63 +64,30 @@ export function parseJsonc(text: string): unknown {
   return result;
 }
 
-// Strict validation of workers-builds-triggers.config.jsonc: unknown or
-// mistyped keys throw rather than silently un-pinning a field, since --apply
-// writes this state to production.
+// Strict validation of workers-builds-triggers.config.jsonc; every issue is
+// reported, prefixed with its dot path into the config.
 export function desiredStateFromConfig(config: unknown): DesiredState {
-  const record = asRecord(config, 'config');
-  for (const key of Object.keys(record)) {
-    if (!['productionBranch', 'production', 'preview'].includes(key)) {
-      throw new Error(`config has unknown key "${key}"`);
-    }
+  const result = v.safeParse(DesiredStateSchema, config);
+  if (!result.success) {
+    const details = result.issues.map((issue) => {
+      const path = v.getDotPath(issue);
+      return path ? `  ${path}: ${issue.message}` : `  ${issue.message}`;
+    });
+    throw new Error(['invalid config:', ...details].join('\n'));
   }
-  const { productionBranch } = record;
-  if (typeof productionBranch !== 'string' || productionBranch === '') {
-    throw new Error('config "productionBranch" must be a non-empty string');
-  }
-  return {
-    productionBranch,
-    production: desiredTrigger(record.production, 'production'),
-    preview: desiredTrigger(record.preview, 'preview'),
-  };
+  return result.output;
 }
 
-function asRecord(value: unknown, what: string): Record<string, unknown> {
-  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
-    throw new Error(`${what} must be an object`);
-  }
-  return value as Record<string, unknown>;
-}
-
-function desiredTrigger(value: unknown, kind: TriggerKind): DesiredTrigger {
-  const record = asRecord(value, `config "${kind}"`);
-  const desired: DesiredTrigger = {};
-  for (const key of Object.keys(record)) {
-    const field = PINNABLE_FIELDS.find((candidate) => candidate === key);
-    if (!field) {
-      throw new Error(
-        `config ${kind}.${key} is not a pinnable field (expected: ${PINNABLE_FIELDS.join(', ')})`,
-      );
-    }
-    const spec = record[field];
-    if (typeof spec !== 'string' || spec === '') {
-      throw new Error(`config ${kind}.${field} must be a non-empty string`);
-    }
-    desired[field] = spec;
-  }
-  return desired;
-}
+// looseObject: wrangler.jsonc has many fields; only `name` matters here.
+const WranglerNameSchema = v.looseObject({ name: nonEmptyString });
 
 /** The `name` field of a parsed wrangler config, or throw. */
 export function workerNameFromConfig(config: unknown): string {
-  const name =
-    typeof config === 'object' && config !== null
-      ? (config as Record<string, unknown>).name
-      : undefined;
-  if (typeof name !== 'string' || name === '') {
+  const result = v.safeParse(WranglerNameSchema, config);
+  if (!result.success) {
     throw new Error('wrangler.jsonc has no "name" field');
   }
-  return name;
+  return result.output.name;
 }
 
 // A trigger that builds the production branch is the production trigger;

--- a/tools/workers-builds/workers-builds-triggers.test.ts
+++ b/tools/workers-builds/workers-builds-triggers.test.ts
@@ -63,21 +63,25 @@ describe('desiredStateFromConfig', () => {
   });
 
   it('rejects non-objects and unknown top-level keys', () => {
-    assert.throws(() => desiredStateFromConfig([]), /must be an object/);
+    assert.throws(() => desiredStateFromConfig(null), /Expected Object/);
+    assert.throws(
+      () => desiredStateFromConfig([]),
+      /productionBranch: Invalid key/,
+    );
     assert.throws(
       () => desiredStateFromConfig({ productionBranch: 'main', prod: {} }),
-      /unknown key "prod"/,
+      /prod: Invalid key/,
     );
   });
 
   it('requires a non-empty productionBranch and both trigger specs', () => {
     assert.throws(
       () => desiredStateFromConfig({ production: {}, preview: {} }),
-      /"productionBranch" must be a non-empty string/,
+      /productionBranch: Invalid key: Expected "productionBranch"/,
     );
     assert.throws(
       () => desiredStateFromConfig({ productionBranch: 'main' }),
-      /config "production" must be an object/,
+      /production: Invalid key: Expected "production"/,
     );
   });
 
@@ -89,12 +93,12 @@ describe('desiredStateFromConfig', () => {
           ...base,
           production: { deploy_comand: 'pnpm wrangler deploy' },
         }),
-      /production\.deploy_comand is not a pinnable field/,
+      /production\.deploy_comand: Invalid key/,
     );
     assert.throws(
       () =>
         desiredStateFromConfig({ ...base, production: { build_command: '' } }),
-      /production\.build_command must be a non-empty string/,
+      /production\.build_command: Invalid length/,
     );
   });
 });


### PR DESCRIPTION
Removes the hand-rolled `asRecord` plain-object guard (`typeof === 'object' && !== null && !Array.isArray`) and the imperative key/field validation in `@tools/workers-builds`, replacing both validators with declarative valibot schemas — mirroring rolldown's options-validation setup (`import * as v`, catalog dep).

## Changes
- `valibot: ^1.4.2` added to the pnpm catalog and as a devDep of `@tools/workers-builds` (first schema lib in the repo)
- `desiredStateFromConfig`: `v.strictObject` schemas; unknown/typoed keys still throw (fail-closed — `--apply` writes production), but now **all** issues are reported at once, each prefixed with its dot path (`production.build_command: Invalid length`)
- `workerNameFromConfig`: `v.looseObject({ name })`, message unchanged
- `DesiredTrigger`/`DesiredState` types now inferred from the schemas; `satisfies Record<PinnableField, unknown>` keeps the schema and `PINNABLE_FIELDS` from drifting
- Tests updated to valibot's message shapes; added a `null` rejection case (valibot reports `[]` as missing keys rather than a type error — still fail-closed)

No line-number plumbing: the config is 13 lines and wrangler.jsonc is 36, so dot paths already uniquely identify any field; syntax errors keep their offsets via `parseJsonc`.

Verified: `turbo run test typecheck lint format:check --filter=@tools/workers-builds` — 14/14 green, including the real config parsed through the new schema.