### PR TITLE
refactor(navigation-location-plugin): seam the Navigation API and test it for real

### DIFF
--- a/packages/navigation-location-plugin/package.json
+++ b/packages/navigation-location-plugin/package.json
@@ -51,8 +51,8 @@
     "format": "oxfmt \"**/*.{ts,js,json,md}\"",
     "format:check": "oxfmt --check \"**/*.{ts,js,json,md}\"",
     "lint": "oxlint .",
-    "test": "VITEST_BROWSER_API_PORT=63340 vitest run --browser=chromium",
-    "test:coverage": "VITEST_BROWSER_API_PORT=63345 vitest run --coverage --browser=chromium",
+    "test": "VITEST_BROWSER_API_PORT=63340 vitest run --project=node --project=happy-dom --project=chrome",
+    "test:coverage": "VITEST_BROWSER_API_PORT=63345 vitest run --coverage --project=node --project=happy-dom --project=chrome",
     "test:engines": "VITEST_BROWSER_API_PORT=63341 vitest run --project=firefox --project=safari",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "typecheck:src": "tsc -p tsconfig.src.json --noEmit"
@@ -68,6 +68,7 @@
     "@uirouter/core": "catalog:",
     "@vitest/browser-playwright": "catalog:",
     "@vitest/coverage-v8": "catalog:",
+    "happy-dom": "catalog:",
     "oxfmt": "catalog:",
     "playwright": "catalog:",
     "release-it": "catalog:",

