### PR TITLE
chore(deps): bump the pnpm workspace SDK

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,17 +34,17 @@ catalogs:
       specifier: 1100.0.0
       version: 1100.0.0
     '@pnpm/types':
-      specifier: 1101.8.0
-      version: 1101.8.0
+      specifier: 1101.9.0
+      version: 1101.9.0
     '@pnpm/workspace.project-manifest-reader':
-      specifier: 1100.0.22
-      version: 1100.0.22
+      specifier: 1100.0.23
+      version: 1100.0.23
     '@pnpm/workspace.projects-reader':
-      specifier: 1101.0.21
-      version: 1101.0.21
+      specifier: 1101.0.22
+      version: 1101.0.22
     '@pnpm/workspace.workspace-manifest-reader':
-      specifier: 1100.1.4
-      version: 1100.1.4
+      specifier: 1100.1.5
+      version: 1100.1.5
     '@release-it/conventional-changelog':
       specifier: ^12.0.0
       version: 12.0.0
@@ -1114,10 +1114,10 @@ importers:
         version: 1100.0.0
       '@pnpm/types':
         specifier: 'catalog:'
-        version: 1101.8.0
+        version: 1101.9.0
       '@pnpm/workspace.project-manifest-reader':
         specifier: 'catalog:'
-        version: 1100.0.22(@pnpm/logger@1100.0.0)
+        version: 1100.0.23(@pnpm/logger@1100.0.0)
       '@tools/shared':
         specifier: workspace:*
         version: link:../shared
@@ -1162,13 +1162,13 @@ importers:
         version: 1100.0.0
       '@pnpm/types':
         specifier: 'catalog:'
-        version: 1101.8.0
+        version: 1101.9.0
       '@pnpm/workspace.projects-reader':
         specifier: 'catalog:'
-        version: 1101.0.21(@pnpm/logger@1100.0.0)
+        version: 1101.0.22(@pnpm/logger@1100.0.0)
       '@pnpm/workspace.workspace-manifest-reader':
         specifier: 'catalog:'
-        version: 1100.1.4
+        version: 1100.1.5
       '@types/node':
         specifier: 'catalog:'
         version: 24.13.3
@@ -2951,28 +2951,28 @@ packages:
     resolution: {integrity: sha512-oeQJs1aa8Ghke8JIK9yuq/+KjMiaYeDZ38jx7MhkXncXlUKjqQ3wEm2X3qCKyjo+ZZofZj+WsEEiqkTtRuE2xQ==}
     engines: {node: ^20.9.0 || >=22.0.0, npm: '>=10.8.2'}
 
-  '@pnpm/cli.meta@1100.0.13':
-    resolution: {integrity: sha512-QAKIFaPgVwsXOuhIlvEhdtWN5CTWbDmMtE3vffaN1dlGc79+SGBaSeT7skIeH79GCipgjcL2+DgKjkpR6edDlg==}
+  '@pnpm/cli.meta@1100.0.14':
+    resolution: {integrity: sha512-XUtk4jElgzD/WnnxqPaPTxRjCE2xC7iyvYwR1eldFgKz9rq1ku3NOHWQ93y6UUXc2wJUTi0s5Qnuvnge7GCzOg==}
     engines: {node: '>=22.13'}
 
-  '@pnpm/cli.utils@1101.0.21':
-    resolution: {integrity: sha512-ZWFXf13HRwb0LLk5ahIg/Rvw8zA3YzZVVBCfA4Ug9AsOxnypjSBmVHdXwDtDbjjR1aZ5wGsCcGGpdyIiRHTLxw==}
-    engines: {node: '>=22.13'}
-    peerDependencies:
-      '@pnpm/logger': ^1100.0.0
-
-  '@pnpm/config.package-is-installable@1100.1.1':
-    resolution: {integrity: sha512-R9ntmsGLnphmrFb8/B2WtYQiszoCg25n2vNwNDyXvupWo8lwjjSRovJ6KXJW1ePNerRg/iEVqwqlFKZzhMBePQ==}
+  '@pnpm/cli.utils@1101.0.22':
+    resolution: {integrity: sha512-06o8hcbxbxu5I2bnjYzC2CYt2UWH33HCDtL+ijbpZywbFfTACt2DCZ3R/8m7OAdPQ/e6C8gig5cH1saod9e8Zg==}
     engines: {node: '>=22.13'}
     peerDependencies:
       '@pnpm/logger': ^1100.0.0
 
