### PR TITLE
docs(readme): link npm version badges to npmx.dev

### DIFF
--- a/packages/lit-ui-router-mobx/README.md
+++ b/packages/lit-ui-router-mobx/README.md
@@ -1,6 +1,6 @@
 # lit-ui-router-mobx
 
-[![npm version](https://img.shields.io/npm/v/lit-ui-router-mobx.svg)](https://www.npmjs.com/package/lit-ui-router-mobx)
+[![npm version](https://img.shields.io/npm/v/lit-ui-router-mobx.svg)](https://npmx.dev/package/lit-ui-router-mobx)
 [![GitHub Release](https://img.shields.io/github/v/release/simshanith/lit-ui-router?filter=lit-ui-router-mobx@*)](https://github.com/simshanith/lit-ui-router/releases/?q=lit-ui-router-mobx)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 [![codecov](https://codecov.io/gh/simshanith/lit-ui-router/graph/badge.svg?component=lit-ui-router-mobx)](https://app.codecov.io/gh/simshanith/lit-ui-router?components%5B0%5D=lit-ui-router-mobx)

--- a/packages/lit-ui-router/README.md
+++ b/packages/lit-ui-router/README.md
@@ -2,7 +2,7 @@
 
 <img src="https://lit-ui-router.dev/images/lit-ui-router.svg" alt="Lit UI Router" width="120" height="120" />
 
-[![npm version](https://img.shields.io/npm/v/lit-ui-router.svg)](https://www.npmjs.com/package/lit-ui-router)
+[![npm version](https://img.shields.io/npm/v/lit-ui-router.svg)](https://npmx.dev/package/lit-ui-router)
 [![GitHub Release](https://img.shields.io/github/v/release/simshanith/lit-ui-router?filter=lit-ui-router@*)](https://github.com/simshanith/lit-ui-router/releases/?q=lit-ui-router)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 [![Website](https://img.shields.io/website?url=https%3A%2F%2Flit-ui-router.dev)](https://lit-ui-router.dev)

--- a/packages/navigation-location-plugin/README.md
+++ b/packages/navigation-location-plugin/README.md
@@ -1,6 +1,6 @@
 # ui-router-navigation-location-plugin
 
-[![npm version](https://img.shields.io/npm/v/ui-router-navigation-location-plugin.svg)](https://www.npmjs.com/package/ui-router-navigation-location-plugin)
+[![npm version](https://img.shields.io/npm/v/ui-router-navigation-location-plugin.svg)](https://npmx.dev/package/ui-router-navigation-location-plugin)
 [![GitHub Release](https://img.shields.io/github/v/release/simshanith/lit-ui-router?filter=ui-router-navigation-location-plugin@*)](https://github.com/simshanith/lit-ui-router/releases/?q=ui-router-navigation-location-plugin)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 [![codecov](https://codecov.io/gh/simshanith/lit-ui-router/graph/badge.svg?component=navigation-location-plugin)](https://app.codecov.io/gh/simshanith/lit-ui-router?components%5B0%5D=navigation-location-plugin)


### PR DESCRIPTION
New convention: keep the standard `img.shields.io` npm version badge images, but point the markdown link target at [npmx.dev](https://npmx.dev) instead of npmjs.com. Canonical URL form is `npmx.dev/package/<name>` (verified live).

Scope is three READMEs — the only npmjs.com links under `packages/*/README.md`:

- `packages/lit-ui-router/README.md` → https://npmx.dev/package/lit-ui-router
- `packages/lit-ui-router-mobx/README.md` → https://npmx.dev/package/lit-ui-router-mobx
- `packages/navigation-location-plugin/README.md` → https://npmx.dev/package/ui-router-navigation-location-plugin

Badge image URLs are unchanged; only the link destinations move.

README changes only reach npm on each package's next publish, so this rides the upcoming release round. Note that `ui-router-navigation-location-plugin` has no release currently queued, so its npm README (and `check:published-diff`) will lag until a patch release goes out.