### PR TITLE
refactor(test): share lit vitest.setup body via @tools/lit-test-env

### DIFF
--- a/apps/sample-app-shared/package.json
+++ b/apps/sample-app-shared/package.json
@@ -30,6 +30,7 @@
     "ui-router-navigation-location-plugin": "workspace:*"
   },
   "devDependencies": {
+    "@tools/lit-test-env": "workspace:*",
     "@types/dom-navigation": "catalog:",
     "@types/lodash": "catalog:",
     "@types/node": "catalog:",

--- a/apps/sample-app-shared/tsconfig.json
+++ b/apps/sample-app-shared/tsconfig.json
@@ -1,5 +1,9 @@
 {
   "extends": "./tooling/tsconfig.app.json",
+  "compilerOptions": {
+    // vitest.setup.ts imports @tools/* source-exported .ts files.
+    "allowImportingTsExtensions": true
+  },
   "include": ["src/**/*", "tooling/**/*", "vitest.setup.ts"],
   "exclude": ["node_modules"]
 }

--- a/apps/sample-app-shared/vitest.setup.ts
+++ b/apps/sample-app-shared/vitest.setup.ts
@@ -1,11 +1,5 @@
-// Suppress the per-browser "Lit is in dev mode" banner: https://github.com/lit/lit/issues/4877
-const g = globalThis as typeof globalThis & {
-  litIssuedWarnings?: Set<unknown>;
-};
-(g.litIssuedWarnings ??= new Set())
-  .add('dev-mode')
-  .add(
-    'Lit is in dev mode. Not recommended for production! See https://lit.dev/msg/dev-mode for more information.',
-  );
+import { silenceLitDevModeBanner } from '@tools/lit-test-env/setup.ts';
+
+silenceLitDevModeBanner();
 
 export {};

--- a/packages/lit-ui-router-mobx/package.json
+++ b/packages/lit-ui-router-mobx/package.json
@@ -64,6 +64,7 @@
     "@tools/bundle-probe": "workspace:*",
     "@tools/compat-guards": "workspace:*",
     "@tools/happy-dom": "workspace:*",
+    "@tools/lit-test-env": "workspace:*",
     "@tools/oxc-emit": "workspace:*",
     "@tools/release-config": "workspace:*",
     "@tools/typedoc-plugin-lit-ui-router": "workspace:*",

--- a/packages/lit-ui-router-mobx/tsconfig.json
+++ b/packages/lit-ui-router-mobx/tsconfig.json
@@ -4,7 +4,7 @@
   "compilerOptions": {
     "rootDir": ".",
     "noEmit": true,
-    // Specs import @tools/happy-dom's source-exported .ts files.
+    // Specs and vitest.setup.ts import @tools/* source-exported .ts files.
     "allowImportingTsExtensions": true,
     // specs are exempt; typecheck:src enforces conformance
     "isolatedDeclarations": false,

--- a/packages/lit-ui-router-mobx/vitest.setup.ts
+++ b/packages/lit-ui-router-mobx/vitest.setup.ts
@@ -1,34 +1,18 @@
-// Suppress the per-worker "Lit is in dev mode" banner: https://github.com/lit/lit/issues/4877
-const g = globalThis as typeof globalThis & {
-  litIssuedWarnings?: Set<unknown>;
-};
-(g.litIssuedWarnings ??= new Set())
-  .add('dev-mode')
-  .add(
-    'Lit is in dev mode. Not recommended for production! See https://lit.dev/msg/dev-mode for more information.',
-  );
+import {
+  assertLitMajor,
+  silenceLitDevModeBanner,
+} from '@tools/lit-test-env/setup.ts';
 
-// Guards the lit2-compat alias swap in both directions: the dev build pushes
-// its lit-html version (majors track lit's own) onto the global, so a run
-// that resolved the wrong lit line fails before any spec does. The expected
-// major arrives via import.meta.env, which reaches the browser projects too
-// (process.env does not); the cast spares every tsconfig vite/client types.
+silenceLitDevModeBanner();
+
+// Both stay in-module: the import so the lit2-compat alias resolves against
+// this package's lit-2 devDep, the env read because vite only injects
+// import.meta.env where it is read in-module (browser projects included).
 const expectedLitMajor =
   (import.meta as { env?: Record<string, string | undefined> }).env
     ?.VITE_EXPECT_LIT_MAJOR ?? '3';
 await import('lit');
-const litHtmlVersions =
-  (globalThis as typeof globalThis & { litHtmlVersions?: string[] })
-    .litHtmlVersions ?? [];
-if (
-  litHtmlVersions.length === 0 ||
-  litHtmlVersions.some((v) => !v.startsWith(`${expectedLitMajor}.`))
-) {
-  throw new Error(
-    `vitest.setup: expected lit-html major ${expectedLitMajor}, ` +
-      `saw [${litHtmlVersions.join(', ')}]`,
-  );
-}
+assertLitMajor(expectedLitMajor);
 
 // top-level await above requires module-hood even with no exports
 export {};

--- a/packages/lit-ui-router/package.json
+++ b/packages/lit-ui-router/package.json
@@ -79,6 +79,7 @@
     "@tools/bundle-probe": "workspace:*",
     "@tools/compat-guards": "workspace:*",
     "@tools/happy-dom": "workspace:*",
+    "@tools/lit-test-env": "workspace:*",
     "@tools/oxc-emit": "workspace:*",
     "@tools/release-config": "workspace:*",
     "@tools/typedoc-plugin-lit-ui-router": "workspace:*",

--- a/packages/lit-ui-router/tsconfig.json
+++ b/packages/lit-ui-router/tsconfig.json
@@ -6,7 +6,7 @@
     "noEmit": true,
     // specs are exempt; typecheck:src enforces conformance
     "isolatedDeclarations": false,
-    // Specs import @tools/happy-dom's source-exported .ts files.
+    // Specs and vitest.setup.ts import @tools/* source-exported .ts files.
     "allowImportingTsExtensions": true,
     "types": ["node", "vitest/globals"]
   },

--- a/packages/lit-ui-router/vitest.setup.ts
+++ b/packages/lit-ui-router/vitest.setup.ts
@@ -1,34 +1,18 @@
-// Suppress the per-worker "Lit is in dev mode" banner: https://github.com/lit/lit/issues/4877
-const g = globalThis as typeof globalThis & {
-  litIssuedWarnings?: Set<unknown>;
-};
-(g.litIssuedWarnings ??= new Set())
-  .add('dev-mode')
-  .add(
-    'Lit is in dev mode. Not recommended for production! See https://lit.dev/msg/dev-mode for more information.',
-  );
+import {
+  assertLitMajor,
+  silenceLitDevModeBanner,
+} from '@tools/lit-test-env/setup.ts';
 
-// Guards the lit2-compat alias swap in both directions: the dev build pushes
-// its lit-html version (majors track lit's own) onto the global, so a run
-// that resolved the wrong lit line fails before any spec does. The expected
-// major arrives via import.meta.env, which reaches the browser projects too
-// (process.env does not); the cast spares every tsconfig vite/client types.
+silenceLitDevModeBanner();
+
+// Both stay in-module: the import so the lit2-compat alias resolves against
+// this package's lit-2 devDep, the env read because vite only injects
+// import.meta.env where it is read in-module (browser projects included).
 const expectedLitMajor =
   (import.meta as { env?: Record<string, string | undefined> }).env
     ?.VITE_EXPECT_LIT_MAJOR ?? '3';
 await import('lit');
-const litHtmlVersions =
-  (globalThis as typeof globalThis & { litHtmlVersions?: string[] })
-    .litHtmlVersions ?? [];
-if (
-  litHtmlVersions.length === 0 ||
-  litHtmlVersions.some((v) => !v.startsWith(`${expectedLitMajor}.`))
-) {
-  throw new Error(
-    `vitest.setup: expected lit-html major ${expectedLitMajor}, ` +
-      `saw [${litHtmlVersions.join(', ')}]`,
-  );
-}
+assertLitMajor(expectedLitMajor);
 
 // top-level await above requires module-hood even with no exports
 export {};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -517,6 +517,9 @@ importers:
         specifier: workspace:*
         version: link:../../packages/navigation-location-plugin
     devDependencies:
+      '@tools/lit-test-env':
+        specifier: workspace:*
+        version: link:../../tools/lit-test-env
       '@types/dom-navigation':
         specifier: 'catalog:'
         version: 1.0.7
@@ -642,6 +645,9 @@ importers:
       '@tools/happy-dom':
         specifier: workspace:*
         version: link:../../tools/happy-dom
+      '@tools/lit-test-env':
+        specifier: workspace:*
+        version: link:../../tools/lit-test-env
       '@tools/oxc-emit':
         specifier: workspace:*
         version: link:../../tools/oxc-emit
@@ -717,6 +723,9 @@ importers:
       '@tools/happy-dom':
         specifier: workspace:*
         version: link:../../tools/happy-dom
+      '@tools/lit-test-env':
+        specifier: workspace:*
+        version: link:../../tools/lit-test-env
       '@tools/oxc-emit':
         specifier: workspace:*
         version: link:../../tools/oxc-emit
@@ -1020,6 +1029,15 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.13.3
+      oxfmt:
+        specifier: 'catalog:'
+        version: 0.61.0
+      typescript:
+        specifier: 'catalog:'
+        version: 7.0.2
+
+  tools/lit-test-env:
+    devDependencies:
       oxfmt:
         specifier: 'catalog:'
         version: 0.61.0

--- a/tools/lit-test-env/package.json
+++ b/tools/lit-test-env/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@tools/lit-test-env",
+  "version": "0.0.1",
+  "private": true,
+  "description": "vitest.setup knowledge shared by every lit suite: the dev-mode banner suppression and the lit2-compat major assertion, minus the lit import itself",
+  "type": "module",
+  "exports": {
+    "./setup.ts": "./src/setup.ts"
+  },
+  "scripts": {
+    "format": "oxfmt \"**/*.{ts,js,json,jsonc,md}\"",
+    "format:check": "oxfmt --check \"**/*.{ts,js,json,jsonc,md}\"",
+    "lint": "oxlint .",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
+  },
+  "devDependencies": {
+    "oxfmt": "catalog:",
+    "typescript": "catalog:"
+  }
+}

