### PR TITLE
fix(docs): mobile-friendly embeds + iOS StackBlitz fallback

### DIFF
--- a/docs/.vitepress/theme/components/ExampleEmbed.vue
+++ b/docs/.vitepress/theme/components/ExampleEmbed.vue
@@ -71,7 +71,7 @@ onUnmounted(() => {
     <iframe
       :src="src"
       :title="title"
-      :style="{ height: props.height }"
+      :style="{ '--embed-height': props.height }"
       ref="iframe"
       loading="lazy"
     />
@@ -109,6 +109,10 @@ onUnmounted(() => {
 
 .example-embed iframe {
   width: 100%;
+  max-width: 100%;
+  height: var(--embed-height, 420px);
+  /* Cap tall embeds so small viewports keep the page (svh dodges iOS toolbars). */
+  height: min(var(--embed-height, 420px), calc(100svh - 120px));
   border: 1px solid var(--vp-c-divider);
   border-radius: 4px;
   overflow: hidden;
@@ -128,7 +132,7 @@ onUnmounted(() => {
 
 .example-embed:fullscreen iframe,
 .example-embed:-webkit-full-screen iframe {
-  height: calc(100vh - 80px) !important;
+  height: calc(100vh - 80px);
   border-radius: 8px;
   width: 88%;
   transition:

--- a/docs/.vitepress/theme/components/StackBlitzEmbed.vue
+++ b/docs/.vitepress/theme/components/StackBlitzEmbed.vue
@@ -1,11 +1,34 @@
 <script setup lang="ts">
-import { useTemplateRef, ref, onMounted, onUnmounted } from 'vue';
+import { useTemplateRef, ref, computed, onMounted, onUnmounted } from 'vue';
 import screenfull from 'screenfull';
+import ExampleEmbed from './ExampleEmbed.vue';
 
-defineProps<{
+const props = defineProps<{
   src: string;
   title: string;
+  fallbackSrc?: string;
+  fallbackHeight?: string;
 }>();
+
+// StackBlitz WebContainers never boot on iOS (every iOS browser is WebKit),
+// so swap the embed for the static example / an external link there.
+function isIOS() {
+  return (
+    /iPad|iPhone|iPod/.test(navigator.userAgent) ||
+    // iPadOS reports itself as macOS; touch support tells it apart.
+    (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1)
+  );
+}
+
+const embedSupported = ref(true);
+
+// The embed src minus embed/view params = the full editor workspace URL.
+const openUrl = computed(() => {
+  const url = new URL(props.src);
+  url.searchParams.delete('embed');
+  url.searchParams.delete('view');
+  return url.toString();
+});
 
 const container = useTemplateRef('container');
 const isFullscreenSupported = ref(false);
@@ -42,6 +65,7 @@ if (!import.meta.env.SSR) {
 }
 
 onMounted(async () => {
+  embedSupported.value = !isIOS();
   isFullscreenSupported.value = screenfull.isEnabled;
   if (screenfull.isEnabled) {
     screenfull.on('change', handleFullscreenChange);
@@ -56,7 +80,33 @@ onUnmounted(() => {
 </script>
 
 <template>
+  <div v-if="!embedSupported" class="stackblitz-fallback">
+    <p class="fallback-note">
+      Embedded StackBlitz (WebContainers) isn't supported in this browser.
+      <template v-if="fallbackSrc">
+        Here's the built example instead — open the workspace on a supported
+        device to edit the code.
+      </template>
+      <template v-else
+        >Open the workspace on a supported device instead.</template
+      >
+    </p>
+    <ExampleEmbed
+      v-if="fallbackSrc"
+      :src="fallbackSrc"
+      :title="title"
+      :height="fallbackHeight"
+    >
+      <a :href="openUrl" target="_blank" rel="noopener" class="btn">
+        Open in StackBlitz
+      </a>
+    </ExampleEmbed>
+    <a v-else :href="openUrl" target="_blank" rel="noopener" class="btn">
+      Open in StackBlitz
+    </a>
+  </div>
   <div
+    v-else
     ref="container"
     class="stackblitz-embed"
     :class="{ fullscreen: isFullscreen }"
@@ -98,7 +148,10 @@ onUnmounted(() => {
 
 .stackblitz-embed iframe {
   width: 100%;
+  max-width: 100%;
   height: 400px;
+  /* Cap on short viewports (svh dodges mobile browser toolbars). */
+  height: min(400px, calc(100svh - 120px));
   border: 0;
   border-radius: 4px;
   overflow: hidden;
@@ -138,8 +191,19 @@ onUnmounted(() => {
 .stackblitz-embed-actions {
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
   gap: 12px;
   margin-top: 8px;
+}
+
+.fallback-note {
+  margin: 0 0 8px;
+  padding: 8px 12px;
+  font-size: 14px;
+  color: var(--vp-c-text-2);
+  background: var(--vp-c-bg-soft);
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 6px;
 }
 
 .btn {
@@ -150,6 +214,7 @@ onUnmounted(() => {
   font-size: 14px;
   font-weight: 500;
   color: var(--vp-c-text-1);
+  text-decoration: none;
   background: var(--vp-c-bg-soft);
   border: 1px solid var(--vp-c-divider);
   border-radius: 6px;
@@ -166,7 +231,7 @@ onUnmounted(() => {
 
 /* Framed like the sibling .btn controls; border present in both states so
    hover changes color only, never size. */
-:deep(a) {
+.stackblitz-embed-actions :deep(a) {
   display: inline-flex;
   align-items: center;
   line-height: 0;
@@ -176,7 +241,7 @@ onUnmounted(() => {
   transition: border-color 0.2s;
 }
 
-:deep(a img) {
+.stackblitz-embed-actions :deep(a img) {
   display: block;
   /* 36px + the 1px frame = 38px, level with the sibling .btn controls. */
   height: 36px;
@@ -184,7 +249,7 @@ onUnmounted(() => {
   margin: 0;
 }
 
-:deep(a:hover) {
+.stackblitz-embed-actions :deep(a:hover) {
   border-color: var(--vp-c-brand-1);
 }
 </style>

--- a/docs/.vitepress/theme/components/StackBlitzEmbed.vue
+++ b/docs/.vitepress/theme/components/StackBlitzEmbed.vue
@@ -11,7 +11,7 @@ const props = defineProps<{
 }>();
 
 // StackBlitz WebContainers never boot on iOS (every iOS browser is WebKit),
-// so swap the embed for the static example / an external link there.
+// even though iOS 16.4+ has SharedArrayBuffer — UA is the primary signal.
 function isIOS() {
   return (
     /iPad|iPhone|iPod/.test(navigator.userAgent) ||
@@ -65,7 +65,9 @@ if (!import.meta.env.SSR) {
 }
 
 onMounted(async () => {
-  embedSupported.value = !isIOS();
+  // The site is crossOriginIsolated (_headers: COOP + COEP credentialless),
+  // so a missing SharedArrayBuffer means an engine too old for WebContainers.
+  embedSupported.value = !isIOS() && typeof SharedArrayBuffer !== 'undefined';
   isFullscreenSupported.value = screenfull.isEnabled;
   if (screenfull.isEnabled) {
     screenfull.on('change', handleFullscreenChange);

--- a/docs/tutorial/hellogalaxy.md
+++ b/docs/tutorial/hellogalaxy.md
@@ -11,6 +11,8 @@ Building on [Hello Solar System](./hellosolarsystem), this tutorial introduces *
 
 <StackBlitzEmbed
 src="https://stackblitz.com/github/simshanith/lit-ui-router/tree/main/examples/hellogalaxy?embed=1&file=src/main.ts&view=preview"
+fallback-src="/examples/hellogalaxy/"
+fallback-height="920px"
 title="lit-ui-router-hellogalaxy"><a href="https://stackblitz.com/github/simshanith/lit-ui-router/tree/main/examples/hellogalaxy?file=src/main.ts" target="_blank"><img alt="Open in StackBlitz" src="https://developer.stackblitz.com/img/open_in_stackblitz.svg" /></a></StackBlitzEmbed>
 
 ## What We're Building

--- a/docs/tutorial/hellosolarsystem.md
+++ b/docs/tutorial/hellosolarsystem.md
@@ -11,6 +11,8 @@ Building on [Hello World](./helloworld), this tutorial introduces data fetching 
 
 <StackBlitzEmbed
 src="https://stackblitz.com/github/simshanith/lit-ui-router/tree/main/examples/hellosolarsystem?embed=1&file=src/main.ts&view=preview"
+fallback-src="/examples/hellosolarsystem/"
+fallback-height="800px"
 title="lit-ui-router-hellosolarsystem"><a href="https://stackblitz.com/github/simshanith/lit-ui-router/tree/main/examples/hellosolarsystem?file=src/main.ts" target="_blank"><img alt="Open in StackBlitz" src="https://developer.stackblitz.com/img/open_in_stackblitz.svg" /></a></StackBlitzEmbed>
 
 ## What We're Building

--- a/docs/tutorial/helloworld.md
+++ b/docs/tutorial/helloworld.md
@@ -11,6 +11,8 @@ This tutorial will guide you through building your first lit-ui-router applicati
 
 <StackBlitzEmbed
 src="https://stackblitz.com/github/simshanith/lit-ui-router/tree/main/examples/helloworld?embed=1&file=src/main.ts&view=preview"
+fallback-src="/examples/helloworld/"
+fallback-height="180px"
 title="lit-ui-router-helloworld"><a href="https://stackblitz.com/github/simshanith/lit-ui-router/tree/main/examples/helloworld?file=src/main.ts" target="_blank"><img alt="Open in StackBlitz" src="https://developer.stackblitz.com/img/open_in_stackblitz.svg" /></a></StackBlitzEmbed>
 
 ## Full Source Code


### PR DESCRIPTION
## Problem

StackBlitz embeds on the tutorial pages are plain iframes to `stackblitz.com/github/...?embed=1`. StackBlitz boots the workspace in WebContainers, which don't run on iOS — every iOS browser is WebKit — so on iPhone/iPad the embed renders a frame that never launches. The same-origin `ExampleEmbed` frames (built examples served under `/examples/<name>/`) work fine on mobile, but the tall ones (800px/920px) overflow small viewports.

## Changes

**`StackBlitzEmbed.vue`**
- Detects unsupported environments on mount (SSR/hydration-safe), two signals:
  - **Primary — iOS UA/platform**: UA match for `iPad|iPhone|iPod`, plus the iPadOS-masquerading-as-macOS case (`platform === 'MacIntel' && maxTouchPoints > 1`). This must be UA-based: the docs site is crossOriginIsolated (`docs/public/_headers` sends COOP `same-origin` + COEP `credentialless` on `/*` — also why the embed iframe carries `credentialless`), and iOS Safari 16.4+ implements SharedArrayBuffer under COI, so a capability probe would pass on exactly the devices where WebContainers fail to boot. (WebContainers run inside stackblitz.com's own iframe under StackBlitz's headers, so our page's isolation doesn't gate them either way.)
  - **Secondary — capability guard**: `typeof SharedArrayBuffer === 'undefined'` also marks the environment unsupported; since our page is COI, a missing SAB means an engine genuinely too old to run WebContainers anywhere.
- On unsupported devices, instead of the dead iframe it renders a short note plus the corresponding static `ExampleEmbed` (new optional `fallback-src`/`fallback-height` props) with an "Open in StackBlitz" link in the actions row; with no `fallback-src` it renders the note and link alone. The link is derived from the embed URL by stripping `embed`/`view` params.
- Responsive: `max-width: 100%`, iframe height capped via `min(400px, calc(100svh - 120px))`, actions row now wraps.
- Narrowed the `:deep(a)` badge rules to `.stackblitz-embed-actions` so they don't leak onto the fallback's anchors.

**`ExampleEmbed.vue`**
- Height moved from an inline style to a `--embed-height` custom property so CSS can cap it: `min(var(--embed-height), calc(100svh - 120px))` (static `height` fallback first for browsers without `svh`), plus `max-width: 100%`. Fullscreen override no longer needs `!important`.

**Tutorial pages** (`helloworld`/`hellosolarsystem`/`hellogalaxy`): pass `fallback-src`/`fallback-height` matching the live-examples page.

Scope note: deliberately no toggle/tabs architecture — a separate design effort is exploring that restructure.

## Verified

- `turbo run build lint typecheck:vue --filter=docs` passes.
- Playwright against `vitepress preview`: desktop Chromium 1280x800 shows the StackBlitz iframe on /tutorial/helloworld and 3 static frames on /tutorial/live-examples, no horizontal scroll, tall frames capped to viewport; iPhone 13 emulation (390x664, iOS UA) renders the fallback (note + 180px static example, zero StackBlitz iframes), no horizontal scroll, live-examples frames capped to 544px.
- Not verified on a real iOS device (Chromium emulates UA, not the WebKit engine); the primary detection keys off UA/platform, which the emulation exercises. The SAB guard is a no-op in the emulated contexts (SAB present).