-  '@pnpm/constants@1100.0.1':
-    resolution: {integrity: sha512-0CqK4HTdfON1IiBIg1ib06hGJv2sDWovOZ8tP/S8BOkhVYXoter1wia1OtgUeSIabDgyeWgL8LRHG4PhkuIAPw==}
+  '@pnpm/config.package-is-installable@1100.1.2':
+    resolution: {integrity: sha512-eqCp2lqk6I8tcd0C9vuIOY8xuSLNv2PeSMjht8ezsUmy2d2fvufEiNaEXsjUz8GDIKoeuLWtxzI7h3anPILSoA==}
+    engines: {node: '>=22.13'}
+    peerDependencies:
+      '@pnpm/logger': ^1100.0.0
+
+  '@pnpm/constants@1101.0.0':
+    resolution: {integrity: sha512-jJQU6y8lhic2at0+W246+tMDdEqhbS1WSRlTjmIXeXrrWU2rAbhixi11loE+lI3f/E1Ci1+3i5N6ewOumeNJdg==}
     engines: {node: '>=22.13'}
 
-  '@pnpm/core-loggers@1100.3.1':
-    resolution: {integrity: sha512-1gbpUBQKcfbxp5XnkYvTdcplFdSvK+QeZA8KXm8sGpqzWxb+ckO1oeFTX1u6I8P30mZgWPQc8ZPMnEG/rU2R1w==}
+  '@pnpm/core-loggers@1100.3.2':
+    resolution: {integrity: sha512-dsxDByU2KFLxTzVdXZCMjsv0rIxMmFMhWWjo6e1Sq8+TqdoPXSAGcFMN0psVJHRj5+xxXqZen4+NfFhHHsRQMg==}
     engines: {node: '>=22.13'}
     peerDependencies:
       '@pnpm/logger': ^1100.0.0
@@ -2981,12 +2981,12 @@ packages:
     resolution: {integrity: sha512-G3J83gBJ5XCKhoJ7XbnF0uVJw7D5FC2X1T+txoGtEV1e1dFLT98b05zlBjgaMonkbxFCIUCuwHxttyEyKJvXow==}
     engines: {node: '>=22.13'}
 
-  '@pnpm/engine.runtime.system-version@1100.0.8':
-    resolution: {integrity: sha512-KTJxFu8Sm4w4j3xAdvHnwbnAUanoHMPeeEV42NHOKCw6XS/9k2RVnM49YDKk/1Bj3Dj387VUyLFoEfCJ65GMrg==}
+  '@pnpm/engine.runtime.system-version@1100.0.9':
+    resolution: {integrity: sha512-ywydCrV79h1rrWzINY/yiho0SMIkRMYYrsvsG17KghOSoWiQcq30qGgfRnr+0keed+oxsCNmqlzYO+rz+MI6qg==}
     engines: {node: '>=22.13'}
 
-  '@pnpm/error@1100.1.0':
-    resolution: {integrity: sha512-ZpinzFJNeHEvNxm3lWvZ1jqZ78DTNoClPrNSvZH83JNEWmyDAdw2QDNmiYjpG5nIYarZjahEGKz+oQlgKrvnNg==}
+  '@pnpm/error@1100.1.1':
+    resolution: {integrity: sha512-dqFXd5jTgBkGkwwI6AO9ON/WBXlQ8LIMRyyRysgSshix1XDyYjMmk7+bdPLuY2gjpB95j0Wu9Xq+3l7uuGZToQ==}
     engines: {node: '>=22.13'}
 
   '@pnpm/fs.graceful-fs@1100.1.1':
@@ -2997,8 +2997,8 @@ packages:
     resolution: {integrity: sha512-A3bRMTIZ5ptDPAE/KsDeY1J5UqqOiyo66+k/mUvaVjx++OJdMbp9If5kisEq9ljAV5r5TRpkxsJbSdrdJ5WtzQ==}
     engines: {node: '>=22.13'}
 
