### PR TITLE
chore(deps): bump hono to 4.12.34 for four security advisories

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -115,8 +115,8 @@ catalogs:
       specifier: ^20.11.1
       version: 20.11.1
     hono:
-      specifier: ^4.12.32
-      version: 4.12.32
+      specifier: ^4.12.34
+      version: 4.13.0
     husky:
       specifier: ^9.1.7
       version: 9.1.7
@@ -839,7 +839,7 @@ importers:
         version: 6.1.2
       hono:
         specifier: 'catalog:'
-        version: 4.12.32
+        version: 4.13.0
       oxfmt:
         specifier: 'catalog:'
         version: 0.61.0
@@ -4604,8 +4604,8 @@ packages:
   hast-util-whitespace@3.0.0:
     resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
 
-  hono@4.12.32:
-    resolution: {integrity: sha512-XcuyW9qE2kJn07PkecMOBd5Vq/hMy7mmGw+idz1yblbg9N17ijJODrvPkn7/dwL3Kulj8LcRJ69DLOWf91dRUg==}
+  hono@4.13.0:
+    resolution: {integrity: sha512-jhunvfHWxd7J5EFfSgH4xsYJzSe/lfqbUCxiyyeaQasUsXeEHXtzVid+7EOGByc5JnFa23SSFL3Y2RV/z1T+eQ==}
     engines: {node: '>=16.9.0'}
 
   hookable@5.5.3:
@@ -9752,7 +9752,7 @@ snapshots:
     dependencies:
       '@types/hast': 3.0.4
 
-  hono@4.12.32: {}
+  hono@4.13.0: {}
 
   hookable@5.5.3: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -44,7 +44,7 @@ catalog:
   eslint-plugin-pnpm: ^1.7.0
   eslint-plugin-turbo: ^2.10.7
   happy-dom: ^20.11.1
-  hono: ^4.12.32
+  hono: ^4.12.34
   husky: ^9.1.7
   jsonc-parser: ^3.3.1
   lit: ^3.3.3


### PR DESCRIPTION
Security bump of the `hono` **`catalog:`** entry from `^4.12.32` to `^4.12.34`.

## Advisories fixed in 4.12.34

| Advisory | Issue |
| --- | --- |
| [GHSA-f23p-vx2j-j53r](https://github.com/honojs/hono/security/advisories/GHSA-f23p-vx2j-j53r) | `hono/jsx` `memo()` retains SSR output across requests (cross-user data disclosure) |
| [GHSA-8j4g-w8fx-2239](https://github.com/honojs/hono/security/advisories/GHSA-8j4g-w8fx-2239) | ReDoS in `hono/cors` via `Access-Control-Request-Headers` |
| [GHSA-54fx-42gc-7vw4](https://github.com/honojs/hono/security/advisories/GHSA-54fx-42gc-7vw4) | Algorithmic-complexity DoS in `hono/language` |
| [GHSA-79qm-7rj5-m7r9](https://github.com/honojs/hono/security/advisories/GHSA-79qm-7rj5-m7r9) | `hono/proxy` does not strip `Connection`-designated response headers |

## Actual exposure: none of the four subpaths are used

A repo-wide grep for `hono/*` imports returns **zero hits**. The only hono
references in source are bare-root:

- `packages/ui-router-server/src/hono.ts` — `import type { MiddlewareHandler } from 'hono'` (type-only)
- `packages/ui-router-server/test/hono.test.ts` — `import { Hono } from 'hono'`

`hono/jsx`, `hono/cors`, `hono/language`, and `hono/proxy` are never imported.
So this is **hygiene, not an active exposure** — it clears the advisories from
the audit surface and protects consumers who route their own app through those
subpaths alongside our middleware.

## Resolution

The catalog spec is `^4.12.34`; the lockfile resolves to **`hono@4.13.0`**,
which satisfies it. That is expected — 4.13.0 is the current release and carries
the fixes.

```
    hono:
-     specifier: ^4.12.32
-     version: 4.12.32
+     specifier: ^4.12.34
+     version: 4.13.0
```

## `publishedPeer` intentionally untouched

`catalogs.publishedPeer.hono` remains `^4.0.0`. That is the published peer range
for `ui-router-server` and deliberately stays wide — narrowing it would force a
hono upgrade on every downstream consumer.

## Replaces #516

Dependabot's #516 landed an inconsistent catalog/lockfile pairing: the catalog
said `^4.12.34` while the lock carried a `4.13.0` resolution that was not
regenerated by a real install against the new spec. This branch edits the
catalog and runs `mise run setup` so `pnpm-lock.yaml` regenerates naturally.

## Verification

`turbo run build test lint typecheck --filter=ui-router-server...`

```
ui-router-server:test: ℹ tests 426
ui-router-server:test: ℹ pass 426
ui-router-server:test: ℹ fail 0
ui-router-server:lint: Found 0 warnings and 0 errors.

 Tasks:    34 successful, 34 total
```

`ui-router-server` is the only workspace package that depends on hono.