### PR TITLE
docs(mobx): add Website badge and point homepage at the docs page

### DIFF
--- a/packages/lit-ui-router-mobx/README.md
+++ b/packages/lit-ui-router-mobx/README.md
@@ -3,7 +3,7 @@
 [![npm version](https://img.shields.io/npm/v/lit-ui-router-mobx.svg)](https://npmx.dev/package/lit-ui-router-mobx)
 [![GitHub Release](https://img.shields.io/github/v/release/simshanith/lit-ui-router?filter=lit-ui-router-mobx@*)](https://github.com/simshanith/lit-ui-router/releases/?q=lit-ui-router-mobx)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
-[![Website](https://img.shields.io/website?url=https%3A%2F%2Flit-ui-router.dev)](https://lit-ui-router.dev)
+[![Website](https://img.shields.io/website?url=https%3A%2F%2Flit-ui-router.dev)](https://lit-ui-router.dev/packages/mobx)
 [![codecov](https://codecov.io/gh/simshanith/lit-ui-router/graph/badge.svg?component=lit-ui-router-mobx)](https://app.codecov.io/gh/simshanith/lit-ui-router?components%5B0%5D=lit-ui-router-mobx)
 
 [MobX](https://mobx.js.org) bindings for [lit-ui-router](https://lit-ui-router.dev): an observable router store and reaction-based Lit ReactiveControllers.
@@ -114,7 +114,7 @@ Mixins like [`MobxLitElement`](https://github.com/adobe/lit-mobx) auto-track eve
 
 - [Docs - MobX Bindings](https://lit-ui-router.dev/packages/mobx)
 - [Docs - Reactive Components guide](https://lit-ui-router.dev/guides/reactive-components)
-- [lit-ui-router](https://lit-ui-router.dev)
+- [lit-ui-router](https://lit-ui-router.dev/packages/mobx)
 - [MobX — reactions](https://mobx.js.org/reactions.html)
 - [Lit — Reactive Controllers](https://lit.dev/docs/composition/controllers/)
 - [@uirouter/core — TransitionService hooks](https://ui-router.github.io/core/docs/latest/classes/transition.transitionservice.html)

--- a/packages/lit-ui-router-mobx/README.md
+++ b/packages/lit-ui-router-mobx/README.md
@@ -3,6 +3,7 @@
 [![npm version](https://img.shields.io/npm/v/lit-ui-router-mobx.svg)](https://npmx.dev/package/lit-ui-router-mobx)
 [![GitHub Release](https://img.shields.io/github/v/release/simshanith/lit-ui-router?filter=lit-ui-router-mobx@*)](https://github.com/simshanith/lit-ui-router/releases/?q=lit-ui-router-mobx)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
+[![Website](https://img.shields.io/website?url=https%3A%2F%2Flit-ui-router.dev)](https://lit-ui-router.dev)
 [![codecov](https://codecov.io/gh/simshanith/lit-ui-router/graph/badge.svg?component=lit-ui-router-mobx)](https://app.codecov.io/gh/simshanith/lit-ui-router?components%5B0%5D=lit-ui-router-mobx)
 
 [MobX](https://mobx.js.org) bindings for [lit-ui-router](https://lit-ui-router.dev): an observable router store and reaction-based Lit ReactiveControllers.
@@ -111,6 +112,8 @@ Mixins like [`MobxLitElement`](https://github.com/adobe/lit-mobx) auto-track eve
 
 ## Links
 
+- [Docs - MobX Bindings](https://lit-ui-router.dev/packages/mobx)
+- [Docs - Reactive Components guide](https://lit-ui-router.dev/guides/reactive-components)
 - [lit-ui-router](https://lit-ui-router.dev)
 - [MobX — reactions](https://mobx.js.org/reactions.html)
 - [Lit — Reactive Controllers](https://lit.dev/docs/composition/controllers/)

--- a/packages/lit-ui-router-mobx/README.md
+++ b/packages/lit-ui-router-mobx/README.md
@@ -114,7 +114,7 @@ Mixins like [`MobxLitElement`](https://github.com/adobe/lit-mobx) auto-track eve
 
 - [Docs - MobX Bindings](https://lit-ui-router.dev/packages/mobx)
 - [Docs - Reactive Components guide](https://lit-ui-router.dev/guides/reactive-components)
-- [lit-ui-router](https://lit-ui-router.dev/packages/mobx)
+- [lit-ui-router](https://lit-ui-router.dev)
 - [MobX — reactions](https://mobx.js.org/reactions.html)
 - [Lit — Reactive Controllers](https://lit.dev/docs/composition/controllers/)
 - [@uirouter/core — TransitionService hooks](https://ui-router.github.io/core/docs/latest/classes/transition.transitionservice.html)

--- a/packages/lit-ui-router-mobx/package.json
+++ b/packages/lit-ui-router-mobx/package.json
@@ -11,7 +11,7 @@
     "state-management",
     "ui-router"
   ],
-  "homepage": "https://github.com/simshanith/lit-ui-router/tree/main/packages/lit-ui-router-mobx",
+  "homepage": "https://lit-ui-router.dev/packages/mobx",
   "bugs": {
     "url": "https://github.com/simshanith/lit-ui-router/issues"
   },


### PR DESCRIPTION
Mirrors #499 for `lit-ui-router-mobx`: adds the `Website` shields badge to the README badge row (after License, before codecov), links the package docs page and the Reactive Components guide from the README's Links section, and repoints `homepage` from the GitHub tree URL to https://lit-ui-router.dev/packages/mobx. This is ship-affecting — the `homepage` change will show as EXPECTED drift on the published-diff board until the next `lit-ui-router-mobx` release, and it rides that release rather than needing one of its own.