### PR TITLE
fix(examples): responsive layouts for mobile embeds

### DIFF
--- a/examples/hellogalaxy/index.html
+++ b/examples/hellogalaxy/index.html
@@ -45,6 +45,19 @@
         background-size: cover;
         background-position: center;
       }
+      @media (max-width: 640px) {
+        /* Smaller backdrop download for phones */
+        body::before {
+          background-image:
+            linear-gradient(rgba(9, 10, 15, 0.4), rgba(9, 10, 15, 0.7)),
+            url('https://science.nasa.gov/wp-content/uploads/2023/09/ssc2006-02a-0.jpg?w=1024');
+        }
+        /* The @uirouter/visualizer overlays cover content on phones */
+        #uirStateVisualizer,
+        #uirTransitionVisualizer {
+          display: none !important;
+        }
+      }
     </style>
   </head>
   <body>

--- a/examples/hellogalaxy/index.html
+++ b/examples/hellogalaxy/index.html
@@ -15,6 +15,12 @@
         padding: 0 20px;
         color: #e6edf3;
       }
+      @media (max-width: 480px) {
+        body {
+          margin: 16px auto;
+          padding: 0 12px;
+        }
+      }
       html {
         min-height: 100%;
         /* Loading fallback while the photo downloads */

--- a/examples/hellogalaxy/src/main.ts
+++ b/examples/hellogalaxy/src/main.ts
@@ -143,6 +143,7 @@ class GalaxyShellComponent extends LitElement {
   static styles = css`
     nav {
       display: flex;
+      flex-wrap: wrap;
       gap: 8px;
       margin-bottom: 24px;
     }
@@ -181,6 +182,15 @@ class GalaxyShellComponent extends LitElement {
     }
     .backdrop-credit a {
       color: #c9d6ea;
+    }
+    /* Tighter panel, larger tap targets on touch-sized screens */
+    @media (max-width: 480px) {
+      nav a {
+        padding: 10px 16px;
+      }
+      .panel {
+        padding: 14px;
+      }
     }
   `;
 
@@ -286,6 +296,23 @@ class StarsContainerComponent extends LitElement {
       color: #6b7c95;
       font-style: italic;
     }
+    /* Stack the list above the detail pane on narrow screens */
+    @media (max-width: 640px) {
+      .container {
+        flex-direction: column;
+        gap: 16px;
+      }
+      .list {
+        flex: none;
+      }
+      .list a {
+        padding: 10px 12px;
+      }
+      .detail {
+        padding: 16px;
+        min-height: 200px;
+      }
+    }
   `;
 
   @property({ attribute: false })
@@ -366,6 +393,16 @@ class StarDetailComponent extends LitElement {
       border-left: 3px solid #7aa2ff;
       padding-left: 12px;
       margin: 0;
+    }
+    /* Stack label/value pairs on narrow screens */
+    @media (max-width: 420px) {
+      dl {
+        grid-template-columns: 1fr;
+        gap: 2px 0;
+      }
+      dt {
+        margin-top: 8px;
+      }
     }
   `;
 

--- a/examples/hellogalaxy/src/main.ts
+++ b/examples/hellogalaxy/src/main.ts
@@ -192,6 +192,14 @@ class GalaxyShellComponent extends LitElement {
         padding: 14px;
       }
     }
+    @media (max-width: 640px) {
+      /* Inflate link tap targets to ~44px without shifting layout */
+      .backdrop-credit a {
+        display: inline-block;
+        padding: 15px 4px;
+        margin: -15px -4px;
+      }
+    }
   `;
 
   // Injected by <ui-view>; required by the RoutedLitElement contract
@@ -418,6 +426,13 @@ class StarDetailComponent extends LitElement {
     return this._uiViewProps.resolves.star;
   }
 
+  firstUpdated() {
+    // The stacked (narrow) layout renders this detail below the star list
+    if (window.matchMedia('(max-width: 640px)').matches) {
+      this.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+    }
+  }
+
   render() {
     if (!this.star) {
       return html`<p>Star not found</p>`;
@@ -468,6 +483,17 @@ class AstronautViewComponent extends LitElement {
     .attribution a {
       color: #9db2ce;
     }
+    @media (max-width: 640px) {
+      model-viewer {
+        height: 320px;
+      }
+      /* Inflate link tap targets to ~44px without shifting layout */
+      .attribution a {
+        display: inline-block;
+        padding: 15px 4px;
+        margin: -15px -4px;
+      }
+    }
   `;
 
   // Injected by <ui-view>; required by the RoutedLitElement contract
@@ -482,12 +508,14 @@ class AstronautViewComponent extends LitElement {
     return html`
       <h3>Someone is exploring out here too</h3>
       <p>Drag to orbit the astronaut. Scroll to zoom.</p>
+      <!-- touch-action="pan-y" keeps one-finger vertical swipes scrolling the page -->
       <model-viewer
         src="https://modelviewer.dev/shared-assets/models/NeilArmstrong.glb"
         alt="Neil Armstrong's Apollo 11 spacesuit, 3D scan"
         camera-controls
         auto-rotate
         ar
+        touch-action="pan-y"
       ></model-viewer>
       <p class="attribution">
         <a

--- a/examples/hellosolarsystem/index.html
+++ b/examples/hellosolarsystem/index.html
@@ -29,10 +29,23 @@
         color: #e6e9f0;
         background: transparent;
       }
+      @media (max-width: 800px) {
+        body {
+          margin: 24px auto;
+        }
+      }
       @media (max-width: 480px) {
         body {
           margin: 16px auto;
           padding: 0 12px;
+        }
+      }
+      /* The visualizer overlay covers content on phones; keep it desktop-only.
+         !important outranks the visualizer's own injected stylesheet. */
+      @media (max-width: 600px) {
+        #uirStateVisualizer,
+        #uirTransitionVisualizer {
+          display: none !important;
         }
       }
     </style>

--- a/examples/hellosolarsystem/index.html
+++ b/examples/hellosolarsystem/index.html
@@ -29,6 +29,12 @@
         color: #e6e9f0;
         background: transparent;
       }
+      @media (max-width: 480px) {
+        body {
+          margin: 16px auto;
+          padding: 0 12px;
+        }
+      }
     </style>
   </head>
   <body>

--- a/examples/hellosolarsystem/src/main.ts
+++ b/examples/hellosolarsystem/src/main.ts
@@ -196,10 +196,17 @@ class PlanetListComponent extends LitElement {
       color: #8892b8;
       font-size: 0.85em;
     }
-    /* Larger tap targets on touch-sized screens */
+    /* ≥44px tap targets on touch-sized screens */
     @media (max-width: 480px) {
       a {
-        padding: 11px 12px;
+        box-sizing: border-box;
+        min-height: 44px;
+        padding: 8px 12px;
+      }
+      /* Cap the log-scaled dots so the Sun doesn't dwarf the row */
+      .body {
+        max-width: 44px;
+        max-height: 44px;
       }
     }
   `;
@@ -276,6 +283,25 @@ class PlanetDetailComponent extends LitElement {
     .back-link:hover {
       text-decoration: underline;
     }
+    /* Top back link only appears on phones, where the bottom one is below the fold */
+    .back-link.top {
+      display: none;
+      margin: 0;
+    }
+    /* ≥44px tap targets on touch-sized screens */
+    @media (max-width: 480px) {
+      .back-link {
+        padding: 13px 0;
+      }
+      .back-link.top {
+        display: block;
+      }
+      /* Cap the doubled detail dot so facts stay above the fold */
+      .body {
+        max-width: 96px;
+        max-height: 96px;
+      }
+    }
     /* Stack label/value pairs on narrow screens */
     @media (max-width: 420px) {
       dl {
@@ -310,6 +336,9 @@ class PlanetDetailComponent extends LitElement {
     const size = dotSize(this.planet.diameterKm) * 2;
     return html`
       <div>
+        <a class="back-link top" ${uiSref('planets')}
+          >&lsaquo; Back to the solar system</a
+        >
         <h3>${this.planet.name}</h3>
         <span
           class="body"
@@ -358,10 +387,10 @@ export class AppRoot extends LitElement {
       font-weight: bold;
       border-bottom: 2px solid #8ab4f8;
     }
-    /* Larger tap targets on touch-sized screens */
+    /* ≥44px tap targets on touch-sized screens */
     @media (max-width: 480px) {
       nav a {
-        padding: 10px 0;
+        padding: 13px 0;
       }
     }
   `;

--- a/examples/hellosolarsystem/src/main.ts
+++ b/examples/hellosolarsystem/src/main.ts
@@ -196,6 +196,12 @@ class PlanetListComponent extends LitElement {
       color: #8892b8;
       font-size: 0.85em;
     }
+    /* Larger tap targets on touch-sized screens */
+    @media (max-width: 480px) {
+      a {
+        padding: 11px 12px;
+      }
+    }
   `;
 
   // The router constructs routed components with injected props.
@@ -270,6 +276,16 @@ class PlanetDetailComponent extends LitElement {
     .back-link:hover {
       text-decoration: underline;
     }
+    /* Stack label/value pairs on narrow screens */
+    @media (max-width: 420px) {
+      dl {
+        grid-template-columns: 1fr;
+        gap: 2px 0;
+      }
+      dt {
+        margin-top: 8px;
+      }
+    }
   `;
 
   @property({ attribute: false })
@@ -333,6 +349,7 @@ export class AppRoot extends LitElement {
       margin-bottom: 16px;
     }
     nav a {
+      display: inline-block;
       margin-right: 16px;
       color: #8ab4f8;
       text-decoration: none;
@@ -340,6 +357,12 @@ export class AppRoot extends LitElement {
     nav a.active {
       font-weight: bold;
       border-bottom: 2px solid #8ab4f8;
+    }
+    /* Larger tap targets on touch-sized screens */
+    @media (max-width: 480px) {
+      nav a {
+        padding: 10px 0;
+      }
     }
   `;
 


### PR DESCRIPTION
Baseline mobile-responsiveness pass over the tutorial example apps. Stacked on #503 (`docs/mobile-embed-fallback`) as a sibling of the LiveExample tabs branch; scope is `examples/*` only — nothing under `docs/` is touched.

All three examples already had a correct viewport meta tag and no fixed widths causing horizontal scroll at 360px. Changes are additive media queries only (72 insertions, 0 deletions); desktop rendering unchanged.

## helloworld — audit only, unchanged
Verified fine at 390px: no horizontal scroll, nav links tappable (34px min height, borderline but acceptable per prior real-device testing), content readable. Deliberately untouched to keep the smallest tutorial minimal.

## hellosolarsystem
Found: nav links were bare inline text (small tap target); planet-list rows ~35px tall; detail `dl` used a two-column `max-content 1fr` grid that gets cramped near 360px; 40px body margin wastes iframe space.

Fixed (all under media queries, <=480px / <=420px):

- `index.html`: body margin 40px -> 16px, padding 20px -> 12px
- `app-root` nav links: `display:inline-block` + vertical padding for tap height
- `planet-list` links: padding bumped to 11px vertical
- `planet-detail` `dl`: stacks to a single column

## hellogalaxy
Found: `stars-container .container` is a fixed flex row (`.list` at `flex: 0 0 220px` + 24px gap + detail pane) — severely squeezed inside a 390px viewport minus panel padding; nav pills ~33px tall; same `dl` cramping; 40px body margin.

Fixed:

- `index.html`: body margin/padding reduction <=480px
- `stars-container`: stacks list above detail <=640px, list links get taller padding, detail pane padding/min-height reduced
- `galaxy-shell`: nav `flex-wrap: wrap`; <=480px pill padding bumped and `.panel` padding 20px -> 14px
- `star-detail` `dl`: stacks to a single column <=420px

## Deliberately NOT addressed (worklist for the deep-pass agents)

### hellosolarsystem (`examples/hellosolarsystem/src/main.ts`, `index.html`)
- **@uirouter/visualizer overlay**: loaded unconditionally (router setup, ~line 395); its fixed-position widget can cover a large fraction of a 390px viewport / 800px iframe. Decide: hide on small viewports, or accept.
- **`planet-detail` back-link placement**: `.back-link` sits below the fold on small screens after the dl + fun fact; consider a top-of-detail back affordance for the iframe context.
- **Planet dot sizes** (`dotSize()`, ~line 160): the Sun's dot is ~70px in list rows — large relative to a 390px row; functional, but a narrow-viewport clamp may look better.
- **Mid-size tuning**: only <=480/420px breakpoints added; 480–800px widths untested beyond no-overflow.

### hellogalaxy (`examples/hellogalaxy/src/main.ts`, `index.html`)
- **Visualizer overlay**: same as above (~line 569).
- **No back affordance on stacked mobile detail**: after stacking, tapping a star renders the detail pane below a 10-item list with no auto-scroll and no "back to list" link in `star-detail`; consider auto-scrolling to `.detail` on selection or collapsing the list (`stars-container` render, ~line 304).
- **`astronaut-view` `model-viewer`**: fixed `height: 420px` (~line 417) eats most of a 664px viewport — consider `min(420px, 55vh)`; its camera-controls also capture touch gestures (scroll-trap inside the iframe); `touch-action` tuning was skipped because it changes interaction behavior.
- **`backdrop-credit` / `.attribution` links**: 0.75–0.8rem inline external links, sub-44px tap targets; low priority (attribution, not navigation).
- **Fixed background images** (`index.html` `body::before` Spitzer JPG, Webb PNG in `astronaut-view`): large downloads on mobile; no smaller variant plumbed.
- **Breakpoint unification**: 640px for the list/detail stack, 480/420px elsewhere; deep pass may want one documented scheme.

## Verification

- `oxfmt`, `oxlint`, `tsc` (all three examples) pass
- `build:embeds` (`node build-embeds.ts` -> `vite build --base=/examples/<name>/` per example) builds all three
- Playwright (repo playwright 1.62, chromium) against built dist served at `/examples/<name>/` on port 4179 (avoiding 5173/5174; server torn down after):
  - 390x664, each example: `document.scrollingElement.scrollWidth <= innerWidth` on landing AND after navigating to a detail state; router links visible with min tap height >=36px (solarsystem 38px, galaxy 38px; helloworld 34px informational); content renders through shadow DOM (About page, planet detail, star detail)
  - 390x664 layout assertions: solarsystem detail `dl` computes to 1 column; galaxy `stars-container .container` computes `flex-direction: column`
  - 1280x800, each example: no horizontal scroll; solarsystem `dl` still 2 columns; galaxy list/detail still `row` — desktop layout unchanged
