### PR TITLE
chore(deps): bump the dev tooling batch (turbo, playwright, release-it, rolldown, pnpm SDK)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,17 +34,17 @@ catalogs:
       specifier: 1100.0.0
       version: 1100.0.0
     '@pnpm/types':
-      specifier: 1101.6.0
-      version: 1101.6.0
+      specifier: 1101.8.0
+      version: 1101.8.0
     '@pnpm/workspace.project-manifest-reader':
-      specifier: 1100.0.20
-      version: 1100.0.20
+      specifier: 1100.0.22
+      version: 1100.0.22
     '@pnpm/workspace.projects-reader':
-      specifier: 1101.0.19
-      version: 1101.0.19
+      specifier: 1101.0.21
+      version: 1101.0.21
     '@pnpm/workspace.workspace-manifest-reader':
-      specifier: 1100.1.2
-      version: 1100.1.2
+      specifier: 1100.1.4
+      version: 1100.1.4
     '@release-it/conventional-changelog':
       specifier: ^12.0.0
       version: 12.0.0
@@ -55,8 +55,8 @@ catalogs:
       specifier: ^1.0.7
       version: 1.0.7
     '@types/lodash':
-      specifier: ^4.17.24
-      version: 4.17.24
+      specifier: ^4.17.25
+      version: 4.17.25
     '@types/node':
       specifier: ^24.13.3
       version: 24.13.3
@@ -109,8 +109,8 @@ catalogs:
       specifier: ^1.7.0
       version: 1.7.0
     eslint-plugin-turbo:
-      specifier: ^2.10.7
-      version: 2.10.7
+      specifier: ^2.10.8
+      version: 2.10.8
     happy-dom:
       specifier: ^20.11.1
       version: 20.11.1
@@ -157,29 +157,29 @@ catalogs:
       specifier: ^22.0.0
       version: 22.0.0
     playwright:
-      specifier: ^1.62.0
-      version: 1.62.0
+      specifier: ^1.62.1
+      version: 1.62.1
     publint:
       specifier: ^0.3.22
       version: 0.3.22
     release-it:
-      specifier: ^21.0.0
-      version: 21.0.0
+      specifier: ^21.0.1
+      version: 21.0.1
     rimraf:
       specifier: ^6.1.3
       version: 6.1.3
     rolldown:
-      specifier: ^1.2.0
-      version: 1.2.0
+      specifier: ^1.2.2
+      version: 1.2.3
     screenfull:
       specifier: ^6.0.2
       version: 6.0.2
     start-server-and-test:
-      specifier: ^3.0.11
-      version: 3.0.11
+      specifier: ^3.0.12
+      version: 3.0.12
     turbo:
-      specifier: ^2.10.7
-      version: 2.10.7
+      specifier: ^2.10.8
+      version: 2.10.8
     typedoc:
       specifier: ^0.28.20
       version: 0.28.20
@@ -223,8 +223,8 @@ catalogs:
       specifier: ^3.5.40
       version: 3.5.40
     vue-tsc:
-      specifier: ^3.3.8
-      version: 3.3.8
+      specifier: ^3.3.9
+      version: 3.3.9
     wrangler:
       specifier: 4.113.0
       version: 4.113.0
@@ -310,7 +310,7 @@ importers:
         version: 1.7.0(eslint@10.8.0(jiti@2.7.0)(supports-color@8.1.1))
       eslint-plugin-turbo:
         specifier: 'catalog:'
-        version: 2.10.7(eslint@10.8.0(jiti@2.7.0)(supports-color@8.1.1))(turbo@2.10.7)
+        version: 2.10.8(eslint@10.8.0(jiti@2.7.0)(supports-color@8.1.1))(turbo@2.10.8)
       husky:
         specifier: 'catalog:'
         version: 9.1.7
@@ -325,7 +325,7 @@ importers:
         version: 7.0.2001
       turbo:
         specifier: 'catalog:'
-        version: 2.10.7
+        version: 2.10.8
       typescript:
         specifier: 'catalog:'
         version: 7.0.2
@@ -344,7 +344,7 @@ importers:
     devDependencies:
       '@types/lodash':
         specifier: 'catalog:'
-        version: 4.17.24
+        version: 4.17.25
       '@types/node':
         specifier: 'catalog:'
         version: 24.13.3
@@ -359,7 +359,7 @@ importers:
         version: 0.61.0
       start-server-and-test:
         specifier: 'catalog:'
-        version: 3.0.11(supports-color@8.1.1)
+        version: 3.0.12
       typescript:
         specifier: catalog:typescript6-compat
         version: '@typescript/typescript6@6.0.2'
@@ -399,7 +399,7 @@ importers:
         version: 1.0.7
       '@types/lodash':
         specifier: 'catalog:'
-        version: 4.17.24
+        version: 4.17.25
       oxfmt:
         specifier: 'catalog:'
         version: 0.61.0
@@ -439,7 +439,7 @@ importers:
         version: 1.0.7
       '@types/lodash':
         specifier: 'catalog:'
-        version: 4.17.24
+        version: 4.17.25
       oxfmt:
         specifier: 'catalog:'
         version: 0.61.0
@@ -510,19 +510,19 @@ importers:
         version: 1.0.7
       '@types/lodash':
         specifier: 'catalog:'
-        version: 4.17.24
+        version: 4.17.25
       '@types/node':
         specifier: 'catalog:'
         version: 24.13.3
       '@vitest/browser-playwright':
         specifier: 'catalog:'
