### PR TITLE
fix(docs): make StackBlitz strictly opt-in — always default to the static preview

### DIFF
--- a/docs/.vitepress/theme/components/LiveExample.vue
+++ b/docs/.vitepress/theme/components/LiveExample.vue
@@ -18,9 +18,6 @@ const props = defineProps<{
 }>();
 
 type Mode = 'preview' | 'stackblitz';
-const STORAGE_KEY = 'lit-ui-router:live-example-mode';
-// Site-wide preference; instances read it on mount but never follow later writes.
-const preference = ref<Mode>('preview');
 
 const example = computed(() => EXAMPLES[props.name]);
 const previewSrc = computed(() => staticSrc(props.name));
@@ -34,33 +31,15 @@ const supported = ref(true);
 // First StackBlitz selection boots the iframe; v-show keeps it alive after.
 const stackblitzBooted = ref(false);
 
-function selectTab(mode: Mode, persist = true) {
+// StackBlitz is strictly opt-in: every instance starts on the static preview,
+// and WebContainers only boot on an explicit tab click.
+function selectTab(mode: Mode) {
   active.value = mode;
   if (mode === 'stackblitz' && supported.value) stackblitzBooted.value = true;
-  if (persist) {
-    preference.value = mode;
-    try {
-      localStorage.setItem(STORAGE_KEY, mode);
-    } catch {
-      // Storage unavailable (private mode etc.) — preference just won't persist.
-    }
-  }
 }
 
 onMounted(() => {
   supported.value = webContainersSupported();
-  let stored: string | null = null;
-  try {
-    stored = localStorage.getItem(STORAGE_KEY);
-  } catch {
-    stored = null;
-  }
-  if (stored === 'preview' || stored === 'stackblitz') {
-    preference.value = stored;
-  }
-  if (supported.value && preference.value === 'stackblitz') {
-    selectTab('stackblitz', false);
-  }
 });
 </script>
 


### PR DESCRIPTION
Follow-up to #504, sibling of #511.

LiveExample persisted the last-picked tab site-wide (`localStorage` key `lit-ui-router:live-example-mode`), so a single "Edit in StackBlitz" click made every LiveExample on every subsequent page auto-boot WebContainers on mount — heavy, and surprising on mobile/data. There are no standalone `StackBlitzEmbed` usages in the docs pages (everything routes through `LiveExample`), so this one change makes StackBlitz opt-in everywhere:

- every instance starts on the static Preview tab, unconditionally
- WebContainers boot only on an explicit "Edit in StackBlitz" click, per instance
- the `STORAGE_KEY`/preference machinery is deleted outright (the stale stored key in existing visitors' browsers is simply never read again)

Gates: `turbo run format:check lint build --filter=docs` 32/32 green.