### PR TITLE
test(e2e): share the crash signature and consolidate deflake lint overrides

### DIFF
--- a/.config/mise/tasks/measure_deflake
+++ b/.config/mise/tasks/measure_deflake
@@ -10,6 +10,7 @@
 #USAGE flag "--workflow <file>" help="Workflow whose runs carry the e2e task" default="build-test.yml"
 #USAGE flag "--max-log-mb <mb>" help="Per-attempt log buffer; an over-cap log aborts rather than undercounting" default="512"
 #USAGE flag "--run-limit <n>" help="gh run list cap; gh caps silently, so a hit clips the window's old end" default="1000"
+#USAGE flag "--port <n>" help="e2e dev-server port the crash signature keys on" default="8787"
 set -euo pipefail
 
 # File-based tasks are raw scripts: mise's {{config_root}} template does NOT
@@ -27,5 +28,6 @@ export MEASURE_DEFLAKE_REPO="${usage_repo:?}"
 export MEASURE_DEFLAKE_WORKFLOW="${usage_workflow:?}"
 export MEASURE_DEFLAKE_MAX_LOG_MB="${usage_max_log_mb:?}"
 export MEASURE_DEFLAKE_RUN_LIMIT="${usage_run_limit:?}"
+export MEASURE_DEFLAKE_PORT="${usage_port:?}"
 
 exec node "$script" "${args[@]}"

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -197,12 +197,12 @@
       }
     },
     {
-      "files": ["**/scripts/measure-deflake.ts"],
+      "files": ["apps/sample-app-lit-e2e/scripts/**"],
       "rules": {
         "turbo/no-undeclared-env-vars": [
           "warn",
           {
-            "allowList": ["^MEASURE_DEFLAKE_"]
+            "allowList": ["^DEFLAKE_", "^MEASURE_DEFLAKE_"]
           }
         ]
       }
@@ -428,17 +428,6 @@
           "warn",
           {
             "allowList": ["^XVFB_"]
-          }
-        ]
-      }
-    },
-    {
-      "files": ["apps/sample-app-lit-e2e/scripts/deflake-e2e.ts"],
-      "rules": {
-        "turbo/no-undeclared-env-vars": [
-          "warn",
-          {
-            "allowList": ["^DEFLAKE_"]
           }
         ]
       }

--- a/apps/sample-app-lit-e2e/README.md
+++ b/apps/sample-app-lit-e2e/README.md
@@ -66,6 +66,7 @@ repo-specific config as flags with defaults — `mise run measure_deflake
 | `--workflow`   | `build-test.yml`           | Workflow whose runs carry the e2e task                |
 | `--max-log-mb` | `512`                      | Per-attempt log buffer; an over-cap log aborts loudly |
 | `--run-limit`  | `1000`                     | `gh run list` cap; a hit clips the window's old end   |
+| `--port`       | `8787`                     | e2e dev-server port the crash signature keys on       |
 
 That spec is the _only_ place defaults live. The task passes `--days` (and
 `--branch`, when given) as positionals and the rest as `MEASURE_DEFLAKE_*`
@@ -78,6 +79,7 @@ MEASURE_DEFLAKE_REPO=simshanith/lit-ui-router \
   MEASURE_DEFLAKE_WORKFLOW=build-test.yml \
   MEASURE_DEFLAKE_MAX_LOG_MB=512 \
   MEASURE_DEFLAKE_RUN_LIMIT=1000 \
+  MEASURE_DEFLAKE_PORT=8787 \
   ./scripts/measure-deflake.ts 2 my-branch
 ```
 

--- a/apps/sample-app-lit-e2e/scripts/measure-deflake.ts
+++ b/apps/sample-app-lit-e2e/scripts/measure-deflake.ts
@@ -2,6 +2,8 @@
 import { execFile as execFileCb } from 'node:child_process';
 import { promisify } from 'node:util';
 
+import { crashSignatureFor } from './deflake-e2e.ts';
+
 // How often the wrangler-dev e2e crash (cloudflare/workers-sdk#14926) fires in
 // CI: scans build-test runs — every attempt, since organic crashes get rerun
 // and latest-attempt logs undercount — and reports crashes per e2e execution.
@@ -10,8 +12,8 @@ import { promisify } from 'node:util';
 // Usage: mise run measure_deflake --days 7 [--branch mybranch] [--repo …]
 // Every default lives in that task's #USAGE spec, so this script requires its
 // full config: the [days] positional plus MEASURE_DEFLAKE_{REPO,WORKFLOW,
-// MAX_LOG_MB,RUN_LIMIT}. Direct exec (./scripts/measure-deflake.ts 7 [branch])
-// works only with those four exported.
+// MAX_LOG_MB,RUN_LIMIT,PORT}. Direct exec (./scripts/measure-deflake.ts 7
+// [branch]) works only with those five exported.
 // [branch] isolates one branch's runs — e.g. rate a wrangler-bump trial
 // branch (forced dispatches against its ref) without main's runs diluting it.
 const execFile = promisify(execFileCb);
@@ -42,6 +44,8 @@ const WORKFLOW = requiredEnv('MEASURE_DEFLAKE_WORKFLOW');
 const MAX_LOG_BYTES = positiveEnv('MEASURE_DEFLAKE_MAX_LOG_MB') * 1024 ** 2;
 // gh returns newest-first and caps silently, so a hit clips the window's old end
 const RUN_LIMIT = positiveEnv('MEASURE_DEFLAKE_RUN_LIMIT');
+// same signature the sampler keys on, so the two can't drift apart
+const CRASH_SIGNATURE = crashSignatureFor(positiveEnv('MEASURE_DEFLAKE_PORT'));
 
 async function gh(args: string[]): Promise<string> {
   const { stdout } = await execFile('gh', args, { maxBuffer: MAX_LOG_BYTES });
@@ -118,7 +122,7 @@ for (const { attempt: attempts, databaseId: id } of runs) {
     executed += 1;
     const hits: string[] = [];
     // pre-deflake signature: the crash strands remaining specs on ECONNREFUSED
-    if (log.includes('ECONNREFUSED 127.0.0.1:8787')) hits.push('crash');
+    if (log.includes(CRASH_SIGNATURE)) hits.push('crash');
     // post-deflake signatures: pm2 respawned wrangler / failed suites rerun
     if ((log.match(/App \[wrangler-dev:0\] online/g) ?? []).length > 1)
       hits.push('respawn');

--- a/apps/sample-app-lit-e2e/tsconfig.json
+++ b/apps/sample-app-lit-e2e/tsconfig.json
@@ -2,6 +2,9 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "allowJs": true,
+    // scripts/ run under node's type stripping, so they import each other by
+    // their real .ts specifier
+    "allowImportingTsExtensions": true,
     "types": ["cypress", "node"],
     "noEmit": true,
     "outDir": "dist",


### PR DESCRIPTION
Two consolidations that were planned follow-ups to #489 (measure-deflake task) and #492 (deflake-e2e sampler), now that both are on main.

**1. One crash signature.** `measure-deflake.ts` hardcoded `ECONNREFUSED 127.0.0.1:8787`; it now imports `crashSignatureFor` from `deflake-e2e.ts` (whose `main` is gated on `import.meta.main`, so the import is side-effect free). Keeping the script's no-fallbacks contract, the port arrives as `MEASURE_DEFLAKE_PORT` via the usage spec's new `--port` flag (`default="8787"`) and goes through the same `positiveEnv` validation as the rest.

`scripts/**` now imports across files, so the package tsconfig gains `allowImportingTsExtensions` — the same setting every other `scripts/`-style package here already uses, since these run under node's type stripping.

**2. One oxlint override.** The two merges each left a `turbo/no-undeclared-env-vars` block scoped to its own script. Merged into one block over `apps/sample-app-lit-e2e/scripts/**` with `["^DEFLAKE_", "^MEASURE_DEFLAKE_"]` — both entries stay, since the anchored `^DEFLAKE_` does not match `MEASURE_DEFLAKE_`.

README flag table and the script header's env-var list updated.

## Verification

- `turbo run format:check lint build --filter=sample-app-lit-e2e --force` — 33/33
- `mise run lint_shellcheck` — clean
- `mise run measure_deflake --days 1` -> `e2e executed 51 times, crash fired 3 times (6%)`
- `mise run measure_deflake --days 1 --port 9999` -> `crash fired 1 times (2%)` — the crash signature stops matching while the respawn/retry signatures still do, which is the plumbing proof
- direct exec with no env -> `missing MEASURE_DEFLAKE_REPO …`; with the old four exported -> `missing MEASURE_DEFLAKE_PORT …`. Neither runs the sampler.