--- a/tools/lit-test-env/src/setup.ts
+++ b/tools/lit-test-env/src/setup.ts
@@ -1,0 +1,46 @@
+/**
+ * Suppresses the per-worker "Lit is in dev mode" banner:
+ * https://github.com/lit/lit/issues/4877
+ *
+ * Both strings are required: lit checks the short key, older lines the
+ * full message.
+ */
+export function silenceLitDevModeBanner(): void {
+  const g = globalThis as typeof globalThis & {
+    litIssuedWarnings?: Set<unknown>;
+  };
+  (g.litIssuedWarnings ??= new Set())
+    .add('dev-mode')
+    .add(
+      'Lit is in dev mode. Not recommended for production! See https://lit.dev/msg/dev-mode for more information.',
+    );
+}
+
+/**
+ * Fails a run that resolved the wrong lit line, before any spec does: the
+ * dev build pushes its lit-html version (majors track lit's own) onto the
+ * global this reads.
+ *
+ * Deliberately takes no part in resolving lit, nor in reading the expected
+ * major. The caller must do both in its own vitest.setup.ts:
+ * - `await import('lit')`, because the lit2-compat alias rewrites `lit` to
+ *   the `lit-2` npm-alias devDep, which pnpm links only into the consuming
+ *   package — an import issued from here resolves against this package.
+ * - `import.meta.env.VITE_EXPECT_LIT_MAJOR`, because vite only injects env
+ *   where it is read in-module; passing `import.meta` across a module
+ *   boundary silently loses it in the browser projects.
+ */
+export function assertLitMajor(expectedMajor: string): void {
+  const litHtmlVersions =
+    (globalThis as typeof globalThis & { litHtmlVersions?: string[] })
+      .litHtmlVersions ?? [];
+  if (
+    litHtmlVersions.length === 0 ||
+    litHtmlVersions.some((v) => !v.startsWith(`${expectedMajor}.`))
+  ) {
+    throw new Error(
+      `vitest.setup: expected lit-html major ${expectedMajor}, ` +
+        `saw [${litHtmlVersions.join(', ')}]`,
+    );
+  }
+}

