### PR TITLE
refactor(tools): read pnpm-workspace.yaml once and select sections from it

### DIFF
--- a/check-patches.ts
+++ b/check-patches.ts
@@ -8,11 +8,14 @@ import { join } from 'node:path';
 import { parsePatch } from 'diff';
 
 import {
-  loadPatchedDependencies,
+  loadWorkspaceManifest,
+  selectPatchedDependencies,
   workspaceRoot,
 } from '@tools/shared/workspace.ts';
 
-const patchedDependencies = await loadPatchedDependencies(workspaceRoot);
+const patchedDependencies = selectPatchedDependencies(
+  await loadWorkspaceManifest(workspaceRoot),
+);
 const entries = Object.entries(patchedDependencies);
 if (entries.length === 0) {
   console.error('check-patches: no patchedDependencies declared');

--- a/check-patches.ts
+++ b/check-patches.ts
@@ -13,8 +13,8 @@ import {
   workspaceRoot,
 } from '@tools/shared/workspace.ts';
 
-const patchedDependencies = selectPatchedDependencies(
-  await loadWorkspaceManifest(workspaceRoot),
+const patchedDependencies = await selectPatchedDependencies(
+  loadWorkspaceManifest(workspaceRoot),
 );
 const entries = Object.entries(patchedDependencies);
 if (entries.length === 0) {

--- a/tools/compat-guards/src/catalog.ts
+++ b/tools/compat-guards/src/catalog.ts
@@ -6,14 +6,18 @@ import { join } from 'node:path';
 
 import { readManifest } from '@tools/shared/manifest.ts';
 import type { PackageManifest } from '@tools/shared/types.ts';
-import { loadCatalogs, workspaceRoot } from '@tools/shared/workspace.ts';
+import {
+  selectCatalogs,
+  loadWorkspaceManifest,
+  workspaceRoot,
+} from '@tools/shared/workspace.ts';
 
 /** A dependency's range in a named catalog; undefined when either is absent. */
 export async function catalogRange(
   catalog: string,
   dep: string,
 ): Promise<string | undefined> {
-  const catalogs = await loadCatalogs(workspaceRoot);
+  const catalogs = selectCatalogs(await loadWorkspaceManifest(workspaceRoot));
   return catalogs[catalog]?.[dep];
 }
 

--- a/tools/compat-guards/src/catalog.ts
+++ b/tools/compat-guards/src/catalog.ts
@@ -17,7 +17,7 @@ export async function catalogRange(
   catalog: string,
   dep: string,
 ): Promise<string | undefined> {
-  const catalogs = selectCatalogs(await loadWorkspaceManifest(workspaceRoot));
+  const catalogs = await selectCatalogs(loadWorkspaceManifest(workspaceRoot));
   return catalogs[catalog]?.[dep];
 }
 

--- a/tools/compat-guards/src/lit-analyzer-ts-guard.ts
+++ b/tools/compat-guards/src/lit-analyzer-ts-guard.ts
@@ -25,15 +25,16 @@ const DEP = 'typescript';
 
 const g = guard('lit-analyzer-ts-guard');
 
-// both halves of the comparison come out of the same parse
-const manifest = await loadWorkspaceManifest(workspaceRoot);
+// one read, awaited by both selectors, so both halves of the comparison come
+// out of the same parse
+const manifest = loadWorkspaceManifest(workspaceRoot);
 
 const expected =
-  selectCatalogs(manifest)[CATALOG]?.[DEP] ??
+  (await selectCatalogs(manifest))[CATALOG]?.[DEP] ??
   g.fail(`no ${CATALOG} ${DEP} entry in pnpm-workspace.yaml`);
 
 const actual =
-  selectPackageExtensions(manifest)[EXTENDED]?.dependencies?.[DEP] ??
+  (await selectPackageExtensions(manifest))[EXTENDED]?.dependencies?.[DEP] ??
   g.fail(
     `packageExtensions.${EXTENDED} injects no ${DEP}, so lit-analyzer will ` +
       'resolve the root TypeScript and crash. Restore the entry in ' +

--- a/tools/compat-guards/src/lit-analyzer-ts-guard.ts
+++ b/tools/compat-guards/src/lit-analyzer-ts-guard.ts
@@ -11,8 +11,9 @@
 // duplicate, and hence this guard.
 // Usage (from anywhere): lit-analyzer-ts-guard
 import {
-  loadCatalogs,
-  loadPackageExtensions,
+  selectCatalogs,
+  loadWorkspaceManifest,
+  selectPackageExtensions,
   workspaceRoot,
 } from '@tools/shared/workspace.ts';
 
@@ -24,14 +25,15 @@ const DEP = 'typescript';
 
 const g = guard('lit-analyzer-ts-guard');
 
-const catalogs = await loadCatalogs(workspaceRoot);
+// both halves of the comparison come out of the same parse
+const manifest = await loadWorkspaceManifest(workspaceRoot);
+
 const expected =
-  catalogs[CATALOG]?.[DEP] ??
+  selectCatalogs(manifest)[CATALOG]?.[DEP] ??
   g.fail(`no ${CATALOG} ${DEP} entry in pnpm-workspace.yaml`);
 
-const extensions = await loadPackageExtensions(workspaceRoot);
 const actual =
-  extensions[EXTENDED]?.dependencies?.[DEP] ??
+  selectPackageExtensions(manifest)[EXTENDED]?.dependencies?.[DEP] ??
   g.fail(
     `packageExtensions.${EXTENDED} injects no ${DEP}, so lit-analyzer will ` +
       'resolve the root TypeScript and crash. Restore the entry in ' +

--- a/tools/shared/src/workspace.ts
+++ b/tools/shared/src/workspace.ts
@@ -33,16 +33,28 @@ export type Member = {
   manifest?: PackageManifest;
 };
 
+/**
+ * Parse pnpm-workspace.yaml. The `select*` selectors below take the result
+ * rather than a root, so a caller needing several sections parses the file once
+ * and passes the manifest around instead of re-reading it per section.
+ */
+export async function loadWorkspaceManifest(
+  root: string,
+): Promise<WorkspaceManifest | undefined> {
+  const { readWorkspaceManifest } =
+    await import('@pnpm/workspace.workspace-manifest-reader');
+  return readWorkspaceManifest(root);
+}
+
 /** Enumerate workspace members (incl. root) and the parsed workspace manifest. */
 export async function loadWorkspace(root: string): Promise<{
   members: Member[];
   workspaceManifest: WorkspaceManifest | undefined;
 }> {
-  const [{ findPackages }, { readWorkspaceManifest }] = await Promise.all([
+  const [{ findPackages }, workspaceManifest] = await Promise.all([
     import('@pnpm/workspace.projects-reader'),
-    import('@pnpm/workspace.workspace-manifest-reader'),
+    loadWorkspaceManifest(root),
   ]);
-  const workspaceManifest = await readWorkspaceManifest(root);
   const projects = await findPackages(root, {
     patterns: workspaceManifest?.packages,
     includeRoot: true,
@@ -58,35 +70,23 @@ export async function loadWorkspace(root: string): Promise<{
   return { members, workspaceManifest };
 }
 
-/** Catalogs from pnpm-workspace.yaml; the unnamed `catalog:` is `default`, per pnpm. */
-export async function loadCatalogs(
-  root: string,
-): Promise<Record<string, Record<string, string>>> {
-  const { readWorkspaceManifest } =
-    await import('@pnpm/workspace.workspace-manifest-reader');
-  const workspaceManifest = await readWorkspaceManifest(root);
-  return {
-    default: workspaceManifest?.catalog ?? {},
-    ...workspaceManifest?.catalogs,
-  };
+/** Catalogs from the manifest; the unnamed `catalog:` is `default`, per pnpm. */
+export function selectCatalogs(
+  manifest: WorkspaceManifest | undefined,
+): Record<string, Record<string, string>> {
+  return { default: manifest?.catalog ?? {}, ...manifest?.catalogs };
 }
 
-/** packageExtensions from pnpm-workspace.yaml: package name -> injected fields. */
-export async function loadPackageExtensions(
-  root: string,
-): Promise<Record<string, { dependencies?: Record<string, string> }>> {
-  const { readWorkspaceManifest } =
-    await import('@pnpm/workspace.workspace-manifest-reader');
-  const workspaceManifest = await readWorkspaceManifest(root);
-  return workspaceManifest?.packageExtensions ?? {};
+/** packageExtensions from the manifest: package name -> injected fields. */
+export function selectPackageExtensions(
+  manifest: WorkspaceManifest | undefined,
+): Record<string, { dependencies?: Record<string, string> }> {
+  return manifest?.packageExtensions ?? {};
 }
 
-/** patchedDependencies from pnpm-workspace.yaml: package name -> patch path. */
-export async function loadPatchedDependencies(
-  root: string,
-): Promise<Record<string, string>> {
-  const { readWorkspaceManifest } =
-    await import('@pnpm/workspace.workspace-manifest-reader');
-  const workspaceManifest = await readWorkspaceManifest(root);
-  return workspaceManifest?.patchedDependencies ?? {};
+/** patchedDependencies from the manifest: package name -> patch path. */
+export function selectPatchedDependencies(
+  manifest: WorkspaceManifest | undefined,
+): Record<string, string> {
+  return manifest?.patchedDependencies ?? {};
 }

--- a/tools/shared/src/workspace.ts
+++ b/tools/shared/src/workspace.ts
@@ -33,10 +33,20 @@ export type Member = {
   manifest?: PackageManifest;
 };
 
+/** A value, or the pending read of one. */
+export type Awaitable<T> = T | Promise<T>;
+
 /**
- * Parse pnpm-workspace.yaml. The `select*` selectors below take the result
- * rather than a root, so a caller needing several sections parses the file once
- * and passes the manifest around instead of re-reading it per section.
+ * What every `select*` below accepts: a parsed manifest, or the in-flight
+ * `loadWorkspaceManifest` call that produces one. Passing the call means the
+ * unit handed around is the read itself, so feeding it to several selectors
+ * still parses pnpm-workspace.yaml exactly once.
+ */
+export type WorkspaceManifestSource = Awaitable<WorkspaceManifest | undefined>;
+
+/**
+ * Parse pnpm-workspace.yaml. Selectors take the result rather than a root, so a
+ * caller needing several sections reads once and passes that read around.
  */
 export async function loadWorkspaceManifest(
   root: string,
@@ -71,22 +81,23 @@ export async function loadWorkspace(root: string): Promise<{
 }
 
 /** Catalogs from the manifest; the unnamed `catalog:` is `default`, per pnpm. */
-export function selectCatalogs(
-  manifest: WorkspaceManifest | undefined,
-): Record<string, Record<string, string>> {
+export async function selectCatalogs(
+  source: WorkspaceManifestSource,
+): Promise<Record<string, Record<string, string>>> {
+  const manifest = await source;
   return { default: manifest?.catalog ?? {}, ...manifest?.catalogs };
 }
 
 /** packageExtensions from the manifest: package name -> injected fields. */
-export function selectPackageExtensions(
-  manifest: WorkspaceManifest | undefined,
-): Record<string, { dependencies?: Record<string, string> }> {
-  return manifest?.packageExtensions ?? {};
+export async function selectPackageExtensions(
+  source: WorkspaceManifestSource,
+): Promise<Record<string, { dependencies?: Record<string, string> }>> {
+  return (await source)?.packageExtensions ?? {};
 }
 
 /** patchedDependencies from the manifest: package name -> patch path. */
-export function selectPatchedDependencies(
-  manifest: WorkspaceManifest | undefined,
-): Record<string, string> {
-  return manifest?.patchedDependencies ?? {};
+export async function selectPatchedDependencies(
+  source: WorkspaceManifestSource,
+): Promise<Record<string, string>> {
+  return (await source)?.patchedDependencies ?? {};
 }


### PR DESCRIPTION
Follow-up to #543, which added a third `load*` function to `tools/shared/src/workspace.ts` that was a copy of the two above it: lazy-import the pnpm SDK, call `readWorkspaceManifest`, return one section. A caller wanting two sections parsed `pnpm-workspace.yaml` twice, and `lit-analyzer-ts-guard` — the guard #543 shipped — did exactly that.

Split the IO from the extraction:

- `loadWorkspaceManifest(root)` parses, and is now the only `readWorkspaceManifest` call site in the repo. `loadWorkspace` shares it instead of inlining its own read.
- `selectCatalogs` / `selectPackageExtensions` / `selectPatchedDependencies` extract one section each.

Selectors take `Awaitable<WorkspaceManifest | undefined>`, so the unit passed around can be the in-flight read rather than its result:

```ts
const manifest = loadWorkspaceManifest(workspaceRoot); // not awaited
const expected = (await selectCatalogs(manifest))[CATALOG]?.[DEP];
const actual = (await selectPackageExtensions(manifest))[EXTENDED]?.dependencies?.[DEP];
```

Feeding one read to several selectors parses the file once without the caller having to sequence an await first, and a caller that already holds a manifest — `loadWorkspace` returns one — still passes it directly. That is what makes "parse once, pass it around" the shape of the API rather than a convention each new caller has to remember.

`catalogRange` and `check-patches` each still parse once; the win there is the deleted boilerplate, not speed. The lazy import stays, so `workspaceRoot` costs nothing to import.

### Why no memo

A module-level `Map<root, Promise>` would make single-parse unconditional, but no caller needs it: `loadWorkspace` has nine callers, all in `tools/release`; `catalogRange` has one, in `compat-guards`; they never share a process. Every real double-parse was within a single file, and passing the read fixes those structurally. Worth revisiting if a caller ever needs the manifest across module boundaries with no natural place to thread it — the `Awaitable` parameter absorbs that with no call-site change.

## Verification

`turbo run lint typecheck` — 89/89, and the full run including `//#lint:templates` was 118/118.

All three consumer paths run live rather than inferred from types:

```
lit-analyzer-ts-guard: packageExtensions.lit-analyzer typescript matches typescript6-compat (npm:@typescript/typescript6@^6.0.2)
check-patches: 3 patches verified against installs
mobx6-compat-guard: mobx-6 -> mobx 6.16.1 within peer range ^6.0.0 || ^7.0.0
```

The last covers `catalogRange`, the path the other compat guards reach the catalog through, so each of the three selectors is exercised by a real invocation.

Also confirmed nothing in the repo writes `pnpm-workspace.yaml` in-process — every match is an error-message string — which is the precondition a memo would have depended on.
