### PR TITLE
fix(release): render refactor commits in package changelogs

### DIFF
--- a/tools/release-config/src/release-it.js
+++ b/tools/release-config/src/release-it.js
@@ -30,10 +30,13 @@ export default {
         name: 'conventionalcommits',
         // Explicit types, not the preset defaults: a package-scoped range of
         // only hidden types renders empty and release-it silently falls back to
-        // a flat repo-wide git log (#423).
+        // a flat repo-wide git log (#423). `refactor` is listed because a
+        // package's whole release can be one — #530 added exported API under
+        // that type, and hiding it re-triggered the #423 fallback.
         types: [
           { type: 'feat', section: 'Features' },
           { type: 'fix', section: 'Bug Fixes' },
+          { type: 'refactor', section: 'Code Refactoring' },
           { type: 'perf', section: 'Performance Improvements' },
           { type: 'revert', section: 'Reverts' },
           { type: 'build', section: 'Build System' },


### PR DESCRIPTION
## Problem

A package's entire release can consist of `refactor` commits. `ui-router-navigation-location-plugin`'s only in-scope change since 0.2.4 is #530.

With `refactor` absent from the explicit type list, the package-scoped range rendered empty and release-it silently fell back to a **flat repo-wide git log** — 26 unrelated commits (`chore(deps): bump hono`, `docs(StackBlitz)`, `ci: deflake-e2e sampler`, …). That is the #423 failure mode the explicit list was introduced to close; listing types narrowed it but didn't close it for a range that is *entirely* hidden types.

Reproduced in a `dryRun=true` bump ([run 31344708241](https://github.com/simshanith/lit-ui-router/actions/runs/31344708241)):

```
$ Writing changelog to undefined
Empty changeset
```

Since releases are immutable, that body would have been permanent.

## Fix

Add `refactor` to the type list. Section name is the `conventionalcommits` preset default (`Code Refactoring`), matching the other five entries rather than inventing a label.

## Verification

`pnpm --silent changelog` in `packages/navigation-location-plugin`, after:

```
### Code Refactoring

* **navigation-location-plugin:** seam the Navigation API and test it for real (#530) (965ac27)
```

Scoped to the one in-scope commit. `lit-ui-router-mobx` was already correct and is unchanged by this.

## Blocking

Must land before the real `ui-router-navigation-location-plugin@0.3.0` dispatch — `bump-version` reads this config from the checked-out `prBase`.