-  '@pnpm/pkg-manifest.utils@1100.3.0':
-    resolution: {integrity: sha512-y51xeTF8oO6b9fpZ4BxIxRvWBdjxBVgRiVJEB0NHT6OjcJ672lyURUzgnJIvfTabnceUxm4WAjkuXZINXRHSUw==}
+  '@pnpm/pkg-manifest.utils@1100.3.1':
+    resolution: {integrity: sha512-9gYZ0NFNac2+qYV8suA7KWmZia0eJJNQDeByAhTfFpM1ji3Md7SFoNY9WnqXntpx/p1r9rRTeww4iwou/NEztg==}
     engines: {node: '>=22.13'}
     peerDependencies:
       '@pnpm/logger': ^1100.0.0
@@ -3007,32 +3007,32 @@ packages:
     resolution: {integrity: sha512-10rRwfC9ffkuS4RugetHD+AiNZLdg9ZVv0rkbr/8o14EW6Vh6ZwFwAfTOlkp3Eyse8518jVFvXXPKQKyeh9kNw==}
     engines: {node: '>=22.13'}
 
-  '@pnpm/types@1101.8.0':
-    resolution: {integrity: sha512-oI4t7shio2C3ld+S8bLfrG6aDyepkWwefa4Lw/I4E2JrPDkp8ZKDD1BcgYbkM+bwtgjyJpD0VgPrkqGqu6Uh/w==}
+  '@pnpm/text.ordinal-comparator@1100.0.0':
+    resolution: {integrity: sha512-1mtSzx973BzS4c0QGW8NMweIG3PXq8LFRjff+JMpXDYyqZEn+1u6brAnaWDH8mgx7pgiUyjTmXNJa+MrSVjXCA==}
     engines: {node: '>=22.13'}
 
-  '@pnpm/util.lex-comparator@4.0.1':
-    resolution: {integrity: sha512-EZ3aWU7ThppE3Xgq7/ftxq8J/nit6z8I2/wZbC/acea2Zw7KJ1k/fLkGBgyyVAE37CULFsOSmPl3EjYM18cB2Q==}
+  '@pnpm/types@1101.9.0':
+    resolution: {integrity: sha512-lB2aSB2h950UX1GX3JW4AZ86xjXD92YJbV92IBSQqHXXZdiemoVKADLA2cDQ4/wKeS7djY8fkITM6X+6iYF62A==}
     engines: {node: '>=22.13'}
 
-  '@pnpm/workspace.project-manifest-reader@1100.0.22':
-    resolution: {integrity: sha512-huzXozgXlQs56d2XMnt/zAoQnxhjt0G2teFJbGiq4uUWxz+9qv7K1mtiVwcvtk7bdso4kjGzTzoIUEuFfy9ksw==}
-    engines: {node: '>=22.13'}
-    peerDependencies:
-      '@pnpm/logger': ^1100.0.0
-
-  '@pnpm/workspace.project-manifest-writer@1100.0.13':
-    resolution: {integrity: sha512-Af+m5JB/Rp70Oqp9KLJEBYqEV5K35xJWVRT6mI28jpWJr97Umlmdj8t5VAILdlSwXkCkD4Kwd7HJvuc9dAKdOQ==}
-    engines: {node: '>=22.13'}
-
-  '@pnpm/workspace.projects-reader@1101.0.21':
-    resolution: {integrity: sha512-+QpeUT1wuMv46o3HRSFLs8hqWk1kiblXw2fhVqRccROAguI6jtj3yAFp/ltk2lbUSXT/6eeRzoX5n+KFIEC4EA==}
+  '@pnpm/workspace.project-manifest-reader@1100.0.23':
+    resolution: {integrity: sha512-sIZ9QLZJOVt9nf7qiWd/bUFqyF12T0HrkRhkkkAAzc50NpXEzvbZjRV1V6r9zoWfJwntFx2jzyzYVIn4Zn9Snw==}
     engines: {node: '>=22.13'}
     peerDependencies:
       '@pnpm/logger': ^1100.0.0
 
