### PR TITLE
docs(StackBlitz): size the StackBlitz tab to the example's embed height

### DIFF
--- a/docs/.vitepress/theme/components/LiveExample.vue
+++ b/docs/.vitepress/theme/components/LiveExample.vue
@@ -106,7 +106,7 @@ onMounted(() => {
     </div>
     <div
       class="live-example-panels"
-      :class="{ collapsed: active === 'stackblitz' && !supported }"
+      :class="{ collapsed: active === 'stackblitz' }"
       :style="{ '--embed-height': previewHeight }"
     >
       <div
@@ -132,7 +132,6 @@ onMounted(() => {
             v-if="stackblitzBooted"
             :src="embedSrc"
             :title="`lit-ui-router-${props.name}`"
-            :height="previewHeight"
           />
         </template>
         <div v-else class="fallback-note">
@@ -227,13 +226,15 @@ onMounted(() => {
   margin: 0;
 }
 
-/* Reserve the taller (preview) pane's frame height so tab switches don't shift the page. */
+/* Reserve the preview pane's frame height so its iframe loading in doesn't
+   shift the page. */
 .live-example-panels {
   min-height: min(var(--embed-height, 420px), calc(100svh - 120px));
 }
 
-/* Unsupported devices show only the short fallback note on the StackBlitz
-   tab — don't hold the reserved frame height as a blank region. */
+/* The StackBlitz pane sizes itself — the editor keeps its own aspect ratio
+   and the unsupported fallback is a short note — so drop the preview
+   reservation whenever that tab is active. */
 .live-example-panels.collapsed {
   min-height: 0;
 }

--- a/docs/.vitepress/theme/components/LiveExample.vue
+++ b/docs/.vitepress/theme/components/LiveExample.vue
@@ -132,6 +132,7 @@ onMounted(() => {
             v-if="stackblitzBooted"
             :src="embedSrc"
             :title="`lit-ui-router-${props.name}`"
+            :height="previewHeight"
           />
         </template>
         <div v-else class="fallback-note">

--- a/docs/.vitepress/theme/components/StackBlitzEmbed.vue
+++ b/docs/.vitepress/theme/components/StackBlitzEmbed.vue
@@ -7,7 +7,6 @@ import { webContainersSupported } from './webcontainers';
 const props = defineProps<{
   src: string;
   title: string;
-  height?: string;
   fallbackSrc?: string;
   fallbackHeight?: string;
 }>();
@@ -106,7 +105,6 @@ onUnmounted(() => {
     <iframe
       :src="src"
       :title="title"
-      :style="{ '--embed-height': props.height }"
       ref="iframe"
       allow="cross-origin-isolated"
       credentialless
@@ -142,9 +140,14 @@ onUnmounted(() => {
 .stackblitz-embed iframe {
   width: 100%;
   max-width: 100%;
-  height: var(--embed-height, 400px);
-  /* Cap on short viewports (svh dodges mobile browser toolbars). */
-  height: min(var(--embed-height, 400px), calc(100svh - 120px));
+  /* The editor keeps its own shape regardless of the example's preview
+     height: 16:10 of the container width, floored so narrow screens still
+     get a usable editor, capped on short viewports (svh dodges mobile
+     browser toolbars). */
+  height: auto;
+  aspect-ratio: 16 / 10;
+  min-height: 320px;
+  max-height: calc(100svh - 120px);
   border: 0;
   border-radius: 4px;
   overflow: hidden;

--- a/docs/.vitepress/theme/components/StackBlitzEmbed.vue
+++ b/docs/.vitepress/theme/components/StackBlitzEmbed.vue
@@ -7,6 +7,7 @@ import { webContainersSupported } from './webcontainers';
 const props = defineProps<{
   src: string;
   title: string;
+  height?: string;
   fallbackSrc?: string;
   fallbackHeight?: string;
 }>();
@@ -105,6 +106,7 @@ onUnmounted(() => {
     <iframe
       :src="src"
       :title="title"
+      :style="{ '--embed-height': props.height }"
       ref="iframe"
       allow="cross-origin-isolated"
       credentialless
@@ -140,9 +142,9 @@ onUnmounted(() => {
 .stackblitz-embed iframe {
   width: 100%;
   max-width: 100%;
-  height: 400px;
+  height: var(--embed-height, 400px);
   /* Cap on short viewports (svh dodges mobile browser toolbars). */
-  height: min(400px, calc(100svh - 120px));
+  height: min(var(--embed-height, 400px), calc(100svh - 120px));
   border: 0;
   border-radius: 4px;
   overflow: hidden;


### PR DESCRIPTION
Follow-up to #504. The LiveExample panels reserved the preview pane's `--embed-height` while `StackBlitzEmbed` hardcoded 400px — so the StackBlitz tab showed blank space below the editor on tall examples.

Matching the editor to the preview height turned out wrong in both directions (180px helloworld = unusably short editor, 920px galaxy = too tall). Instead the editor keeps its own shape and the container follows **it** when toggled:

- `StackBlitzEmbed` iframe: `aspect-ratio: 16 / 10` of the container width (≈430px at docs content width, close to the old 400px), `min-height: 320px` so narrow screens still get a usable editor, `max-height: calc(100svh - 120px)` short-viewport cap as before. Fullscreen sizing unchanged (explicit height wins over aspect-ratio).
- `LiveExample`: the panels container's preview-height reservation now drops whenever the StackBlitz tab is active (`.collapsed`), so it shrinks on the tall examples and grows on helloworld to fit the editor. The unsupported-fallback collapse is subsumed by the same rule.

Gates: `turbo run format:check lint build --filter=docs` 32/32 green.