### PR TITLE
chore(navigation-location-plugin): docs-site homepage, README badge + links, npmx sweep

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,7 @@ hero:
     alt: Lit UI Router
   tagline: |
     A <a href="https://ui-router.github.io/" target="_blank" class="library"><img src="/images/ui-router.svg" width="24" height="24" alt="UI Router">UI-Router</a> implementation for <a href="https://lit.dev" target="_blank" class="library"><img src="/images/lit-flame.svg" width="24" height="24" alt="Lit">Lit</a> web components
-    <a href="https://www.npmjs.com/package/lit-ui-router" target="_blank" class="badge"><img alt="NPM Version" src="https://img.shields.io/npm/v/lit-ui-router" /></a> <a href="https://github.com/simshanith/lit-ui-router/releases/?q=lit-ui-router" target="_blank" class="badge"><img alt="GitHub Release" src="https://img.shields.io/github/v/release/simshanith/lit-ui-router?filter=lit-ui-router@*" /></a>
+    <a href="https://npmx.dev/package/lit-ui-router" target="_blank" class="badge"><img alt="NPM Version" src="https://img.shields.io/npm/v/lit-ui-router" /></a> <a href="https://github.com/simshanith/lit-ui-router/releases/?q=lit-ui-router" target="_blank" class="badge"><img alt="GitHub Release" src="https://img.shields.io/github/v/release/simshanith/lit-ui-router?filter=lit-ui-router@*" /></a>
   actions:
     - theme: brand
       text: Get Started

--- a/docs/packages/mobx.md
+++ b/docs/packages/mobx.md
@@ -6,7 +6,7 @@ description: Observable router state and reaction-based controllers with lit-ui-
 # lit-ui-router-mobx
 
 <p class="badges">
-<a href="https://www.npmjs.com/package/lit-ui-router-mobx" target="_blank" class="badge"><img alt="NPM Version" src="https://img.shields.io/npm/v/lit-ui-router-mobx" /></a>
+<a href="https://npmx.dev/package/lit-ui-router-mobx" target="_blank" class="badge"><img alt="NPM Version" src="https://img.shields.io/npm/v/lit-ui-router-mobx" /></a>
 <a href="https://github.com/simshanith/lit-ui-router/releases/?q=lit-ui-router-mobx" target="_blank" class="badge"><img alt="GitHub Release" src="https://img.shields.io/github/v/release/simshanith/lit-ui-router?filter=lit-ui-router-mobx@*" /></a>
 </p>
 

--- a/docs/packages/navigation-plugin.md
+++ b/docs/packages/navigation-plugin.md
@@ -6,7 +6,7 @@ description: Manage URLs with the modern browser Navigation API using ui-router-
 # ui-router-navigation-location-plugin
 
 <p class="badges">
-<a href="https://www.npmjs.com/package/ui-router-navigation-location-plugin" target="_blank" class="badge"><img alt="NPM Version" src="https://img.shields.io/npm/v/ui-router-navigation-location-plugin" /></a>
+<a href="https://npmx.dev/package/ui-router-navigation-location-plugin" target="_blank" class="badge"><img alt="NPM Version" src="https://img.shields.io/npm/v/ui-router-navigation-location-plugin" /></a>
 <a href="https://github.com/simshanith/lit-ui-router/releases/?q=ui-router-navigation-location-plugin" target="_blank" class="badge"><img alt="GitHub Release" src="https://img.shields.io/github/v/release/simshanith/lit-ui-router?filter=ui-router-navigation-location-plugin@*" /></a>
 </p>
 

--- a/docs/packages/server.md
+++ b/docs/packages/server.md
@@ -6,7 +6,7 @@ description: Honest HTTP verdicts for a static SPA with ui-router-server — the
 # ui-router-server
 
 <p class="badges">