-  '@pnpm/workspace.workspace-manifest-reader@1100.1.4':
-    resolution: {integrity: sha512-MDqtRle/sGlwiMi1K2OOE2gGPaOTYKui4Jk30TLI3ZOy6d7HLGXDVQmrrfB2rSl2e9ob3VfJaHl2kpgqlHj8Tg==}
+  '@pnpm/workspace.project-manifest-writer@1100.0.14':
+    resolution: {integrity: sha512-1s+T0xtNHbfQ73LdyE5mEZ8+cXKPQRT0N8qUXp+AZio9Mbgu2R9Qsz2n68vh4tiBrNSndaDc6PlyIb1N/tAEUA==}
+    engines: {node: '>=22.13'}
+
+  '@pnpm/workspace.projects-reader@1101.0.22':
+    resolution: {integrity: sha512-rH1MGGvI01+zxFLRS3xqGN9FGNgJ6v4/6AXUEqfzEnUxzMsvilPvwtUBYNsw37Y8Z4lp3OCGMxN7tAOe0MTUlw==}
+    engines: {node: '>=22.13'}
+    peerDependencies:
+      '@pnpm/logger': ^1100.0.0
+
+  '@pnpm/workspace.workspace-manifest-reader@1100.1.5':
+    resolution: {integrity: sha512-NMUVtTcyY8vm9xPMmpWRtWaCTdO3JyaHrm1AHdCpTQUhvhemLnULrSp5LG36o6BqUOF/P/cj/i8j97vDOypO5A==}
     engines: {node: '>=22.13'}
 
   '@polka/url@1.0.0-next.29':
@@ -8082,57 +8082,57 @@ snapshots:
 
   '@phun-ky/typeof@2.0.3': {}
 
-  '@pnpm/cli.meta@1100.0.13':
+  '@pnpm/cli.meta@1100.0.14':
     dependencies:
-      '@pnpm/types': 1101.8.0
+      '@pnpm/types': 1101.9.0
       load-json-file: 7.0.1
 
-  '@pnpm/cli.utils@1101.0.21(@pnpm/logger@1100.0.0)':
+  '@pnpm/cli.utils@1101.0.22(@pnpm/logger@1100.0.0)':
     dependencies:
-      '@pnpm/cli.meta': 1100.0.13
-      '@pnpm/config.package-is-installable': 1100.1.1(@pnpm/logger@1100.0.0)
-      '@pnpm/error': 1100.1.0
+      '@pnpm/cli.meta': 1100.0.14
+      '@pnpm/config.package-is-installable': 1100.1.2(@pnpm/logger@1100.0.0)
+      '@pnpm/error': 1100.1.1
       '@pnpm/logger': 1100.0.0
-      '@pnpm/pkg-manifest.utils': 1100.3.0(@pnpm/logger@1100.0.0)
-      '@pnpm/types': 1101.8.0
-      '@pnpm/workspace.project-manifest-reader': 1100.0.22(@pnpm/logger@1100.0.0)
+      '@pnpm/pkg-manifest.utils': 1100.3.1(@pnpm/logger@1100.0.0)
+      '@pnpm/types': 1101.9.0
+      '@pnpm/workspace.project-manifest-reader': 1100.0.23(@pnpm/logger@1100.0.0)
       chalk: 6.0.0
       load-json-file: 7.0.1
 
-  '@pnpm/config.package-is-installable@1100.1.1(@pnpm/logger@1100.0.0)':
+  '@pnpm/config.package-is-installable@1100.1.2(@pnpm/logger@1100.0.0)':
     dependencies:
-      '@pnpm/cli.meta': 1100.0.13
-      '@pnpm/core-loggers': 1100.3.1(@pnpm/logger@1100.0.0)
-      '@pnpm/engine.runtime.system-version': 1100.0.8
-      '@pnpm/error': 1100.1.0
+      '@pnpm/cli.meta': 1100.0.14
+      '@pnpm/core-loggers': 1100.3.2(@pnpm/logger@1100.0.0)
+      '@pnpm/engine.runtime.system-version': 1100.0.9
+      '@pnpm/error': 1100.1.1
       '@pnpm/logger': 1100.0.0
-      '@pnpm/types': 1101.8.0
+      '@pnpm/types': 1101.9.0
       detect-libc: 2.1.2
       execa: safe-execa@0.3.0
       memoize: 11.0.0
       semver: 7.8.5
 
-  '@pnpm/constants@1100.0.1': {}
+  '@pnpm/constants@1101.0.0': {}
 
-  '@pnpm/core-loggers@1100.3.1(@pnpm/logger@1100.0.0)':
+  '@pnpm/core-loggers@1100.3.2(@pnpm/logger@1100.0.0)':
     dependencies:
       '@pnpm/logger': 1100.0.0
