### PR TITLE
feat(docs): enable VitePress local search on lit-ui-router.dev

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -187,6 +187,16 @@ const config = {
   },
   themeConfig: {
     logo: '/images/lit-ui-router.svg',
+    search: {
+      // `config` is an un-annotated literal, so without `as const` the provider
+      // widens to `string` and the discriminated union rejects it at defineConfig.
+      provider: 'local' as const,
+      options: {
+        // API pages are reference tables; the excerpt is what makes a hit
+        // readable, so show it rather than the heading alone.
+        detailedView: true,
+      },
+    },
     nav: [
       { text: 'Home', link: '/' },
       {


### PR DESCRIPTION
## Evaluation: should lit-ui-router.dev have search?

**Recommendation: yes — VitePress local search.** Landed here as a 10-line config change.

> ⚠️ `docs/` **is** the production site. `docs/dist` deploys to https://lit-ui-router.dev via Cloudflare Workers Builds directly on merge to main — no staging, no separate deploy workflow. Merging this ships it.

---

## 1. The current state, confirmed

`docs/.vitepress/config.ts` had no `themeConfig.search` key at all. The nav renders:

```html
<div class="VPNavBarSearch search" data-v-5500ca23 data-v-0d243e36><!----></div>
```

An empty flex container. Reading `vitepress/dist/client/theme-default/components/VPNavBarSearch.vue` explains why — the component is mounted unconditionally, but:

```js
const provider = __ALGOLIA__ ? 'algolia' : __VP_LOCAL_SEARCH__ ? 'local' : ''
```

With no provider configured both `v-if` branches are false, so **no button is rendered at all**. This is stock VitePress default behaviour, not a half-finished configuration — worth stating precisely, because the framing that prompted this was "a search affordance that does nothing when clicked." There was nothing to click. The visible symptom was an unexplained gap in the nav bar.

### Does `@docsearch/*` weight actually ship? **No.**

`@docsearch/css`, `@docsearch/js` and `@docsearch/sidepanel-js` (4.6.3) are in `node_modules` as **VitePress's own dependencies** — not ours, nothing in `docs/package.json` references them. `__ALGOLIA__` and `__VP_LOCAL_SEARCH__` are build-time defines, so Rollup drops both branches entirely.

Measured by grepping every file in `docs/dist`:

| | baseline | with local search |
|---|---|---|
| files containing `docsearch`/`DocSearch` | **0** | **0** |
| files containing `minisearch` | **0** | **1** (the lazy search-box chunk only) |

So the premise "the site carries DocSearch weight it never uses" **does not hold for shipped bytes** — the weight is install-time only, and it is not ours to remove.

### That eliminates option 3

"Remove the dead weight" is not an available option. There is no dead weight in the bundle, and `@docsearch/*` are transitive deps of `vitepress` — removing them would mean patching or forking VitePress to save zero shipped bytes. Not worth considering.

---

## 2. Measured cost of local search

Built both ways with `turbo run build --filter=docs...`.

### Whole-site totals

| | files | total bytes | HTML pages |
|---|---|---|---|
| baseline | 555 | 16,119,039 | 131 |
| local search | 557 | 16,513,947 | 131 |
| **delta** | **+2** | **+394,908** | — |

### The two new chunks — both lazy

| chunk | raw | gzip | when fetched |
|---|---|---|---|
| `assets/chunks/@localSearchIndexroot.BdO3amkL.js` | 303,474 B | 64,951 B | on first search-modal open |
| `assets/chunks/VPLocalSearchBox.DuWefIiI.js` | 61,884 B | 21,083 B | on first search-modal open |

`VPLocalSearchBox` is a `defineAsyncComponent`, and the index is imported from inside it — neither appears in any `<link rel="modulepreload">`. Confirmed against `index.html`, which preloads only `theme`, `framework` and the page chunk.

### The eager cost — what every visitor actually pays

| eager chunk | baseline | after | Δ raw | Δ gzip |
|---|---|---|---|---|
| `chunks/theme.*.js` | 88,071 | 88,487 | +416 | +476 |
| `chunks/framework.*.js` | 103,664 | 110,970 | +7,306 | +2,721 |
| **total critical path** | | | **+7,722 B** | **+3,197 B** |

The `framework` growth is Vue's **`Teleport`** runtime becoming reachable (the search modal teleports to `body`) — `Teleport` occurrences go 1 → 3 in that chunk. It is not the search code itself.

**~3.2 kB gzip on the critical path** is the honest per-visitor bundle/perf cost. The 86 kB gzip of index + search UI is paid only by visitors who actually open search.

---

## 3. How well does it index the typedoc-generated API pages?

This was the real risk: 103 of 121 source `.md` files are typedoc output, and typedoc pages are dense reference tables with boilerplate headings, structurally unlike prose.

Parsed the generated index directly:

- **592 documents** indexed (VitePress splits each page per heading)
- **453 (76.5%) come from `/api/*`**, 139 from prose
- Indexed fields: `title`, `titles`, `text`; only `title` + `titles` are stored
- **226 documents (38.2%) have a structurally meaningless title** — `Returns`, `Parameters`, `Type Parameters`, `Implements`, `Constructor`, `Returns-1`, …

That 38% looked disqualifying until I checked the `titles` breadcrumb stored alongside each one:

```
/api/lit-ui-router-mobx/classes/ReactionController#parameters
  titles = ["Class: ReactionController<T>", "Constructors", "Constructor"]
  title  = "Parameters"
```

VitePress renders that chain above the title, so the boilerplate heading arrives fully contextualised as `Class: ReactionController<T> › Constructors › Constructor › Parameters`. The `text` field still carries the actual member names, so searching a property name matches the table body.

### Verdict on tuning: **defaults are good enough to ship, with named follow-ups**

Browser testing (§6) bore the prediction out — every symbol query put the exact API page at rank 1 or 2, and generated boilerplate does **not** drown the results. But it also surfaced three real rough edges that all originate in the typedoc pages; they are itemised honestly in §7 rather than buried.

I am not adding `_render` customization or index exclusions **in this PR**:

- Excluding the API pages would drop 76% of the corpus, including the highest-value lookups (finding a component's props) — and the measured ranking shows those lookups work.
- A custom `_render` must be maintained against `typedoc-vitepress-theme`'s output and is exactly the custom-over-standard this repo disprefers. It should be justified by the specific defects in §7, sized against them, and reviewed on its own — not smuggled in alongside the decision to have search at all.

The only option set is `detailedView: true`, so hits show a content excerpt rather than a bare heading — which is what makes a reference-table hit readable.

---

## 4. Cloudflare Workers Builds deploy path: non-issue, confirmed

Checked `wrangler.jsonc`. `docs/dist` is served wholesale as static assets, and `run_worker_first` lists only the sample-app and 404-exhibit prefixes. Both new chunks land under `/assets/chunks/` — ordinary hashed assets, no worker code path, no config change.

Verified they serve over HTTP from a `vitepress preview` of the built `dist`:

```
index asset: 200 size=303474
searchbox:   200 size=61884
```

Also well inside Workers static-asset limits (25 MiB/file, 20,000 files — we ship 557 files, largest new one 303 kB).

Because the index is generated from the same build that produces the HTML, **it can never drift from the deployed site**, and it works identically in preview builds and offline.

---

## 5. Why not Algolia DocSearch

Not recommended — and explicitly *not* rejected on effort grounds, but because it is worse for this site on the axis that matters.

**The application is a real gate.** DocSearch is free for OSS docs but requires applying through the Algolia dashboard, automated domain validation, manual review of 1–2 business days when validation is inconclusive, and domain-ownership verification within 7 days of approval. In exchange you must keep the "Search by Algolia" branding next to results.

**Ongoing burden:**
- A crawler that must stay healthy and be re-run; the index is rebuilt out-of-band with deploys, so **the index lags the site**. Every merge here goes live immediately, but search results would only catch up on the next crawl. For a docs site whose API reference regenerates from source on every release, a stale index is a real correctness problem.
- Preview and local builds would search the **production** index — wrong results for unmerged content.
- A runtime dependency on a third-party service: search breaks if Algolia is down or the account lapses.

**On the credentials angle** — honestly, this is weaker than it first appears. The DocSearch `apiKey` is a search-only key that is *designed* to be public and ships in the client bundle, so the gitignored-mise-dotenv pattern used for `TURBO_TOKEN` would not be needed for it. Only crawler-admin credentials would be secret, and those live in Algolia's dashboard, not this repo. I am not going to inflate a secrets-management argument that does not exist.

**What would justify it:** corpus size where minisearch's in-browser index becomes impractical, cross-version/multi-locale search, or analytics on search queries. At 592 documents and 65 kB gzip, none of those apply.

**The dependency being present is not an argument for using it.** It arrives via VitePress regardless of provider and costs zero shipped bytes either way.

---

## 6. Verification

### Checks — all green

`turbo run typecheck lint format:check --filter=docs`

```
docs:lint             Found 0 warnings and 0 errors.
docs:format:check     All matched files use the correct format.
docs:typecheck        tsc -p tsconfig.json --noEmit
docs:typecheck:vue    vue-check docs/tsconfig.vue.json
docs:typecheck:worker tsc -p worker/tsconfig.json --noEmit
docs:typecheck:worker:tests  tsc -p worker/test/tsconfig.json --noEmit

Tasks:    31 successful, 31 total
```

### Browser — verified

Built `docs/dist`, served it with `vitepress preview`, and drove Playwright/chromium 1.62 against the static preview on `localhost:4183`: 10 queries, 4 click-throughs, both themes, at 1440px and mobile 390×780.

**Opening it.** The nav renders `.VPNavBarSearchButton` (`aria-keyshortcuts="/ control+k meta+k"`) where the baseline had the empty `<div>`. All four open paths work — click, `/`, `Meta+K`, `Control+K` — focus lands on `#localsearch-input`, `Escape` closes.

**Ranking on generated API pages — the thing that was actually at risk.** Every symbol query put the exact API page at rank 1 or 2:

| query | result |
|---|---|
| `UiView` | `/api/reference/components/UiView` **#1**; all 5 hits API pages |
| `uiRouter` | `Class: UIRouterLit` **#1** |
| `mergeSearch` | `Function: mergeSearch()` **#1** |
| `ReactionController` | prose #1, API class #2 |
| `route guards` | all 5 hits the correct guide |
| `transition` | `TransitionController#transition` #1, `/guides/route-guards` #2 — see §7.1 |

Generated boilerplate does **not** drown the results. The breadcrumb contextualisation works as predicted.

**Navigation.** All 4 click-throughs landed on the correct URL with the fragment target present and scrolled to the sticky-header offset (`targetTop 88`).

**`detailedView`** genuinely renders formatted markdown excerpts — prose, syntax-highlighted code blocks, symbol lists, `<mark>` highlighting. Excerpt lengths ranged 21–2381 chars.

**Themes.** Modal text `rgb(60,60,67)` light / `rgb(223,223,214)` dark; `<mark>` inverts appropriately. No invisible text, no clipping, no horizontal overflow at either 1440px or 390px.

**Zero console errors, zero warnings, zero failed requests** across the whole session.

**Laziness confirmed by measurement.** After full load + `networkidle` + 2s idle with the modal never opened: **zero requests** for `@localSearchIndexroot.*.js`. It is fetched only on first modal open, alongside `VPLocalSearchBox.*.js` — 303,474 B + 61,884 B, so **first-open cost ≈ 365 KB uncompressed**.

### What is not verified

- **Compressed transfer size.** The static preview served uncompressed, so the on-the-wire number was not measurable. The gzip figures in §2 are `gzip -c` over the built files — a reasonable proxy for what Cloudflare would serve, but not an observed transfer size.
- **Behaviour on the deployed Workers site.** Verified only by static reasoning over `wrangler.jsonc` plus HTTP serving from a local preview. Nothing was deployed.
- Index coverage of pages never queried; i18n variants; the modal's detailed-view toggle button.
- No e2e suite was run locally (deliberately — left to CI).

---

## 7. Known weaknesses — measured, not hypothetical

These are real and reviewers should weigh them. All four originate in the typedoc-generated pages.

**7.1 Empty-excerpt hits at rank 1.** `transition` — plausibly the single most likely real-user query — returns `/api/reference/controllers/TransitionController#transition` at **rank 1 with a 0-character excerpt**: a bare breadcrumb row with a blank body, while the genuinely useful `/guides/route-guards` sits at #2. `/api/navigation-location-plugin/` does the same. Under `detailedView: true` these read as a half-broken feature. This is the most visible defect in the change.

**7.2 Same-page sub-section stacking.** `ReactionController` spent 3 of 5 result slots on sections of one page, including a `Constructor › Returns` row with a 21-character excerpt. VitePress local search has **no per-page result cap**, so a heading-dense generated page can crowd out other pages.

**7.3 `ui-view` and `UiView` return disjoint result sets.** Typing the custom-element tag name never reaches the API class page. This is MiniSearch tokenization, not a config bug — but it is a genuine discoverability gap for a router library whose public surface *is* custom elements, where the tag name is exactly what a user would type.

**7.4 `lazyLoad`** returns one prose hit and no API page. Not investigated whether the symbol exists in the typedoc output at all.

### Follow-up lever

7.1–7.3 are all fixable from the same place: a `_render` customization, or excluding empty generated sub-sections from the index. **Deliberately not done here** — it should be sized against these specific defects and reviewed on its own, not bundled with the decision to have search at all.

**These weaknesses do not change the recommendation.** The alternative to shipping this is no search, which is strictly worse than search with three known rough edges — and none of them are regressions, since there is nothing to regress from.

---

## The change

```ts
search: {
  // `config` is an un-annotated literal, so without `as const` the provider
  // widens to `string` and the discriminated union rejects it at defineConfig.
  provider: 'local' as const,
  options: {
    // API pages are reference tables; the excerpt is what makes a hit
    // readable, so show it rather than the heading alone.
    detailedView: true,
  },
},
```

The `as const` is load-bearing — verified by removing it and re-running `tsc`, which fails with `TS2345: Type 'string' is not assignable to type '"algolia"'`.

No new dependencies, no lockfile change, no catalog entry, no secrets, no workflow change.
