### PR TITLE
build(lint): gate unknown events in lit templates

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,12 +19,15 @@
     // the nearest tsconfig from cwd (the repo root) and merges this entry.
     // The unknown-* rules ship at `warn` upstream and warnings alone do not
     // fail a run, so gating them means promoting each to `error`.
+    // `no-unknown-event` is the exception: it ships `off` even under `strict`,
+    // so `error` is what turns it on at all.
     "plugins": [
       {
         "name": "ts-lit-plugin",
         "strict": true,
         "rules": {
           "no-unknown-attribute": "error",
+          "no-unknown-event": "error",
           "no-unknown-property": "error",
           "no-unknown-tag-name": "error"
         }


### PR DESCRIPTION
Promotes lit-analyzer's `no-unknown-event` to `error`, extending the `//#lint:templates` gate #543 introduced.

## What it buys

#543 promoted `no-unknown-attribute`, `no-unknown-property` and `no-unknown-tag-name`, and relies on `--strict` + `--maxWarnings 0` to catch everything else. That covers every rule lit-analyzer ships at `warn` — but not the ones it ships **`off` even under `strict`**. `no-unknown-event` is one of those, so `error` is what turns it on at all, not merely what makes it fail.

The rule checks the event name in every template event binding (`@foo=${...}`) against the events lit-analyzer knows for the bound element. That closes the last of the four "does this name actually exist" axes on a lit template: tag, attribute, property, event.

## Result

Zero findings, zero fixes, no source changes. The rule is a pure guard promotion.

```
$ pnpm run lint:templates
Analyzing 112 files...
  ✓ Found 0 problems in 112 files
```

Identical before and after. `turbo run lint` is 42/42 successful.

## Proof it actually gates

A rule that reports nothing may be working, or may be looking at an empty definition set. Proven the way #543 did — by injecting a violation and confirming a nonzero exit.

Injected `@ui-router-contex` (typo) on the `<ui-router>` in `apps/sample-app-shared/src/main.ts`:

```
./apps/sample-app-shared/src/main.ts

    Unknown event 'ui-router-contex'. Did you mean '@ui-router-context'?
    30:  tml` <ui-router @ui-router-contex=${handleUiRouterContext}
    no-unknown-event

  ✖ 1 problem in 1 file (1 error, 0 warnings)
```

Exit code 1. The **"Did you mean"** suggestion is the load-bearing part: it proves `ui-router`'s event definitions are in the analyzed set. A bare `Unknown event` with no suggestion would have meant the tag resolved to nothing and the rule was vacuous.

Reverted; the branch contains no injected violation.

## Finding: the analyzer infers events beyond `@fires`

Going in, the assumption was that this rule keys purely on `@fires` JSDoc, and that the repo would need `@fires` tags added before it could pass. That is **not** how it behaves.

A second injection, `@logoutt` on `<sample-nav-header>` in `apps/sample-app-lit-vanilla/src/app/main/App.ts`:

```
    Unknown event 'logoutt'. Did you mean '@logout'?
    no-unknown-event
```

`NavHeader` carries **no `@fires` tag at all**. web-component-analyzer inferred `logout` from the `this.dispatchEvent(new Event('logout'))` call in the class body. So string-literal `dispatchEvent` calls are picked up automatically; `@fires` is only needed where the event name is not a literal at the dispatch site — which is exactly why `ui-router-context` and `ui-view-context` have it (they are dispatched through factory methods).

## Blind spots — stated explicitly

- **Only bound events are checked.** The rule fires on template bindings. An event that is dispatched but never bound in any template in this repo is invisible to it, correct or not.
- **Two library events remain undocumented, deliberately.** A full `dispatchEvent`/`new CustomEvent` sweep across `packages/*/src` and `apps/*/src` found four distinct library event types. Two carry `@fires` (`ui-router-context`, `ui-view-context`). The other two do not:
  - `UI_SREF_TARGET_EVENT` = `'uiSrefTarget'` (`packages/lit-ui-router/src/ui-sref.ts:21`)
  - `TRANSITION_STATE_CHANGE_EVENT` = `'transitionStateChange'` (`packages/lit-ui-router/src/ui-sref-active.ts:41`)

  Both are marked `@internal`, both are dispatched by **directive** classes onto whatever host element the directive is applied to (typically a plain `<a>`), and both are consumed via `addEventListener` inside the library. Neither is ever bound in a template, here or in a plausible consumer. `@fires` on a directive class would not help the rule either, since the binding site would be a native `<a>`, not a custom element. Adding it would document internal plumbing as public surface for no gate benefit, so this PR does not.

- **`no-missing-element-type-definition` is NOT in this PR.** See below.

## The CEM second-order win does not exist here — measured

The hypothesis going in was that adding `@fires` would also enrich the published `custom-elements.json` that `lit-ui-router` ships (`"customElements": "dist/custom-elements.json"`). Checked against a built manifest rather than asserted.

It does not apply, for two independent reasons:

1. **The two custom elements are already fully documented.** `turbo run build:custom-elements` produces a manifest whose only `events` arrays are on `ui-view` (`ui-router-context`, `ui-view-context`) and `ui-router` (`ui-router-context`). That is every event either element dispatches. Nothing is missing.

2. **The directive modules are not analyzed at all.** `packages/lit-ui-router/custom-elements-manifest.config.js` scopes CEM to four modules:

   ```js
   globs: ['src/ui-{router,view}.ts', 'src/ui-{router,view}.register.ts'],
   ```

   `ui-sref.ts` and `ui-sref-active.ts` are outside that glob, so `@fires` added there could not reach the manifest even if it were desirable.

**The published `custom-elements.json` is byte-identical on this branch.** There is no manifest diff to show, because this PR touches no source file.

Whether the CEM glob *should* widen to cover the directives is a real question, but it would change the published manifest and belongs in its own PR.

## Bundling decision: `no-missing-element-type-definition` is deferred

Measured on a scratch commit before deciding, per the brief. Enabling it as `error` alongside `no-unknown-event`:

```
  ✖ 39 problems in 27 files (39 errors, 0 warnings)
```

All 39 are `no-missing-element-type-definition`. This **cascades well outside `packages/`**:

| Area | Findings | Files |
| --- | ---: | ---: |
| `apps/sample-app-shared` | 14 | 14 |
| `apps/sample-app-lit-vanilla` | 4 | 4 |
| `apps/sample-app-lit-mobx` | 4 | 4 |
| `examples/hellogalaxy` | 5 | 1 |
| `examples/hellosolarsystem` | 3 | 1 |
| `examples/helloworld` | 1 | 1 |
| `packages/lit-ui-router` specs | 8 | 2 |
| **Total** | **39** | **27** |

Notably, `packages/lit-ui-router`'s own two shipped elements are clean — `ui-router.register.ts` and `ui-view.register.ts` already declare the map. Every finding is a sample-app element, an example element, or a throwaway fixture class in a spec (`test-element-guard-1`, `test-params-component`, …). That is far past the "≤5, all inside `packages/`" bar for bundling, so it ships separately or not at all.

Fixing it honestly would mean adding a `declare global { interface HTMLElementTagNameMap { … } }` block to 27 files including 8 single-use spec fixtures, which is most of the cost with the least of the value. Worth noting the rule did **not** demand entries for the `@element`-declared third-party elements (`api-docs`, `model-viewer`) — so it does not directly conflict with #543's deliberate choice to leave those out of the tag map (TS2717/TS2669, masked by `skipLibCheck`). The blocker is volume and spec-fixture noise, not that conflict.

## One-off nondeterminism observed (pre-existing, not introduced here)

Flagging honestly: across ~16 gate runs, exactly one reported a finding that no other run reproduced —

```
./apps/sample-app-shared/src/main.ts
    Unknown attribute 'src'.
    37:  ? html`<api-docs src=${customElementsJsonUrl}
    no-unknown-attribute
```

That is `no-unknown-attribute`, a rule #543 already gates, on `api-docs` — the `@element`-declared third-party element in `apps/sample-app-shared/src/api-docs.d.ts`. It is unrelated to `no-unknown-event`.

Tried to reproduce: 12 consecutive runs on the final config, all `Found 0 problems in 112 files`, plus a `touch tsconfig.json` to test a stale-config theory. Not reproducible. The plausible mechanism is analysis-order dependence — whether `api-docs.d.ts` has been folded into the tag registry by the time `main.ts` is checked — but that is a hypothesis, not a demonstrated cause. Recording it here so that if CI ever flakes on this exact message, it is a known pre-existing condition of the #543 gate rather than a regression from this PR.

## Commits

| Commit | Subject |
| --- | --- |
| `a8f71df` | `build(lint): gate unknown events in lit templates` |

## Verification

| Check | Result |
| --- | --- |
| `pnpm run lint:templates` (baseline, before) | `Found 0 problems in 112 files` |
| `pnpm run lint:templates` (after) | `Found 0 problems in 112 files` |
| `turbo run lint` | 42 successful, 42 total |
| `turbo run format:check` | 29 successful, 29 total |
| Injected typo on documented element | exit 1, `Unknown event 'ui-router-contex'. Did you mean '@ui-router-context'?` |
| Injected typo on inferred-event element | exit 1, `Unknown event 'logoutt'. Did you mean '@logout'?` |
| `custom-elements.json` | unchanged (no source files touched) |

Gate runs went through `turbo` so the packages' `build:types` ran first — without the emitted `.d.ts`, cross-package bindings silently report 0 problems instead of failing.

Parent work: #543.
