### PR TITLE
fix(deps): override brace-expansion to 5.0.9 (GHSA-mh99-v99m-4gvg)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -246,6 +246,7 @@ catalogs:
       version: 6.0.2
 
 overrides:
+  brace-expansion@5: 5.0.9
   d3-color: 3.1.0
   dompurify: 3.4.12
   fast-uri: 3.1.4
@@ -3736,9 +3737,9 @@ packages:
   bole@5.0.29:
     resolution: {integrity: sha512-eYR9i2ubLv5/4TFGyZsQ1cVH4jF9+qLJA72Aow+E7ZZQfqHqQNUZeX3w+pVWF76PQyjl5eDKf2xylyOOX76ozA==}
 
-  brace-expansion@5.0.7:
-    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
+    engines: {node: 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -8851,7 +8852,7 @@ snapshots:
       fast-safe-stringify: 2.1.1
       individual: 3.0.0
 
-  brace-expansion@5.0.7:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -10435,7 +10436,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.7
+      brace-expansion: 5.0.9
 
   minimist@1.2.8: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -112,6 +112,7 @@ allowBuilds:
   workerd: true
 
 overrides:
+  'brace-expansion@5': 5.0.9
   d3-color: 3.1.0
   dompurify: 3.4.12
   fast-uri: 3.1.4


### PR DESCRIPTION
`pnpm audit` flags a **high** advisory that GitHub has not opened a dependabot alert for yet — all 39 alerts on the repo are currently `fixed`, so this would have gone unnoticed until the bot caught up.

| Advisory | Package | Vulnerable | Fix | Severity |
|---|---|---|---|---|
| [GHSA-mh99-v99m-4gvg](https://github.com/advisories/GHSA-mh99-v99m-4gvg) | `brace-expansion` | `>=4.0.0 <5.0.8` (tree had 5.0.7) | 5.0.9 | high |

DoS via unbounded expansion length causing an out-of-memory process crash.

## Scope

All 35 paths are dev-scoped, reaching the tree through eslint's `minimatch`:

```
.>eslint>@eslint/config-array>minimatch>brace-expansion
.>eslint>minimatch>brace-expansion
.>eslint-plugin-package-json>eslint>@eslint/config-array>minimatch>brace-expansion
```

None reach the published library packages.

## Why the override is scoped to `@5`

`brace-expansion` still publishes 1.x, 2.x and 3.x lines. A bare `brace-expansion: 5.0.9` pin would force any future consumer of those lines across a major. Scoping to the 5 line matches the existing `'undici@6'` / `'undici@7'` precedent in this file. Only 5.0.7 was present, so nothing else is affected.

5.0.9 rather than the advisory's minimum 5.0.8: it is the newest patch on the line and is clear of the repo's 24h `minimumReleaseAge` floor.

## Verification

- `pnpm audit`: 1 high → **No known vulnerabilities found**
- Lockfile resolves a single `brace-expansion@5.0.9`; no other package versions changed
- `turbo lint` (34 tasks) and `format` green — eslint is the actual consumer, so lint passing is the meaningful check here
