### PR TITLE
fix(docs): resolve [[Symbol]] links on accessors and function-type params

### DIFF
--- a/tools/typedoc-plugin-lit-ui-router/README.md
+++ b/tools/typedoc-plugin-lit-ui-router/README.md
@@ -69,22 +69,21 @@ Add custom symbol mappings in your `typedoc.json`:
 ```json
 {
   "externalSymbolLinkMappings": {
-    "CustomType": {
-      "": "https://example.com/docs/customtype.html"
+    "@uirouter/core": {
+      "CustomType": "https://example.com/docs/customtype.html"
     }
   }
 }
 ```
 
+TypeDoc's own `{ package: { symbol: url } }` shape and the legacy
+`{ symbol: { "": url } }` shape both feed `[[SymbolName]]` resolution.
+
 ## Unknown Symbols
 
-Symbols not in the predefined map or custom mappings are logged as warnings and linked to local anchors:
-
-```bash
-[typedoc-plugin-lit-ui-router] Unknown symbol: [[MyCustomType]]
-```
-
-This generates: `{@link #mycustomtype | MyCustomType}`
+A symbol in neither the predefined map, the custom mappings, nor the local
+symbol pages renders as bare text — the `[[…]]` brackets are stripped but no
+link is emitted.
 
 ## URL Templates
 

--- a/tools/typedoc-plugin-lit-ui-router/src/index.ts
+++ b/tools/typedoc-plugin-lit-ui-router/src/index.ts
@@ -13,6 +13,7 @@ import {
   Context,
   DeclarationReflection,
   Reflection,
+  ReflectionKind,
   Comment,
   CommentTag,
   RendererEvent,
@@ -175,6 +176,28 @@ function buildExternalSymbolMappings(
   }
 
   return mappings;
+}
+
+/**
+ * Flatten an `externalSymbolLinkMappings` map to `symbolName -> url`.
+ *
+ * Two shapes land in that option: TypeDoc's own `{ package: { symbol: url } }`
+ * (what `typedoc.json` declares) and this plugin's `{ symbol: { '': url } }`.
+ * Both feed `[[SymbolName]]` resolution, which is keyed by symbol alone.
+ */
+function flattenExternalSymbolMappings(
+  mappings: Record<string, Record<string, string>>,
+): Record<string, string> {
+  const flat: Record<string, string> = {};
+
+  for (const [outer, entries] of Object.entries(mappings)) {
+    for (const [inner, url] of Object.entries(entries)) {
+      if (!url || inner === '*') continue;
+      flat[inner === '' ? outer : inner] = url;
+    }
+  }
+
+  return flat;
 }
 
 /**
@@ -524,36 +547,21 @@ function linkReflectionTypes(
 function handleSymbolLinks(context: Context, app: Application): void {
   const customMappings =
     app.options.getValue('externalSymbolLinkMappings') || {};
-  const symbolMap: Record<string, string> = { ...EXTERNAL_SYMBOLS };
-
-  for (const key in customMappings) {
-    symbolMap[key] = customMappings[key][''] || '';
-  }
-
-  const visitReflection = (reflection: Reflection): void => {
-    if (reflection instanceof DeclarationReflection && reflection.signatures) {
-      for (const sig of reflection.signatures) {
-        if (sig.comment) {
-          processComment(sig.comment, symbolMap);
-        }
-      }
-    }
-
-    if (reflection instanceof DeclarationReflection && reflection.comment) {
-      processComment(reflection.comment, symbolMap);
-    }
-
-    if ('children' in reflection) {
-      const withChildren = reflection as { children?: Reflection[] };
-      if (withChildren.children) {
-        for (const child of withChildren.children) {
-          visitReflection(child);
-        }
-      }
-    }
+  const symbolMap: Record<string, string> = {
+    ...EXTERNAL_SYMBOLS,
+    ...flattenExternalSymbolMappings(customMappings),
   };
 
-  visitReflection(context.project);
+  // The project registry holds every reflection, including the ones a
+  // children-only walk misses: accessor get/set signatures, parameters, and
+  // the signatures hanging off a function type alias's declaration.
+  for (const reflection of context.project.getReflectionsByKind(
+    ReflectionKind.All,
+  )) {
+    if (reflection.comment) {
+      processComment(reflection.comment, symbolMap);
+    }
+  }
 }
 
 /**


### PR DESCRIPTION
`[[SymbolName]]` was rendering literally on the live docs — [TransitionController](https://lit-ui-router.dev/api/reference/controllers/TransitionController) and [TransitionCallback](https://lit-ui-router.dev/api/reference/controllers/TransitionCallback), 7 occurrences. Two causes in `@tools/typedoc-plugin-lit-ui-router`, the plugin that converts the shorthand to links.

## 1. Traversal gap

`handleSymbolLinks` walked `reflection.comment` + `reflection.signatures[].comment`, recursing only through `children`. That never reaches:

- **accessor comments** — TypeDoc parks those on `getSignature`/`setSignature`, not `signatures`. Every leak on the `TransitionController` page was a getter: `router`, `globals`, `current`, `transition`.
- **parameter comments on a function type alias** — those hang off `type.declaration.signatures[].parameters`, which `children` doesn't cover. Both `TransitionCallback` leaks.

Methods worked (`includes()` has real `signatures`), which is why this went unnoticed.

Replaced the bespoke walk with `project.getReflectionsByKind(ReflectionKind.All)` — the registry holds every reflection, including the shapes above. Re-processing is idempotent: once `[[X]]` becomes an anchor the regex no longer matches.

## 2. Custom-mapping shape mismatch

The merge read `customMappings[key]['']`, which only understands the plugin's own `{ symbol: { '': url } }` shape. Each package's `typedoc.json` declares TypeDoc's `{ package: { symbol: url } }` shape, so all 17 entries collapsed to a single `''` key.

Symbols also present in the plugin's built-in `EXTERNAL_SYMBOLS` (`UIRouter`, `Transition`, `StateDeclaration`) still linked, masking the bug. `UIRouterGlobals` is declared **only** in `typedoc.json` — with fix 1 alone it went from `[[UIRouterGlobals]]` to bare unlinked text, trading a loud leak for a silent one. `flattenExternalSymbolMappings` now accepts both shapes.

## Verification

- Zero `[[…]]` remain in `docs/**/*.md` or `docs/dist/**/*.html` after `turbo run docs:api`.
- Swept rendered output for adjacent literal-leak classes — raw `{@link}`, `{@inheritDoc}`, `{@label}`, `{@include}`, stray block tags in prose: none.
- Audited every `[[X]]` in `packages/*/src` **per package**, against that package's own resolvable set (built-ins + its `typedoc.json` + local pages): no symbol renders as bare text, no `[[…]]` form the regex can't match, and no cross-package refs from the other three packages into `lit-ui-router`'s local page paths.
- `lint`, `typecheck`, `format:check` green.

Generated docs (`docs/api/*`, `docs/dist`) are gitignored, so the diff is the plugin only. README updated: the Custom Symbols example showed the shape that didn't work, and Unknown Symbols claimed a warning + anchor fallback the code never emitted.
