### PR TITLE
docs: prefer npmx.dev for package prose links

### DIFF
--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -82,12 +82,12 @@ resolves. `lit-ui-router` layers the Lit integration on top:
 This repository publishes a small family of packages. The core router is all
 you need to start; the companions are optional layers.
 
-| Package                                                                                                      | What it is                                                                                                                              |
-| ------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------- |
-| [`lit-ui-router`](https://www.npmjs.com/package/lit-ui-router)                                               | The router: state machine, `<ui-router>`/`<ui-view>` elements, navigation directives, `TransitionController`. [API →](./api/reference/) |
-| [`lit-ui-router-mobx`](https://www.npmjs.com/package/lit-ui-router-mobx)                                     | [MobX](https://mobx.js.org) bindings: an observable `RouterStore` and reaction-based controllers. [Guide →](./packages/mobx)            |
-| [`ui-router-navigation-location-plugin`](https://www.npmjs.com/package/ui-router-navigation-location-plugin) | An experimental location plugin built on the modern browser Navigation API. [Guide →](./packages/navigation-plugin)                     |
-| [`ui-router-server`](https://www.npmjs.com/package/ui-router-server)                                         | Server-side routing verdicts at the edge — honest 404/302/200 for static SPAs (in development). [Guide →](./packages/server)            |
+| Package                                                                                                 | What it is                                                                                                                              |
+| ------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| [`lit-ui-router`](https://npmx.dev/package/lit-ui-router)                                               | The router: state machine, `<ui-router>`/`<ui-view>` elements, navigation directives, `TransitionController`. [API →](./api/reference/) |
+| [`lit-ui-router-mobx`](https://npmx.dev/package/lit-ui-router-mobx)                                     | [MobX](https://mobx.js.org) bindings: an observable `RouterStore` and reaction-based controllers. [Guide →](./packages/mobx)            |
+| [`ui-router-navigation-location-plugin`](https://npmx.dev/package/ui-router-navigation-location-plugin) | An experimental location plugin built on the modern browser Navigation API. [Guide →](./packages/navigation-plugin)                     |
+| [`ui-router-server`](https://npmx.dev/package/ui-router-server)                                         | Server-side routing verdicts at the edge — honest 404/302/200 for static SPAs (in development). [Guide →](./packages/server)            |
 
 Because lit-ui-router is a `@uirouter/core` implementation, the wider
 UI-Router plugin ecosystem works too. The <a href="/app" target="_self">sample

--- a/docs/packages/mobx.md
+++ b/docs/packages/mobx.md
@@ -10,7 +10,7 @@ description: Observable router state and reaction-based controllers with lit-ui-
 <a href="https://github.com/simshanith/lit-ui-router/releases/?q=lit-ui-router-mobx" target="_blank" class="badge"><img alt="GitHub Release" src="https://img.shields.io/github/v/release/simshanith/lit-ui-router?filter=lit-ui-router-mobx@*" /></a>
 </p>
 
-[`lit-ui-router-mobx`](https://www.npmjs.com/package/lit-ui-router-mobx)
+[`lit-ui-router-mobx`](https://npmx.dev/package/lit-ui-router-mobx)
 provides [MobX](https://mobx.js.org) bindings for lit-ui-router: an observable
 mirror of the router's state and reaction-based
 [ReactiveControllers](https://lit.dev/docs/composition/controllers/) that keep

--- a/docs/packages/navigation-plugin.md
+++ b/docs/packages/navigation-plugin.md
@@ -10,7 +10,7 @@ description: Manage URLs with the modern browser Navigation API using ui-router-
 <a href="https://github.com/simshanith/lit-ui-router/releases/?q=ui-router-navigation-location-plugin" target="_blank" class="badge"><img alt="GitHub Release" src="https://img.shields.io/github/v/release/simshanith/lit-ui-router?filter=ui-router-navigation-location-plugin@*" /></a>
 </p>
 
-[`ui-router-navigation-location-plugin`](https://www.npmjs.com/package/ui-router-navigation-location-plugin)
+[`ui-router-navigation-location-plugin`](https://npmx.dev/package/ui-router-navigation-location-plugin)
 is a UI-Router [location plugin](#how-location-plugins-fit-in) that manages
 URLs with the modern browser
 [Navigation API](https://developer.mozilla.org/en-US/docs/Web/API/Navigation_API)


### PR DESCRIPTION
Follows the npmx.dev convention established for badges in #493/#494 (and applied in #499/#500): links to **our** published packages point at `https://npmx.dev/package/<name>` instead of `https://www.npmjs.com/package/<name>`.

This PR extends that preference from badges to the docs-site **prose** links.

## Changed

- `docs/introduction.md` — the package family table (4 links: `lit-ui-router`, `lit-ui-router-mobx`, `ui-router-navigation-location-plugin`, `ui-router-server`); the table repadded via `turbo run format --filter=docs`
- `docs/packages/mobx.md:13` — `lit-ui-router-mobx`
- `docs/packages/navigation-plugin.md:13` — `ui-router-navigation-location-plugin`

`docs/packages/server.md` prose was already on npmx.dev (#500), as were the badges in `docs/index.md` and `docs/packages/index.md`.

## Deliberately excluded

- **Third-party packages** — `connect-history-api-fallback` in `docs/guides/server-route-matching.md:130` stays on npmjs.com. The convention is about our own packages.
- **`packages/*/README.md` and the root README** — ship-affecting content, out of scope here.

After the sweep, `grep -rn 'npmjs.com/package' docs/` returns only the third-party link above.

## Checks

`corepack pnpm install --frozen-lockfile` then `turbo run format:check build --filter=docs` — 24/24 tasks successful.