--- a/packages/navigation-location-plugin/src/index.ts
+++ b/packages/navigation-location-plugin/src/index.ts
@@ -40,6 +40,28 @@ export function isUIRouterNavigateEvent(
 }
 
 /**
+ * Composes the absolute URL handed to `navigation.navigate()` from a
+ * router-relative `url` and the document's `baseHref`.
+ *
+ * Pure string math — no DOM, no Navigation API.
+ *
+ * - `''` and `'/'` resolve to `baseHref` itself (so `<base href='/app/'>`
+ *   navigates to `/app/`, not `/app`).
+ * - anything else is prefixed with the base prefix
+ *   ({@link stripLastPathElement} of `baseHref`), inserting the leading slash
+ *   the caller may have omitted.
+ *
+ * @internal
+ */
+export function composeNavigateUrl(url: string, baseHref: string): string {
+  if (url === '' || url === '/') {
+    return baseHref;
+  }
+  const slash = url.startsWith('/') ? '' : '/';
+  return stripLastPathElement(baseHref) + slash + url;
+}
+
+/**
  * Location service implementation using the Navigation API.
  *
  * Uses the browser's Navigation API for URL management instead of the
@@ -65,11 +87,22 @@ export class NavigationLocationService extends BaseLocationServices {
     super(router, false);
     this._router = router;
     this._config = router.urlService.config;
-    globalRoot.navigation.addEventListener(
+    this._navigation().addEventListener(
       CURRENT_ENTRY_CHANGE_EVENT,
       this._listener,
       false,
     );
+  }
+
+  /**
+   * The Navigation API object this service drives.
+   *
+   * Single seam for every `navigation` touch point, so tests can subclass and
+   * substitute a stub instead of booting a browser to spy on a global.
+   * @internal
+   */
+  protected _navigation(): Navigation {
+    return globalRoot.navigation;
   }
 
   /**
@@ -128,14 +161,9 @@ export class NavigationLocationService extends BaseLocationServices {
     url: string,
     replace: boolean,
   ): void {
-    const basePrefix = this._getBasePrefix();
-    const slash = url && !url.startsWith('/') ? '/' : '';
-    const fullUrl =
-      url === '' || url === '/'
-        ? this._config.baseHref()
-        : basePrefix + slash + url;
+    const fullUrl = composeNavigateUrl(url, this._config.baseHref());
 
-    globalRoot.navigation.navigate(fullUrl, {
+    this._navigation().navigate(fullUrl, {
       state,
       info: {
         uiRouter: this._router,
@@ -151,7 +179,7 @@ export class NavigationLocationService extends BaseLocationServices {
    */
   public dispose(router: UIRouter): void {
     super.dispose(router);
-    globalRoot.navigation.removeEventListener(
+    this._navigation().removeEventListener(
       CURRENT_ENTRY_CHANGE_EVENT,
       this._listener,
     );

--- a/packages/navigation-location-plugin/src/specs/compose-navigate-url.spec.ts
+++ b/packages/navigation-location-plugin/src/specs/compose-navigate-url.spec.ts
@@ -1,0 +1,50 @@
+/// <reference types="vitest/globals" />
+
+import { composeNavigateUrl } from '../index.js';
+
+// Pure string math over (url, baseHref): no DOM, no Navigation API, so this
+// runs in the plain node project rather than paying for happy-dom or a browser.
+describe('composeNavigateUrl', () => {
+  it('returns the baseHref for an empty URL', () => {
+    expect(composeNavigateUrl('', '/app/')).toBe('/app/');
+  });
+
+  it('returns the baseHref for the root URL', () => {
+    expect(composeNavigateUrl('/', '/app/')).toBe('/app/');
+  });
+
+  it('prepends the base prefix to non-root URLs', () => {
+    expect(composeNavigateUrl('/users', '/app/')).toBe('/app/users');
+  });
+
+  it('adds a leading slash if the URL does not start with one', () => {
+    expect(composeNavigateUrl('users', '/app/')).toBe('/app/users');
+  });
+
+  it('leaves URLs untouched under a root baseHref', () => {
+    expect(composeNavigateUrl('/users', '/')).toBe('/users');
+    expect(composeNavigateUrl('users', '/')).toBe('/users');
+    expect(composeNavigateUrl('', '/')).toBe('/');
+    expect(composeNavigateUrl('/', '/')).toBe('/');
+  });
+
+  it('strips a trailing filename from the baseHref', () => {
+    expect(composeNavigateUrl('/users', '/base/index.html')).toBe(
+      '/base/users',
+    );
+  });
+
+  it('handles a nested baseHref', () => {
+    expect(composeNavigateUrl('/users', '/foo/base/')).toBe('/foo/base/users');
+  });
+
+  it('treats a baseHref without a trailing slash as having no prefix', () => {
+    expect(composeNavigateUrl('/users', '/base')).toBe('/users');
+  });
+
+  it('preserves query and hash on the composed URL', () => {
+    expect(composeNavigateUrl('/users?q=1#top', '/app/')).toBe(
+      '/app/users?q=1#top',
+    );
+  });
+});

--- a/packages/navigation-location-plugin/src/specs/index.spec.ts
+++ b/packages/navigation-location-plugin/src/specs/index.spec.ts
@@ -7,6 +7,7 @@ import {
   navigationLocationPlugin,
   isUIRouterNavigateEvent,
 } from '../index.js';
+import { interceptNavigations, restoreUrl } from './real-navigation.js';
 
 /**
  * Check if the Navigation API is available in this browser.
@@ -25,433 +26,163 @@ function createTestRouter(baseHref = '/'): UIRouter {
   return router;
 }
 
-describe('isUIRouterNavigateEvent', () => {
-  it('returns true for events with valid UIRouter instance in info', () => {
-    const router = new UIRouter();
-    const event = {
-      info: { uiRouter: router },
-    } as unknown as NavigateEvent;
+// The pure isUIRouterNavigateEvent predicate lives in
+// is-ui-router-navigate-event.spec.ts, which runs in happy-dom, and the pure
+// URL composition in compose-navigate-url.spec.ts, which runs in node.
+// Everything that only needs `navigation` stubbed goes through the
+// `_navigation()` seam in navigation-service.spec.ts, also happy-dom.
+//
+// What is left here — and the only thing that belongs here — are real
+// round-trips through a real Navigation API: navigations that actually commit,
+// URLs that actually change, and events that actually fire. No stubs.
 
-    expect(isUIRouterNavigateEvent(event)).toBe(true);
-  });
-
-  it('returns false for events without info', () => {
-    const event = {} as NavigateEvent;
-    expect(isUIRouterNavigateEvent(event)).toBe(false);
-  });
-
-  it('returns false for events with non-UIRouter info', () => {
-    const event = {
-      info: { uiRouter: {} },
-    } as unknown as NavigateEvent;
-
-    expect(isUIRouterNavigateEvent(event)).toBe(false);
-  });
-
-  it('returns false for events with null info', () => {
-    const event = {
-      info: null,
-    } as unknown as NavigateEvent;
-
-    expect(isUIRouterNavigateEvent(event)).toBe(false);
-  });
-
-  it('returns false for undefined input', () => {
-    expect(isUIRouterNavigateEvent(undefined)).toBe(false);
-  });
-});
-
-// Navigation API tests - only run in browsers that support it (Chromium-based)
 describe.skipIf(!hasNavigationAPI)('NavigationLocationService', () => {
   let router: UIRouter;
-  let service: NavigationLocationService;
-  let addEventListenerSpy: ReturnType<typeof vi.spyOn>;
-  let removeEventListenerSpy: ReturnType<typeof vi.spyOn>;
-  let navigateSpy: ReturnType<typeof vi.spyOn>;
+  let service: NavigationLocationService | null;
+  let stopIntercepting: () => void;
+  let originalHref: string;
 
   beforeEach(() => {
-    // Spy on Navigation API methods and prevent actual navigation
-    addEventListenerSpy = vi.spyOn(window.navigation, 'addEventListener');
-    removeEventListenerSpy = vi.spyOn(window.navigation, 'removeEventListener');
-    navigateSpy = vi
-      .spyOn(window.navigation, 'navigate')
-      .mockImplementation(() => ({
-        committed: Promise.resolve({} as NavigationHistoryEntry),
-        finished: Promise.resolve({} as NavigationHistoryEntry),
-      }));
+    originalHref = window.location.href;
+    stopIntercepting = interceptNavigations();
+    router = createTestRouter('/');
+    service = new NavigationLocationService(router);
   });
 
-  afterEach(() => {
-    // Clean up
-    if (service) {
-      service.dispose(router);
+  afterEach(async () => {
+    service?.dispose(router);
+    service = null;
+    stopIntercepting();
+    await restoreUrl(originalHref);
+  });
+
+  it('really changes the URL when navigating', async () => {
+    expect(window.location.pathname).not.toBe('/real-path');
+
+    service!.url('/real-path');
+
+    await vi.waitFor(() => {
+      expect(window.location.pathname).toBe('/real-path');
+    });
+    expect(window.navigation.currentEntry?.url).toContain('/real-path');
+  });
+
+  it('reads the real URL back through url(), including query and hash', async () => {
+    service!.url('/read-back?q=1#frag');
+
+    await vi.waitFor(() => {
+      expect(window.location.pathname).toBe('/read-back');
+    });
+    expect(service!.url()).toBe('/read-back?q=1#frag');
+  });
+
+  it('reads the current URL relative to a non-root baseHref', async () => {
+    service!.dispose(router);
+    router = createTestRouter('/app/');
+    service = new NavigationLocationService(router);
+
+    service.url('/deep');
+
+    await vi.waitFor(() => {
+      expect(window.location.pathname).toBe('/app/deep');
+    });
+    expect(service.url()).toBe('/deep');
+  });
+
+  it('fires onChange listeners from a real currententrychange event', async () => {
+    const onChange = vi.fn();
+    service!.onChange(onChange);
+
+    service!.url('/listener-path');
+
+    await vi.waitFor(() => {
+      expect(onChange).toHaveBeenCalled();
+    });
+    // the callback receives the real NavigationCurrentEntryChangeEvent
+    const [event] = onChange.mock.calls[0] as [Event];
+    expect(event.type).toBe('currententrychange');
+  });
+
+  it('stops firing onChange listeners after dispose', async () => {
+    const onChange = vi.fn();
+    service!.onChange(onChange);
+
+    service!.url('/before-dispose');
+    await vi.waitFor(() => {
+      expect(onChange).toHaveBeenCalled();
+    });
+
+    service!.dispose(router);
+    service = null;
+    onChange.mockClear();
+
+    await window.navigation.navigate('/after-dispose', { history: 'push' })
+      .finished;
+    await vi.waitFor(() => {
+      expect(window.location.pathname).toBe('/after-dispose');
+    });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('fires navigate event with UIRouter info when navigating', () => {
+    let capturedEvent: NavigateEvent | null = null;
+    const navigateHandler = (event: NavigateEvent) => {
+      capturedEvent = event;
+    };
+
+    window.navigation.addEventListener('navigate', navigateHandler);
+
+    try {
+      service!.url('/test-path');
+
+      expect(capturedEvent).not.toBeNull();
+      expect(capturedEvent!.destination.url).toContain('/test-path');
+      // Verify the UIRouter info is attached
+      expect(isUIRouterNavigateEvent(capturedEvent!)).toBe(true);
+    } finally {
+      window.navigation.removeEventListener('navigate', navigateHandler);
     }
-    vi.restoreAllMocks();
-  });
-
-  describe('constructor', () => {
-    it('creates service with router instance', () => {
-      router = createTestRouter();
-      service = new NavigationLocationService(router);
-
-      expect(service).toBeInstanceOf(NavigationLocationService);
-    });
-
-    it('registers currententrychange listener on Navigation API', () => {
-      router = createTestRouter();
-      service = new NavigationLocationService(router);
-
-      expect(addEventListenerSpy).toHaveBeenCalledWith(
-        'currententrychange',
-        expect.any(Function),
-        false,
-      );
-    });
-
-    it('stores config reference from router', () => {
-      router = createTestRouter('/app/');
-      service = new NavigationLocationService(router);
-
-      expect(service._config).toBe(router.urlService.config);
-    });
-  });
-
-  describe('_get (via url())', () => {
-    // Note: Testing _get() requires controlling the browser location,
-    // which we can't do without actually navigating (which breaks tests).
-    // Instead, we test the behavior through the service.url() method
-    // by verifying the initial URL reading works.
-
-    it('reads current URL from browser location', () => {
-      router = createTestRouter('/');
-      service = new NavigationLocationService(router);
-
-      // The service should return a string representing the current URL
-      const url = service.url();
-      expect(typeof url).toBe('string');
-    });
-  });
-
-  describe('_set (via url() setter and testable subclass)', () => {
-    it('calls navigation.navigate with correct URL', () => {
-      router = createTestRouter('/');
-      service = new NavigationLocationService(router);
-
-      service.url('/new-path');
-
-      // Note: BaseLocationServices.url() setter uses replace mode by default
-      expect(navigateSpy).toHaveBeenCalledWith(
-        '/new-path',
-        expect.objectContaining({
-          history: 'replace',
-        }),
-      );
-    });
-
-    it('includes state in navigate options', () => {
-      router = createTestRouter('/');
-
-      // Create a testable subclass to access protected _set method
-      class TestableService extends NavigationLocationService {
-        testSet(
-          state: unknown,
-          title: string,
-          url: string,
-          replace: boolean,
-        ): void {
-          this._set(state, title, url, replace);
-        }
-      }
-
-      const testService = new TestableService(router);
-      const state = { key: 'value' };
-
-      testService.testSet(state, 'Test Title', '/path', false);
-
-      expect(navigateSpy).toHaveBeenCalledWith(
-        '/path',
-        expect.objectContaining({
-          state,
-        }),
-      );
-
-      testService.dispose(router);
-      // Prevent afterEach from disposing again
-      service = null!;
-    });
-
-    it('includes info with uiRouter reference and title', () => {
-      router = createTestRouter('/');
-
-      class TestableService extends NavigationLocationService {
-        testSet(
-          state: unknown,
-          title: string,
-          url: string,
-          replace: boolean,
-        ): void {
-          this._set(state, title, url, replace);
-        }
-      }
-
-      const testService = new TestableService(router);
-      testService.testSet(null, 'Page Title', '/path', false);
-
-      expect(navigateSpy).toHaveBeenCalledWith(
-        '/path',
-        expect.objectContaining({
-          info: expect.objectContaining({
-            uiRouter: router,
-            title: 'Page Title',
-          }),
-        }),
-      );
-
-      testService.dispose(router);
-      service = null!;
-    });
-
-    it('uses replace history mode when replace=true', () => {
-      router = createTestRouter('/');
-
-      class TestableService extends NavigationLocationService {
-        testSet(
-          state: unknown,
-          title: string,
-          url: string,
-          replace: boolean,
-        ): void {
-          this._set(state, title, url, replace);
-        }
-      }
-
-      const testService = new TestableService(router);
-      testService.testSet(null, '', '/path', true);
-
-      expect(navigateSpy).toHaveBeenCalledWith(
-        '/path',
-        expect.objectContaining({
-          history: 'replace',
-        }),
-      );
-
-      testService.dispose(router);
-      service = null!;
-    });
-
-    it('uses push history mode when replace=false', () => {
-      router = createTestRouter('/');
-
-      class TestableService extends NavigationLocationService {
-        testSet(
-          state: unknown,
-          title: string,
-          url: string,
-          replace: boolean,
-        ): void {
-          this._set(state, title, url, replace);
-        }
-      }
-
-      const testService = new TestableService(router);
-      testService.testSet(null, '', '/path', false);
-
-      expect(navigateSpy).toHaveBeenCalledWith(
-        '/path',
-        expect.objectContaining({
-          history: 'push',
-        }),
-      );
-
-      testService.dispose(router);
-      service = null!;
-    });
-
-    it('handles empty URL by using baseHref', () => {
-      router = createTestRouter('/app/');
-
-      class TestableService extends NavigationLocationService {
-        testSet(
-          state: unknown,
-          title: string,
-          url: string,
-          replace: boolean,
-        ): void {
-          this._set(state, title, url, replace);
-        }
-      }
-
-      const testService = new TestableService(router);
-      testService.testSet(null, '', '', false);
-
-      expect(navigateSpy).toHaveBeenCalledWith('/app/', expect.any(Object));
-
-      testService.dispose(router);
-      service = null!;
-    });
-
-    it('handles root URL (/) by using baseHref', () => {
-      router = createTestRouter('/app/');
-
-      class TestableService extends NavigationLocationService {
-        testSet(
-          state: unknown,
-          title: string,
-          url: string,
-          replace: boolean,
-        ): void {
-          this._set(state, title, url, replace);
-        }
-      }
-
-      const testService = new TestableService(router);
-      testService.testSet(null, '', '/', false);
-
-      expect(navigateSpy).toHaveBeenCalledWith('/app/', expect.any(Object));
-
-      testService.dispose(router);
-      service = null!;
-    });
-
-    it('prepends base prefix to non-root URLs', () => {
-      router = createTestRouter('/app/');
-
-      class TestableService extends NavigationLocationService {
-        testSet(
-          state: unknown,
-          title: string,
-          url: string,
-          replace: boolean,
-        ): void {
-          this._set(state, title, url, replace);
-        }
-      }
-
-      const testService = new TestableService(router);
-      testService.testSet(null, '', '/users', false);
-
-      expect(navigateSpy).toHaveBeenCalledWith(
-        '/app/users',
-        expect.any(Object),
-      );
-
-      testService.dispose(router);
-      service = null!;
-    });
-
-    it('adds leading slash if URL does not start with one', () => {
-      router = createTestRouter('/app/');
-
-      class TestableService extends NavigationLocationService {
-        testSet(
-          state: unknown,
-          title: string,
-          url: string,
-          replace: boolean,
-        ): void {
-          this._set(state, title, url, replace);
-        }
-      }
-
-      const testService = new TestableService(router);
-      testService.testSet(null, '', 'users', false);
-
-      expect(navigateSpy).toHaveBeenCalledWith(
-        '/app/users',
-        expect.any(Object),
-      );
-
-      testService.dispose(router);
-      service = null!;
-    });
-  });
-
-  describe('dispose', () => {
-    it('removes currententrychange event listener', () => {
-      router = createTestRouter();
-      service = new NavigationLocationService(router);
-
-      service.dispose(router);
-
-      expect(removeEventListenerSpy).toHaveBeenCalledWith(
-        'currententrychange',
-        expect.any(Function),
-      );
-
-      // Prevent double dispose in afterEach
-      service = null!;
-    });
   });
 });
 
-// Test real navigate event interception (without mocking navigate)
-describe.skipIf(!hasNavigationAPI)(
-  'NavigationLocationService navigate event interception',
-  () => {
-    it('fires navigate event with UIRouter info when navigating', () => {
-      const router = createTestRouter('/');
-      const service = new NavigationLocationService(router);
-
-      let capturedEvent: NavigateEvent | null = null;
-      const navigateHandler = (event: NavigateEvent) => {
-        capturedEvent = event;
-        event.intercept(); // Prevent actual navigation
-      };
-
-      window.navigation.addEventListener('navigate', navigateHandler);
-
-      try {
-        service.url('/test-path');
-
-        expect(capturedEvent).not.toBeNull();
-        expect(capturedEvent!.destination.url).toContain('/test-path');
-        // Verify the UIRouter info is attached
-        expect(isUIRouterNavigateEvent(capturedEvent!)).toBe(true);
-      } finally {
-        window.navigation.removeEventListener('navigate', navigateHandler);
-        service.dispose(router);
-      }
-    });
-  },
-);
-
 describe.skipIf(!hasNavigationAPI)('navigationLocationPlugin', () => {
+  let stopIntercepting: () => void;
+  let originalHref: string;
+
   beforeEach(() => {
-    // Mock navigate to prevent actual navigation
-    vi.spyOn(window.navigation, 'navigate').mockImplementation(() => ({
-      committed: Promise.resolve({} as NavigationHistoryEntry),
-      finished: Promise.resolve({} as NavigationHistoryEntry),
-    }));
+    originalHref = window.location.href;
+    stopIntercepting = interceptNavigations();
   });
 
-  afterEach(() => {
-    vi.restoreAllMocks();
+  afterEach(async () => {
+    stopIntercepting();
+    await restoreUrl(originalHref);
   });
 
-  it('is a function that returns a LocationPlugin', () => {
-    expect(typeof navigationLocationPlugin).toBe('function');
-
+  // The shape half — that this is a factory, that it returns something, and
+  // that what it returns is a LocationPlugin core accepts — is pinned at
+  // compile time in ./plugin-seams.types.ts. What stays here is the value the
+  // compiler cannot know: the name core keys the registered instance by.
+  it('registers under the vanilla.navigationLocation name', () => {
     const router = new UIRouter();
     const plugin = navigationLocationPlugin(router);
 
-    expect(plugin).toBeDefined();
     expect(plugin.name).toBe('vanilla.navigationLocation');
 
-    // Clean up
-    if (plugin.dispose) {
-      plugin.dispose(router);
-    }
+    plugin.dispose?.(router);
   });
 
-  it('plugin provides LocationServices', () => {
+  it('provides LocationServices that really drive the browser URL', async () => {
     const router = new UIRouter();
+    router.urlService.config.baseHref = () => '/';
     const plugin = navigationLocationPlugin(router);
 
-    expect(router.urlService).toBeDefined();
+    router.urlService.url('/plugin-path');
 
-    // Clean up
-    if (plugin.dispose) {
-      plugin.dispose(router);
-    }
+    await vi.waitFor(() => {
+      expect(window.location.pathname).toBe('/plugin-path');
+    });
+
+    plugin.dispose?.(router);
   });
 });

--- a/packages/navigation-location-plugin/src/specs/is-ui-router-navigate-event.spec.ts
+++ b/packages/navigation-location-plugin/src/specs/is-ui-router-navigate-event.spec.ts
@@ -1,0 +1,43 @@
+/// <reference types="vitest/globals" />
+/// <reference types="@types/dom-navigation" />
+
+import { UIRouter } from '@uirouter/core';
+import { isUIRouterNavigateEvent } from '../index.js';
+
+// Pure predicate over plain objects: no window.navigation, so this runs in
+// happy-dom while the rest of the suite pays for a real browser.
+describe('isUIRouterNavigateEvent', () => {
+  it('returns true for events with valid UIRouter instance in info', () => {
+    const router = new UIRouter();
+    const event = {
+      info: { uiRouter: router },
+    } as unknown as NavigateEvent;
+
+    expect(isUIRouterNavigateEvent(event)).toBe(true);
+  });
+
+  it('returns false for events without info', () => {
+    const event = {} as NavigateEvent;
+    expect(isUIRouterNavigateEvent(event)).toBe(false);
+  });
+
+  it('returns false for events with non-UIRouter info', () => {
+    const event = {
+      info: { uiRouter: {} },
+    } as unknown as NavigateEvent;
+
+    expect(isUIRouterNavigateEvent(event)).toBe(false);
+  });
+
+  it('returns false for events with null info', () => {
+    const event = {
+      info: null,
+    } as unknown as NavigateEvent;
+
+    expect(isUIRouterNavigateEvent(event)).toBe(false);
+  });
+
+  it('returns false for undefined input', () => {
+    expect(isUIRouterNavigateEvent(undefined)).toBe(false);
+  });
+});

--- a/packages/navigation-location-plugin/src/specs/navigation-service.spec.ts
+++ b/packages/navigation-location-plugin/src/specs/navigation-service.spec.ts
@@ -1,0 +1,194 @@
+/// <reference types="vitest/globals" />
+/// <reference types="@types/dom-navigation" />
+
+import { UIRouter } from '@uirouter/core';
+import { NavigationLocationService } from '../index.js';
+
+// These specs assert what this plugin *passes to* the Navigation API — the
+// listener registration, and the arguments of `navigation.navigate()`. They
+// used to spy on the real `window.navigation` and therefore booted Chromium to
+// call a mock; the `_navigation()` seam lets the same stub sit one layer
+// earlier, so they run in happy-dom. Real round-trips through the Navigation
+// API stay in index.spec.ts, in the browser project.
+
+interface StubNavigation {
+  addEventListener: ReturnType<typeof vi.fn>;
+  removeEventListener: ReturnType<typeof vi.fn>;
+  navigate: ReturnType<typeof vi.fn>;
+}
+
+let stub: StubNavigation;
+
+/**
+ * The spec file's "testable subclass" idiom, extended to the seam: reads the
+ * stub from module scope so it is available during `super()`, and exposes the
+ * protected `_set`.
+ */
+class TestableService extends NavigationLocationService {
+  protected override _navigation(): Navigation {
+    return stub as unknown as Navigation;
+  }
+
+  testSet(state: unknown, title: string, url: string, replace: boolean): void {
+    this._set(state, title, url, replace);
+  }
+}
+
+function createTestRouter(baseHref = '/'): UIRouter {
+  const router = new UIRouter();
+  router.urlService.config.baseHref = () => baseHref;
+  return router;
+}
+
+describe('NavigationLocationService (stubbed Navigation seam)', () => {
+  let router: UIRouter;
+  let service: TestableService | null;
+
+  beforeEach(() => {
+    stub = {
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      navigate: vi.fn(() => ({
+        committed: Promise.resolve({} as NavigationHistoryEntry),
+        finished: Promise.resolve({} as NavigationHistoryEntry),
+      })),
+    };
+    service = null;
+  });
+
+  afterEach(() => {
+    service?.dispose(router);
+    vi.restoreAllMocks();
+  });
+
+  describe('constructor', () => {
+    it('throws without a router instance', () => {
+      expect(() => new TestableService()).toThrow(
+        'NavigationLocationService requires a UIRouter instance',
+      );
+    });
+
+    it('creates service with router instance', () => {
+      router = createTestRouter();
+      service = new TestableService(router);
+
+      expect(service).toBeInstanceOf(NavigationLocationService);
+    });
+
+    it('registers currententrychange listener on the Navigation API', () => {
+      router = createTestRouter();
+      service = new TestableService(router);
+
+      expect(stub.addEventListener).toHaveBeenCalledWith(
+        'currententrychange',
+        expect.any(Function),
+        false,
+      );
+    });
+
+    it('stores config reference from router', () => {
+      router = createTestRouter('/app/');
+      service = new TestableService(router);
+
+      expect(service._config).toBe(router.urlService.config);
+    });
+  });
+
+  describe('_set', () => {
+    it('calls navigate with the URL, in replace mode, via url()', () => {
+      router = createTestRouter('/');
+      service = new TestableService(router);
+
+      // BaseLocationServices.url() setter defaults to replace mode
+      service.url('/new-path');
+
+      expect(stub.navigate).toHaveBeenCalledWith(
+        '/new-path',
+        expect.objectContaining({ history: 'replace' }),
+      );
+    });
+
+    it('includes state in navigate options', () => {
+      router = createTestRouter('/');
+      service = new TestableService(router);
+      const state = { key: 'value' };
+
+      service.testSet(state, 'Test Title', '/path', false);
+
+      expect(stub.navigate).toHaveBeenCalledWith(
+        '/path',
+        expect.objectContaining({ state }),
+      );
+    });
+
+    it('includes info with uiRouter reference and title', () => {
+      router = createTestRouter('/');
+      service = new TestableService(router);
+
+      service.testSet(null, 'Page Title', '/path', false);
+
+      expect(stub.navigate).toHaveBeenCalledWith(
+        '/path',
+        expect.objectContaining({
+          info: expect.objectContaining({
+            uiRouter: router,
+            title: 'Page Title',
+          }),
+        }),
+      );
+    });
+
+    it('uses replace history mode when replace=true', () => {
+      router = createTestRouter('/');
+      service = new TestableService(router);
+
+      service.testSet(null, '', '/path', true);
+
+      expect(stub.navigate).toHaveBeenCalledWith(
+        '/path',
+        expect.objectContaining({ history: 'replace' }),
+      );
+    });
+
+    it('uses push history mode when replace=false', () => {
+      router = createTestRouter('/');
+      service = new TestableService(router);
+
+      service.testSet(null, '', '/path', false);
+
+      expect(stub.navigate).toHaveBeenCalledWith(
+        '/path',
+        expect.objectContaining({ history: 'push' }),
+      );
+    });
+
+    it('composes the full URL from the router baseHref', () => {
+      // exhaustive composition cases live in compose-navigate-url.spec.ts;
+      // this asserts _set is wired to the router's baseHref
+      router = createTestRouter('/app/');
+      service = new TestableService(router);
+
+      service.testSet(null, '', 'users', false);
+
+      expect(stub.navigate).toHaveBeenCalledWith(
+        '/app/users',
+        expect.any(Object),
+      );
+    });
+  });
+
+  describe('dispose', () => {
+    it('removes the currententrychange event listener', () => {
+      router = createTestRouter();
+      service = new TestableService(router);
+
+      service.dispose(router);
+      service = null;
+
+      expect(stub.removeEventListener).toHaveBeenCalledWith(
+        'currententrychange',
+        expect.any(Function),
+      );
+    });
+  });
+});

--- a/packages/navigation-location-plugin/src/specs/plugin-seams.types.ts
+++ b/packages/navigation-location-plugin/src/specs/plugin-seams.types.ts
@@ -1,0 +1,39 @@
+import type {
+  LocationConfig,
+  LocationPlugin,
+  LocationServices,
+  PluginFactory,
+  UIRouterPlugin,
+} from '@uirouter/core';
+
+import { navigationLocationPlugin } from '../index.js';
+
+// The upstream contract the plugin must keep with @uirouter/core: it has to be
+// a thing `router.plugin()` accepts, and what it hands back has to be a
+// LocationPlugin (a UIRouterPlugin that carries the location services the
+// urlService drives). Type-level only — the `.types.ts` name keeps this out of
+// vitest's `src/specs/**/*.spec.ts` glob, and out of `typecheck:src` (which
+// excludes src/specs); the package `typecheck` compile IS the assertion.
+//
+// This replaces the runtime shape assertions the browser suite used to carry
+// (`typeof navigationLocationPlugin === 'function'`, `expect(plugin).toBeDefined()`,
+// and a `router.urlService` check that was true of a bare UIRouter with no
+// plugin at all). Each cost three browser engines to decide something the
+// compiler already knows — and none of them pinned the core seam this does.
+// The behaviour half (the plugin's name, and that it actually drives
+// window.navigation) stays in index.spec.ts / url-shape.spec.ts.
+
+// `true` iff From is assignable to To — tuple-wrapped so unions don't distribute.
+type AssignableTo<From, To> = [From] extends [To] ? true : false;
+
+// A diverged seam makes its slot's TYPE `false`, so the `true` initializer at
+// that position fails to compile ("Type 'true' is not assignable to 'false'").
+export const seams: [
+  // router.plugin(navigationLocationPlugin) — the documented installation path.
+  AssignableTo<typeof navigationLocationPlugin, PluginFactory<LocationPlugin>>,
+  // ...and what it returns is a plugin core will accept and read services off.
+  AssignableTo<ReturnType<typeof navigationLocationPlugin>, LocationPlugin>,
+  AssignableTo<LocationPlugin, UIRouterPlugin>,
+  AssignableTo<LocationPlugin['service'], LocationServices>,
+  AssignableTo<LocationPlugin['configuration'], LocationConfig>,
+] = [true, true, true, true, true];

--- a/packages/navigation-location-plugin/src/specs/real-navigation.ts
+++ b/packages/navigation-location-plugin/src/specs/real-navigation.ts
@@ -1,0 +1,39 @@
+/// <reference types="@types/dom-navigation" />
+
+/**
+ * Helpers for the browser project's real Navigation API round-trips.
+ *
+ * Not a spec file: `src/specs/**\/*.spec.ts` does not collect it.
+ */
+
+/**
+ * Intercepts every navigation so it commits as a same-document navigation —
+ * the URL really changes and `currententrychange` really fires, but the test
+ * page is never torn down by a document load.
+ *
+ * @returns a teardown function that unregisters the interceptor
+ */
+export function interceptNavigations(): () => void {
+  const handler = (event: NavigateEvent) => {
+    if (!event.canIntercept) return;
+    event.intercept({ handler: () => Promise.resolve() });
+  };
+  window.navigation.addEventListener('navigate', handler);
+  return () => window.navigation.removeEventListener('navigate', handler);
+}
+
+/**
+ * Restores the tester URL after a test navigated away, intercepting so the
+ * restore itself stays same-document.
+ */
+export async function restoreUrl(href: string): Promise<void> {
+  if (window.location.href === href) return;
+  const stop = interceptNavigations();
+  try {
+    await window.navigation.navigate(href, { history: 'replace' }).finished;
+  } catch {
+    // an aborted restore is not a test failure
+  } finally {
+    stop();
+  }
+}

--- a/packages/navigation-location-plugin/src/specs/url-shape.spec.ts
+++ b/packages/navigation-location-plugin/src/specs/url-shape.spec.ts
@@ -3,6 +3,7 @@
 
 import { UIRouter } from '@uirouter/core';
 import { navigationLocationPlugin } from '../index.js';
+import { interceptNavigations, restoreUrl } from './real-navigation.js';
 
 const hasNavigationAPI =
   typeof window !== 'undefined' && 'navigation' in window;
@@ -10,44 +11,52 @@ const hasNavigationAPI =
 // Boot + URL-shape invariants for this plugin: it requires window.navigation
 // and drives clean (hash-free) URLs through navigation.navigate (hash and
 // pushState shapes are asserted in lit-ui-router's location-plugins spec).
+// Asserted against the real browser URL, not a spy: a stub can prove which
+// string we passed, only a real navigation proves the address bar agrees.
 describe.skipIf(!hasNavigationAPI)('navigationLocationPlugin URL shape', () => {
-  let navigateSpy: ReturnType<typeof vi.spyOn>;
+  let stopIntercepting: () => void;
+  let originalHref: string;
 
   beforeEach(() => {
-    navigateSpy = vi
-      .spyOn(window.navigation, 'navigate')
-      .mockImplementation(() => ({
-        committed: Promise.resolve({} as NavigationHistoryEntry),
-        finished: Promise.resolve({} as NavigationHistoryEntry),
-      }));
+    originalHref = window.location.href;
+    stopIntercepting = interceptNavigations();
   });
 
-  afterEach(() => {
-    vi.restoreAllMocks();
+  afterEach(async () => {
+    stopIntercepting();
+    await restoreUrl(originalHref);
   });
 
-  it('routes through window.navigation', () => {
+  it('routes through window.navigation', async () => {
     const router = new UIRouter();
     router.urlService.config.baseHref = () => '/';
     const plugin = navigationLocationPlugin(router);
 
     expect(window.navigation).toBeDefined();
+    const before = window.navigation.currentEntry;
+
     router.urlService.url('/home');
-    expect(navigateSpy).toHaveBeenCalled();
+
+    await vi.waitFor(() => {
+      expect(window.navigation.currentEntry).not.toBe(before);
+    });
+    expect(window.navigation.currentEntry?.url).toContain('/home');
 
     plugin.dispose?.(router);
   });
 
-  it('produces clean URLs without a hash fragment', () => {
+  it('produces clean URLs without a hash fragment', async () => {
     const router = new UIRouter();
     router.urlService.config.baseHref = () => '/';
     const plugin = navigationLocationPlugin(router);
 
     router.urlService.url('/home');
 
-    const [url] = navigateSpy.mock.calls[0] as [string];
-    expect(url).toBe('/home');
-    expect(url).not.toContain('#');
+    await vi.waitFor(() => {
+      expect(window.location.pathname).toBe('/home');
+    });
+    expect(window.location.hash).toBe('');
+    expect(window.location.href).not.toContain('#');
 
     plugin.dispose?.(router);
   });

--- a/packages/navigation-location-plugin/vitest.config.ts
+++ b/packages/navigation-location-plugin/vitest.config.ts
@@ -1,11 +1,28 @@
-import { defineConfig } from 'vitest/config';
+import { configDefaults, defineConfig } from 'vitest/config';
 import { playwright } from '@vitest/browser-playwright';
 
+// partition: every spec runs in exactly one project
+const allSpecs = ['src/specs/**/*.spec.ts'];
+// Pure functions — no DOM at all, so they get plain node speed.
+const nodeSpecs = ['src/specs/compose-navigate-url.spec.ts'];
+// This plugin wraps the Navigation API (window.navigation), which happy-dom
+// does not implement. NavigationLocationService reaches it through the
+// protected `_navigation()` seam, so specs that only need to observe what we
+// pass to the API subclass-and-stub it and run in happy-dom. Only real
+// round-trips — navigations that actually commit, events that actually fire —
+// need a real browser, and those are the specs listed here.
+const browserOnlySpecs = [
+  'src/specs/index.spec.ts',
+  'src/specs/url-shape.spec.ts',
+];
+
+// Key caches by the API port so the concurrently running `test` and
+// `test:coverage` turbo tasks never share a Vite dep-optimizer dir.
+const cacheKey = process.env.VITEST_BROWSER_API_PORT ?? 'default';
+
 export default defineConfig({
-  cacheDir: `node_modules/.vite-${process.env.VITEST_BROWSER_API_PORT ?? 'default'}`,
+  cacheDir: `node_modules/.vite-${cacheKey}`,
   test: {
-    globals: true,
-    include: ['src/specs/**/*.spec.ts'],
     // hanging-process logs the open handles in CI
     reporters: process.env.CI ? ['default', 'hanging-process'] : ['default'],
     coverage: {
@@ -13,30 +30,63 @@ export default defineConfig({
       reportsDirectory: './coverage',
       exclude: ['src/specs/**'],
     },
-    browser: {
-      enabled: true,
-      headless: true,
-      api: process.env.VITEST_BROWSER_API_PORT
-        ? { port: Number(process.env.VITEST_BROWSER_API_PORT) }
-        : undefined,
-      provider: playwright({}),
-      instances: [
-        {
-          name: 'chrome',
-          browser: 'chromium',
-          headless: true,
+    projects: [
+      {
+        cacheDir: `node_modules/.vite-${cacheKey}-node`,
+        test: {
+          name: 'node',
+          globals: true,
+          environment: 'node',
+          include: nodeSpecs,
         },
-        {
-          name: 'firefox',
-          browser: 'firefox',
-          headless: true,
+      },
+      {
+        cacheDir: `node_modules/.vite-${cacheKey}-happy-dom`,
+        test: {
+          name: 'happy-dom',
+          globals: true,
+          environment: 'happy-dom',
+          include: allSpecs,
+          exclude: [
+            ...configDefaults.exclude,
+            ...browserOnlySpecs,
+            ...nodeSpecs,
+          ],
         },
-        {
-          name: 'safari',
-          browser: 'webkit',
-          headless: true,
+      },
+      {
+        cacheDir: `node_modules/.vite-${cacheKey}-browser`,
+        test: {
+          name: 'browser',
+          globals: true,
+          include: browserOnlySpecs,
+          browser: {
+            enabled: true,
+            headless: true,
+            api: process.env.VITEST_BROWSER_API_PORT
+              ? { port: Number(process.env.VITEST_BROWSER_API_PORT) }
+              : undefined,
+            provider: playwright({}),
+            instances: [
+              {
+                name: 'chrome',
+                browser: 'chromium',
+                headless: true,
+              },
+              {
+                name: 'firefox',
+                browser: 'firefox',
+                headless: true,
+              },
+              {
+                name: 'safari',
+                browser: 'webkit',
+                headless: true,
+              },
+            ],
+          },
         },
-      ],
-    },
+      },
+    ],
   },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -798,6 +798,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: 'catalog:'
         version: 4.1.10(@vitest/browser@4.1.10)(vitest@4.1.10)
+      happy-dom:
+        specifier: 'catalog:'
+        version: 20.11.1
       oxfmt:
         specifier: 'catalog:'
         version: 0.61.0


### PR DESCRIPTION
## The problem

The nav-plugin browser suite asserted its own arguments. Of its twenty tests, **nineteen spied on `navigation.navigate` and checked what we passed it**; exactly one touched the real API. That shape passes whether or not the plugin actually drives a browser — so it could not catch the class of bug it existed to catch.

## Two seams in `src/index.ts`

- **`composeNavigateUrl(url, baseHref)`** — lifts the base-href/slash composition out of `_set` into a pure function. That was the part genuinely worth asserting argument-wise, and it now costs no browser.
- **`protected _navigation(): Navigation`** — routes all three Navigation API touch points (the constructor's `addEventListener`, `_set`'s `navigate`, `dispose`'s `removeEventListener`) through one overridable accessor.

Registration stays in the constructor. Core's own `PushStateLocationService` binds `popstate` there, so this **matches the reference implementation** rather than diverging to suit a test.

## Three tiers, split by what each can actually decide

| project | environment | decides |
|---|---|---|
| `node` | none | pure URL composition (9 tests) |
| `happy-dom` | happy-dom | event predicate + service logic vs. a stubbed Navigation (16 tests) |
| `chrome` / `firefox` / `safari` | real browser | what only a browser can answer (10 tests) |

The browser tier now asserts **real state** — `window.location.pathname`, `navigation.currentEntry.url` — after real same-document navigations, via an `intercept({ handler: () => Promise.resolve() })` harness in `specs/real-navigation.ts`.

**Real-integration coverage goes from 1 test to 10, across three engines instead of notionally one.**

## Bottom of the pyramid: `plugin-seams.types.ts`

Pins that `navigationLocationPlugin` is a `PluginFactory<LocationPlugin>` core's `router.plugin()` accepts, and that `LocationPlugin` still carries the service/configuration surface `urlService` drives. Type-level only — **the package `typecheck` compile IS the assertion.**

Verified by injecting a diverged seam (`PluginFactory<LocationPlugin>` → `string`): `TS2322: Type 'true' is not assignable to type 'false'`, exit 1. Restored byte-identical and re-verified green. This is a real guard, not a decorative one.

That retires three runtime assertions the compiler already settled:

- `typeof navigationLocationPlugin === 'function'`
- `expect(plugin).toBeDefined()`
- `expect(router.urlService).toBeDefined()` — which held for a bare `UIRouter` with no plugin installed at all

Each cost three browser engines to decide. None pinned the core seam.

## Numbers

- **24 tests → 35**
- Coverage stays **100%** of `src/index.ts` (28/28 stmts, 18/18 branch, 8/8 funcs). Note the branch denominator drops **20 → 18** — the extraction collapsed two duplicate paths, so it is 100% of a slightly smaller set.
- Wall clock is a wash (~1.3s before and after).

## Known gaps, marked as such

Two behaviours remain stub-only, deliberately:

- **`dispose` removing the `currententrychange` listener specifically** — `super.dispose()` also empties `_listeners` via `deregAll`, so the callback goes quiet either way and real integration cannot isolate the call.
- **The `state` / push-vs-replace options payload** — reading it back needs `currentEntry.getState()` and `entries()` bookkeeping that fights the vitest browser tester's own history.

## Verification

- `turbo run typecheck lint test --force` — 15/15 tasks, 35 tests, exit 0
- `pnpm run test:engines` — 20 passed on firefox + safari, exit 0
- `format` + `format:check` — clean
- Negative test on the type guard — fails as designed (above)