### PR TITLE
ci(e2e): upload the runner's wrangler logs when the job fails

### DIFF
--- a/.github/workflows/build-test-run.yml
+++ b/.github/workflows/build-test-run.yml
@@ -163,6 +163,18 @@ jobs:
           path: apps/sample-app-lit-e2e/cypress/videos*/
           retention-days: 5
           if-no-files-found: warn
+      - name: Upload wrangler logs
+        # The e2e dev server (wrangler dev) intermittently crashes mid-suite
+        # with an empty error; its crash log lands only in the runner's
+        # ~/.config/.wrangler/logs, so keep it when the job fails. A failure
+        # before the e2e server starts leaves no files, hence warn.
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: wrangler-logs
+          path: ~/.config/.wrangler/logs/
+          retention-days: 5
+          if-no-files-found: warn
       - name: Upload to Codecov
         # Branch-head runs skip upload; merge-head/main covers the same SHA.
         if: ${{ github.event_name != 'push' || github.ref == 'refs/heads/main' }}


### PR DESCRIPTION
Hardening from the 2026-08-01 e2e flake triage: `wrangler dev` (the docs worker serving the sample apps on :8787) crashed mid-suite on #473's first attempt and on #482's 04:50 run — an empty `✘ [ERROR]` line, then every remaining `cy.visit()` failing `ECONNREFUSED`. Both recovered on same-code rerun, and the crash log wrangler points at (`~/.config/.wrangler/logs/…`) dies with the runner, so the actual cause has never been observable.

This adds a `failure()`-gated `upload-artifact` step (mirroring the cypress-videos step's shape: 5-day retention, `if-no-files-found: warn` since a failure before the e2e server starts leaves no logs). Next crash, the artifact tells us what workerd actually said.

## Verification

`turbo run lint:workflows --filter=//` — 4/4 successful