### PR TITLE
chore(examples): bump lit-ui-router to ^1.9.0

### DIFF
--- a/examples/hellogalaxy/package-lock.json
+++ b/examples/hellogalaxy/package-lock.json
@@ -12,7 +12,7 @@
         "@uirouter/core": "^6.1.2",
         "@uirouter/visualizer": "^7.2.1",
         "lit": "^3.3.3",
-        "lit-ui-router": "^1.8.0"
+        "lit-ui-router": "^1.9.0"
       },
       "devDependencies": {
         "typescript": "^7.0.2",
@@ -1189,16 +1189,16 @@
       }
     },
     "node_modules/lit-ui-router": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/lit-ui-router/-/lit-ui-router-1.8.0.tgz",
-      "integrity": "sha512-gl0XBgnvLo4SAYwBmS9LCqqdvzG2l6DlUURVzjilQIHz548kvDYWIK4GBamUqD0hVu+qWpc17y1lD+YU+GR8TA==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/lit-ui-router/-/lit-ui-router-1.9.0.tgz",
+      "integrity": "sha512-pwnamYE4Hvpogcm1NdqmtwM3oN/Ndf1vj4xlYHqTo0NmmAosTWLrYOxkPQubeSxw48/WDq6gzYLHpacHIkJZnQ==",
       "license": "MIT",
       "dependencies": {
         "@oxc-project/runtime": ">=0.50.0"
       },
       "peerDependencies": {
         "@uirouter/core": "^6.0.8",
-        "lit": "^3.0.0"
+        "lit": "^2.0.0 || ^3.0.0"
       }
     },
     "node_modules/nanoid": {

--- a/examples/hellogalaxy/package.json
+++ b/examples/hellogalaxy/package.json
@@ -13,7 +13,7 @@
     "@uirouter/core": "^6.1.2",
     "@uirouter/visualizer": "^7.2.1",
     "lit": "^3.3.3",
-    "lit-ui-router": "^1.8.0"
+    "lit-ui-router": "^1.9.0"
   },
   "devDependencies": {
     "typescript": "^7.0.2",

--- a/examples/hellosolarsystem/package-lock.json
+++ b/examples/hellosolarsystem/package-lock.json
@@ -11,7 +11,7 @@
         "@uirouter/core": "^6.1.2",
         "@uirouter/visualizer": "^7.2.1",
         "lit": "^3.3.3",
-        "lit-ui-router": "^1.8.0"
+        "lit-ui-router": "^1.9.0"
       },
       "devDependencies": {
         "typescript": "^7.0.2",
@@ -1139,16 +1139,16 @@
       }
     },
     "node_modules/lit-ui-router": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/lit-ui-router/-/lit-ui-router-1.8.0.tgz",
-      "integrity": "sha512-gl0XBgnvLo4SAYwBmS9LCqqdvzG2l6DlUURVzjilQIHz548kvDYWIK4GBamUqD0hVu+qWpc17y1lD+YU+GR8TA==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/lit-ui-router/-/lit-ui-router-1.9.0.tgz",
+      "integrity": "sha512-pwnamYE4Hvpogcm1NdqmtwM3oN/Ndf1vj4xlYHqTo0NmmAosTWLrYOxkPQubeSxw48/WDq6gzYLHpacHIkJZnQ==",
       "license": "MIT",
       "dependencies": {
         "@oxc-project/runtime": ">=0.50.0"
       },
       "peerDependencies": {
         "@uirouter/core": "^6.0.8",
-        "lit": "^3.0.0"
+        "lit": "^2.0.0 || ^3.0.0"
       }
     },
     "node_modules/nanoid": {

--- a/examples/hellosolarsystem/package.json
+++ b/examples/hellosolarsystem/package.json
@@ -12,7 +12,7 @@
     "@uirouter/core": "^6.1.2",
     "@uirouter/visualizer": "^7.2.1",
     "lit": "^3.3.3",
-    "lit-ui-router": "^1.8.0"
+    "lit-ui-router": "^1.9.0"
   },
   "devDependencies": {
     "typescript": "^7.0.2",

--- a/examples/helloworld/package-lock.json
+++ b/examples/helloworld/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@uirouter/core": "^6.1.2",
         "lit": "^3.3.3",
-        "lit-ui-router": "^1.8.0"
+        "lit-ui-router": "^1.9.0"
       },
       "devDependencies": {
         "typescript": "^7.0.2",
@@ -1100,16 +1100,16 @@
       }
     },
     "node_modules/lit-ui-router": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/lit-ui-router/-/lit-ui-router-1.8.0.tgz",
-      "integrity": "sha512-gl0XBgnvLo4SAYwBmS9LCqqdvzG2l6DlUURVzjilQIHz548kvDYWIK4GBamUqD0hVu+qWpc17y1lD+YU+GR8TA==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/lit-ui-router/-/lit-ui-router-1.9.0.tgz",
+      "integrity": "sha512-pwnamYE4Hvpogcm1NdqmtwM3oN/Ndf1vj4xlYHqTo0NmmAosTWLrYOxkPQubeSxw48/WDq6gzYLHpacHIkJZnQ==",
       "license": "MIT",
       "dependencies": {
         "@oxc-project/runtime": ">=0.50.0"
       },
       "peerDependencies": {
         "@uirouter/core": "^6.0.8",
-        "lit": "^3.0.0"
+        "lit": "^2.0.0 || ^3.0.0"
       }
     },
     "node_modules/nanoid": {

--- a/examples/helloworld/package.json
+++ b/examples/helloworld/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@uirouter/core": "^6.1.2",
     "lit": "^3.3.3",
-    "lit-ui-router": "^1.8.0"
+    "lit-ui-router": "^1.9.0"
   },
   "devDependencies": {
     "typescript": "^7.0.2",


### PR DESCRIPTION
Bumps the three tutorial examples to the released 1.9.0.

- `lit-ui-router` `^1.8.0` → `^1.9.0` in each example's `package.json`, npm lockfiles regenerated against the live registry (all resolve 1.9.0).
- **No dependency additions needed**: every example already declares `lit ^3.3.3` and `@uirouter/core ^6.1.2` as direct dependencies, and 1.9.0 only *widens* the lit peer (`^3.0.0` → `^2.0.0 || ^3.0.0`, #490), so the existing ranges still satisfy it.
- Lockfile delta is exactly the version/integrity bump plus that widened peer range — nothing else moved.
- No example depends on `lit-ui-router-mobx` or references `ui-router-server`, so 0.4.0 / 0.1.0 are out of scope here.

Verified: `turbo run typecheck lint format:check --filter=examples` — 13 tasks green.