### PR TITLE
test(lit-ui-router): guard context-listener identity across reconnect

### DIFF
--- a/packages/lit-ui-router/src/specs/listener-identity.spec.ts
+++ b/packages/lit-ui-router/src/specs/listener-identity.spec.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
+
+import { UIRouterLitElement } from '../ui-router.js';
+import '../ui-router.register.js';
+import '../ui-view.register.js';
+import { UIRouterLit } from '../core.js';
+import { createTestRouter, waitForUpdate, tick } from './test-utils.js';
+
+/**
+ * `<ui-router>` and `<ui-view>` both add a `ui-router-context` listener on
+ * connect and never remove it. That is safe only because each handler is a
+ * `readonly` class-field arrow: re-connecting passes an identical
+ * (type, callback, capture) triple, which `addEventListener` ignores per spec.
+ *
+ * Rewriting either registration to take a fresh function — an inline arrow, a
+ * `.bind(this)`, a wrapper closure — stacks a handler per connect with no
+ * other visible symptom. `wc/require-listener-teardown` cannot see these sites
+ * (it needs a string-literal event name; these read `this.constructor` statics),
+ * so this spec is the only thing guarding the idiom.
+ */
+
+/** Reconnects an element in place, driving disconnect/connect `times` over. */
+async function reconnect(element: HTMLElement, times: number): Promise<void> {
+  const parent = element.parentElement!;
+  for (let i = 0; i < times; i++) {
+    element.remove();
+    parent.appendChild(element);
+    await tick();
+  }
+}
+
+// Control fixture: the mistake this spec exists to catch. Registers a fresh
+// arrow on every connect, so its handler count grows with reconnects.
+let inlineArrowInvocations = 0;
+
+@customElement('test-inline-arrow-listener')
+class TestInlineArrowListener extends LitElement {
+  createRenderRoot() {
+    return this;
+  }
+
+  connectedCallback(): void {
+    super.connectedCallback();
+    this.addEventListener(UIRouterLitElement.uiRouterContextEventName, () => {
+      inlineArrowInvocations++;
+    });
+  }
+
+  render() {
+    return html`<slot></slot>`;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'test-inline-arrow-listener': TestInlineArrowListener;
+  }
+}
+
+describe('context listener identity across reconnect', () => {
+  let container: HTMLElement;
+  let router: UIRouterLit;
+  let onContextEvent: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    router = createTestRouter([{ name: 'home', url: '/home' }]);
+    inlineArrowInvocations = 0;
+    // The instance handlers on both elements delegate to this static on every
+    // dispatch, so spying on it counts handler invocations without reaching
+    // into private fields. `vi.spyOn` calls through, so behaviour is unchanged.
+    onContextEvent = vi.spyOn(UIRouterLitElement, 'onUiRouterContextEvent');
+  });
+
+  afterEach(() => {
+    onContextEvent.mockRestore();
+    container.remove();
+  });
+
+  it('control: an inline-arrow registration does stack, one handler per connect', async () => {
+    const element = document.createElement('test-inline-arrow-listener');
+    container.appendChild(element);
+    await waitForUpdate(element);
+
+    await reconnect(element, 3);
+    element.dispatchEvent(UIRouterLitElement.uiRouterContextEvent(router));
+
+    // 4 connects (initial + 3), 4 distinct callbacks, all invoked by one
+    // dispatch. If this ever reads 1, the assertions below prove nothing.
+    expect(inlineArrowInvocations).toBe(4);
+  });
+
+  it('<ui-router> answers a context event once after repeated reconnects', async () => {
+    const element = document.createElement('ui-router');
+    element.uiRouter = router;
+    container.appendChild(element);
+    await waitForUpdate(element);
+
+    const child = document.createElement('div');
+    element.appendChild(child);
+
+    await reconnect(element, 3);
+
+    // Reconnecting re-dispatches through seekRouter; only the final probe counts.
+    onContextEvent.mockClear();
+    const seen = UIRouterLitElement.seekRouter(child);
+
+    expect(onContextEvent).toHaveBeenCalledTimes(1);
+    expect(seen).toBe(router);
+  });
+
+  it('<ui-view> answers a context event once after repeated reconnects', async () => {
+    const routerElement = document.createElement('ui-router');
+    routerElement.uiRouter = router;
+    container.appendChild(routerElement);
+    await waitForUpdate(routerElement);
+
+    const view = document.createElement('ui-view');
+    routerElement.appendChild(view);
+    await waitForUpdate(view);
+
+    await reconnect(view, 3);
+
+    onContextEvent.mockClear();
+    const seen = UIRouterLitElement.seekRouter(view);
+
+    // Exactly one: <ui-view> handles it and stops propagation before it
+    // reaches <ui-router>. Two would mean <ui-view> stacked a handler.
+    expect(onContextEvent).toHaveBeenCalledTimes(1);
+    expect(seen).toBe(router);
+  });
+
+  it('<ui-view> keeps answering after a disconnect, having kept its listener', async () => {
+    const routerElement = document.createElement('ui-router');
+    routerElement.uiRouter = router;
+    container.appendChild(routerElement);
+    await waitForUpdate(routerElement);
+
+    const view = document.createElement('ui-view');
+    routerElement.appendChild(view);
+    await waitForUpdate(view);
+
+    view.remove();
+    await tick();
+
+    onContextEvent.mockClear();
+    UIRouterLitElement.seekRouter(view);
+
+    // Documents the asymmetry deliberately left in place: disconnect drains the
+    // transition hooks but keeps this listener. Nothing leaks — the handler is
+    // bound to the element and collected with it.
+    expect(onContextEvent).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Standalone rather than folded into #557 — this tests the listener idiom, not the lint lane, and #557 is currently conflicting on main.

## The invariant

`<ui-router>` and `<ui-view>` both add a `ui-router-context` listener on connect and never remove it. That is safe, but only because each handler is a `readonly` class-field arrow: re-connecting passes an identical (type, callback, capture) triple, which `addEventListener` ignores per spec.

Swap either registration for a fresh function — an inline arrow, a `.bind(this)`, a wrapper closure — and every reconnect stacks another handler. There is no other visible symptom: no leak, no error, no failing test. The handlers are idempotent, so even the event payload looks correct.

## Why a spec and not a lint rule

`wc/require-listener-teardown` (adopted in #557) cannot see these sites. It matches only a **string-literal** event name at the call site, and both of ours read `this.constructor` statics. Probed on #557: no named-constant form is accepted either — not a module-level `const`, not a plain `ClassName.evName` static. Making the rule fire would mean hardcoding `'ui-router-context'` / `'ui-view-context'` at the listener sites while `ui-router.ts:45` and `ui-view.ts:165` keep reading the statics to *dispatch* them, which splits one fact in two with nothing tying the halves together.

So a runtime spec is the only thing that can guard this, and it guards the invariant that actually matters — handler identity — rather than teardown, which these elements deliberately don't do.

## How it observes

Both instance handlers delegate to the static `UIRouterLitElement.onUiRouterContextEvent` on every dispatch, so spying on it counts handler invocations without reaching into private fields. `vi.spyOn` calls through, so behaviour is unchanged.

## Mutation-tested, not assumed

Given what #557 turned up about green-but-inert gates, this was verified by breaking the source:

| Mutation | Result |
| --- | --- |
| inline arrow at `ui-router.ts:96` | only the `<ui-router>` case fails — `expected 1, got 4` |
| inline arrow at `ui-view.ts:193` | only the `<ui-view>` case fails — `expected 1, got 4` |

Four invocations for four connects, and each mutation is caught by exactly its own test. Source restored to `ddd7f2d` unmodified — the diff is one new file.

The suite also carries a **control fixture** that registers an inline arrow deliberately and asserts it *does* stack. If that ever reads 1, the other assertions are inert and prove nothing — the failure mode this repo just hit with the lint rule.

The fourth case pins the asymmetry left in place on purpose: disconnect drains the transition hooks but keeps this listener. Nothing leaks — the handler is bound to the element and collected with it.

## Verification

`turbo run test typecheck lint --filter=lit-ui-router` — 22/22 tasks, **169 tests** (165 on main + 4), across both the happy-dom and chrome projects.

Context: #553, #557.