--- a/tools/lit-test-env/tsconfig.json
+++ b/tools/lit-test-env/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  // Source-exported setup helpers consumed through each suite's vite
+  // transform — .ts import extensions, nothing emitted. No lit dependency:
+  // resolving lit is the consumer's job.
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "allowImportingTsExtensions": true,
+    "erasableSyntaxOnly": true,
+    "verbatimModuleSyntax": true,
+    "types": [],
+    "lib": ["ES2022", "DOM", "DOM.Iterable"]
+  },
+  "include": ["**/*.ts"]
+}


### PR DESCRIPTION
Collapses the `vitest.setup.ts` duplication that #529 made visible. (Originally drafted to stack on #529; that merged mid-flight, so this targets `main` and was re-verified on top of both #529 and #525's lit2 lane split.)

Two setup files were byte-identical at 34 lines (`lit-ui-router`, `lit-ui-router-mobx`) and a third (`sample-app-shared`) was an 11-line suppression-only subset. Most of that predates #529 — the 6-line banner block landed on top of 30 already-identical lines.

New `@tools/lit-test-env` exports two functions, mirroring `@tools/happy-dom`'s source-exported `.ts` layout:

- `silenceLitDevModeBanner()` — the banner suppression, previously copied 3×
- `assertLitMajor(expectedMajor)` — the version predicate and error message, previously copied 2×