-<a href="https://www.npmjs.com/package/ui-router-server" target="_blank" class="badge"><img alt="NPM Version" src="https://img.shields.io/npm/v/ui-router-server" /></a>
+<a href="https://npmx.dev/package/ui-router-server" target="_blank" class="badge"><img alt="NPM Version" src="https://img.shields.io/npm/v/ui-router-server" /></a>
 </p>
 
 [`ui-router-server`](https://www.npmjs.com/package/ui-router-server) runs the

--- a/packages/navigation-location-plugin/README.md
+++ b/packages/navigation-location-plugin/README.md
@@ -3,6 +3,7 @@
 [![npm version](https://img.shields.io/npm/v/ui-router-navigation-location-plugin.svg)](https://npmx.dev/package/ui-router-navigation-location-plugin)
 [![GitHub Release](https://img.shields.io/github/v/release/simshanith/lit-ui-router?filter=ui-router-navigation-location-plugin@*)](https://github.com/simshanith/lit-ui-router/releases/?q=ui-router-navigation-location-plugin)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
+[![Website](https://img.shields.io/website?url=https%3A%2F%2Flit-ui-router.dev)](https://lit-ui-router.dev)
 [![codecov](https://codecov.io/gh/simshanith/lit-ui-router/graph/badge.svg?component=navigation-location-plugin)](https://app.codecov.io/gh/simshanith/lit-ui-router?components%5B0%5D=navigation-location-plugin)
 [![Can I Use Navigation API](https://img.shields.io/badge/caniuse-Navigation%20API-orange)](https://caniuse.com/mdn-api_navigation)
 
@@ -121,6 +122,8 @@ For older browsers, consider using:
 
 ## Links
 
+- [Docs - Navigation API Plugin](https://lit-ui-router.dev/packages/navigation-plugin)
+- [Docs - Location Plugins guide](https://lit-ui-router.dev/guides/location-plugins)
 - [MDN - Navigation API](https://developer.mozilla.org/en-US/docs/Web/API/Navigation_API)
 - [@uirouter/core - LocationPlugin](https://ui-router.github.io/core/docs/latest/interfaces/_vanilla_interface_.locationplugin.html)
 - [@uirouter/core - LocationServices](https://ui-router.github.io/core/docs/latest/interfaces/_common_coreservices_.locationservices.html)

--- a/packages/navigation-location-plugin/package.json
+++ b/packages/navigation-location-plugin/package.json
@@ -10,7 +10,7 @@
     "spa",
     "ui-router"
   ],
-  "homepage": "https://github.com/simshanith/lit-ui-router/tree/main/packages/navigation-location-plugin",
+  "homepage": "https://lit-ui-router.dev/packages/navigation-plugin",
   "bugs": {
     "url": "https://github.com/simshanith/lit-ui-router/issues"
   },


### PR DESCRIPTION
Enriches what the queued `ui-router-navigation-location-plugin` 0.2.3 → 0.2.4 patch ships, plus a docs-site npmx sweep.

## Plugin package (ship-affecting / manifest-affecting)

- `package.json`: `homepage` now points at the docs page `https://lit-ui-router.dev/packages/navigation-plugin` instead of a GitHub tree URL, mirroring the `ui-router-server` precedent. Key order left to the package's own oxfmt `format` script.
- `README.md`: adds the `Website` badge to the badge row (positioned to match `lit-ui-router`'s ordering — npm, GitHub Release, License, Website, codecov) and extends `## Links` with the package's own docs page and the Location Plugins guide.

Both changes are ship-affecting/manifest-affecting for the plugin and intentionally ride the queued 0.2.4 patch — no separate release is needed.

## Docs site (deploys on merge)

npm version badge **links** retargeted from `www.npmjs.com` to `https://npmx.dev/package/<name>`; badge images are unchanged.

- `docs/index.md` (hero badge, `lit-ui-router`)
- `docs/packages/navigation-plugin.md`
- `docs/packages/mobx.md`
- `docs/packages/server.md`

`docs/packages/index.md` is deliberately untouched — another in-flight PR owns that file. `packages/lit-ui-router-mobx/README.md` is likewise untouched: no release is queued for it, so editing it would re-open published-diff drift.

Prose (non-badge) `npmjs.com` links in `docs/introduction.md`, `docs/packages/mobx.md`, and `docs/packages/server.md` were left as-is — this sweep is scoped to badge links.

## Verification

`turbo run format:check lint --filter=ui-router-navigation-location-plugin --filter=docs` → 19/19 tasks successful, 0 warnings, 0 errors. No repadding was needed.
