### PR TITLE
feat(docs): inline LiveExample tabs in tutorials

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -65,7 +65,7 @@ function makeSidebar() {
         { text: 'Hello World', link: '/tutorial/helloworld' },
         { text: 'Hello Solar System', link: '/tutorial/hellosolarsystem' },
         { text: 'Hello Galaxy', link: '/tutorial/hellogalaxy' },
-        { text: 'Live Examples', link: '/tutorial/live-examples' },
+        { text: 'All Examples', link: '/tutorial/live-examples' },
       ],
     },
     {

--- a/docs/.vitepress/theme/components/LiveExample.vue
+++ b/docs/.vitepress/theme/components/LiveExample.vue
@@ -1,0 +1,236 @@
+<script setup lang="ts">
+import { ref, computed, onMounted, useId } from 'vue';
+import ExampleEmbed from './ExampleEmbed.vue';
+import StackBlitzEmbed from './StackBlitzEmbed.vue';
+import {
+  EXAMPLES,
+  staticSrc,
+  stackblitzEmbedSrc,
+  stackblitzOpenSrc,
+  type ExampleName,
+} from './examples';
+import { webContainersSupported } from './webcontainers';
+
+const props = defineProps<{
+  name: ExampleName;
+  height?: string;
+  file?: string;
+}>();
+
+type Mode = 'preview' | 'stackblitz';
+const STORAGE_KEY = 'lit-ui-router:live-example-mode';
+// Site-wide preference; instances read it on mount but never follow later writes.
+const preference = ref<Mode>('preview');
+
+const example = computed(() => EXAMPLES[props.name]);
+const previewSrc = computed(() => staticSrc(props.name));
+const embedSrc = computed(() => stackblitzEmbedSrc(props.name, props.file));
+const openSrc = computed(() => stackblitzOpenSrc(props.name, props.file));
+const previewHeight = computed(() => props.height ?? example.value.height);
+
+const uid = useId();
+const active = ref<Mode>('preview');
+const supported = ref(true);
+// First StackBlitz selection boots the iframe; v-show keeps it alive after.
+const stackblitzBooted = ref(false);
+
+function selectTab(mode: Mode, persist = true) {
+  active.value = mode;
+  if (mode === 'stackblitz' && supported.value) stackblitzBooted.value = true;
+  if (persist) {
+    preference.value = mode;
+    try {
+      localStorage.setItem(STORAGE_KEY, mode);
+    } catch {
+      // Storage unavailable (private mode etc.) — preference just won't persist.
+    }
+  }
+}
+
+onMounted(() => {
+  supported.value = webContainersSupported();
+  let stored: string | null = null;
+  try {
+    stored = localStorage.getItem(STORAGE_KEY);
+  } catch {
+    stored = null;
+  }
+  if (stored === 'preview' || stored === 'stackblitz') {
+    preference.value = stored;
+  }
+  if (supported.value && preference.value === 'stackblitz') {
+    selectTab('stackblitz', false);
+  }
+});
+</script>
+
+<template>
+  <div class="live-example">
+    <div class="live-example-bar">
+      <div
+        class="live-example-tablist"
+        role="tablist"
+        :aria-label="`${example.title} example`"
+      >
+        <button
+          type="button"
+          role="tab"
+          class="tab"
+          :id="`${uid}-tab-preview`"
+          :aria-selected="active === 'preview'"
+          :aria-controls="`${uid}-panel-preview`"
+          :class="{ active: active === 'preview' }"
+          @click="selectTab('preview')"
+        >
+          Preview
+        </button>
+        <button
+          type="button"
+          role="tab"
+          class="tab"
+          :id="`${uid}-tab-stackblitz`"
+          :aria-selected="active === 'stackblitz'"
+          :aria-controls="`${uid}-panel-stackblitz`"
+          :class="{ active: active === 'stackblitz' }"
+          @click="selectTab('stackblitz')"
+        >
+          Edit in StackBlitz
+        </button>
+      </div>
+      <a class="open-badge" :href="openSrc" target="_blank" rel="noopener">
+        <img
+          alt="Open in StackBlitz"
+          src="https://developer.stackblitz.com/img/open_in_stackblitz.svg"
+        />
+      </a>
+    </div>
+    <div
+      class="live-example-panels"
+      :style="{ '--embed-height': previewHeight }"
+    >
+      <div
+        v-show="active === 'preview'"
+        role="tabpanel"
+        :id="`${uid}-panel-preview`"
+        :aria-labelledby="`${uid}-tab-preview`"
+      >
+        <ExampleEmbed
+          :src="previewSrc"
+          :title="`${example.title} example`"
+          :height="previewHeight"
+        />
+      </div>
+      <div
+        v-show="active === 'stackblitz'"
+        role="tabpanel"
+        :id="`${uid}-panel-stackblitz`"
+        :aria-labelledby="`${uid}-tab-stackblitz`"
+      >
+        <template v-if="supported">
+          <StackBlitzEmbed
+            v-if="stackblitzBooted"
+            :src="embedSrc"
+            :title="`lit-ui-router-${props.name}`"
+          />
+        </template>
+        <div v-else class="fallback-note">
+          <p>
+            StackBlitz's in-browser environment isn't supported here (e.g. iOS
+            Safari). Use the Preview tab to try the running example, or
+            <a :href="openSrc" target="_blank" rel="noopener"
+              >open the workspace on StackBlitz</a
+            >
+            from a supported device.
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.live-example {
+  margin: 16px 0;
+}
+
+.live-example-bar {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-bottom: 8px;
+}
+
+.live-example-tablist {
+  display: inline-flex;
+  gap: 4px;
+  padding: 3px;
+  background: var(--vp-c-bg-soft);
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 8px;
+}
+
+.tab {
+  padding: 5px 12px;
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--vp-c-text-2);
+  background: transparent;
+  border: 0;
+  border-radius: 6px;
+  cursor: pointer;
+  transition:
+    background-color 0.2s,
+    color 0.2s;
+}
+
+.tab:hover {
+  color: var(--vp-c-text-1);
+}
+
+.tab.active {
+  color: var(--vp-c-text-1);
+  background: var(--vp-c-bg);
+  box-shadow: 0 0 0 1px var(--vp-c-divider);
+}
+
+.open-badge {
+  display: inline-flex;
+  align-items: center;
+  line-height: 0;
+  margin-left: auto;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 6px;
+  overflow: hidden;
+  transition: border-color 0.2s;
+}
+
+.open-badge:hover {
+  border-color: var(--vp-c-brand-1);
+}
+
+.open-badge img {
+  display: block;
+  height: 36px;
+  /* .vp-doc gives content imgs 16px vertical margin — kill the gap. */
+  margin: 0;
+}
+
+/* Reserve the taller (preview) pane's frame height so tab switches don't shift the page. */
+.live-example-panels {
+  min-height: min(var(--embed-height, 420px), calc(100svh - 120px));
+}
+
+.fallback-note {
+  padding: 8px 12px;
+  font-size: 14px;
+  color: var(--vp-c-text-2);
+  background: var(--vp-c-bg-soft);
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 6px;
+}
+
+.fallback-note p {
+  margin: 0;
+}
+</style>

