### PR TITLE
feat(navigation-location-plugin): support subclassing the Navigation seam

### DIFF
--- a/packages/navigation-location-plugin/README.md
+++ b/packages/navigation-location-plugin/README.md
@@ -67,6 +67,32 @@ router.plugin(navigationLocationPlugin);
 
 The location service class that extends `BaseLocationServices` from `@uirouter/core`. Handles URL reading and writing using the Navigation API.
 
+#### `protected _navigation(): Navigation`
+
+Returns the Navigation API object the service drives — the single seam through
+which every `navigation` touch point goes (`addEventListener` on construct,
+`navigate` on `_set`, `removeEventListener` on `dispose`).
+
+Override it in a subclass to substitute a stub, so tests can assert against the
+calls the service makes without booting a browser to spy on a global:
+
+```typescript
+class StubbedNavigationLocationService extends NavigationLocationService {
+  readonly calls: string[] = [];
+
+  protected override _navigation(): Navigation {
+    return {
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      navigate: (url: string) => {
+        this.calls.push(url);
+        return { committed: Promise.resolve(), finished: Promise.resolve() };
+      },
+    } as unknown as Navigation;
+  }
+}
+```
+
 ### `isUIRouterNavigateEvent(event)`
 
 Type guard function to check if a `NavigateEvent` was triggered by UIRouter.

--- a/packages/navigation-location-plugin/src/index.ts
+++ b/packages/navigation-location-plugin/src/index.ts
@@ -97,9 +97,18 @@ export class NavigationLocationService extends BaseLocationServices {
   /**
    * The Navigation API object this service drives.
    *
-   * Single seam for every `navigation` touch point, so tests can subclass and
-   * substitute a stub instead of booting a browser to spy on a global.
-   * @internal
+   * Single seam for every `navigation` touch point. Override in a subclass to
+   * substitute a stub — tests get to assert against the calls this service
+   * makes without booting a browser to spy on a global.
+   *
+   * @example
+   * ```ts
+   * class StubbedNavigationLocationService extends NavigationLocationService {
+   *   protected override _navigation(): Navigation {
+   *     return this.stub;
+   *   }
+   * }
+   * ```
    */
   protected _navigation(): Navigation {
     return globalRoot.navigation;


### PR DESCRIPTION
## Why

#530 added `_navigation()` as the single point every `navigation` touch goes through (`addEventListener` on construct, `navigate` in `_set`, `removeEventListener` in `dispose`) — then tagged it `@internal`.

There is no `stripInternal` anywhere in the repo, so the declaration ships in the public `dist/index.d.ts` regardless. `check:published-diff` flagged it as one of two ship-affecting files against the published 0.2.4. The result is a symbol consumers see in autocomplete while the tag tells them it isn't theirs to use.

That contradiction should be resolved *before* 0.3.0 publishes, not after — otherwise a released version carries an ambiguous contract that a later version has to bless.

## What

Resolve it toward support rather than concealment:

- Drop `@internal` from `_navigation()`, and document the override contract with an `@example`.
- Cover it in the README's `NavigationLocationService` API section with a working stub subclass.

The seam is useful to consumers for exactly the reason it's useful to our own tests — asserting the navigation calls a service makes without booting a browser to spy on a global — and `protected` already reads as designed-for-extension.

## Semver

**No emitted symbol changes.** The only `.d.ts` delta is the doc comment on a declaration that already shipped. This doesn't itself move the version; it makes the minor that #530 already earns an honest one.

## Verification

`turbo run build typecheck lint --filter=ui-router-navigation-location-plugin` — 16/16 green. Emitted `dist/index.d.ts` carries the example and no `@internal`.

## Sequencing

Lands alongside #535 (changelog fix), both before the real `ui-router-navigation-location-plugin@0.3.0` dispatch. Disjoint file sets, no conflict.