### PR TITLE
ci(release): attest provenance with actions/attest, retiring the wrapper

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -107,9 +107,10 @@ jobs:
           TURBO_TEAM: ${{ vars.TURBO_TEAM }}
       - name: Attest build provenance
         # Generate SLSA provenance attestation for supply chain security.
+        # subject-path alone (no predicate/sbom input) selects attest's provenance mode.
         # Skipped on manual dry runs: this hits Sigstore/rekor for real and isn't part of release-it's --dry-run.
         if: ${{ !inputs.dryRun }}
-        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
         with:
           subject-path: ${{ steps.pack.outputs.tarball }}
       - name: Publish


### PR DESCRIPTION
Supersedes #544.

## Why

Dependabot's #544 bumps `actions/attest-build-provenance` 4.1.1 → 4.2.2. That release's own note says the quiet part out loud:

> As of version 4, `actions/attest-build-provenance` is simply a wrapper on top of [`actions/attest`](https://github.com/actions/attest). Existing applications may continue to use the `attest-build-provenance` action, but new implementations should use `actions/attest` instead.

So rather than keep bumping a wrapper that no longer does anything, point the publish job at the action it wraps.

## What changes

One `uses:` line in `.github/workflows/publish-npm.yml`:

```diff
-        uses: actions/attest-build-provenance@0f67c3f... # v4.1.1
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
```

`actions/attest` picks its mode from the inputs: `subject-path` with no `sbom-path` and no `predicate*` input is **provenance mode**, which auto-generates the same SLSA build provenance predicate the wrapper produced. Same subject (the packed tarball), same Sigstore signing path, same attestations API. Like-for-like.

The job's `permissions` block already grants exactly the three the `actions/attest` README documents — `id-token: write`, `attestations: write`, `artifact-metadata: write` — so nothing else moves.

## Verification

`mise run lint_workflows` (actionlint + zizmor + taplo + shellcheck) is clean; the pin is a full-SHA tag ref so zizmor's pinning audit stays satisfied.

The real proof is a publish run — the attest step is `if: ${{ !inputs.dryRun }}` and hits Sigstore for real, so it is not exercised by a dry run. Per the release-gated-verification habit this rides the next owed release: after it, `gh attestation verify <tarball> --repo simshanith/lit-ui-router` should pass as before.

## Follow-up

Close #544 with `@dependabot close` once this lands — the wrapper is gone from the tree, so the bot has nothing left to bump there. (Never `ignore`: that would suppress future majors of a dependency we may care about again.)