### PR TITLE
docs(release): add dist-tag policy and first-publish runbook

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -234,6 +234,13 @@ Break the cycle by hand, once, before adding the package to any workflow list:
    expected and is the reason the seed should be a version nobody would want:
    short-lived, obviously prerelease.
 
+   Worked example — `lit-ui-router-mobx` was seeded at `0.1.0-rc.0` with
+   `--tag next`, and `0.1.0` followed twenty minutes later. The seed took
+   `latest` regardless of the flag; `0.1.0` then moved `latest` on and left
+   `next` pinned to the seed for a year. Note the tag name does not match the
+   version's `rc` identifier — a hand-passed `--tag`, not release-it's
+   derivation. `ui-router-server` acquired its `alpha` the same way.
+
 2. **Configure the trusted publisher** on npmjs.com for the new package,
    pointing at `publish-npm.yml`.
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -210,7 +210,10 @@ For prereleases like `1.2.3-beta.0`:
 
 2. Follow standard process from step 2
 
-3. Retire the channel dist-tag once the line ships — see [Dist-Tags](#dist-tags)
+   The publish creates a dist-tag named after the prerelease identifier
+   (`1.2.3-beta.0` → `beta`) automatically; `latest` is untouched.
+
+3. Retire that dist-tag once the line ships — see [Dist-Tags](#dist-tags)
 
 ### First Publish (New Package)
 
@@ -244,6 +247,20 @@ Break the cycle by hand, once, before adding the package to any workflow list:
 npm gives built-in meaning to exactly one tag: `latest`, the default install
 target. `next`, `canary`, `alpha`, `beta` are conventions with no registry
 semantics.
+
+**Channel tags are created automatically — you never opt in.** Publishing any
+prerelease version creates one. release-it resolves the dist-tag from the
+version itself (`lib/plugin/npm/npm.js`, `resolveTag`): a non-prerelease gets
+`latest`, and a prerelease gets its own identifier — `1.8.0-canary.0` publishes
+to `canary`, `0.2.0-beta.1` to `beta`. A prerelease with no identifier falls
+back to any existing non-`latest` tag on the package, then to `next`.
+
+Two consequences:
+
+- Every prerelease line manufactures a tag that outlives it. Retiring the tag
+  is a recurring step after each prerelease, not a one-off cleanup.
+- A leftover tag can silently capture a later identifier-less prerelease
+  through that fallback, republishing a channel nobody meant to revive.
 
 **Policy: `latest` only in the steady state.** A channel tag exists solely
 while a prerelease on that channel is live. Retiring it is the closing step of

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -222,7 +222,10 @@ cannot be published by the workflow until trusted publishing is configured.
 Break the cycle by hand, once, before adding the package to any workflow list:
 
 1. **Seed the package manually** — publish a throwaway prerelease from a local
-   checkout (e.g. `0.0.1-alpha.0`) with a plain `npm publish`.
+   checkout (e.g. `0.0.1-alpha.0`) with a bare `pnpm publish`, using a real
+   token. It must be `pnpm`, not `npm`: pnpm rewrites `workspace:` and
+   `catalog:` dependency specifiers to real semver on pack, and `npm` ships
+   them verbatim into an uninstallable tarball.
 
    A package's **first** publish always takes `latest`, whatever `--tag` says;
    npm requires the tag to exist. Passing `--tag alpha` does not protect

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -190,6 +190,9 @@ meaning a release or floor bump is owed — never a CI failure.
    - Merge with squash commit
    - The merge runs main CI (including the main-only guards); a green run
      triggers tagging automatically
+   - Merge it on its own and let its main run reach tagging before merging
+     anything else — a queued main run can be evicted by a later push, which
+     silently skips the tag (see [Tag workflow not running](#tag-workflow-not-running))
 
 4. **Verify the release:**
    - Check Actions for tag-release workflow
@@ -207,6 +210,68 @@ For prereleases like `1.2.3-beta.0`:
 
 2. Follow standard process from step 2
 
+3. Retire the channel dist-tag once the line ships — see [Dist-Tags](#dist-tags)
+
+### First Publish (New Package)
+
+A package cannot use OIDC trusted publishing until it exists on npm, and it
+cannot be published by the workflow until trusted publishing is configured.
+Break the cycle by hand, once, before adding the package to any workflow list:
+
+1. **Seed the package manually** — publish a throwaway prerelease from a local
+   checkout (e.g. `0.0.1-alpha.0`) with `npm publish --tag alpha`. The `--tag`
+   is load-bearing: without it the seed takes `latest`.
+
+2. **Configure the trusted publisher** on npmjs.com for the new package,
+   pointing at `publish-npm.yml`.
+
+3. **Add the package** to the `bump-version.yml`, `publish-gh.yml`, and
+   `publish-npm.yml` package lists, and to the tag ruleset globs.
+
+4. **Cut the real release** through the standard process.
+
+5. **Retire the seed's dist-tag** once the real release holds `latest`:
+
+   ```bash
+   npm dist-tag rm <package> alpha
+   ```
+
+   Skipping this leaves a channel tag pointing behind `latest` forever — see
+   [Dist-Tags](#dist-tags).
+
+### Dist-Tags
+
+npm gives built-in meaning to exactly one tag: `latest`, the default install
+target. `next`, `canary`, `alpha`, `beta` are conventions with no registry
+semantics.
+
+**Policy: `latest` only in the steady state.** A channel tag exists solely
+while a prerelease on that channel is live. Retiring it is the closing step of
+the prerelease, not an optional cleanup.
+
+**A channel tag must never resolve older than `latest`.** `npm i pkg@next`
+pointing at an older version than `npm i pkg` is a silent downgrade for anyone
+who opts into the channel. Prerelease versions don't match caret ranges, so a
+stale tag can't leak into ordinary installs — the blast radius is limited to
+people who explicitly ask for it, which is exactly the audience it misleads.
+
+Retire a tag with:
+
+```bash
+npm dist-tag rm <package> <tag>
+```
+
+This does **not** unpublish. The version stays installable by exact version and
+the tag can be re-added later. Note that dist-tag changes are not covered by
+OIDC trusted publishing — they need a local npm token with write access, so
+this is a manual maintainer step rather than something CI does.
+
+Check the current state of every package with:
+
+```bash
+npm view <package> dist-tags
+```
+
 ## Troubleshooting
 
 ### Build failing on PR
@@ -220,6 +285,14 @@ For prereleases like `1.2.3-beta.0`:
 - Verify the PR was merged (not closed)
 - Check that the main Build and Test run is green — tagging only fires after
   green main CI; `workflow_dispatch` on Tag & push is the escape hatch
+- Check whether the run was **cancelled with zero jobs**. Main pushes share one
+  concurrency group holding at most one running plus one pending run, so a
+  third merge in quick succession evicts the queued one
+  (`Canceling since a higher priority waiting request ... exists`). `tag_push`
+  needs `build_and_test`, so an evicted run skips tagging with nothing marked
+  red. Self-heals on the next green main run, since tagging uses
+  `--no-increment` and tags whatever version main currently carries; force it
+  sooner with `workflow_dispatch` on Tag & push
 - Check that `GH_PERSONAL_ACCESS_TOKEN` has correct permissions
 - Ensure the `tag-release` environment is configured
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -222,8 +222,17 @@ cannot be published by the workflow until trusted publishing is configured.
 Break the cycle by hand, once, before adding the package to any workflow list:
 
 1. **Seed the package manually** — publish a throwaway prerelease from a local
-   checkout (e.g. `0.0.1-alpha.0`) with `npm publish --tag alpha`. The `--tag`
-   is load-bearing: without it the seed takes `latest`.
+   checkout (e.g. `0.0.1-alpha.0`) with a plain `npm publish`.
+
+   A package's **first** publish always takes `latest`, whatever `--tag` says;
+   npm requires the tag to exist. Passing `--tag alpha` does not protect
+   `latest` — it points _both_ tags at the seed, and the extra one survives as
+   a fossil after the real release moves `latest` on. Publish the seed bare and
+   there is nothing to clean up.
+
+   The seed therefore occupies `latest` until step 4 supersedes it. That is
+   expected and is the reason the seed should be a version nobody would want:
+   short-lived, obviously prerelease.
 
 2. **Configure the trusted publisher** on npmjs.com for the new package,
    pointing at `publish-npm.yml`.
@@ -233,14 +242,14 @@ Break the cycle by hand, once, before adding the package to any workflow list:
 
 4. **Cut the real release** through the standard process.
 
-5. **Retire the seed's dist-tag** once the real release holds `latest`:
+5. **Confirm the tag state** once the real release holds `latest`:
 
    ```bash
-   npm dist-tag rm <package> alpha
+   npm view <package> dist-tags
    ```
 
-   Skipping this leaves a channel tag pointing behind `latest` forever — see
-   [Dist-Tags](#dist-tags).
+   Expect `latest` only. Anything else is a fossil from a `--tag` on the seed
+   or from a prerelease bump; retire it — see [Dist-Tags](#dist-tags).
 
 ### Dist-Tags
 
@@ -249,7 +258,8 @@ target. `next`, `canary`, `alpha`, `beta` are conventions with no registry
 semantics.
 
 **Channel tags are created automatically — you never opt in.** Publishing any
-prerelease version creates one. release-it resolves the dist-tag from the
+prerelease version creates one, except on a package's very first publish, which
+always takes `latest` regardless. release-it resolves the dist-tag from the
 version itself (`lib/plugin/npm/npm.js`, `resolveTag`): a non-prerelease gets
 `latest`, and a prerelease gets its own identifier — `1.8.0-canary.0` publishes
 to `canary`, `0.2.0-beta.1` to `beta`. A prerelease with no identifier falls

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -221,28 +221,29 @@ A package cannot use OIDC trusted publishing until it exists on npm, and it
 cannot be published by the workflow until trusted publishing is configured.
 Break the cycle by hand, once, before adding the package to any workflow list:
 
-1. **Seed the package manually** — publish a throwaway prerelease from a local
-   checkout (e.g. `0.0.1-alpha.0`) with a bare `pnpm publish`, using a real
-   token. It must be `pnpm`, not `npm`: pnpm rewrites `workspace:` and
-   `catalog:` dependency specifiers to real semver on pack, and `npm` ships
-   them verbatim into an uninstallable tarball.
+1. **Seed the package manually** — from a scratch directory containing a
+   **minimal hand-written `package.json`** (name and a throwaway prerelease
+   version such as `0.0.1-alpha.0`, nothing else), run a bare `npm publish`
+   with a real token.
 
-   A package's **first** publish always takes `latest`, whatever `--tag` says;
-   npm requires the tag to exist. Passing `--tag alpha` does not protect
-   `latest` — it points _both_ tags at the seed, and the extra one survives as
-   a fossil after the real release moves `latest` on. Publish the seed bare and
-   there is nothing to clean up.
+   Publishing a stub rather than the real package is deliberate: a minimal
+   manifest has no `workspace:` or `catalog:` specifiers, so none of the
+   pack-time rewriting the pipeline relies on
+   (`publishPath`, `check:pack`) has to be reproduced by hand. The seed only
+   has to make the name exist.
 
-   The seed therefore occupies `latest` until step 4 supersedes it. That is
-   expected and is the reason the seed should be a version nobody would want:
-   short-lived, obviously prerelease.
+   **Do not pass `--tag`.** A package's first publish always takes `latest`
+   regardless — npm requires that tag to exist. `--tag alpha` cannot protect
+   `latest`; it only points a _second_ tag at the seed, and that one strands as
+   a fossil once the real release moves `latest` on. Both fossils this repo
+   accumulated came from exactly that: `lit-ui-router-mobx` seeded at
+   `0.1.0-rc.0` under `next` (superseded by `0.1.0` twenty minutes later, tag
+   stranded for five weeks), and `ui-router-server` at `0.0.1-alpha.1` under
+   `alpha`.
 
-   Worked example — `lit-ui-router-mobx` was seeded at `0.1.0-rc.0` with
-   `--tag next`, and `0.1.0` followed twenty minutes later. The seed took
-   `latest` regardless of the flag; `0.1.0` then moved `latest` on and left
-   `next` pinned to the seed for a year. Note the tag name does not match the
-   version's `rc` identifier — a hand-passed `--tag`, not release-it's
-   derivation. `ui-router-server` acquired its `alpha` the same way.
+   The seed therefore holds `latest` until step 4 supersedes it. That is
+   expected, and is why it should be a version nobody would want: short-lived
+   and obviously prerelease.
 
 2. **Configure the trusted publisher** on npmjs.com for the new package,
    pointing at `publish-npm.yml`.


### PR DESCRIPTION
Documentation only — no tooling or workflow changes.

## Why

Three gaps in `RELEASE.md`, each of which cost something this week.

### 1. No dist-tag policy

Three of four packages carried a channel tag pointing *behind* `latest`:

```
lit-ui-router          alpha: 1.0.3-alpha.2   canary: 1.8.0-canary.0   latest: 1.9.0
lit-ui-router-mobx     next:  0.1.0-rc.0                               latest: 0.5.0
ui-router-server       alpha: 0.0.1-alpha.1                            latest: 0.1.0
```

`npm i lit-ui-router-mobx@next` was a silent four-minor downgrade. Prerelease versions don't match caret ranges, so these can't leak into ordinary installs — the blast radius is limited to people who explicitly opt into the channel, which is exactly the audience they mislead.

Adds a **Dist-Tags** section: `latest` only in the steady state, a channel tag exists only while a prerelease on it is live, never behind `latest`, and retiring it is the closing step of the prerelease rather than optional cleanup. Notes that `npm dist-tag rm` doesn't unpublish, and that dist-tag changes aren't covered by OIDC trusted publishing (manual maintainer step, not CI).

### 2. First publish was tribal knowledge

A package can't use trusted publishing until it exists on npm, and can't be published by the workflow until trusted publishing is configured. Breaking that cycle isn't guessable, and the step that retires the seed's dist-tag is precisely the one skipped for `ui-router-server` — so the undocumented procedure *manufactured* one of the fossils above.

Adds a **First Publish (New Package)** section with the five steps, including `--tag alpha` on the seed (load-bearing: without it the seed takes `latest`) and retiring that tag once the real release holds `latest`.

### 3. Tagging can be skipped silently

`lit-ui-router-mobx@0.5.0` merged and did not tag. Main pushes share one concurrency group holding at most one running plus one pending run; a third merge in quick succession evicts the queued one. `tag_push` needs `build_and_test`, so an evicted release commit never tags — and nothing goes red.

Adds the **zero-jobs-cancelled** signature to *Tag workflow not running*, with the self-heal behavior (`--no-increment` tags whatever version main carries, so the next green main run recovers it) and the `workflow_dispatch` escape hatch. Also adds a note to step 3 of Standard Release to merge release PRs on their own.

The underlying concurrency bug is tracked separately in #539; this PR documents the symptom and the recovery, it does not fix the cause.

## Verification

`oxfmt --check RELEASE.md` clean (root `*.md` is in `format:check:root`'s glob). Anchor links resolve to headings in the same document.