### PR TITLE
Release 0.5.0

### DIFF
--- a/packages/lit-ui-router-mobx/package.json
+++ b/packages/lit-ui-router-mobx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lit-ui-router-mobx",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "MobX bindings for lit-ui-router: an observable router store and reaction-based Lit ReactiveControllers",
   "keywords": [
     "lit",


### PR DESCRIPTION
### Features

* **deps:** support mobx 6 and 7 via a widened peer range ([#521](https://github.com/simshanith/lit-ui-router/issues/521)) ([9a367e5](https://github.com/simshanith/lit-ui-router/commit/9a367e53706581d4a92133fc2202def8c9328d05))

### Bug Fixes

* clear the two warnings left in a green CI run ([#529](https://github.com/simshanith/lit-ui-router/issues/529)) ([f3ee0de](https://github.com/simshanith/lit-ui-router/commit/f3ee0de54d7bf3d268d79a42d7b83dd17695e31a))
