### PR TITLE
test(lit-ui-router): hoist element fixtures to module scope

### DIFF
--- a/packages/lit-ui-router/src/specs/core.spec.ts
+++ b/packages/lit-ui-router/src/specs/core.spec.ts
@@ -17,6 +17,31 @@ import {
   NormalizedLitViewDeclaration,
 } from '../interface.js';
 
+@customElement('test-element-guard-1')
+class TestElementGuard extends LitElement {}
+
+@customElement('test-element-routed-1')
+class TestElementRouted extends LitElement {}
+
+@customElement('test-element-argless-1')
+class TestElementArgless extends LitElement {}
+
+@customElement('test-routed-element')
+class TestRoutedElement extends LitElement {
+  render() {
+    return html`<div>Routed Element</div>`;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'test-element-guard-1': TestElementGuard;
+    'test-element-routed-1': TestElementRouted;
+    'test-element-argless-1': TestElementArgless;
+    'test-routed-element': TestRoutedElement;
+  }
+}
+
 describe('UIRouterLit', () => {
   let router: UIRouterLit;
 
@@ -179,17 +204,13 @@ describe('isLitViewDeclarationTemplate', () => {
   });
 
   it('should return true for LitElement classes with argless constructors', () => {
-    @customElement('test-element-guard-1')
-    class TestElement extends LitElement {}
-    expect(isLitViewDeclarationTemplate(TestElement)).toBe(true);
+    expect(isLitViewDeclarationTemplate(TestElementGuard)).toBe(true);
   });
 });
 
 describe('isRoutedLitElement', () => {
   it('should return true for LitElement subclass', () => {
-    @customElement('test-element-routed-1')
-    class TestElement extends LitElement {}
-    expect(isRoutedLitElement(TestElement)).toBe(true);
+    expect(isRoutedLitElement(TestElementRouted)).toBe(true);
   });
 
   it('should return false for regular functions', () => {
@@ -407,13 +428,6 @@ describe('litViewsBuilder', () => {
   });
 
   it('should wrap LitElement class component', async () => {
-    @customElement('test-routed-element')
-    class TestRoutedElement extends LitElement {
-      render() {
-        return html`<div>Routed Element</div>`;
-      }
-    }
-
     const stateDecl: LitStateDeclaration = {
       name: 'test',
       url: '/test',
@@ -448,14 +462,11 @@ describe('litViewsBuilder', () => {
   });
 
   it('should register a bare argless LitElement class and deliver props via property', async () => {
-    @customElement('test-element-argless-1')
-    class TestElement extends LitElement {}
-
     const stateDecl: LitStateDeclaration = {
       name: 'argless',
       url: '/argless',
       views: {
-        $default: TestElement,
+        $default: TestElementArgless,
       },
     };
 
@@ -487,10 +498,10 @@ describe('litViewsBuilder', () => {
 
     const props = {} as UIViewInjectedProps;
     const result = views?.$default.component(props);
-    const instance = result?.values[0] as TestElement & {
+    const instance = result?.values[0] as TestElementArgless & {
       _uiViewProps?: UIViewInjectedProps;
     };
-    expect(instance).toBeInstanceOf(TestElement);
+    expect(instance).toBeInstanceOf(TestElementArgless);
     expect(instance._uiViewProps).toBe(props);
   });
 });

--- a/packages/lit-ui-router/src/specs/ui-view.spec.ts
+++ b/packages/lit-ui-router/src/specs/ui-view.spec.ts
@@ -21,6 +21,66 @@ import {
   routerGo,
 } from './test-utils.js';
 
+// Module-scope fixtures delegate to these handles, reassigned per test so each
+// test keeps its own spy/state.
+let canExit: UiOnExit['uiCanExit'];
+let paramsChanged: UiOnParamsChanged['uiOnParamsChanged'];
+let receiveParams: UiOnParamsChanged['uiOnParamsChanged'];
+
+@customElement('test-exit-component')
+class TestExitComponent extends LitElement implements UiOnExit {
+  uiCanExit = (trans?: Transition) => canExit(trans);
+  render() {
+    return html`<div>Exit Component</div>`;
+  }
+}
+
+@customElement('test-block-exit-component')
+class TestBlockExitComponent extends LitElement implements UiOnExit {
+  uiCanExit() {
+    return false;
+  }
+  render() {
+    return html`<div>Block Exit</div>`;
+  }
+}
+
+@customElement('test-params-component')
+class TestParamsComponent extends LitElement implements UiOnParamsChanged {
+  uiOnParamsChanged(
+    ...args: Parameters<UiOnParamsChanged['uiOnParamsChanged']>
+  ) {
+    paramsChanged(...args);
+  }
+  render() {
+    return html`<div>Params Component</div>`;
+  }
+}
+
+@customElement('test-params-receive-component')
+class TestParamsReceiveComponent
+  extends LitElement
+  implements UiOnParamsChanged
+{
+  uiOnParamsChanged(
+    ...args: Parameters<UiOnParamsChanged['uiOnParamsChanged']>
+  ) {
+    receiveParams(...args);
+  }
+  render() {
+    return html`<div>Params Component</div>`;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'test-exit-component': TestExitComponent;
+    'test-block-exit-component': TestBlockExitComponent;
+    'test-params-component': TestParamsComponent;
+    'test-params-receive-component': TestParamsReceiveComponent;
+  }
+}
+
 describe('UiView', () => {
   let container: HTMLElement;
   let router: UIRouterLit;
@@ -28,6 +88,10 @@ describe('UiView', () => {
   beforeEach(() => {
     container = document.createElement('div');
     document.body.appendChild(container);
+    // Fresh, inert defaults so no handle leaks between tests.
+    canExit = () => true;
+    paramsChanged = () => {};
+    receiveParams = () => {};
   });
 
   afterEach(() => {
@@ -294,14 +358,7 @@ describe('UiView', () => {
   describe('uiCanExit hook', () => {
     it('should call uiCanExit on component before exiting', async () => {
       const uiCanExitSpy = vi.fn().mockReturnValue(true);
-
-      @customElement('test-exit-component')
-      class TestExitComponent extends LitElement implements UiOnExit {
-        uiCanExit = uiCanExitSpy;
-        render() {
-          return html`<div>Exit Component</div>`;
-        }
-      }
+      canExit = uiCanExitSpy;
 
       const states: LitStateDeclaration[] = [
         {
@@ -328,16 +385,6 @@ describe('UiView', () => {
     });
 
     it('should prevent navigation when uiCanExit returns false', async () => {
-      @customElement('test-block-exit-component')
-      class TestBlockExitComponent extends LitElement implements UiOnExit {
-        uiCanExit() {
-          return false;
-        }
-        render() {
-          return html`<div>Block Exit</div>`;
-        }
-      }
-
       const states: LitStateDeclaration[] = [
         {
           name: 'home',
@@ -371,17 +418,7 @@ describe('UiView', () => {
   describe('uiOnParamsChanged hook', () => {
     it('should call uiOnParamsChanged when params change', async () => {
       const onParamsChangedSpy = vi.fn();
-
-      @customElement('test-params-component')
-      class TestParamsComponent
-        extends LitElement
-        implements UiOnParamsChanged
-      {
-        uiOnParamsChanged = onParamsChangedSpy;
-        render() {
-          return html`<div>Params Component</div>`;
-        }
-      }
+      paramsChanged = onParamsChangedSpy;
 
       const states: LitStateDeclaration[] = [
         {
@@ -407,19 +444,9 @@ describe('UiView', () => {
 
     it('should pass changed params to uiOnParamsChanged', async () => {
       let receivedParams: Record<string, unknown> | undefined;
-
-      @customElement('test-params-receive-component')
-      class TestParamsReceiveComponent
-        extends LitElement
-        implements UiOnParamsChanged
-      {
-        uiOnParamsChanged(newParams: Record<string, unknown>) {
-          receivedParams = newParams;
-        }
-        render() {
-          return html`<div>Params Component</div>`;
-        }
-      }
+      receiveParams = (newParams) => {
+        receivedParams = newParams;
+      };
 
       const states: LitStateDeclaration[] = [
         {


### PR DESCRIPTION
Step 1 of 3 from #550. **This PR does not adopt the
`no-missing-element-type-definition` rule** — that is step 3 and stays
unadopted here. `tsconfig.json` is untouched.

## What

Hoists the 8 remaining custom-element test fixtures in
`core.spec.ts` and `ui-view.spec.ts` from inside `it()` bodies to module
scope, each with a colocated `HTMLElementTagNameMap` entry. This extends
the convention `transition-controller.spec.ts` already uses.

## Why this stands on its own

Defining a custom element inside an `it()` body permanently mutates the
global `CustomElementRegistry` as a side effect of one test. The
definition outlives the test and cannot be undone. It works here only
because every tag name happens to be unique — three of the classes were
all literally named `TestElement`, and a naive hoist would have collided.
Module-scope fixtures make registration explicit and once-per-file.

The honest counter-argument: defining the element inside the test keeps
the fixture adjacent to the assertion that uses it, and three of these
tests genuinely *are* about a component's hook behaviour.

## Preserving per-test isolation

Three fixtures closed over test-local state. Hoisting them naively would
share one spy across tests. Each now delegates to a module-level handle
that is reassigned per test, so every test still gets a **fresh** spy —
only the class moved:

- `test-exit-component` → `canExit`
- `test-params-component` → `paramsChanged`
- `test-params-receive-component` → `receiveParams`

`beforeEach` resets all three to inert defaults so a stale handle cannot
leak into a later test. No test's assertions changed.

## Verification

- `turbo run test typecheck lint --filter=lit-ui-router`: green.
  10 test files, 165 tests passed.
- Scratch check (reverted before commit): with the rule temporarily
  promoted to `error`, `no-missing-element-type-definition` findings drop
  **39 → 31**, with all 31 remaining findings in `apps/` and `examples/`.