-      '@pnpm/types': 1101.8.0
+      '@pnpm/types': 1101.9.0
 
   '@pnpm/deps.peer-range@1100.1.1':
     dependencies:
       semver: 7.8.5
 
-  '@pnpm/engine.runtime.system-version@1100.0.8':
+  '@pnpm/engine.runtime.system-version@1100.0.9':
     dependencies:
-      '@pnpm/cli.meta': 1100.0.13
-      '@pnpm/types': 1101.8.0
+      '@pnpm/cli.meta': 1100.0.14
+      '@pnpm/types': 1101.9.0
       execa: safe-execa@0.3.0
       memoize: 11.0.0
 
-  '@pnpm/error@1100.1.0':
+  '@pnpm/error@1100.1.1':
     dependencies:
-      '@pnpm/constants': 1100.0.1
+      '@pnpm/constants': 1101.0.0
 
   '@pnpm/fs.graceful-fs@1100.1.1':
     dependencies:
@@ -8143,32 +8143,32 @@ snapshots:
       bole: 5.0.29
       split2: 4.2.0
 
-  '@pnpm/pkg-manifest.utils@1100.3.0(@pnpm/logger@1100.0.0)':
+  '@pnpm/pkg-manifest.utils@1100.3.1(@pnpm/logger@1100.0.0)':
     dependencies:
-      '@pnpm/core-loggers': 1100.3.1(@pnpm/logger@1100.0.0)
+      '@pnpm/core-loggers': 1100.3.2(@pnpm/logger@1100.0.0)
       '@pnpm/deps.peer-range': 1100.1.1
-      '@pnpm/error': 1100.1.0
+      '@pnpm/error': 1100.1.1
       '@pnpm/logger': 1100.0.0
-      '@pnpm/types': 1101.8.0
+      '@pnpm/types': 1101.9.0
       semver: 7.8.5
 
   '@pnpm/text.comments-parser@1100.0.1':
     dependencies:
       strip-comments-strings: 1.2.0
 
-  '@pnpm/types@1101.8.0': {}
+  '@pnpm/text.ordinal-comparator@1100.0.0': {}
 
-  '@pnpm/util.lex-comparator@4.0.1': {}
+  '@pnpm/types@1101.9.0': {}
 
-  '@pnpm/workspace.project-manifest-reader@1100.0.22(@pnpm/logger@1100.0.0)':
+  '@pnpm/workspace.project-manifest-reader@1100.0.23(@pnpm/logger@1100.0.0)':
     dependencies:
-      '@pnpm/error': 1100.1.0
+      '@pnpm/error': 1100.1.1
       '@pnpm/fs.graceful-fs': 1100.1.1
       '@pnpm/logger': 1100.0.0
-      '@pnpm/pkg-manifest.utils': 1100.3.0(@pnpm/logger@1100.0.0)
+      '@pnpm/pkg-manifest.utils': 1100.3.1(@pnpm/logger@1100.0.0)
       '@pnpm/text.comments-parser': 1100.0.1
-      '@pnpm/types': 1101.8.0
-      '@pnpm/workspace.project-manifest-writer': 1100.0.13
+      '@pnpm/types': 1101.9.0
+      '@pnpm/workspace.project-manifest-writer': 1100.0.14
       detect-indent: 7.0.2
       fast-deep-equal: 3.1.3
       is-windows: 1.0.2
@@ -8178,30 +8178,30 @@ snapshots:
       read-yaml-file: 3.0.0
       strip-bom: 5.0.0
 
-  '@pnpm/workspace.project-manifest-writer@1100.0.13':
+  '@pnpm/workspace.project-manifest-writer@1100.0.14':
     dependencies:
       '@pnpm/text.comments-parser': 1100.0.1
-      '@pnpm/types': 1101.8.0
+      '@pnpm/types': 1101.9.0
       json5: 2.2.3
       write-file-atomic: 7.0.1
       write-yaml-file: 6.0.0
 
-  '@pnpm/workspace.projects-reader@1101.0.21(@pnpm/logger@1100.0.0)':
+  '@pnpm/workspace.projects-reader@1101.0.22(@pnpm/logger@1100.0.0)':
     dependencies:
