### PR TITLE
docs(server): add a Website badge driving to the package detail page

### DIFF
--- a/docs/guides/server-route-matching.md
+++ b/docs/guides/server-route-matching.md
@@ -127,7 +127,7 @@ and
 and a documented one-liner everywhere else: nginx
 `try_files $uri /index.html;`, a Netlify `/* /index.html 200` redirect. The
 pattern even ships as a package —
-[`connect-history-api-fallback`](https://www.npmjs.com/package/connect-history-api-fallback),
+[`connect-history-api-fallback`](https://npmx.dev/package/connect-history-api-fallback),
 ~14 million weekly downloads — and it is what this site itself shipped
 before this stack.
 

--- a/packages/ui-router-server/README.md
+++ b/packages/ui-router-server/README.md
@@ -3,6 +3,7 @@
 [![npm version](https://img.shields.io/npm/v/ui-router-server.svg)](https://npmx.dev/package/ui-router-server)
 [![GitHub Release](https://img.shields.io/github/v/release/simshanith/lit-ui-router?filter=ui-router-server@*)](https://github.com/simshanith/lit-ui-router/releases/?q=ui-router-server)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
+[![Website](https://img.shields.io/website?url=https%3A%2F%2Flit-ui-router.dev)](https://lit-ui-router.dev/packages/server)
 [![codecov](https://codecov.io/gh/simshanith/lit-ui-router/graph/badge.svg?component=ui-router-server)](https://app.codecov.io/gh/simshanith/lit-ui-router?components%5B0%5D=ui-router-server)
 
 Server-side routing for ui-router state trees. Given per-mount routing config and a request URL, it resolves the path against the registered states and returns a plain routing verdict (render, redirect, or miss) — runtime-agnostic, with no fetch/Response or workers types in the core. Adapters turn verdicts into HTTP for Connect/Vite middleware and fetch/Hono handlers. Matcher-only mounts are dependency-free; `simulate` mounts lazily replay the path through a headless `@uirouter/core` router (an optional peer dependency).


### PR DESCRIPTION
Completes the #500 badge row: `ui-router-server`'s README was the only published package without a Website badge. Drives to the package detail page (`/packages/server`) per the convention set in #507, probe on the site root like the siblings.

Ship-affecting, but the README already carries expected published-diff drift from #500 — this rides the same owed release at no extra cost.

Also folds in the last stray `www.npmjs.com` prose link (#499/#502 leftover): `connect-history-api-fallback` in `docs/guides/server-route-matching.md` now points at npmx.dev. Docs-site only, not ship-affecting.