--- a/docs/.vitepress/theme/components/LiveExample.vue
+++ b/docs/.vitepress/theme/components/LiveExample.vue
@@ -151,6 +151,7 @@ onMounted(() => {
 <style scoped>
 .live-example {
   margin: 16px 0;
+  container-type: inline-size;
 }
 
 .live-example-bar {
@@ -203,6 +204,14 @@ onMounted(() => {
   border-radius: 6px;
   overflow: hidden;
   transition: border-color 0.2s;
+}
+
+/* Below the tabs+badge intrinsic width the bar wraps the badge onto its own
+   row — align it with the tabs instead of the far edge. */
+@container (max-width: 420px) {
+  .open-badge {
+    margin-left: 0;
+  }
 }
 
 .open-badge:hover {

--- a/docs/.vitepress/theme/components/LiveExample.vue
+++ b/docs/.vitepress/theme/components/LiveExample.vue
@@ -106,6 +106,7 @@ onMounted(() => {
     </div>
     <div
       class="live-example-panels"
+      :class="{ collapsed: active === 'stackblitz' && !supported }"
       :style="{ '--embed-height': previewHeight }"
     >
       <div
@@ -228,6 +229,12 @@ onMounted(() => {
 /* Reserve the taller (preview) pane's frame height so tab switches don't shift the page. */
 .live-example-panels {
   min-height: min(var(--embed-height, 420px), calc(100svh - 120px));
+}
+
+/* Unsupported devices show only the short fallback note on the StackBlitz
+   tab — don't hold the reserved frame height as a blank region. */
+.live-example-panels.collapsed {
+  min-height: 0;
 }
 
 .fallback-note {

--- a/docs/.vitepress/theme/components/StackBlitzEmbed.vue
+++ b/docs/.vitepress/theme/components/StackBlitzEmbed.vue
@@ -2,6 +2,7 @@
 import { useTemplateRef, ref, computed, onMounted, onUnmounted } from 'vue';
 import screenfull from 'screenfull';
 import ExampleEmbed from './ExampleEmbed.vue';
+import { webContainersSupported } from './webcontainers';
 
 const props = defineProps<{
   src: string;
@@ -9,16 +10,6 @@ const props = defineProps<{
   fallbackSrc?: string;
   fallbackHeight?: string;
 }>();
-
-// StackBlitz WebContainers never boot on iOS (every iOS browser is WebKit),
-// even though iOS 16.4+ has SharedArrayBuffer — UA is the primary signal.
-function isIOS() {
-  return (
-    /iPad|iPhone|iPod/.test(navigator.userAgent) ||
-    // iPadOS reports itself as macOS; touch support tells it apart.
-    (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1)
-  );
-}
 
 const embedSupported = ref(true);
 
@@ -65,9 +56,7 @@ if (!import.meta.env.SSR) {
 }
 
 onMounted(async () => {
-  // The site is crossOriginIsolated (_headers: COOP + COEP credentialless),
-  // so a missing SharedArrayBuffer means an engine too old for WebContainers.
-  embedSupported.value = !isIOS() && typeof SharedArrayBuffer !== 'undefined';
+  embedSupported.value = webContainersSupported();
   isFullscreenSupported.value = screenfull.isEnabled;
   if (screenfull.isEnabled) {
     screenfull.on('change', handleFullscreenChange);

--- a/docs/.vitepress/theme/components/examples.ts
+++ b/docs/.vitepress/theme/components/examples.ts
@@ -1,0 +1,37 @@
+// Keep in sync with examples/build-embeds.ts and EMBEDDED_EXAMPLES in docs/.vitepress/vite.config.ts.
+export const EXAMPLES = {
+  helloworld: { title: 'Hello World', height: '180px', file: 'src/main.ts' },
+  hellosolarsystem: {
+    title: 'Hello Solar System',
+    height: '800px',
+    file: 'src/main.ts',
+  },
+  hellogalaxy: {
+    title: 'Hello Galaxy',
+    height: '920px',
+    file: 'src/main.ts',
+  },
+} as const;
+
+export type ExampleName = keyof typeof EXAMPLES;
+
+const REPO_TREE =
+  'https://stackblitz.com/github/simshanith/lit-ui-router/tree/main/examples';
+
+export function staticSrc(name: ExampleName): string {
+  return `/examples/${name}/`;
+}
+
+export function stackblitzEmbedSrc(
+  name: ExampleName,
+  file: string = EXAMPLES[name].file,
+): string {
+  return `${REPO_TREE}/${name}?embed=1&file=${file}&view=preview`;
+}
+
+export function stackblitzOpenSrc(
+  name: ExampleName,
+  file: string = EXAMPLES[name].file,
+): string {
+  return `${REPO_TREE}/${name}?file=${file}`;
+}

--- a/docs/.vitepress/theme/components/webcontainers.ts
+++ b/docs/.vitepress/theme/components/webcontainers.ts
@@ -1,0 +1,17 @@
+// Client-only: call from onMounted, never at module scope (SSG has no navigator).
+
+// StackBlitz WebContainers never boot on iOS (every iOS browser is WebKit),
+// even though iOS 16.4+ has SharedArrayBuffer — UA is the primary signal.
+export function isIOS(): boolean {
+  return (
+    /iPad|iPhone|iPod/.test(navigator.userAgent) ||
+    // iPadOS reports itself as macOS; touch support tells it apart.
+    (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1)
+  );
+}
+
+// The site is crossOriginIsolated (_headers: COOP + COEP credentialless),
+// so a missing SharedArrayBuffer means an engine too old for WebContainers.
+export function webContainersSupported(): boolean {
+  return !isIOS() && typeof SharedArrayBuffer !== 'undefined';
+}

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -3,6 +3,7 @@ import DefaultTheme from 'vitepress/theme';
 import './custom.css';
 import StackBlitzEmbed from './components/StackBlitzEmbed.vue';
 import ExampleEmbed from './components/ExampleEmbed.vue';
+import LiveExample from './components/LiveExample.vue';
 import FrameworkSpectrum from './components/FrameworkSpectrum.vue';
 import FrameworkCards from './components/FrameworkCards.vue';
 
@@ -11,6 +12,7 @@ export default {
   enhanceApp({ app }) {
     app.component('StackBlitzEmbed', StackBlitzEmbed);
     app.component('ExampleEmbed', ExampleEmbed);
+    app.component('LiveExample', LiveExample);
     app.component('FrameworkSpectrum', FrameworkSpectrum);
     app.component('FrameworkCards', FrameworkCards);
   },

--- a/docs/tutorial/hellogalaxy.md
+++ b/docs/tutorial/hellogalaxy.md
@@ -9,11 +9,7 @@ Building on [Hello Solar System](./hellosolarsystem), this tutorial introduces *
 
 ## Live Demo
 
-<StackBlitzEmbed
-src="https://stackblitz.com/github/simshanith/lit-ui-router/tree/main/examples/hellogalaxy?embed=1&file=src/main.ts&view=preview"
-fallback-src="/examples/hellogalaxy/"
-fallback-height="920px"
-title="lit-ui-router-hellogalaxy"><a href="https://stackblitz.com/github/simshanith/lit-ui-router/tree/main/examples/hellogalaxy?file=src/main.ts" target="_blank"><img alt="Open in StackBlitz" src="https://developer.stackblitz.com/img/open_in_stackblitz.svg" /></a></StackBlitzEmbed>
+<LiveExample name="hellogalaxy" />
 
 ## What We're Building
 

--- a/docs/tutorial/hellosolarsystem.md
+++ b/docs/tutorial/hellosolarsystem.md
@@ -9,11 +9,7 @@ Building on [Hello World](./helloworld), this tutorial introduces data fetching 
 
 ## Live Demo
 
-<StackBlitzEmbed
-src="https://stackblitz.com/github/simshanith/lit-ui-router/tree/main/examples/hellosolarsystem?embed=1&file=src/main.ts&view=preview"
-fallback-src="/examples/hellosolarsystem/"
-fallback-height="800px"
-title="lit-ui-router-hellosolarsystem"><a href="https://stackblitz.com/github/simshanith/lit-ui-router/tree/main/examples/hellosolarsystem?file=src/main.ts" target="_blank"><img alt="Open in StackBlitz" src="https://developer.stackblitz.com/img/open_in_stackblitz.svg" /></a></StackBlitzEmbed>
+<LiveExample name="hellosolarsystem" />
 
 ## What We're Building
 

--- a/docs/tutorial/helloworld.md
+++ b/docs/tutorial/helloworld.md
@@ -9,11 +9,7 @@ This tutorial will guide you through building your first lit-ui-router applicati
 
 ## Live Demo
 
-<StackBlitzEmbed
-src="https://stackblitz.com/github/simshanith/lit-ui-router/tree/main/examples/helloworld?embed=1&file=src/main.ts&view=preview"
-fallback-src="/examples/helloworld/"
-fallback-height="180px"
-title="lit-ui-router-helloworld"><a href="https://stackblitz.com/github/simshanith/lit-ui-router/tree/main/examples/helloworld?file=src/main.ts" target="_blank"><img alt="Open in StackBlitz" src="https://developer.stackblitz.com/img/open_in_stackblitz.svg" /></a></StackBlitzEmbed>
+<LiveExample name="helloworld" />
 
 ## Full Source Code
 

--- a/docs/tutorial/live-examples.md
+++ b/docs/tutorial/live-examples.md
@@ -1,26 +1,22 @@
 ---
-title: Live Examples
-description: The tutorial example apps, running live inside the docs site
+title: All Examples
+description: Every tutorial example app in one place, running live
 ---
 
-# Live Examples
+# All Examples
 
-All three tutorial examples run right here — built from
-[`examples/`](https://github.com/simshanith/lit-ui-router/tree/main/examples)
-and served by this site, no StackBlitz boot required. Each frame below is the
-real app, installed from the published npm packages.
-
-The examples route with `hashLocationPlugin`, so navigation stays inside each
-frame. Open one in its own tab to watch the URL change as you click around, or
-head to its tutorial for the full walkthrough with an editable StackBlitz
-workspace.
+Every tutorial example in one place. The Preview tab runs the built app served
+by this site; the Edit in StackBlitz tab boots an editable workspace installed
+from the published npm packages. Each example routes with
+`hashLocationPlugin`, so navigation stays inside the frame — open one in its
+own tab to watch the URL change.
 
 ## Hello World
 
 Two sibling states, one `<ui-view>`, and `uiSref` navigation — the smallest
 possible router. Walkthrough: [Hello World tutorial](./helloworld).
 
-<ExampleEmbed src="/examples/helloworld/" title="helloworld example" height="180px" />
+<LiveExample name="helloworld" />
 
 ## Hello Solar System
 
@@ -28,13 +24,12 @@ A master-detail list of the real solar system: URL parameters, async resolves,
 and transition-driven data loading. Walkthrough:
 [Hello Solar System tutorial](./hellosolarsystem).
 
-<ExampleEmbed src="/examples/hellosolarsystem/" title="hellosolarsystem example" height="800px" />
+<LiveExample name="hellosolarsystem" />
 
 ## Hello Galaxy
 
 Nested states and views: a star catalog in a three-level state tree, resolve
-inheritance, and a lazily loaded 3D astronaut (the `model-viewer` chunk only
-downloads when you visit the astronaut state — watch the network tab).
-Walkthrough: [Hello Galaxy tutorial](./hellogalaxy).
+inheritance, and a lazily loaded 3D astronaut. Walkthrough:
+[Hello Galaxy tutorial](./hellogalaxy).
 
-<ExampleEmbed src="/examples/hellogalaxy/" title="hellogalaxy example" height="920px" />
+<LiveExample name="hellogalaxy" />


### PR DESCRIPTION
Stacked on #503 (`docs/mobile-embed-fallback`) — merge that first; this PR's base is that branch, not `main`.

## What

Replaces the tutorial pages' bare `<StackBlitzEmbed>` blocks with a new `<LiveExample name="...">` component that renders a Preview / Edit-in-StackBlitz tab bar, and turns `tutorial/live-examples.md` into a slim "All Examples" index using the same component.

## Design

- **Static-first default**: the Preview tab (same-origin built example via `ExampleEmbed`) is active everywhere, including desktop. It loads instantly, works on every device, and matches the SSG output so there is nothing to hydrate differently.
- **Lazy StackBlitz boot**: the `StackBlitzEmbed` iframe enters the DOM only on first selection of the "Edit in StackBlitz" tab (`v-if`), then stays alive across tab toggles (`v-show`) so a booted WebContainer isn't torn down.
- **Persistence**: the chosen tab is stored in `localStorage['lit-ui-router:live-example-mode']` via a module-level preference ref. New page loads honor it (SB preselects only when WebContainers are supported); already-mounted instances on the same page are not yanked to follow another instance's tab change.
- **Unsupported fallback**: the iOS/SAB detection from #503 moved to `theme/components/webcontainers.ts` (shared by both components, still called only in `onMounted`). When unsupported, selecting the SB tab shows a notice + external StackBlitz link instead of booting an iframe. `StackBlitzEmbed`'s own `fallbackSrc` mechanism is untouched for standalone use; `LiveExample` just doesn't pass it.
- **Single-source registry**: `theme/components/examples.ts` holds name/title/height/file per example plus the static/embed/open URL builders, cross-referenced with the two build-side example lists.
- **Layout stability**: the panel container reserves the preview pane's frame height so tab switches don't shift the page.

## Verified

- `turbo run build lint typecheck:vue --filter=docs` green.
- Playwright against `vitepress preview`, desktop Chromium (SAB enabled via flag since preview doesn't serve the `_headers` COOP/COEP): Preview active on load, no stackblitz.com iframe until the SB tab is clicked, iframe survives switching back, localStorage preference preselects SB on a fresh load, live-examples renders 3 blocks, no hydration warnings, no horizontal scroll.
- iPhone 13 emulation: SB tab shows the fallback notice + external link, zero stackblitz.com iframes, no horizontal scroll.