-      '@pnpm/cli.utils': 1101.0.21(@pnpm/logger@1100.0.0)
-      '@pnpm/constants': 1100.0.1
+      '@pnpm/cli.utils': 1101.0.22(@pnpm/logger@1100.0.0)
+      '@pnpm/constants': 1101.0.0
       '@pnpm/logger': 1100.0.0
-      '@pnpm/types': 1101.8.0
-      '@pnpm/util.lex-comparator': 4.0.1
-      '@pnpm/workspace.project-manifest-reader': 1100.0.22(@pnpm/logger@1100.0.0)
+      '@pnpm/text.ordinal-comparator': 1100.0.0
+      '@pnpm/types': 1101.9.0
+      '@pnpm/workspace.project-manifest-reader': 1100.0.23(@pnpm/logger@1100.0.0)
       p-filter: 4.1.0
       tinyglobby: 0.2.17
 
-  '@pnpm/workspace.workspace-manifest-reader@1100.1.4':
+  '@pnpm/workspace.workspace-manifest-reader@1100.1.5':
     dependencies:
-      '@pnpm/constants': 1100.0.1
-      '@pnpm/error': 1100.1.0
-      '@pnpm/types': 1101.8.0
+      '@pnpm/constants': 1101.0.0
+      '@pnpm/error': 1100.1.1
+      '@pnpm/types': 1101.9.0
       read-yaml-file: 3.0.0
 
   '@polka/url@1.0.0-next.29': {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -17,10 +17,10 @@ catalog:
   '@commitlint/types': ^21.2.0
   '@custom-elements-manifest/analyzer': ^0.11.0
   '@pnpm/logger': 1100.0.0
-  '@pnpm/types': 1101.8.0
-  '@pnpm/workspace.project-manifest-reader': 1100.0.22
-  '@pnpm/workspace.projects-reader': 1101.0.21
-  '@pnpm/workspace.workspace-manifest-reader': 1100.1.4
+  '@pnpm/types': 1101.9.0
+  '@pnpm/workspace.project-manifest-reader': 1100.0.23
+  '@pnpm/workspace.projects-reader': 1101.0.22
+  '@pnpm/workspace.workspace-manifest-reader': 1100.1.5
   '@release-it/conventional-changelog': ^12.0.0
   '@spectrum-web-components/icons-workflow': ^1.12.2
   '@types/dom-navigation': ^1.0.7


### PR DESCRIPTION
Third slice of the dependabot #545 redo (see #552 for why #545 was closed). Stacked on #554 — **merge #552, then #554, then this**.

| Package | From | To |
| --- | --- | --- |
| @pnpm/types | 1101.8.0 | 1101.9.0 |
| @pnpm/workspace.project-manifest-reader | 1100.0.22 | 1100.0.23 |
| @pnpm/workspace.projects-reader | 1101.0.21 | 1101.0.22 |
| @pnpm/workspace.workspace-manifest-reader | 1100.1.4 | 1100.1.5 |

## Pre-adoption checks

**Broken publishes (pnpm/pnpm#13185).** A run of `@pnpm/*` releases has shipped tarballs containing only `lib/index.js` — no `.d.ts`, no sibling modules — which installs fine and then fails at import. All four candidates were downloaded from the registry and listed before adopting; each carries its full `lib/` tree with declarations:

- `@pnpm/types` — 12 `lib/` files (config, misc, options, package, peerDependencyIssues, project, versioning) + `.d.ts` for each
- `@pnpm/workspace.project-manifest-reader` — `index` + `readFile`, both with `.d.ts`
- `@pnpm/workspace.projects-reader` — `index` + `findPackages`, both with `.d.ts`
- `@pnpm/workspace.workspace-manifest-reader` — `index`, `catalogs`, `versioning`, `errors/InvalidWorkspaceManifestError`, all with `.d.ts`

**Auto-peers.** `pnpm peers check` re-run after install: no issues. Auto-peers do not re-resolve on their own when a peer range moves, so this is checked explicitly on every SDK line bump rather than inferred from a green install.

These SDKs back `@tools/compat-guards`, whose guard bins run inside the CI graph — `mise run //:ci` green, 153/153 tasks, all 5 Cypress suites.

Note for sequencing: #548 also touches the workspace-manifest read path. Whichever lands second will want a rebase, but the two changes are independent.
