### PR TITLE
chore(deps): trial wrangler 4.118.0 to test the e2e deflake pin

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -226,8 +226,8 @@ catalogs:
       specifier: ^3.3.8
       version: 3.3.8
     wrangler:
-      specifier: 4.113.0
-      version: 4.113.0
+      specifier: 4.118.0
+      version: 4.118.0
   lit2-compat:
     lit-2:
       specifier: npm:lit@^2.8.0
@@ -334,7 +334,7 @@ importers:
         version: 8.1.3(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)
       wrangler:
         specifier: 'catalog:'
-        version: 4.113.0
+        version: 4.118.0
 
   apps/sample-app-lit-e2e:
     dependencies:
@@ -411,7 +411,7 @@ importers:
         version: 8.1.3(@types/node@25.0.9)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)
       wrangler:
         specifier: 'catalog:'
-        version: 4.113.0
+        version: 4.118.0
 
   apps/sample-app-lit-vanilla:
     dependencies:
@@ -451,7 +451,7 @@ importers:
         version: 8.1.3(@types/node@25.0.9)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)
       wrangler:
         specifier: 'catalog:'
-        version: 4.113.0
+        version: 4.118.0
 
   apps/sample-app-routes:
     dependencies:
@@ -589,7 +589,7 @@ importers:
         version: 2.0.0-alpha.18(@types/node@24.13.3)(axios@1.18.1)(change-case@5.4.4)(esbuild@0.28.1)(jiti@2.7.0)(postcss@8.5.22)(typescript@7.0.2)(yaml@2.9.0)
       wrangler:
         specifier: 'catalog:'
-        version: 4.113.0
+        version: 4.118.0
 
   examples:
     devDependencies:
@@ -1194,32 +1194,32 @@ packages:
       workerd:
         optional: true
 