## The dynamic import stays in the consumer

`await import('lit')` and the `import.meta.env.VITE_EXPECT_LIT_MAJOR` read are **deliberately not extracted**. Both are resolution-site sensitive, and moving either one guts the lit2 guard.

**The import.** The lit2 lane aliases `lit` → `lit-2`, an npm-alias devDep. pnpm links it only into the two consuming packages:

```
packages/lit-ui-router/node_modules/lit-2       -> .pnpm/lit@2.8.0/node_modules/lit/
packages/lit-ui-router-mobx/node_modules/lit-2  -> .pnpm/lit@2.8.0/node_modules/lit/
node_modules/lit-2                               (absent)
tools/*/node_modules/lit-2                       (absent)
```

An import issued from `tools/lit-test-env` resolves relative to that file, so it would miss the alias entirely. The obvious "fix" — adding `lit`/`lit-2` devDeps to the tools package — is the dangerous one: it makes the import resolve, but against the *tools* package's graph rather than the consumer's, so the guard would assert about a resolution no spec uses. The lit2 lane would stay green while testing lit 3.

The shared package therefore declares **no lit dependency** and provably cannot resolve one:

```
require.resolve('lit',   { paths: ['tools/lit-test-env/src'] }) -> MODULE_NOT_FOUND
require.resolve('lit-2', { paths: ['tools/lit-test-env/src'] }) -> MODULE_NOT_FOUND
```

`assertLitMajor` only reads `globalThis.litHtmlVersions`, which the dev build populates as a side effect — genuinely location-independent.

**The env read.** This one was found the hard way. A first pass extracted an `expectedLitMajorFrom(import.meta)` helper; it passed the happy-dom project and **failed the browser project** with `expected lit-html major 3, saw [2.8.0]`. Vite injects `import.meta.env` where it is read in-module; handing `import.meta` to a function in another module loses it in the browser build, and the `?? '3'` fallback takes over. It fails closed rather than silently, but it breaks the lane, so the read stays inline. That constraint now lives in the helper's doc comment instead of waiting to be rediscovered.

## Evidence

All re-run after moving onto current `main`.

`turbo run ci` — 143/143 successful.

Both lit2 lanes green: `lit-ui-router` 10/10, `lit-ui-router-mobx` 3/3. `typecheck:lit2` green for both.

Negative test — alias forced on (scratch `lit2Compat = true`), expectation forced to 3. Scratch reverted afterward; `grep -rn SCRATCH` returns 0.

`lit-ui-router`, `VITE_EXPECT_LIT_MAJOR=3`:
```
EXIT=1
Error: vitest.setup: expected lit-html major 3, saw [2.8.0]
 Test Files  10 failed (10)
```

`lit-ui-router-mobx`, `VITE_EXPECT_LIT_MAJOR=3`:
```
EXIT=1
Error: vitest.setup: expected lit-html major 3, saw [2.8.0]
 Test Files  3 failed (3)
```

Normal direction, uncached (`turbo run test:lit2-compat typecheck:lit2 --force`):
```
lit-ui-router-mobx:test:lit2-compat:  Test Files  3 passed (3)
lit-ui-router:test:lit2-compat:       Test Files  10 passed (10)
Tasks:    25 successful, 25 total
```

Zero-banner grep over the full CI log: `grep -cE "Lit is in dev mode"` → `0`.

`turbo run format`, then clean `format:check` + `lint` — 66/66.

## On whether this earns a package

Raw line count is close to a wash: consumer setups go 34/34/11 → 18/18/5, and the new package adds 46 lines of module (25 of them doc comment) plus 35 of manifest/tsconfig. The win is that the three things that actually drift — lit's exact banner string, the version predicate, and the error message — are single-sourced, and remaining duplication between the two package setups drops from 34 identical lines to 13.

For calibration against this repo's own bar: `@tools/happy-dom` is 8 lines of code shared by 2 consumers. This is 22 lines shared by 3.