-        version: 4.1.10(playwright@1.62.0)(vite@8.1.3(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(vitest@4.1.10)
+        version: 4.1.10(playwright@1.62.1)(vite@8.1.3(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(vitest@4.1.10)
       oxfmt:
         specifier: 'catalog:'
         version: 0.61.0
       playwright:
         specifier: 'catalog:'
-        version: 1.62.0
+        version: 1.62.1
       typescript:
         specifier: 'catalog:'
         version: 7.0.2
@@ -531,7 +531,7 @@ importers:
         version: 8.1.3(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)
       vite-plugin-checker:
         specifier: 'catalog:'
-        version: 0.14.5(eslint@10.8.0(jiti@2.7.0))(meow@13.2.0)(optionator@0.9.4)(oxlint@1.76.0(oxlint-tsgolint@7.0.2001))(typescript@7.0.2)(vite@8.1.3(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(vue-tsc@3.3.8(typescript@7.0.2))
+        version: 0.14.5(eslint@10.8.0(jiti@2.7.0))(meow@13.2.0)(optionator@0.9.4)(oxlint@1.76.0(oxlint-tsgolint@7.0.2001))(typescript@7.0.2)(vite@8.1.3(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(vue-tsc@3.3.9(typescript@7.0.2))
       vite-plugin-static-copy:
         specifier: 'catalog:'
         version: 4.1.1(vite@8.1.3(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
@@ -611,7 +611,7 @@ importers:
         version: 0.11.0
       '@release-it/conventional-changelog':
         specifier: 'catalog:'
-        version: 12.0.0(conventional-commits-filter@6.0.1)(conventional-commits-parser@7.1.0)(release-it@21.0.0(@types/node@24.13.3)(magicast@0.5.3))
+        version: 12.0.0(conventional-commits-filter@6.0.1)(conventional-commits-parser@7.1.0)(release-it@21.0.1(@types/node@24.13.3)(magicast@0.5.3))
       '@tools/bundle-probe':
         specifier: workspace:*
         version: link:../../tools/bundle-probe
@@ -635,7 +635,7 @@ importers:
         version: 6.1.2
       '@vitest/browser-playwright':
         specifier: 'catalog:'
-        version: 4.1.10(playwright@1.62.0)(vite@8.1.3(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(vitest@4.1.10)
+        version: 4.1.10(playwright@1.62.1)(vite@8.1.3(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(vitest@4.1.10)
       '@vitest/coverage-v8':
         specifier: 'catalog:'
         version: 4.1.10(@vitest/browser@4.1.10)(vitest@4.1.10)
@@ -656,10 +656,10 @@ importers:
         version: 0.61.0
       playwright:
         specifier: 'catalog:'
-        version: 1.62.0
+        version: 1.62.1
       release-it:
         specifier: 'catalog:'
-        version: 21.0.0(@types/node@24.13.3)(magicast@0.5.3)(supports-color@8.1.1)
+        version: 21.0.1(@types/node@24.13.3)(magicast@0.5.3)
       rimraf:
         specifier: 'catalog:'
         version: 6.1.3
@@ -683,7 +683,7 @@ importers:
     devDependencies:
       '@release-it/conventional-changelog':
         specifier: 'catalog:'
-        version: 12.0.0(conventional-commits-filter@6.0.1)(conventional-commits-parser@7.1.0)(release-it@21.0.0(@types/node@24.13.3)(magicast@0.5.3))
+        version: 12.0.0(conventional-commits-filter@6.0.1)(conventional-commits-parser@7.1.0)(release-it@21.0.1(@types/node@24.13.3)(magicast@0.5.3))
       '@tools/bundle-probe':
         specifier: workspace:*
         version: link:../../tools/bundle-probe
@@ -731,7 +731,7 @@ importers:
         version: 0.61.0
       release-it:
         specifier: 'catalog:'
-        version: 21.0.0(@types/node@24.13.3)(magicast@0.5.3)(supports-color@8.1.1)
+        version: 21.0.1(@types/node@24.13.3)(magicast@0.5.3)
       rimraf:
         specifier: 'catalog:'
         version: 6.1.3
@@ -755,7 +755,7 @@ importers:
     devDependencies:
       '@release-it/conventional-changelog':
         specifier: 'catalog:'
-        version: 12.0.0(conventional-commits-filter@6.0.1)(conventional-commits-parser@7.1.0)(release-it@21.0.0(@types/node@24.13.3)(magicast@0.5.3))
+        version: 12.0.0(conventional-commits-filter@6.0.1)(conventional-commits-parser@7.1.0)(release-it@21.0.1(@types/node@24.13.3)(magicast@0.5.3))
       '@tools/bundle-probe':
         specifier: workspace:*
         version: link:../../tools/bundle-probe
@@ -779,7 +779,7 @@ importers:
         version: 6.1.2
       '@vitest/browser-playwright':
         specifier: 'catalog:'
-        version: 4.1.10(playwright@1.62.0)(vite@8.1.3(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(vitest@4.1.10)
+        version: 4.1.10(playwright@1.62.1)(vite@8.1.3(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(vitest@4.1.10)
       '@vitest/coverage-v8':
         specifier: 'catalog:'
         version: 4.1.10(@vitest/browser@4.1.10)(vitest@4.1.10)
@@ -788,10 +788,10 @@ importers:
         version: 0.61.0
       playwright:
         specifier: 'catalog:'
-        version: 1.62.0
+        version: 1.62.1
       release-it:
         specifier: 'catalog:'
-        version: 21.0.0(@types/node@24.13.3)(magicast@0.5.3)(supports-color@8.1.1)
+        version: 21.0.1(@types/node@24.13.3)(magicast@0.5.3)
       rimraf:
         specifier: 'catalog:'
         version: 6.1.3
@@ -815,7 +815,7 @@ importers:
     devDependencies:
       '@release-it/conventional-changelog':
         specifier: 'catalog:'
-        version: 12.0.0(conventional-commits-filter@6.0.1)(conventional-commits-parser@7.1.0)(release-it@21.0.0(@types/node@24.13.3)(magicast@0.5.3))
+        version: 12.0.0(conventional-commits-filter@6.0.1)(conventional-commits-parser@7.1.0)(release-it@21.0.1(@types/node@24.13.3)(magicast@0.5.3))
       '@tools/bundle-probe':
         specifier: workspace:*
         version: link:../../tools/bundle-probe
@@ -845,7 +845,7 @@ importers:
         version: 0.61.0
       release-it:
         specifier: 'catalog:'
-        version: 21.0.0(@types/node@24.13.3)(magicast@0.5.3)(supports-color@8.1.1)
+        version: 21.0.1(@types/node@24.13.3)(magicast@0.5.3)
       rimraf:
         specifier: 'catalog:'
         version: 6.1.3
@@ -878,7 +878,7 @@ importers:
         version: 15.19.0
       playwright:
         specifier: 'catalog:'
-        version: 1.62.0
+        version: 1.62.1
       typescript:
         specifier: 'catalog:'
         version: 7.0.2
@@ -902,7 +902,7 @@ importers:
         version: 0.61.0
       rolldown:
         specifier: 'catalog:'
-        version: 1.2.0
+        version: 1.2.3
       typescript:
         specifier: 'catalog:'
         version: 7.0.2
@@ -1005,10 +1005,10 @@ importers:
         version: 1100.0.0
       '@pnpm/types':
         specifier: 'catalog:'
-        version: 1101.6.0
+        version: 1101.8.0
       '@pnpm/workspace.project-manifest-reader':
         specifier: 'catalog:'
-        version: 1100.0.20(@pnpm/logger@1100.0.0)
+        version: 1100.0.22(@pnpm/logger@1100.0.0)
       '@tools/shared':
         specifier: workspace:*
         version: link:../shared
@@ -1053,10 +1053,10 @@ importers:
         version: 1100.0.0
       '@pnpm/workspace.projects-reader':
         specifier: 'catalog:'
-        version: 1101.0.19(@pnpm/logger@1100.0.0)
+        version: 1101.0.21(@pnpm/logger@1100.0.0)
       '@pnpm/workspace.workspace-manifest-reader':
         specifier: 'catalog:'
-        version: 1100.1.2
+        version: 1100.1.4
       '@types/node':
         specifier: 'catalog:'
         version: 24.13.3
@@ -1090,7 +1090,7 @@ importers:
         version: 6.0.3
       vue-tsc:
         specifier: 'catalog:'
-        version: 3.3.8(typescript@6.0.3)
+        version: 3.3.9(typescript@6.0.3)
 
   tools/workers-builds:
     devDependencies:
@@ -2175,8 +2175,8 @@ packages:
   '@oxc-project/types@0.138.0':
     resolution: {integrity: sha512-1a7ZKmrRTCoN1XMZ4L0PyyqrMnrNlLyPuOkdSX2MZg7IiIGRUyurNhAm73ptDOraoBcIordsIGKNPKUzy3ZmfA==}
 
-  '@oxc-project/types@0.140.0':
-    resolution: {integrity: sha512-h5LUOzGArYemnW1NMz/DuuQhBi96J6JL2Bk8zE4kvqxB5Sg3jxmCiH4uyOWHDkiKSt5vWlG4FIwCR/DbstcNRQ==}
+  '@oxc-project/types@0.143.0':
+    resolution: {integrity: sha512-u6JZdLBTLotrNC9Vd6vPssINdzcCzleKAH6EJKImQb7GtYvX5keN2dxkoK44stCc4tffE6QQRtZTXVSzsLUlWA==}
 
   '@oxc-resolver/binding-android-arm-eabi@11.23.0':
     resolution: {integrity: sha512-8IJyWRLVAyhTfe9/TIEbQqSQnl5rUqYJrUOS6Dkr+Mq9FGHMxDGeiEmwkBqCvDP5KckpPh/GYSgbag66O6JsCw==}
@@ -2686,18 +2686,18 @@ packages:
     resolution: {integrity: sha512-oeQJs1aa8Ghke8JIK9yuq/+KjMiaYeDZ38jx7MhkXncXlUKjqQ3wEm2X3qCKyjo+ZZofZj+WsEEiqkTtRuE2xQ==}
     engines: {node: ^20.9.0 || >=22.0.0, npm: '>=10.8.2'}
 
-  '@pnpm/cli.meta@1100.0.11':
-    resolution: {integrity: sha512-G4u/WFflFQFvR9zKoKBtGMSdprCbninVsx7Gqezixnn9XQwsFYP9H5P/DcSxNgNScPfWNIc+FnOC5x0nEBCRiw==}
+  '@pnpm/cli.meta@1100.0.13':
+    resolution: {integrity: sha512-QAKIFaPgVwsXOuhIlvEhdtWN5CTWbDmMtE3vffaN1dlGc79+SGBaSeT7skIeH79GCipgjcL2+DgKjkpR6edDlg==}
     engines: {node: '>=22.13'}
 
-  '@pnpm/cli.utils@1101.0.19':
-    resolution: {integrity: sha512-KkyM5vf1YnsvsL+mKCCPT84slBlbC608TlEXLKj4cfSFUjmXeIqCSAIMKuMz+R9x2pBrMLbs4zwrc/Rs0lS8DQ==}
+  '@pnpm/cli.utils@1101.0.21':
+    resolution: {integrity: sha512-ZWFXf13HRwb0LLk5ahIg/Rvw8zA3YzZVVBCfA4Ug9AsOxnypjSBmVHdXwDtDbjjR1aZ5wGsCcGGpdyIiRHTLxw==}
     engines: {node: '>=22.13'}
     peerDependencies:
       '@pnpm/logger': ^1100.0.0
 
-  '@pnpm/config.package-is-installable@1100.0.16':
-    resolution: {integrity: sha512-oOzZry1MCzn/avtn3lzrwk54ht/ixySOQxnMa+HzN27AzPEQOWmkIsK1gApSJu7etVZGZ76VjSY7w2P8J/tsTA==}
+  '@pnpm/config.package-is-installable@1100.1.1':
+    resolution: {integrity: sha512-R9ntmsGLnphmrFb8/B2WtYQiszoCg25n2vNwNDyXvupWo8lwjjSRovJ6KXJW1ePNerRg/iEVqwqlFKZzhMBePQ==}
     engines: {node: '>=22.13'}
     peerDependencies:
       '@pnpm/logger': ^1100.0.0
@@ -2706,8 +2706,8 @@ packages:
     resolution: {integrity: sha512-0CqK4HTdfON1IiBIg1ib06hGJv2sDWovOZ8tP/S8BOkhVYXoter1wia1OtgUeSIabDgyeWgL8LRHG4PhkuIAPw==}
     engines: {node: '>=22.13'}
 
-  '@pnpm/core-loggers@1100.2.5':
-    resolution: {integrity: sha512-AgCqyzvIC10FVyKMUQWuuTkHvWweH8u3koUd8Ht8JPtrmC8fvyQ35kCuaVcxjJjKf9kM+8ogE1gxSa64AQsbcA==}
+  '@pnpm/core-loggers@1100.3.1':
+    resolution: {integrity: sha512-1gbpUBQKcfbxp5XnkYvTdcplFdSvK+QeZA8KXm8sGpqzWxb+ckO1oeFTX1u6I8P30mZgWPQc8ZPMnEG/rU2R1w==}
     engines: {node: '>=22.13'}
     peerDependencies:
       '@pnpm/logger': ^1100.0.0
@@ -2716,8 +2716,8 @@ packages:
     resolution: {integrity: sha512-G3J83gBJ5XCKhoJ7XbnF0uVJw7D5FC2X1T+txoGtEV1e1dFLT98b05zlBjgaMonkbxFCIUCuwHxttyEyKJvXow==}
     engines: {node: '>=22.13'}
 
-  '@pnpm/engine.runtime.system-version@1100.0.6':
-    resolution: {integrity: sha512-cwYFz3ZWOcG2rxHlY7bmCTMoYf/bKPq/HqtUoYQjnyA+pcypJASR26E7PFW0bnujLPkzyN5Y5U0T93GJJrFL2g==}
+  '@pnpm/engine.runtime.system-version@1100.0.8':
+    resolution: {integrity: sha512-KTJxFu8Sm4w4j3xAdvHnwbnAUanoHMPeeEV42NHOKCw6XS/9k2RVnM49YDKk/1Bj3Dj387VUyLFoEfCJ65GMrg==}
     engines: {node: '>=22.13'}
 
   '@pnpm/error@1100.1.0':
@@ -2732,8 +2732,8 @@ packages:
     resolution: {integrity: sha512-A3bRMTIZ5ptDPAE/KsDeY1J5UqqOiyo66+k/mUvaVjx++OJdMbp9If5kisEq9ljAV5r5TRpkxsJbSdrdJ5WtzQ==}
     engines: {node: '>=22.13'}
 
-  '@pnpm/pkg-manifest.utils@1100.2.12':
-    resolution: {integrity: sha512-Go/9NuO9l5kLcqJeytHAxg18fKUPz1tMFUJNIAmbsLyAnCVhASYFFpmZWtRJrCtNu94BUyqUlk1iyxOXTFsf9Q==}
+  '@pnpm/pkg-manifest.utils@1100.3.0':
+    resolution: {integrity: sha512-y51xeTF8oO6b9fpZ4BxIxRvWBdjxBVgRiVJEB0NHT6OjcJ672lyURUzgnJIvfTabnceUxm4WAjkuXZINXRHSUw==}
     engines: {node: '>=22.13'}
     peerDependencies:
       '@pnpm/logger': ^1100.0.0
@@ -2742,32 +2742,32 @@ packages:
     resolution: {integrity: sha512-10rRwfC9ffkuS4RugetHD+AiNZLdg9ZVv0rkbr/8o14EW6Vh6ZwFwAfTOlkp3Eyse8518jVFvXXPKQKyeh9kNw==}
     engines: {node: '>=22.13'}
 
-  '@pnpm/types@1101.6.0':
-    resolution: {integrity: sha512-oqJsbjsYcvbONsMTCQQHxpIyhGDSgRUsIoGM8TMWoydgeSdtnqpGVAvxljkvP2mgYO3Y8EwRRZ1usESSoySYjg==}
+  '@pnpm/types@1101.8.0':
+    resolution: {integrity: sha512-oI4t7shio2C3ld+S8bLfrG6aDyepkWwefa4Lw/I4E2JrPDkp8ZKDD1BcgYbkM+bwtgjyJpD0VgPrkqGqu6Uh/w==}
     engines: {node: '>=22.13'}
 
   '@pnpm/util.lex-comparator@4.0.1':
     resolution: {integrity: sha512-EZ3aWU7ThppE3Xgq7/ftxq8J/nit6z8I2/wZbC/acea2Zw7KJ1k/fLkGBgyyVAE37CULFsOSmPl3EjYM18cB2Q==}
     engines: {node: '>=22.13'}
 
-  '@pnpm/workspace.project-manifest-reader@1100.0.20':
-    resolution: {integrity: sha512-kXO5rf8pzcyR+dHRv9wvzVRzJDv4D/KqhP3+kARpfLn6xkVt6JGBnNnxtUN2wTViTfIHjqccRSxczoqCAD2baw==}
+  '@pnpm/workspace.project-manifest-reader@1100.0.22':
+    resolution: {integrity: sha512-huzXozgXlQs56d2XMnt/zAoQnxhjt0G2teFJbGiq4uUWxz+9qv7K1mtiVwcvtk7bdso4kjGzTzoIUEuFfy9ksw==}
     engines: {node: '>=22.13'}
     peerDependencies:
       '@pnpm/logger': ^1100.0.0
 
-  '@pnpm/workspace.project-manifest-writer@1100.0.11':
-    resolution: {integrity: sha512-cy+0PABL1vVgGuDpVnMj0KvjCeFQBrE1xgqap/4n9GbJcQu/TNFv0teTD2sjNPBVgTtrXnK0//PyPR/4OSRQXg==}
+  '@pnpm/workspace.project-manifest-writer@1100.0.13':
+    resolution: {integrity: sha512-Af+m5JB/Rp70Oqp9KLJEBYqEV5K35xJWVRT6mI28jpWJr97Umlmdj8t5VAILdlSwXkCkD4Kwd7HJvuc9dAKdOQ==}
     engines: {node: '>=22.13'}
 
-  '@pnpm/workspace.projects-reader@1101.0.19':
-    resolution: {integrity: sha512-klPw2JeNEPTPFXJDJlOlJCXECvJBXYHbm9K/b9/681gRabpDH9thBqsRNOQuDOkpmPe9ieKEP7JcElso6fDoRQ==}
+  '@pnpm/workspace.projects-reader@1101.0.21':
+    resolution: {integrity: sha512-+QpeUT1wuMv46o3HRSFLs8hqWk1kiblXw2fhVqRccROAguI6jtj3yAFp/ltk2lbUSXT/6eeRzoX5n+KFIEC4EA==}
     engines: {node: '>=22.13'}
     peerDependencies:
       '@pnpm/logger': ^1100.0.0
 
-  '@pnpm/workspace.workspace-manifest-reader@1100.1.2':
-    resolution: {integrity: sha512-+HKSEE8jlPLcrK/7r5ig/42r+5LhjQUOiZkkllZvZDH1Sfdr3Tc0ymJzlN6Y44A/XzlZv7RQhEljSXmHzkfoTg==}
+  '@pnpm/workspace.workspace-manifest-reader@1100.1.4':
+    resolution: {integrity: sha512-MDqtRle/sGlwiMi1K2OOE2gGPaOTYKui4Jk30TLI3ZOy6d7HLGXDVQmrrfB2rSl2e9ob3VfJaHl2kpgqlHj8Tg==}
     engines: {node: '>=22.13'}
 
   '@polka/url@1.0.0-next.29':
@@ -2798,8 +2798,8 @@ packages:
     cpu: [arm64]
     os: [android]
 
-  '@rolldown/binding-android-arm64@1.2.0':
-    resolution: {integrity: sha512-9yB1l95IrJuNGDFdOYe79vdApdz6WWBCObE+rQ2LUliYUlcyFwSYIb2xb5/Ifw7dAtMy2ZqNyd8QTSOc7duAKw==}
+  '@rolldown/binding-android-arm64@1.2.3':
+    resolution: {integrity: sha512-zrJtHDcaZJ1Fp7xf4hNl+7seH9Cn/N5TwLYkhgXREtBwAd/jaqW3uqeHxpDugJLVICWg4eW44kOQEGJ1r6jCGw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
@@ -2810,8 +2810,8 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-arm64@1.2.0':
-    resolution: {integrity: sha512-pexNaW9ACLUOaBITOpU6qVu4VrsOFIjTv6bzgu0YUATo4eUJx0V605PxwZfndpPOn0ilqGqvGQ0M8UW0IE24jg==}
+  '@rolldown/binding-darwin-arm64@1.2.3':
+    resolution: {integrity: sha512-ieIiibVCp0tX7TLu2cafoNPv8wJyYi01ekXpbf8q2j7F4rGAhhXb/eQh7ge9DRBY78GwmRQtvjZDux7EDbA8kA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
@@ -2822,8 +2822,8 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-x64@1.2.0':
-    resolution: {integrity: sha512-NqKYaq0355ZmNMG4QGpxtEDxsc7tGDhjhCm4PpE0cwnBW+5Il95LJyq414niEiaKLVjnVHBEjSo1wngKxJNiFw==}
+  '@rolldown/binding-darwin-x64@1.2.3':
+    resolution: {integrity: sha512-Zh9tCon19eDXJoihx0rqKhMUlMYqzwj3aPsSuHmI4RWZh62dWUL+DJN4C5YQya5TcQBJU/Fe8+rY0jhXTQITqA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
@@ -2834,8 +2834,8 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  '@rolldown/binding-freebsd-x64@1.2.0':
-    resolution: {integrity: sha512-3vPoHzh6eBTz9IbB0/qZdSr0Qeks2echn+I4cHu2joV74VriPDdldswksEDzrl1mBB+oPRi+67+3Ib59paxIPQ==}
+  '@rolldown/binding-freebsd-x64@1.2.3':
+    resolution: {integrity: sha512-nGbJWewA1wrXXZiQhjAT5rhibGfns5ZNkDVqxsO6zJ3f3YvpoDNNmGMSbbhLuXKjNScaBJVOAboztAWVespQMg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
@@ -2846,8 +2846,8 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.2.0':
-    resolution: {integrity: sha512-E6NNefZ1bUVmKJq2tJkf45J4Zyczj7qm9rUT7NY+Xo2474Y13qWAwc2tvBt0BAVbmtXR1llkxXg0Ou1jbDf2SQ==}
+  '@rolldown/binding-linux-arm-gnueabihf@1.2.3':
+    resolution: {integrity: sha512-QNniJr5Kml0kDEB98jiDOJjXNroxIIi0IXIbdYzY26Xt1pVbeP62+KnoIZLwirOymX/0jDk/2gI/bNUv7A7OIw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
@@ -2859,8 +2859,8 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-arm64-gnu@1.2.0':
-    resolution: {integrity: sha512-D+TgkdgM1vu+7/Fpf8+v0ARW+RXEP9Ccazgm8zQ4JFFd9Q7SrYQ2TakU5S5ihazQDgpKyAgZDOcIFsvoHmTZ8w==}
+  '@rolldown/binding-linux-arm64-gnu@1.2.3':
+    resolution: {integrity: sha512-TkqEAcmmvH3I/q4114NB4RVt6241Dao48pF45uLcFGrwAaIn0iITgTAKP/dLjbN0R4buJjGb91+UHSoFmpgIWw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
@@ -2873,8 +2873,8 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-linux-arm64-musl@1.2.0':
-    resolution: {integrity: sha512-wUqdwJBbAv0APN87GecstdMUtLjjNTs0hBALpxETD73mccFxdmt/XeizXDtN5RAlBwNKmI+Tg+blect2G+8IeQ==}
+  '@rolldown/binding-linux-arm64-musl@1.2.3':
+    resolution: {integrity: sha512-NHqjnxpsndf4MPymxteFAWHHfkTL8HjWh1KB7z23ofZ6QO2euONuxDXjat69dKZRALnGypg8k8SsK8vZJoXv1Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
@@ -2887,8 +2887,8 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-ppc64-gnu@1.2.0':
-    resolution: {integrity: sha512-9DtF35qR9/NrfhM4oxLplCzVVjE+KKm8Pjemi0i/sdhAWkUasjmSo8WTTubNJClhSHCfyk2yeyoXDQEDPtDAAw==}
+  '@rolldown/binding-linux-ppc64-gnu@1.2.3':
+    resolution: {integrity: sha512-6tbrbwfz5GB9DQ4Jwo6hy9v+vR31xZlvzZ6n5Xut6Hhx5PvrA9q/HsK8KMaYQp063iqZGXwNvZtYNLD7EM/x0w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
@@ -2901,8 +2901,8 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-s390x-gnu@1.2.0':
-    resolution: {integrity: sha512-RzuHrBh8X8Hntd2N4VR02QGEciq/9JhcZoTpR/Cee6otRrlILGCf3cg2ygHuih+ZebUnWmMrDX6ITI85btO6rQ==}
+  '@rolldown/binding-linux-s390x-gnu@1.2.3':
+    resolution: {integrity: sha512-oyuXxXmoZHjXC917IAPFAAv4wWAa0cM9afk8nx1+9/jNNOX1uPf8yDA6p7G0RypOfw/X0PQt5IfoquY1um+zSg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
@@ -2915,8 +2915,8 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-x64-gnu@1.2.0':
-    resolution: {integrity: sha512-MK7L0018jjh1jR3mh21G2j1zAVcpscJBlPo2z19pRjv2XOYGRhaV4LyiD8HO6nCDdZln9IFgCMIV5yt4E3klGQ==}
+  '@rolldown/binding-linux-x64-gnu@1.2.3':
+    resolution: {integrity: sha512-TytMwF2KVGqP2tgd0I1OY0PAv78dZRAYcF5ssDzjM34SUXCED3uXvSd5+lHoC0bTD6eEdFz7LdQNCO1y0oVk9w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
@@ -2929,8 +2929,8 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-linux-x64-musl@1.2.0':
-    resolution: {integrity: sha512-gyrxLQ9NfGb/9LoVnC4kb9miUghw1mghnkfYvNHSnVIXriabnfgGPUP4RLcJm87q3KgYz4FYUG8IDiWUT+CpSw==}
+  '@rolldown/binding-linux-x64-musl@1.2.3':
+    resolution: {integrity: sha512-/E9m3qstrJFVPoULV25mVQblSNExY2+kBsYe4sy0Tn0yOOgJ8wZbZt3KnRbF/XeU2Gl1STKUQnDNTqhIE5MD4A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
@@ -2942,8 +2942,8 @@ packages:
     cpu: [arm64]
     os: [openharmony]
 
-  '@rolldown/binding-openharmony-arm64@1.2.0':
-    resolution: {integrity: sha512-/6VFMQGRmrhP77KXDC+StIxGzcNp5JOIyYtw0CQ8gPlzhpiIRucYfoM5FaFamHd5BJYIdH86yfP46l1p3WdrFA==}
+  '@rolldown/binding-openharmony-arm64@1.2.3':
+    resolution: {integrity: sha512-Kr0OcsoQI816i6HOl3vFHpd1K0eZyh76zgfj4c1nTyaTsd5r2Mj1lwM4R90y/qaCfmTn9eHy0SKwi98eitRxug==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
@@ -2953,19 +2953,14 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [wasm32]
 
-  '@rolldown/binding-wasm32-wasi@1.2.0':
-    resolution: {integrity: sha512-rwdbUL465kisF24WEJLvP3JrEG6E5GRuIHt5wpMwHGERtHe4Wm2CIvtf5gTBgr2tGOHKh5NdKEAFS2VkOPE91g==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [wasm32]
-
   '@rolldown/binding-win32-arm64-msvc@1.1.4':
     resolution: {integrity: sha512-PnWBtw3TV5KOg69HQQDR0mnQuyCmSGR2pAB4DC1rPF808fgKeTUMj2EOEyKATpgiuxuR5APQmiDO7PDgEjTFSA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@rolldown/binding-win32-arm64-msvc@1.2.0':
-    resolution: {integrity: sha512-+5suHwRiKGmhwyUaNT8a5QbrBvLFh2DbO910TEmGRH1aSxwrCezodvGQnulv4uiWEIv1Kq4ypRsJ5+O+ry1DiA==}
+  '@rolldown/binding-win32-arm64-msvc@1.2.3':
+    resolution: {integrity: sha512-hOtMwTqnME+/gJcH/PCZ0wn0zPUjiWOgkHpxbSJpfGKMezHltx1S7/k1SitzVa7Ww2cqrDDaFbZEhcJZO8o+Jw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
@@ -2976,8 +2971,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@rolldown/binding-win32-x64-msvc@1.2.0':
-    resolution: {integrity: sha512-WfFv6/qGufotqBSBzBYwgpCkJBk8Nj7697LL9vTz/XWc67e0r3oewu8iMRwQj3AUL45GVD7wVsPjCsAAtW66Wg==}
+  '@rolldown/binding-win32-x64-msvc@1.2.3':
+    resolution: {integrity: sha512-ekcqMMkI2PlhYnfzQnB/cEdYUVVJViWvoUyLrbzgDoi3Snfc1mVBwdnc306ufA5ejy8JSPjT2RlW1nQSjW7efg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -3118,33 +3113,33 @@ packages:
     resolution: {integrity: sha512-U4mVcdFGOi6pt8n38LdWZp67Svn7ppnU1Pj8SGOVaBi1X4gm+G4ztQlLfkoJbKSHfjA6WeaiJp2A4V83AJF6nQ==}
     engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
 
-  '@turbo/darwin-64@2.10.7':
-    resolution: {integrity: sha512-/c9cSBRermWDv85oufLhoH6XRLOVbvzJLRd+WLyfJCP+i0HFLQj4PVNDrHcY17/ve5l8X0Oua4bJBqJUgJPnZA==}
+  '@turbo/darwin-64@2.10.8':
+    resolution: {integrity: sha512-po+7rfJfUnFXjWlcoN2RwhErgzCdRtBc1T26vYPcywHlggmCQiQe1uWaE4j+BibI2uY9/2pDoFzMN0rmSaPFOw==}
     cpu: [x64]
     os: [darwin]
 
-  '@turbo/darwin-arm64@2.10.7':
-    resolution: {integrity: sha512-8lpCCGWZBl9PIF8w8f2iEWrLMbHBWIfJeV6l2UEGqysD6HRIM4ySj/8R7HGEzbECJ4r/gnJcHmxEoG8yjFe64A==}
+  '@turbo/darwin-arm64@2.10.8':
+    resolution: {integrity: sha512-+zB2btDJ00lnPRuqOvpVvgl4x34k/djZQGZTTCfjn7JgNCl8QFY5Njo5+dqkY1g/+9gbbsnAvWm9CmJg9ebcXA==}
     cpu: [arm64]
     os: [darwin]
 
-  '@turbo/linux-64@2.10.7':
-    resolution: {integrity: sha512-Midw9Ed00yw9rqkWN82fY3LmLNFQ6yiL1GXB56DJKUEjWaEd27zh7ohCxzzrjfjQVrEeVWd3UPytTAV16XDQlA==}
+  '@turbo/linux-64@2.10.8':
+    resolution: {integrity: sha512-K1dxqiVisyN7cViVsfQLs6xscQbYuI8aO2nbUhFURDACgEDfZRdP/b4CCxeosBJpcMfhYyiibWqJorCnvz9kKg==}
     cpu: [x64]
-    os: [linux]
+    os: [android, linux]
 
-  '@turbo/linux-arm64@2.10.7':
-    resolution: {integrity: sha512-UVEy+MW/xn4BcsiV3v3uv0/oObyaQgVtRT+Jj4WE53rNH05VEYEc1Z13q3zV6276wCZR4Yxc4hiTTcjw7PjSpg==}
+  '@turbo/linux-arm64@2.10.8':
+    resolution: {integrity: sha512-Gi77ibVnrE1fEmvr+/wBD/yvRqhwp/RQuCp2+//lv1U1wNFFyVg0V7Wj8FG9FXPFAw5QHReo8rxc9+wBSDZjzA==}
     cpu: [arm64]
-    os: [linux]
+    os: [android, linux]
 
-  '@turbo/windows-64@2.10.7':
-    resolution: {integrity: sha512-l2nH9KGLV46SWjcXvyc2+xo5gdf5J0NVADknQk9OCJhzJBpiNl/byd26yIfwZBjLupdqT6UOdPhPxcpUPxRykQ==}
+  '@turbo/windows-64@2.10.8':
+    resolution: {integrity: sha512-znnLO1haJPYTHoKMKwlAvlkjRiYbbhBzME6wIGaMd+fwir23U6jVd1ecaTWWi1fbnRVqxMfgDBKseQ/hLKb83g==}
     cpu: [x64]
     os: [win32]
 
-  '@turbo/windows-arm64@2.10.7':
-    resolution: {integrity: sha512-qjE1apG6RThuX49vUJd5ks2dV2ndXC2qktDChQonFMvUzrMrEnZMQzO+IgxBiYq1j+NbXQcRwj84nGnk1TBw1g==}
+  '@turbo/windows-arm64@2.10.8':
+    resolution: {integrity: sha512-VN30vh3b3Czh2WzYHNTfF1FE0YMZ5aHsLO8dBMGHJewA6792wX6iJR8ZxlzFW6WdOu0gEAKIvlYhfyT81Wkm4Q==}
     cpu: [arm64]
     os: [win32]
 
@@ -3178,8 +3173,8 @@ packages:
   '@types/linkify-it@5.0.0':
     resolution: {integrity: sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==}
 
-  '@types/lodash@4.17.24':
-    resolution: {integrity: sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ==}
+  '@types/lodash@4.17.25':
+    resolution: {integrity: sha512-+K1NIO8I+F9/wNulfVvu23QYd0Pe9/OCqRrim4NoYIf1VoEDL90Ve4ClzpyqBLc7NpGGWRvYNCKZ1BE/Jpf8dQ==}
 
   '@types/markdown-it@14.1.2':
     resolution: {integrity: sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==}
@@ -3479,8 +3474,8 @@ packages:
   '@vue/devtools-shared@8.1.5':
     resolution: {integrity: sha512-mhT4zcPFhF+Xk1O4BfhhrbXzpmfqY03fS6xGpcllbQG7lDjhQf8pQHcTIhqQIYx1hfwtHmk/6jM96ele0UxPqQ==}
 
-  '@vue/language-core@3.3.8':
-    resolution: {integrity: sha512-ieGT8jJdhhy0mGzStZhsg/qPw5bQZJg5yF+3+XU6saf4sM7yo9ZXy3h+nCwrm2+b4qS/SypkNdR2jAF3uei9tA==}
+  '@vue/language-core@3.3.9':
+    resolution: {integrity: sha512-in/68oAa4BCtVY6n/nkuhLIkV8DHYd2UivedJ6cMZ6UYtlq9jaoaSNUBHYCVO44z3nKg7MdE5OBoHKt5SxeBKQ==}
 
   '@vue/reactivity@3.5.40':
     resolution: {integrity: sha512-B7ot9UlUZOi1zbq61/LvE88ZLTV8IlajTdiZTAEiDQgrnIMIZoPr9kGw0Zw46ObW62O9+H/Be3kMbfb7kYPQZA==}
@@ -3835,6 +3830,10 @@ packages:
   chalk@5.6.2:
     resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+
+  chalk@6.0.0:
+    resolution: {integrity: sha512-2uNTXIuTTxk7ciZgAU1BQcgnchcG0xXnrs6jzkQfj9SsRa9M2s5zE8WT96hS6KmG4MzWHSrvH43DF1m4XRkrFg==}
+    engines: {node: '>=22'}
 
   change-case@5.4.4:
     resolution: {integrity: sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==}
@@ -4277,8 +4276,8 @@ packages:
     peerDependencies:
       eslint: ^9.0.0 || ^10.0.0
 
-  eslint-plugin-turbo@2.10.7:
-    resolution: {integrity: sha512-c+ayTSJuyWAdQiiAGDAqAMsX1p1TiGPVSPdkZSVh9UZJHYNww6Fdb5e4EEPVyFaMXqWRXh4suzmxAKMa9nnKIQ==}
+  eslint-plugin-turbo@2.10.8:
+    resolution: {integrity: sha512-D6/FZUlP5IkZl/Wahoyi9q/UYFnyuh0cyqf3x5aHJNTmlu+bC6+h03cNPzPoQS7708ts54KYreUZW+FdRG5BWg==}
     peerDependencies:
       eslint: '>6.6.0'
       turbo: '>2.0.0'
@@ -5535,13 +5534,13 @@ packages:
   pkg-types@2.3.1:
     resolution: {integrity: sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==}
 
-  playwright-core@1.62.0:
-    resolution: {integrity: sha512-nsNRyq0r2zsG8AcRHWknc9QRA5XCueC7gWMrs+Gx2tlZn9hcl8zudfh00lhJPY1DE7NmZ6bDsT9g2yey8mXljA==}
+  playwright-core@1.62.1:
+    resolution: {integrity: sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==}
     engines: {node: '>=20'}
     hasBin: true
 
-  playwright@1.62.0:
-    resolution: {integrity: sha512-Z14dG305dgaLu6foB1TXQagFiW8JfSUIUaUuPaKQ6NtBPKF1P/qXcqfh6c6K/icPqdy37JmjbiBXf6JNg6Sylw==}
+  playwright@1.62.1:
+    resolution: {integrity: sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==}
     engines: {node: '>=20'}
     hasBin: true
 
@@ -5674,8 +5673,8 @@ packages:
   regex@6.1.0:
     resolution: {integrity: sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==}
 
-  release-it@21.0.0:
-    resolution: {integrity: sha512-oAOiUcDpJEbLSOT0HqnHByDTomSvpwRktU2fnk7zbpJK9wOiXbHnP1mFy+80P6k5cJnMBx1PIuHmwXzd5R1jLw==}
+  release-it@21.0.1:
+    resolution: {integrity: sha512-xbPuv2tau3gb0Xw0NVqV3QjOhytFvbsBZDqzmURqlwtgNpFIlIbpDbuZG64ptytFOX4H/7k65bbPSLTwAL34/g==}
     engines: {node: ^22.21.0 || >=24.0.0}
     hasBin: true
 
@@ -5727,8 +5726,8 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
-  rolldown@1.2.0:
-    resolution: {integrity: sha512-u7tgm5l4Yw1iTqUL4EcYOAt7fFvCgQMLeidrnD4GALlC6aOznCjezYajgxeyKw27u0Q5N7fwgCzjVyPIWzwuBA==}
+  rolldown@1.2.3:
+    resolution: {integrity: sha512-rn9wpmxplLf7NLNyCk9FyWh3FM43DbY8jOzCdEPzH7uflhTftRbCEpqi6Ly2osgoU8OwObtmavMbWLaWy4LX7A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
@@ -5897,8 +5896,8 @@ packages:
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
-  start-server-and-test@3.0.11:
-    resolution: {integrity: sha512-NRapOwJl6jr1DNSaQ+SRukHI2OKcFZA2Iv2tfTW9fI/S+6YmJGiwacR+0MG3o5p39lY4xWUOE5JFkKJBZUjxuQ==}
+  start-server-and-test@3.0.12:
+    resolution: {integrity: sha512-JhW9LiYXqJxyzmgMvBQ6JxVcz16wV+c5IE6rTHofqLBKjSE075Yr9e6sTr8QgrkHMHlHqkDegzKpQfVKxwauJw==}
     engines: {node: ^22 || >=24}
     hasBin: true
 
@@ -6047,8 +6046,8 @@ packages:
     resolution: {integrity: sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==}
     engines: {node: '>=0.6.11 <=0.7.0 || >=0.7.3'}
 
-  turbo@2.10.7:
-    resolution: {integrity: sha512-GHx6WExIFSKNJ5qMlzDpXBXlu9ApxaMjqxAVrCNcW94xf/+uqgIz41SAuRUMbXva2ExNAaY/h8V0q90SWSzmRw==}
+  turbo@2.10.8:
+    resolution: {integrity: sha512-9+8YX5QOkGXzZxcIykTHgaooRHGMWO+jfdyRK0o+rN0U7hBIig2MrJ8r/aNzIPDPhdA73SGb0O+tIztaModTMg==}
     hasBin: true
 
   tweetnacl@0.14.5:
@@ -6362,8 +6361,8 @@ packages:
   vscode-uri@3.1.0:
     resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
 
-  vue-tsc@3.3.8:
-    resolution: {integrity: sha512-xXmYlVQpcwJDWyGlqbHrGVOl1h3UOsASymRibrHc+iy9j/UNnOrOn4u+fntHz4D6Cs74RtapeqVV6CzJeg+UlA==}
+  vue-tsc@3.3.9:
+    resolution: {integrity: sha512-TS3Y1ux/IRoE8OCP2PpACAeOseuIs0UvWrcr7u+w3PmfY+SlCfEf8zjrBgnQksHUgLpthi5vHlffcQTQTdPBZA==}
     hasBin: true
     peerDependencies:
       typescript: '>=5.0.0'
@@ -6376,8 +6375,8 @@ packages:
       typescript:
         optional: true
 
-  wait-on@9.0.10:
-    resolution: {integrity: sha512-rCoJEhvMr0X6alHmwc9abbrA5ZrLZFKpFQVKPNFwl2h7DapXOGdmimIHDtLOWhT4PjhZhxFEtZoQgEXbkDWdZw==}
+  wait-on@9.1.0:
+    resolution: {integrity: sha512-PymrLXHLBM1Ju/Xspb2ADUhbPSMvbnuNvy/mN2hWtpbJ3da0h3Ky1LqwKPG5QSVR57liyO0iUpfipYl/s5qNvA==}
     engines: {node: '>=20.0.0'}
     hasBin: true
 
@@ -7330,8 +7329,8 @@ snapshots:
   '@npmcli/agent@5.0.2':
     dependencies:
       agent-base: 9.0.0
-      http-proxy-agent: 9.1.0(supports-color@8.1.1)
-      https-proxy-agent: 9.1.0(supports-color@8.1.1)
+      http-proxy-agent: 9.1.0
+      https-proxy-agent: 9.1.0
       lru-cache: 11.5.1
       socks-proxy-agent: 10.1.0
     transitivePeerDependencies:
@@ -7515,7 +7514,7 @@ snapshots:
 
   '@oxc-project/types@0.138.0': {}
 
-  '@oxc-project/types@0.140.0': {}
+  '@oxc-project/types@0.143.0': {}
 
   '@oxc-resolver/binding-android-arm-eabi@11.23.0':
     optional: true
@@ -7776,31 +7775,31 @@ snapshots:
 
   '@phun-ky/typeof@2.0.3': {}
 
-  '@pnpm/cli.meta@1100.0.11':
+  '@pnpm/cli.meta@1100.0.13':
     dependencies:
-      '@pnpm/types': 1101.6.0
+      '@pnpm/types': 1101.8.0
       load-json-file: 7.0.1
 
-  '@pnpm/cli.utils@1101.0.19(@pnpm/logger@1100.0.0)':
+  '@pnpm/cli.utils@1101.0.21(@pnpm/logger@1100.0.0)':
     dependencies:
-      '@pnpm/cli.meta': 1100.0.11
-      '@pnpm/config.package-is-installable': 1100.0.16(@pnpm/logger@1100.0.0)
+      '@pnpm/cli.meta': 1100.0.13
+      '@pnpm/config.package-is-installable': 1100.1.1(@pnpm/logger@1100.0.0)
       '@pnpm/error': 1100.1.0
       '@pnpm/logger': 1100.0.0
-      '@pnpm/pkg-manifest.utils': 1100.2.12(@pnpm/logger@1100.0.0)
-      '@pnpm/types': 1101.6.0
-      '@pnpm/workspace.project-manifest-reader': 1100.0.20(@pnpm/logger@1100.0.0)
-      chalk: 5.6.2
+      '@pnpm/pkg-manifest.utils': 1100.3.0(@pnpm/logger@1100.0.0)
+      '@pnpm/types': 1101.8.0
+      '@pnpm/workspace.project-manifest-reader': 1100.0.22(@pnpm/logger@1100.0.0)
+      chalk: 6.0.0
       load-json-file: 7.0.1
 
-  '@pnpm/config.package-is-installable@1100.0.16(@pnpm/logger@1100.0.0)':
+  '@pnpm/config.package-is-installable@1100.1.1(@pnpm/logger@1100.0.0)':
     dependencies:
-      '@pnpm/cli.meta': 1100.0.11
-      '@pnpm/core-loggers': 1100.2.5(@pnpm/logger@1100.0.0)
-      '@pnpm/engine.runtime.system-version': 1100.0.6
+      '@pnpm/cli.meta': 1100.0.13
+      '@pnpm/core-loggers': 1100.3.1(@pnpm/logger@1100.0.0)
+      '@pnpm/engine.runtime.system-version': 1100.0.8
       '@pnpm/error': 1100.1.0
       '@pnpm/logger': 1100.0.0
-      '@pnpm/types': 1101.6.0
+      '@pnpm/types': 1101.8.0
       detect-libc: 2.1.2
       execa: safe-execa@0.3.0
       memoize: 11.0.0
@@ -7808,19 +7807,19 @@ snapshots:
 
   '@pnpm/constants@1100.0.1': {}
 
-  '@pnpm/core-loggers@1100.2.5(@pnpm/logger@1100.0.0)':
+  '@pnpm/core-loggers@1100.3.1(@pnpm/logger@1100.0.0)':
     dependencies:
       '@pnpm/logger': 1100.0.0
-      '@pnpm/types': 1101.6.0
+      '@pnpm/types': 1101.8.0
 
   '@pnpm/deps.peer-range@1100.1.1':
     dependencies:
       semver: 7.8.5
 
-  '@pnpm/engine.runtime.system-version@1100.0.6':
+  '@pnpm/engine.runtime.system-version@1100.0.8':
     dependencies:
-      '@pnpm/cli.meta': 1100.0.11
-      '@pnpm/types': 1101.6.0
+      '@pnpm/cli.meta': 1100.0.13
+      '@pnpm/types': 1101.8.0
       execa: safe-execa@0.3.0
       memoize: 11.0.0
 
@@ -7837,32 +7836,32 @@ snapshots:
       bole: 5.0.29
       split2: 4.2.0
 
-  '@pnpm/pkg-manifest.utils@1100.2.12(@pnpm/logger@1100.0.0)':
+  '@pnpm/pkg-manifest.utils@1100.3.0(@pnpm/logger@1100.0.0)':
     dependencies:
-      '@pnpm/core-loggers': 1100.2.5(@pnpm/logger@1100.0.0)
+      '@pnpm/core-loggers': 1100.3.1(@pnpm/logger@1100.0.0)
       '@pnpm/deps.peer-range': 1100.1.1
       '@pnpm/error': 1100.1.0
       '@pnpm/logger': 1100.0.0
-      '@pnpm/types': 1101.6.0
+      '@pnpm/types': 1101.8.0
       semver: 7.8.5
 
   '@pnpm/text.comments-parser@1100.0.1':
     dependencies:
       strip-comments-strings: 1.2.0
 
-  '@pnpm/types@1101.6.0': {}
+  '@pnpm/types@1101.8.0': {}
 
   '@pnpm/util.lex-comparator@4.0.1': {}
 
-  '@pnpm/workspace.project-manifest-reader@1100.0.20(@pnpm/logger@1100.0.0)':
+  '@pnpm/workspace.project-manifest-reader@1100.0.22(@pnpm/logger@1100.0.0)':
     dependencies:
       '@pnpm/error': 1100.1.0
       '@pnpm/fs.graceful-fs': 1100.1.1
       '@pnpm/logger': 1100.0.0
-      '@pnpm/pkg-manifest.utils': 1100.2.12(@pnpm/logger@1100.0.0)
+      '@pnpm/pkg-manifest.utils': 1100.3.0(@pnpm/logger@1100.0.0)
       '@pnpm/text.comments-parser': 1100.0.1
-      '@pnpm/types': 1101.6.0
-      '@pnpm/workspace.project-manifest-writer': 1100.0.11
+      '@pnpm/types': 1101.8.0
+      '@pnpm/workspace.project-manifest-writer': 1100.0.13
       detect-indent: 7.0.2
       fast-deep-equal: 3.1.3
       is-windows: 1.0.2
@@ -7872,30 +7871,30 @@ snapshots:
       read-yaml-file: 3.0.0
       strip-bom: 5.0.0
 
-  '@pnpm/workspace.project-manifest-writer@1100.0.11':
+  '@pnpm/workspace.project-manifest-writer@1100.0.13':
     dependencies:
       '@pnpm/text.comments-parser': 1100.0.1
-      '@pnpm/types': 1101.6.0
+      '@pnpm/types': 1101.8.0
       json5: 2.2.3
       write-file-atomic: 7.0.1
       write-yaml-file: 6.0.0
 
-  '@pnpm/workspace.projects-reader@1101.0.19(@pnpm/logger@1100.0.0)':
+  '@pnpm/workspace.projects-reader@1101.0.21(@pnpm/logger@1100.0.0)':
     dependencies:
-      '@pnpm/cli.utils': 1101.0.19(@pnpm/logger@1100.0.0)
+      '@pnpm/cli.utils': 1101.0.21(@pnpm/logger@1100.0.0)
       '@pnpm/constants': 1100.0.1
       '@pnpm/logger': 1100.0.0
-      '@pnpm/types': 1101.6.0
+      '@pnpm/types': 1101.8.0
       '@pnpm/util.lex-comparator': 4.0.1
-      '@pnpm/workspace.project-manifest-reader': 1100.0.20(@pnpm/logger@1100.0.0)
+      '@pnpm/workspace.project-manifest-reader': 1100.0.22(@pnpm/logger@1100.0.0)
       p-filter: 4.1.0
       tinyglobby: 0.2.17
 
-  '@pnpm/workspace.workspace-manifest-reader@1100.1.2':
+  '@pnpm/workspace.workspace-manifest-reader@1100.1.4':
     dependencies:
       '@pnpm/constants': 1100.0.1
       '@pnpm/error': 1100.1.0
-      '@pnpm/types': 1101.6.0
+      '@pnpm/types': 1101.8.0
       read-yaml-file: 3.0.0
 
   '@polka/url@1.0.0-next.29': {}
@@ -7916,7 +7915,7 @@ snapshots:
     dependencies:
       tinyexec: 1.2.4
 
-  '@release-it/conventional-changelog@12.0.0(conventional-commits-filter@6.0.1)(conventional-commits-parser@7.1.0)(release-it@21.0.0(@types/node@24.13.3)(magicast@0.5.3))':
+  '@release-it/conventional-changelog@12.0.0(conventional-commits-filter@6.0.1)(conventional-commits-parser@7.1.0)(release-it@21.0.1(@types/node@24.13.3)(magicast@0.5.3))':
     dependencies:
       '@conventional-changelog/git-client': 3.1.0(conventional-commits-filter@6.0.1)(conventional-commits-parser@7.1.0)
       concat-stream: 2.0.0
@@ -7924,7 +7923,7 @@ snapshots:
       conventional-changelog-angular: 9.2.1
       conventional-changelog-conventionalcommits: 10.2.1
       conventional-recommended-bump: 12.1.0
-      release-it: 21.0.0(@types/node@24.13.3)(magicast@0.5.3)(supports-color@8.1.1)
+      release-it: 21.0.1(@types/node@24.13.3)(magicast@0.5.3)
       semver: 7.8.5
     transitivePeerDependencies:
       - conventional-commits-filter
@@ -7933,73 +7932,73 @@ snapshots:
   '@rolldown/binding-android-arm64@1.1.4':
     optional: true
 
-  '@rolldown/binding-android-arm64@1.2.0':
+  '@rolldown/binding-android-arm64@1.2.3':
     optional: true
 
   '@rolldown/binding-darwin-arm64@1.1.4':
     optional: true
 
-  '@rolldown/binding-darwin-arm64@1.2.0':
+  '@rolldown/binding-darwin-arm64@1.2.3':
     optional: true
 
   '@rolldown/binding-darwin-x64@1.1.4':
     optional: true
 
-  '@rolldown/binding-darwin-x64@1.2.0':
+  '@rolldown/binding-darwin-x64@1.2.3':
     optional: true
 
   '@rolldown/binding-freebsd-x64@1.1.4':
     optional: true
 
-  '@rolldown/binding-freebsd-x64@1.2.0':
+  '@rolldown/binding-freebsd-x64@1.2.3':
     optional: true
 
   '@rolldown/binding-linux-arm-gnueabihf@1.1.4':
     optional: true
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.2.0':
+  '@rolldown/binding-linux-arm-gnueabihf@1.2.3':
     optional: true
 
   '@rolldown/binding-linux-arm64-gnu@1.1.4':
     optional: true
 
-  '@rolldown/binding-linux-arm64-gnu@1.2.0':
+  '@rolldown/binding-linux-arm64-gnu@1.2.3':
     optional: true
 
   '@rolldown/binding-linux-arm64-musl@1.1.4':
     optional: true
 
-  '@rolldown/binding-linux-arm64-musl@1.2.0':
+  '@rolldown/binding-linux-arm64-musl@1.2.3':
     optional: true
 
   '@rolldown/binding-linux-ppc64-gnu@1.1.4':
     optional: true
 
-  '@rolldown/binding-linux-ppc64-gnu@1.2.0':
+  '@rolldown/binding-linux-ppc64-gnu@1.2.3':
     optional: true
 
   '@rolldown/binding-linux-s390x-gnu@1.1.4':
     optional: true
 
-  '@rolldown/binding-linux-s390x-gnu@1.2.0':
+  '@rolldown/binding-linux-s390x-gnu@1.2.3':
     optional: true
 
   '@rolldown/binding-linux-x64-gnu@1.1.4':
     optional: true
 
-  '@rolldown/binding-linux-x64-gnu@1.2.0':
+  '@rolldown/binding-linux-x64-gnu@1.2.3':
     optional: true
 
   '@rolldown/binding-linux-x64-musl@1.1.4':
     optional: true
 
-  '@rolldown/binding-linux-x64-musl@1.2.0':
+  '@rolldown/binding-linux-x64-musl@1.2.3':
     optional: true
 
   '@rolldown/binding-openharmony-arm64@1.1.4':
     optional: true
 
-  '@rolldown/binding-openharmony-arm64@1.2.0':
+  '@rolldown/binding-openharmony-arm64@1.2.3':
     optional: true
 
   '@rolldown/binding-wasm32-wasi@1.1.4':
@@ -8009,23 +8008,16 @@ snapshots:
       '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
     optional: true
 
-  '@rolldown/binding-wasm32-wasi@1.2.0':
-    dependencies:
-      '@emnapi/core': 1.11.2
-      '@emnapi/runtime': 1.11.2
-      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
-    optional: true
-
   '@rolldown/binding-win32-arm64-msvc@1.1.4':
     optional: true
 
-  '@rolldown/binding-win32-arm64-msvc@1.2.0':
+  '@rolldown/binding-win32-arm64-msvc@1.2.3':
     optional: true
 
   '@rolldown/binding-win32-x64-msvc@1.1.4':
     optional: true
 
-  '@rolldown/binding-win32-x64-msvc@1.2.0':
+  '@rolldown/binding-win32-x64-msvc@1.2.3':
     optional: true
 
   '@rolldown/pluginutils@1.0.1': {}
@@ -8193,22 +8185,22 @@ snapshots:
       '@tufjs/canonical-json': 2.0.0
       minimatch: 10.2.5
 
-  '@turbo/darwin-64@2.10.7':
+  '@turbo/darwin-64@2.10.8':
     optional: true
 
-  '@turbo/darwin-arm64@2.10.7':
+  '@turbo/darwin-arm64@2.10.8':
     optional: true
 
-  '@turbo/linux-64@2.10.7':
+  '@turbo/linux-64@2.10.8':
     optional: true
 
-  '@turbo/linux-arm64@2.10.7':
+  '@turbo/linux-arm64@2.10.8':
     optional: true
 
-  '@turbo/windows-64@2.10.7':
+  '@turbo/windows-64@2.10.8':
     optional: true
 
-  '@turbo/windows-arm64@2.10.7':
+  '@turbo/windows-arm64@2.10.8':
     optional: true
 
   '@tybys/wasm-util@0.10.3':
@@ -8241,7 +8233,7 @@ snapshots:
 
   '@types/linkify-it@5.0.0': {}
 
-  '@types/lodash@4.17.24': {}
+  '@types/lodash@4.17.25': {}
 
   '@types/markdown-it@14.1.2':
     dependencies:
@@ -8405,11 +8397,11 @@ snapshots:
       vite: 8.1.3(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)
       vue: 3.5.40(typescript@7.0.2)
 
-  '@vitest/browser-playwright@4.1.10(playwright@1.62.0)(vite@8.1.3(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(vitest@4.1.10)':
+  '@vitest/browser-playwright@4.1.10(playwright@1.62.1)(vite@8.1.3(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(vitest@4.1.10)':
     dependencies:
       '@vitest/browser': 4.1.10(patch_hash=5d79da8178f159b23c7475d749ef63f29e9613181535363eb1697e7359f1e63f)(vite@8.1.3(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(vitest@4.1.10)
       '@vitest/mocker': 4.1.10(vite@8.1.3(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
-      playwright: 1.62.0
+      playwright: 1.62.1
       tinyrainbow: 3.1.0
       vitest: 4.1.10(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.1)(vite@8.1.3(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
     transitivePeerDependencies:
@@ -8547,7 +8539,7 @@ snapshots:
 
   '@vue/devtools-shared@8.1.5': {}
 
-  '@vue/language-core@3.3.8':
+  '@vue/language-core@3.3.9':
     dependencies:
       '@volar/language-core': 2.4.28
       '@vue/compiler-dom': 3.5.40
@@ -8594,7 +8586,7 @@ snapshots:
       '@vueuse/shared': 14.3.0(vue@3.5.40(typescript@7.0.2))
       vue: 3.5.40(typescript@7.0.2)
     optionalDependencies:
-      axios: 1.18.1(debug@4.4.3(supports-color@8.1.1))
+      axios: 1.18.1(debug@4.4.3)
       change-case: 5.4.4
       focus-trap: 8.2.2
 
@@ -8734,9 +8726,9 @@ snapshots:
 
   aws4@1.13.2: {}
 
-  axios@1.18.1(debug@4.4.3(supports-color@8.1.1)):
+  axios@1.18.1(debug@4.4.3):
     dependencies:
-      follow-redirects: 1.16.0(debug@4.4.3(supports-color@8.1.1))
+      follow-redirects: 1.16.0(debug@4.4.3)
       form-data: 4.0.6
       https-proxy-agent: 5.0.1
       proxy-from-env: 2.1.0
@@ -8850,6 +8842,8 @@ snapshots:
       supports-color: 7.2.0
 
   chalk@5.6.2: {}
+
+  chalk@6.0.0: {}
 
   change-case@5.4.4: {}
 
@@ -9325,11 +9319,11 @@ snapshots:
       yaml: 2.9.0
       yaml-eslint-parser: 2.1.0
 
-  eslint-plugin-turbo@2.10.7(eslint@10.8.0(jiti@2.7.0)(supports-color@8.1.1))(turbo@2.10.7):
+  eslint-plugin-turbo@2.10.8(eslint@10.8.0(jiti@2.7.0)(supports-color@8.1.1))(turbo@2.10.8):
     dependencies:
       dotenv: 16.0.3
       eslint: 10.8.0(jiti@2.7.0)(supports-color@8.1.1)
-      turbo: 2.10.7
+      turbo: 2.10.8
 
   eslint-scope@9.1.2:
     dependencies:
@@ -9578,7 +9572,7 @@ snapshots:
 
   focus-visible@5.2.1: {}
 
-  follow-redirects@1.16.0(debug@4.4.3(supports-color@8.1.1)):
+  follow-redirects@1.16.0(debug@4.4.3):
     optionalDependencies:
       debug: 4.4.3(supports-color@8.1.1)
 
@@ -9644,7 +9638,7 @@ snapshots:
       '@sec-ant/readable-stream': 0.4.1
       is-stream: 4.0.1
 
-  get-uri@8.0.1(supports-color@8.1.1):
+  get-uri@8.0.1:
     dependencies:
       basic-ftp: 5.3.1
       data-uri-to-buffer: 8.0.0
@@ -9770,7 +9764,7 @@ snapshots:
 
   http-cache-semantics@4.2.0: {}
 
-  http-proxy-agent@9.1.0(supports-color@8.1.1):
+  http-proxy-agent@9.1.0:
     dependencies:
       agent-base: 9.0.0
       debug: 4.4.3(supports-color@8.1.1)
@@ -9792,7 +9786,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  https-proxy-agent@9.1.0(supports-color@8.1.1):
+  https-proxy-agent@9.1.0:
     dependencies:
       agent-base: 9.0.0
       debug: 4.4.3(supports-color@8.1.1)
@@ -10634,13 +10628,13 @@ snapshots:
 
   p-map@7.0.5: {}
 
-  pac-proxy-agent@9.1.0(supports-color@8.1.1):
+  pac-proxy-agent@9.1.0:
     dependencies:
       agent-base: 9.0.0
       debug: 4.4.3(supports-color@8.1.1)
-      get-uri: 8.0.1(supports-color@8.1.1)
-      http-proxy-agent: 9.1.0(supports-color@8.1.1)
-      https-proxy-agent: 9.1.0(supports-color@8.1.1)
+      get-uri: 8.0.1
+      http-proxy-agent: 9.1.0
+      https-proxy-agent: 9.1.0
       pac-resolver: 9.0.1(quickjs-wasi@2.2.0)
       quickjs-wasi: 2.2.0
       socks-proxy-agent: 10.1.0
@@ -10757,11 +10751,11 @@ snapshots:
       exsolve: 1.1.0
       pathe: 2.0.3
 
-  playwright-core@1.62.0: {}
+  playwright-core@1.62.1: {}
 
-  playwright@1.62.0:
+  playwright@1.62.1:
     dependencies:
-      playwright-core: 1.62.0
+      playwright-core: 1.62.1
     optionalDependencies:
       fsevents: 2.3.2
 
@@ -10809,14 +10803,14 @@ snapshots:
 
   proxy-agent-negotiate@1.1.0: {}
 
-  proxy-agent@8.0.2(supports-color@8.1.1):
+  proxy-agent@8.0.2:
     dependencies:
       agent-base: 9.0.0
       debug: 4.4.3(supports-color@8.1.1)
-      http-proxy-agent: 9.1.0(supports-color@8.1.1)
-      https-proxy-agent: 9.1.0(supports-color@8.1.1)
+      http-proxy-agent: 9.1.0
+      https-proxy-agent: 9.1.0
       lru-cache: 7.18.3
-      pac-proxy-agent: 9.1.0(supports-color@8.1.1)
+      pac-proxy-agent: 9.1.0
       proxy-from-env: 2.1.0
       socks-proxy-agent: 10.1.0
     transitivePeerDependencies:
@@ -10884,7 +10878,7 @@ snapshots:
     dependencies:
       regex-utilities: 2.3.0
 
-  release-it@21.0.0(@types/node@24.13.3)(magicast@0.5.3)(supports-color@8.1.1):
+  release-it@21.0.1(@types/node@24.13.3)(magicast@0.5.3):
     dependencies:
       '@inquirer/prompts': 8.5.2(@types/node@24.13.3)
       '@octokit/rest': 22.0.1
@@ -10902,7 +10896,7 @@ snapshots:
       open: 11.0.0
       ora: 9.4.1
       os-name: 7.0.0
-      proxy-agent: 8.0.2(supports-color@8.1.1)
+      proxy-agent: 8.0.2
       semver: 7.8.5
       tinyglobby: 0.2.17
       undici: 7.28.0
@@ -10965,26 +10959,25 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.1.4
       '@rolldown/binding-win32-x64-msvc': 1.1.4
 
-  rolldown@1.2.0:
+  rolldown@1.2.3:
     dependencies:
-      '@oxc-project/types': 0.140.0
+      '@oxc-project/types': 0.143.0
       '@rolldown/pluginutils': 1.0.1
     optionalDependencies:
-      '@rolldown/binding-android-arm64': 1.2.0
-      '@rolldown/binding-darwin-arm64': 1.2.0
-      '@rolldown/binding-darwin-x64': 1.2.0
-      '@rolldown/binding-freebsd-x64': 1.2.0
-      '@rolldown/binding-linux-arm-gnueabihf': 1.2.0
-      '@rolldown/binding-linux-arm64-gnu': 1.2.0
-      '@rolldown/binding-linux-arm64-musl': 1.2.0
-      '@rolldown/binding-linux-ppc64-gnu': 1.2.0
-      '@rolldown/binding-linux-s390x-gnu': 1.2.0
-      '@rolldown/binding-linux-x64-gnu': 1.2.0
-      '@rolldown/binding-linux-x64-musl': 1.2.0
-      '@rolldown/binding-openharmony-arm64': 1.2.0
-      '@rolldown/binding-wasm32-wasi': 1.2.0
-      '@rolldown/binding-win32-arm64-msvc': 1.2.0
-      '@rolldown/binding-win32-x64-msvc': 1.2.0
+      '@rolldown/binding-android-arm64': 1.2.3
+      '@rolldown/binding-darwin-arm64': 1.2.3
+      '@rolldown/binding-darwin-x64': 1.2.3
+      '@rolldown/binding-freebsd-x64': 1.2.3
+      '@rolldown/binding-linux-arm-gnueabihf': 1.2.3
+      '@rolldown/binding-linux-arm64-gnu': 1.2.3
+      '@rolldown/binding-linux-arm64-musl': 1.2.3
+      '@rolldown/binding-linux-ppc64-gnu': 1.2.3
+      '@rolldown/binding-linux-s390x-gnu': 1.2.3
+      '@rolldown/binding-linux-x64-gnu': 1.2.3
+      '@rolldown/binding-linux-x64-musl': 1.2.3
+      '@rolldown/binding-openharmony-arm64': 1.2.3
+      '@rolldown/binding-win32-arm64-msvc': 1.2.3
+      '@rolldown/binding-win32-x64-msvc': 1.2.3
 
   rs-module-lexer@2.8.0:
     optionalDependencies:
@@ -11214,7 +11207,7 @@ snapshots:
 
   stackback@0.0.2: {}
 
-  start-server-and-test@3.0.11(supports-color@8.1.1):
+  start-server-and-test@3.0.12:
     dependencies:
       arg: 5.0.2
       check-more-types: 2.24.0
@@ -11222,7 +11215,7 @@ snapshots:
       execa: 5.1.1
       lazy-ass: 2.0.3
       tree-kill: 1.2.2
-      wait-on: 9.0.10(debug@4.4.3(supports-color@8.1.1))
+      wait-on: 9.1.0(debug@4.4.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -11351,14 +11344,14 @@ snapshots:
 
   tunnel@0.0.6: {}
 
-  turbo@2.10.7:
+  turbo@2.10.8:
     optionalDependencies:
-      '@turbo/darwin-64': 2.10.7
-      '@turbo/darwin-arm64': 2.10.7
-      '@turbo/linux-64': 2.10.7
-      '@turbo/linux-arm64': 2.10.7
-      '@turbo/windows-64': 2.10.7
-      '@turbo/windows-arm64': 2.10.7
+      '@turbo/darwin-64': 2.10.8
+      '@turbo/darwin-arm64': 2.10.8
+      '@turbo/linux-64': 2.10.8
+      '@turbo/linux-arm64': 2.10.8
+      '@turbo/windows-64': 2.10.8
+      '@turbo/windows-arm64': 2.10.8
 
   tweetnacl@0.14.5: {}
 
@@ -11517,7 +11510,7 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite-plugin-checker@0.14.5(eslint@10.8.0(jiti@2.7.0))(meow@13.2.0)(optionator@0.9.4)(oxlint@1.76.0(oxlint-tsgolint@7.0.2001))(typescript@7.0.2)(vite@8.1.3(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(vue-tsc@3.3.8(typescript@7.0.2)):
+  vite-plugin-checker@0.14.5(eslint@10.8.0(jiti@2.7.0))(meow@13.2.0)(optionator@0.9.4)(oxlint@1.76.0(oxlint-tsgolint@7.0.2001))(typescript@7.0.2)(vite@8.1.3(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(vue-tsc@3.3.9(typescript@7.0.2)):
     dependencies:
       '@babel/code-frame': 7.29.7
       chokidar: 5.0.0
@@ -11533,7 +11526,7 @@ snapshots:
       optionator: 0.9.4
       oxlint: 1.76.0(oxlint-tsgolint@7.0.2001)
       typescript: 7.0.2
-      vue-tsc: 3.3.8(typescript@7.0.2)
+      vue-tsc: 3.3.9(typescript@7.0.2)
 
   vite-plugin-static-copy@4.1.1(vite@8.1.3(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)):
     dependencies:
@@ -11644,7 +11637,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.13.3
-      '@vitest/browser-playwright': 4.1.10(playwright@1.62.0)(vite@8.1.3(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(vitest@4.1.10)
+      '@vitest/browser-playwright': 4.1.10(playwright@1.62.1)(vite@8.1.3(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(vitest@4.1.10)
       '@vitest/coverage-v8': 4.1.10(@vitest/browser@4.1.10)(vitest@4.1.10)
       happy-dom: 20.11.1
     transitivePeerDependencies:
@@ -11652,16 +11645,16 @@ snapshots:
 
   vscode-uri@3.1.0: {}
 
-  vue-tsc@3.3.8(typescript@6.0.3):
+  vue-tsc@3.3.9(typescript@6.0.3):
     dependencies:
       '@volar/typescript': 2.4.28
-      '@vue/language-core': 3.3.8
+      '@vue/language-core': 3.3.9
       typescript: 6.0.3
 
-  vue-tsc@3.3.8(typescript@7.0.2):
+  vue-tsc@3.3.9(typescript@7.0.2):
     dependencies:
       '@volar/typescript': 2.4.28
-      '@vue/language-core': 3.3.8
+      '@vue/language-core': 3.3.9
       typescript: 7.0.2
     optional: true
 
@@ -11675,9 +11668,9 @@ snapshots:
     optionalDependencies:
       typescript: 7.0.2
 
-  wait-on@9.0.10(debug@4.4.3(supports-color@8.1.1)):
+  wait-on@9.1.0(debug@4.4.3):
     dependencies:
-      axios: 1.18.1(debug@4.4.3(supports-color@8.1.1))
+      axios: 1.18.1(debug@4.4.3)
       joi: 18.2.3
       lodash: 4.18.1
       minimist: 1.2.8

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -17,14 +17,14 @@ catalog:
   '@commitlint/types': ^21.2.0
   '@custom-elements-manifest/analyzer': ^0.11.0
   '@pnpm/logger': 1100.0.0
-  '@pnpm/types': 1101.6.0
-  '@pnpm/workspace.project-manifest-reader': 1100.0.20
-  '@pnpm/workspace.projects-reader': 1101.0.19
-  '@pnpm/workspace.workspace-manifest-reader': 1100.1.2
+  '@pnpm/types': 1101.8.0
+  '@pnpm/workspace.project-manifest-reader': 1100.0.22
+  '@pnpm/workspace.projects-reader': 1101.0.21
+  '@pnpm/workspace.workspace-manifest-reader': 1100.1.4
   '@release-it/conventional-changelog': ^12.0.0
   '@spectrum-web-components/icons-workflow': ^1.12.2
   '@types/dom-navigation': ^1.0.7
-  '@types/lodash': ^4.17.24
+  '@types/lodash': ^4.17.25
   '@types/node': ^24.13.3
   '@types/pacote': ^11.1.8
   '@uirouter/core': ^6.1.2
@@ -42,7 +42,7 @@ catalog:
   eslint-plugin-oxlint: ^1.76.0
   eslint-plugin-package-json: ^1.6.2
   eslint-plugin-pnpm: ^1.7.0
-  eslint-plugin-turbo: ^2.10.7
+  eslint-plugin-turbo: ^2.10.8
   happy-dom: ^20.11.1
   hono: ^4.12.32
   husky: ^9.1.7
@@ -57,14 +57,14 @@ catalog:
   oxlint: 1.76.0
   oxlint-tsgolint: 7.0.2001
   pacote: ^22.0.0
-  playwright: ^1.62.0
+  playwright: ^1.62.1
   publint: ^0.3.22
-  release-it: ^21.0.0
+  release-it: ^21.0.1
   rimraf: ^6.1.3
-  rolldown: ^1.2.0
+  rolldown: ^1.2.2
   screenfull: ^6.0.2
-  start-server-and-test: ^3.0.11
-  turbo: ^2.10.7
+  start-server-and-test: ^3.0.12
+  turbo: ^2.10.8
   typedoc: ^0.28.20
   typedoc-plugin-markdown: ^4.12.0
   typedoc-vitepress-theme: ^1.1.3
@@ -79,7 +79,7 @@ catalog:
   vitepress: ^2.0.0-alpha.18
   vitest: ^4.1.10
   vue: ^3.5.40
-  vue-tsc: ^3.3.8
+  vue-tsc: ^3.3.9
   wrangler: 4.113.0
 
 catalogMode: prefer


### PR DESCRIPTION
Ship-inert dev-tooling slice carved out of Dependabot #513. Nothing here reaches a published tarball — these are build, test, lint, and release tools only.

Deliberately **not** in this PR (they belong to sibling slices): `hono`, `oxc-minify`, `oxc-transform`, `oxc-project-runtime`, `publishedDependencies`, `mobx`, `vitepress`, `wrangler`.

## Moves

All in the `pnpm-workspace.yaml` `catalog:` block.

| package | from | to |
| --- | --- | --- |
| `@types/lodash` | `^4.17.24` | `^4.17.25` |
| `eslint-plugin-turbo` | `^2.10.7` | `^2.10.8` |
| `turbo` | `^2.10.7` | `^2.10.8` |
| `playwright` | `^1.62.0` | `^1.62.1` |
| `release-it` | `^21.0.0` | `^21.0.1` |
| `rolldown` | `^1.2.0` | `^1.2.2` |
| `start-server-and-test` | `^3.0.11` | `^3.0.12` |
| `vue-tsc` | `^3.3.8` | `^3.3.9` |
| `@pnpm/types` | `1101.6.0` | `1101.8.0` |
| `@pnpm/workspace.project-manifest-reader` | `1100.0.20` | `1100.0.22` |
| `@pnpm/workspace.projects-reader` | `1101.0.19` | `1101.0.21` |
| `@pnpm/workspace.workspace-manifest-reader` | `1100.1.2` | `1100.1.4` |

`turbo` and `eslint-plugin-turbo` move together — the plugin peers on `turbo`.

The pnpm workspace SDK quartet stays **exact-pinned** (no caret) by design.

## pnpm SDK tarball verification (pnpm/pnpm#13185)

A run of `@pnpm/*` releases around 2026-07-16 shipped tarballs containing only `lib/index.js`, with the rest of the closure missing. Each of the four new tarballs was `npm pack`ed and its file list diffed against the currently-pinned version. **All four file lists are identical to the versions they replace** — no truncation:

- `@pnpm/types@1101.8.0` — 20 entries incl. `lib/config`, `lib/misc`, `lib/options`, `lib/package`, `lib/peerDependencyIssues`, `lib/project`, `lib/versioning` (+ `.d.ts` for each). `diff` vs `1101.6.0`: identical.
- `@pnpm/workspace.project-manifest-reader@1100.0.22` — 8 entries incl. `lib/readFile.{js,d.ts}`. `diff` vs `1100.0.20`: identical.
- `@pnpm/workspace.projects-reader@1101.0.21` — 8 entries incl. `lib/findPackages.{js,d.ts}`. `diff` vs `1101.0.19`: identical.
- `@pnpm/workspace.workspace-manifest-reader@1100.1.4` — 12 entries incl. `lib/catalogs.{js,d.ts}`, `lib/errors/InvalidWorkspaceManifestError.{js,d.ts}`, `lib/versioning.{js,d.ts}`. `diff` vs `1100.1.2`: identical.

The installed closure was then actually imported in node from the packages that consume it, and each module exported its full surface:

```
# from tools/shared
projects-reader: findPackages,findWorkspaceProjects,findWorkspaceProjectsNoCheck
wm-reader:       readWorkspaceManifest,validateWorkspaceManifest
# from tools/release
pm-reader:       readExactProjectManifest,readProjectManifest,readProjectManifestOnly,
                 safeReadProjectManifestOnly,tryReadProjectManifest
types:           loaded (object)
```

Nothing was dropped from the batch.

## Peers check

Auto-peers do not re-resolve when a peer range moves (this is what forced the `@pnpm/logger` declaration in #485), so this was checked explicitly after install:

```
$ corepack pnpm peers check
No peer dependency issues found
```

No new peer declarations were needed.

## Verification

```
$ mise run setup                      # clean, pnpm v11.10.0
$ corepack pnpm peers check           # No peer dependency issues found
$ turbo run build test lint typecheck format:check --filter=!sample-app-lit-e2e
  Tasks: 117 successful, 117 total
```

The turbo task graph resolves correctly under `turbo` 2.10.8 (117 tasks discovered and ordered; `turbo.json` untouched), and `vue-tsc` 3.3.9 typechecks the docs site as part of that run.

`release-it` 21.0.1 still loads `.release-it.js` and its pinned conventional-changelog preset — `--changelog` dry run on `packages/lit-ui-router` rendered the commit list correctly against the `lit-ui-router@*` tag match.

**e2e was left to CI rather than run locally.** A first pass ran the full graph including `sample-app-lit-e2e` (120/121 tasks green); the e2e task failed on `Address already in use (127.0.0.1:8787)` — `wrangler dev` never bound, so all four Cypress suites hit `ECONNREFUSED`. That is environmental, not a regression from these bumps. The rerun was cut short to free up the machine, so CI owns the e2e signal on this PR.

`patches/@vitest__browser.patch` is untouched and unaffected — `vitest` is not moving in this PR, so the content-hashed bundle target still matches.