-  '@cloudflare/workerd-darwin-64@1.20260721.1':
-    resolution: {integrity: sha512-VivNMhiEdZIB4JBWxf1RMJGROErv53qmQ+dvhjA1evrCouvqRYW718VqDideU3PSV7Ythl5Df48NqZYWoaEHpQ==}
+  '@cloudflare/workerd-darwin-64@1.20260730.1':
+    resolution: {integrity: sha512-+MBHmPaiTe2KajryW0T24rZvWFxb41hD3d8anNzQqHzft6vSEb18+sp0znSwxgij7ApPhSM1+vhkNg4f3YMguA==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [darwin]
 
-  '@cloudflare/workerd-darwin-arm64@1.20260721.1':
-    resolution: {integrity: sha512-k7oye1ZiuwnnBBA2eTMduconr/ud5ZxFtRNTsYwMdmJeeeislw2+M72otrHxxvybCP7JWPPlJ38uhfajpcyhOA==}
+  '@cloudflare/workerd-darwin-arm64@1.20260730.1':
+    resolution: {integrity: sha512-SBHKntPkKvNPgaCrTe99xC1CAl8ygJDzlYfK0LbuJ1muKadIw35WnhO0wu894fKBtllsVQdNzDLee+cm0ppLSQ==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [darwin]
 
-  '@cloudflare/workerd-linux-64@1.20260721.1':
-    resolution: {integrity: sha512-hon0lW4ZQ4boAVgaw+0ZFTNS8v5MWPWvK0HZnt4tDpKYnDUviLZawtUW3KqvFmCQTipVHl1S34j3J8Eqb93hGQ==}
+  '@cloudflare/workerd-linux-64@1.20260730.1':
+    resolution: {integrity: sha512-ouyPOSMbiKPeSwUJUvxtMcxGAXs2J4aPE4T5ABIYX5ClcQx5j5bbHTmnqOQEY8sAuLTPjH7dY+iB6UI5ISlwwA==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [linux]
 
-  '@cloudflare/workerd-linux-arm64@1.20260721.1':
-    resolution: {integrity: sha512-nAl+HRQqpX5b7xVwWcvLPZmCk8NQ2yjI0yvJTWcHiRswbMEg1ZZckVmjJUAn0PHzZARbCSyIV7v3UjM+SPRmIQ==}
+  '@cloudflare/workerd-linux-arm64@1.20260730.1':
+    resolution: {integrity: sha512-YQ+Mi78U3TPdgBPtwq+Sm6rJU+Ihl2y0pjYtuuKkdmUbYzL7oLR6Xqq9wljhasnuCFICssDJaqhMep5WizYoEQ==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [linux]
 
-  '@cloudflare/workerd-windows-64@1.20260721.1':
-    resolution: {integrity: sha512-9paFG5cMTKz/CRixnEEnZbe5uvFPBFSDthxJHANfCWhUtBj49GSL1FPIokIg+Q+H8DGJEExU0lL92LtxD0lTxQ==}
+  '@cloudflare/workerd-windows-64@1.20260730.1':
+    resolution: {integrity: sha512-27fAN+vUECW1oYVc1KOcHYpkL8COM2Uxtxql7TL595kxbjoqS5yckw7NLz7bTf2pALFCZWjqXDjZGJ/xbG4ZKQ==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
@@ -5178,10 +5178,9 @@ packages:
     resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
     engines: {node: '>=18'}
 
-  miniflare@4.20260721.0:
-    resolution: {integrity: sha512-fBLaCxZ2i/nPH8iyLzvza0C8/sSF4sjD1ma1Skf+pkZVK0TlaW5ujHJlUHwcwR66v2JZt+Q28d4DCX/oaLG0cA==}
+  miniflare@5.20260730.0-alpha:
+    resolution: {integrity: sha512-8/dspSXDshP6nSkCpjKO7BYc2qZoYSXm7iM+QxY7qJyJpAB3onnQSaiu0cvKJlfuMGwULl55hG69FJCcCMXU1Q==}
     engines: {node: '>=22.0.0'}
-    hasBin: true
 
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
@@ -6418,17 +6417,17 @@ packages:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
 
-  workerd@1.20260721.1:
-    resolution: {integrity: sha512-b/DWhpV0jTudzQpLhDovcOgBz233386q+3Hbari7CLCNT9UXxjQziSTZ9yCoKdT2K3TSx5jrwlOisq8hlLWXYg==}
+  workerd@1.20260730.1:
+    resolution: {integrity: sha512-zmfNIjwYSWFY5chGBOjWtH3xAE7p97FTC6vR4Ep98290ho6AeAR/NVcBD274YCLEUYzqm8yxdtZlxMybU8a3jA==}
     engines: {node: '>=16'}
     hasBin: true
 
-  wrangler@4.113.0:
-    resolution: {integrity: sha512-ROGzSloJv0y21It6Oc9LaruNcu1tdiQ/XzL3Jc3YkFjzXEMXzTqVhA8vQaGMTdZHTjFP0PVcwAHNgaw3gXu4wA==}
+  wrangler@4.118.0:
+    resolution: {integrity: sha512-9pkBw/b8zWqGx2S+oLhgHMR1M/4VOE8SynUFABnGWiSFGlcOQ4xiI/B71Xf66RYP2xzngU37IQFPtUruij3lYw==}
     engines: {node: '>=22.0.0'}
     hasBin: true
     peerDependencies:
-      '@cloudflare/workers-types': ^5.20260721.1
+      '@cloudflare/workers-types': ^5.20260730.1
     peerDependenciesMeta:
       '@cloudflare/workers-types':
         optional: true
@@ -6633,25 +6632,25 @@ snapshots:
 
   '@cloudflare/kv-asset-handler@0.5.0': {}
 
-  '@cloudflare/unenv-preset@2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260721.1)':
+  '@cloudflare/unenv-preset@2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260730.1)':
     dependencies:
       unenv: 2.0.0-rc.24
     optionalDependencies:
-      workerd: 1.20260721.1
+      workerd: 1.20260730.1
 
-  '@cloudflare/workerd-darwin-64@1.20260721.1':
+  '@cloudflare/workerd-darwin-64@1.20260730.1':
     optional: true
 
-  '@cloudflare/workerd-darwin-arm64@1.20260721.1':
+  '@cloudflare/workerd-darwin-arm64@1.20260730.1':
     optional: true
 
-  '@cloudflare/workerd-linux-64@1.20260721.1':
+  '@cloudflare/workerd-linux-64@1.20260730.1':
     optional: true
 
-  '@cloudflare/workerd-linux-arm64@1.20260721.1':
+  '@cloudflare/workerd-linux-arm64@1.20260730.1':
     optional: true
 
-  '@cloudflare/workerd-windows-64@1.20260721.1':
+  '@cloudflare/workerd-windows-64@1.20260730.1':
     optional: true
 
   '@codecov/bundle-analyzer@2.0.1':
@@ -10273,12 +10272,12 @@ snapshots:
 
   mimic-function@5.0.1: {}
 
-  miniflare@4.20260721.0:
+  miniflare@5.20260730.0-alpha:
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       sharp: 0.35.0
       undici: 7.28.0
-      workerd: 1.20260721.1
+      workerd: 1.20260730.1
       ws: 8.21.0
       youch: 4.1.0-beta.10
     transitivePeerDependencies:
@@ -11713,24 +11712,24 @@ snapshots:
 
   word-wrap@1.2.5: {}
 
-  workerd@1.20260721.1:
+  workerd@1.20260730.1:
     optionalDependencies:
-      '@cloudflare/workerd-darwin-64': 1.20260721.1
-      '@cloudflare/workerd-darwin-arm64': 1.20260721.1
-      '@cloudflare/workerd-linux-64': 1.20260721.1
-      '@cloudflare/workerd-linux-arm64': 1.20260721.1
-      '@cloudflare/workerd-windows-64': 1.20260721.1
+      '@cloudflare/workerd-darwin-64': 1.20260730.1
+      '@cloudflare/workerd-darwin-arm64': 1.20260730.1
+      '@cloudflare/workerd-linux-64': 1.20260730.1
+      '@cloudflare/workerd-linux-arm64': 1.20260730.1
+      '@cloudflare/workerd-windows-64': 1.20260730.1
 
-  wrangler@4.113.0:
+  wrangler@4.118.0:
     dependencies:
       '@cloudflare/kv-asset-handler': 0.5.0
-      '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260721.1)
+      '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260730.1)
       blake3-wasm: 2.1.5
       esbuild: 0.28.1
-      miniflare: 4.20260721.0
+      miniflare: 5.20260730.0-alpha
       path-to-regexp: 6.3.0
       unenv: 2.0.0-rc.24
-      workerd: 1.20260721.1
+      workerd: 1.20260730.1
     optionalDependencies:
       fsevents: 2.3.3
     transitivePeerDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -80,7 +80,7 @@ catalog:
   vitest: ^4.1.10
   vue: ^3.5.40
   vue-tsc: ^3.3.8
-  wrangler: 4.113.0
+  wrangler: 4.118.0
 
 catalogMode: prefer
 


### PR DESCRIPTION
Carved out of dependabot #513 (which also bundles a `vue-tsc` bump). **This is a trial, not a routine bump.**

## Why wrangler is pinned

`wrangler` is EXACT-pinned (no caret) at `4.113.0` in the `catalog:` block by commit 4803b2d — "chore(deps): pin wrangler to 4.113.0 to deflake e2e (cloudflare/workers-sdk#14926)" (#488). Newer wrangler crashes mid-suite during the Cypress e2e run. The crash signature, shared in `apps/sample-app-lit-e2e` since #510:

- an empty `✘ [ERROR]` line mid-suite (the error genuinely carries no message),
- followed by `ECONNREFUSED` on port 8787,
- **after** some specs have already gone green.

A lockfile-missing-dependency error during setup is a *different* failure class and is not this flake.

This PR bumps the catalog to `4.118.0`, still exact-pinned, purely to sample whether the upstream regression is resolved. It may legitimately be closed as "still crashing".

## Upstream status: cloudflare/workers-sdk#14926 — **still OPEN**

- Labels: `regression`, `package:wrangler`, `package:miniflare`, **`awaiting-response:cloudflare`**. No fix PR is linked, and no wrangler release claims the fix.
- Root cause per the report: miniflare PR #14792 ("Recover from workerd crashes in Miniflare", first shipped in `miniflare@4.20260722.0` / `wrangler@4.114.0`) made miniflare auto-restart `workerd` after a post-startup crash and exposed an opt-in `unsafeHandleRuntimeRestart` hook for embedders. **wrangler never implements that hook.** Its `ProxyController` keeps pointing at the dead runtime, the in-flight request fails, and `emitErrorEvent` treats it as fatal and exits the dev server — every later request gets `ECONNREFUSED`. The empty `✘ [ERROR]` is `castErrorCause` wrapping a causeless error (tracked separately as #14906).
- Explicitly **not** a duplicate of #14916/#14921 — those fix only a D1 `SQLITE_BUSY` trigger; this trigger (`Network connection lost.` after a workerd crash) never touches D1.
- Upstream bisect: `4.111.0` / `4.113.0` green; `4.114.0` onward red.

**Direct check against the version this PR installs:**

```
$ grep -c unsafeHandleRuntimeRestart node_modules/.pnpm/wrangler@4.118.0/node_modules/wrangler/wrangler-dist/cli.js
0
```

The hook is still unimplemented in `4.118.0` — the same `0` the upstream reporter measured on 4.113/4.114/4.115.

Two independent confirmations on the issue also report it still reproducing on 4.116.0 and 4.118.0. One commenter posted a 30-cell stress matrix (~27% aggregate failure) in which **every** failed cell carried the ProxyController / `Network connection lost.` signature and no passing cell did:

| wrangler | miniflare | pass / fail |
| --- | --- | --- |
| 4.115.0 | 4.20260722.1 | 4 / 1 (n=5) |
| 4.116.0 | 4.20260730.0 | 8 / 2 (n=10) |
| 4.117.0 | 5.20260730.0-alpha | 5 / 0 (n=5) |
| 4.118.0 | 5.20260730.0-alpha | 5 / 5 (n=10) |

Their own conclusion: the sample is too small to rank versions, but downgrading *within* 4.115..4.118 is not a reliable escape hatch.

## Changelog 4.113.0 → 4.118.0, dev-server relevant

- **4.114.0** — adds local-dev observability (opt-in behind `X_LOCAL_OBSERVABILITY=true`). This is the release that first ships the miniflare auto-restart, i.e. the start of the regression window.
- **4.116.0** — no dev-server lifecycle changes (agent-deploy naming, build-output layout, `check startup`).
- **4.117.0** — **jumps to Miniflare v5** (`5.20260730.0-alpha`). Local testing paths move to `/cdn-cgi/local/*` and `/__cf_local/*`, with transparent rewrites from the old paths.
- **4.118.0** — #14944 **enables local observability capture by default in dev** (previously opt-in). This adds per-worker collector and streaming-tail services to every `wrangler dev`; the changelog itself flags them as a possible source of trouble, with `X_LOCAL_OBSERVABILITY=false` as the opt-out. Also fixes `jsx_fragment` under custom builds and stops `wrangler dev` starting new work after stop/reload.

Nothing in this range touches `unsafeHandleRuntimeRestart`, the `ProxyController` fatal path, or crash recovery. The one new dev-lifecycle change (default-on observability) *adds* long-lived dev-server services rather than removing a crash path. Note also that this lock resolves miniflare to `5.20260730.0-alpha` — an alpha, in the dev server that fronts the docs site during e2e.

## Lockfile

Regenerated by a real `pnpm install` off the edited catalog, not by hand. Dependabot's #513 lock rewrote the **root** importer's wrangler specifier from `catalog:` to the literal `4.118.0`; this one does not. All four wrangler importers (root, `docs`, `apps/sample-app-lit-vanilla`, `apps/sample-app-lit-mobx`) read:

```yaml
      wrangler:
        specifier: 'catalog:'
        version: 4.118.0
```

`turbo run build lint typecheck` — 81/81 tasks green.

## Sampling

Labeled `deflake` (a functional CI opt-in, not a board-state label) so `.github/workflows/deflake-e2e.yml` samples 5 fresh serial e2e attempts per push, plus a manual `workflow_dispatch` at `runs=10` for a larger sample. That check is **informational and never required** — red means "the flake fired", not "don't merge".

**Result: 6/15 attempts failed (40%), every failure the #14926 class** — 4/10 on the dispatch run, 2/5 on the label-triggered run, with `Network connection lost.` in the wrangler log of exactly the failing attempts and none of the passing ones. Per-attempt detail and artifact evidence in the comment below.

**Recommendation: close this PR and hold the 4.113.0 pin.** Re-trial only once #14926 is closed by a release that implements the hook (or makes `emitErrorEvent` non-fatal for restart/disconnect causes).

Note that the ordinary `build_and_test / run` e2e on this PR passed — a single run lands on the 60% side more often than not, which is exactly why the sampler exists.
