### PR TITLE
build(lint): gate Markdown with rumdl

### DIFF
--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -52,6 +52,9 @@ idiomatic_version_file_enable_tools = ["node"]
 # TOML formatter; oxfmt handles everything but .toml, so this owns the mise
 # configs and member mise.toml files. Pinned like the other aqua tools.
 "aqua:tamasfe/taplo" = "0.10.0"
+# Markdown linter (markdownlint's rule set, in Rust). Check-only: oxfmt formats
+# .md, rumdl lints it. Pre-1.0, so the pin is load-bearing.
+"aqua:rvben/rumdl" = "0.2.55"
 
 # Provisioning tasks, not hooks: hooks warn-and-continue, task failures are
 # loud; and tool-only bumps (actionlint) skip the corepack ceremony.
@@ -116,6 +119,13 @@ run = "mise run taplo lint"
 # (.config/mise/tasks/shellcheck)
 description = "Static-analyze repo shell scripts (mise tasks, *.sh) with shellcheck"
 run = "mise run shellcheck"
+
+[tasks.lint_markdown]
+# Thin alias; file selection + rationale live in the `rumdl` file task
+# (.config/mise/tasks/rumdl). Deliberately NOT in lint_workflows: that umbrella
+# is CI/config plumbing, and markdown is content.
+description = "Lint tracked Markdown (README, docs, examples) with rumdl"
+run = "mise run rumdl check"
 
 [tasks.lint_workflows]
 # Virtual grouping task; the legs are independent and run in parallel. Covers

--- a/.config/mise/mise.lock
+++ b/.config/mise/mise.lock
@@ -117,6 +117,52 @@ checksum = "sha256:6e7241b51e6817ea6a047693d8e6fed13b31819c9a0dd6c5a726e1592d22f
 url = "https://github.com/rhysd/actionlint/releases/download/v1.7.12/actionlint_1.7.12_windows_amd64.zip"
 provenance = "github-attestations"
 
+[[tools."aqua:rvben/rumdl"]]
+version = "0.2.55"
+backend = "aqua:rvben/rumdl"
+
+[tools."aqua:rvben/rumdl"."platforms.linux-arm64"]
+checksum = "sha256:baed03dac3bf50565f4e1e461fb8162fcff58742034c6d643a1977d9025dfdb6"
+url = "https://github.com/rvben/rumdl/releases/download/v0.2.55/rumdl-v0.2.55-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/rvben/rumdl/releases/assets/512169605"
+provenance = "github-attestations"
+
+[tools."aqua:rvben/rumdl"."platforms.linux-arm64-musl"]
+checksum = "sha256:baed03dac3bf50565f4e1e461fb8162fcff58742034c6d643a1977d9025dfdb6"
+url = "https://github.com/rvben/rumdl/releases/download/v0.2.55/rumdl-v0.2.55-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/rvben/rumdl/releases/assets/512169605"
+provenance = "github-attestations"
+
+[tools."aqua:rvben/rumdl"."platforms.linux-x64"]
+checksum = "sha256:09c8f72cb57f1ff646d68b5ec2ef6a7b296e6d9f945093db2698c260e81d9f90"
+url = "https://github.com/rvben/rumdl/releases/download/v0.2.55/rumdl-v0.2.55-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/rvben/rumdl/releases/assets/512169600"
+provenance = "github-attestations"
+
+[tools."aqua:rvben/rumdl"."platforms.linux-x64-musl"]
+checksum = "sha256:09c8f72cb57f1ff646d68b5ec2ef6a7b296e6d9f945093db2698c260e81d9f90"
+url = "https://github.com/rvben/rumdl/releases/download/v0.2.55/rumdl-v0.2.55-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/rvben/rumdl/releases/assets/512169600"
+provenance = "github-attestations"
+
+[tools."aqua:rvben/rumdl"."platforms.macos-arm64"]
+checksum = "sha256:98dd5620e7eb8ba8fd77830fe1f313530ae2a6368ae867149f7de13dbebde6e3"
+url = "https://github.com/rvben/rumdl/releases/download/v0.2.55/rumdl-v0.2.55-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/rvben/rumdl/releases/assets/512169607"
+provenance = "github-attestations"
+
+[tools."aqua:rvben/rumdl"."platforms.macos-x64"]
+checksum = "sha256:8dadf1b9aeda17f8a41ab4fcdd2a7f7dfb6eda8981ddce3ebf61b72e3d1d3f89"
+url = "https://github.com/rvben/rumdl/releases/download/v0.2.55/rumdl-v0.2.55-x86_64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/rvben/rumdl/releases/assets/512169601"
+provenance = "github-attestations"
+
+[tools."aqua:rvben/rumdl"."platforms.windows-x64"]
+checksum = "sha256:47c04176f960e2d196b1e465564869363469ec00714c2970e1f441deff7f679d"
+url = "https://github.com/rvben/rumdl/releases/download/v0.2.55/rumdl-v0.2.55-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/rvben/rumdl/releases/assets/512169608"
+provenance = "github-attestations"
+
 [[tools."aqua:tamasfe/taplo"]]
 version = "0.10.0"
 backend = "aqua:tamasfe/taplo"

--- a/.config/mise/tasks/rumdl
+++ b/.config/mise/tasks/rumdl
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+#MISE description="Run rumdl over the tracked *.md set (or given files)"
+#USAGE arg "<cmd>" help="rumdl subcommand: check | fmt"
+#USAGE arg "[file]…" help="Markdown files to target; default: every tracked *.md"
+set -euo pipefail
+
+case "${usage_cmd:?}" in
+  check | fmt) ;;
+  *) echo "rumdl: unknown cmd '$usage_cmd' (check | fmt)" >&2; exit 2 ;;
+esac
+
+set -- "$usage_cmd"
+
+if [ -n "${usage_file:-}" ]; then
+  read -ra files <<<"$usage_file" # given files: split the mise-joined arg string
+else
+  mapfile -t files < <(git ls-files -- '*.md')
+fi
+
+# git ls-files never comes back empty in this repo; warn (don't silently pass) if
+# it ever does, rather than letting rumdl fall back to its own walk, which does
+# not skip node_modules.
+if [ "${#files[@]}" -eq 0 ]; then
+  echo "rumdl: no tracked *.md files matched; nothing to do" >&2
+  exit 0
+fi
+
+exec rumdl "$@" "${files[@]}"

--- a/.config/rumdl.toml
+++ b/.config/rumdl.toml
@@ -1,0 +1,26 @@
+# Auto-discovered from this path (`rumdl config file` confirms it) — unlike
+# .config/taplo.toml, no mise [env] pointer is needed.
+#
+# File selection is NOT done here: the mise task passes rumdl an explicit list
+# from `git ls-files -- '*.md'` (rumdl's own walker does not skip node_modules).
+
+[global]
+# MD013 (line length 80): oxfmt does not hard-wrap markdown prose, so the rule
+# fights the formatter. MD033 (inline HTML): docs/ is VitePress, where inline
+# HTML is legitimate. MD057 (relative link targets exist): docs/api/* links
+# point into docs/api/reference, typedoc output that is gitignored and absent at
+# lint time; VitePress's own ignoreDeadLinks-gated build already checks these.
+# MD036 (emphasis as heading): the hits are labels on sibling code samples, and
+# only the labels without a trailing parenthetical trip it — promoting them
+# would inject partial entries into the VitePress outline and sidebar.
+disable = ["MD013", "MD033", "MD036", "MD057"]
+
+# rumdl counts a VitePress frontmatter `title:` as an H1, so any page with both
+# `title:` and an `#` heading reads as a duplicate/missing H1. Empty = don't
+# treat frontmatter as the title. Without it the autofix demotes the whole
+# heading tree, breaking the rendered page title and every anchor.
+[MD025]
+front_matter_title = ""
+
+[MD041]
+front_matter_title = ""

--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,9 @@ mise.*.local.toml
 # package-local resolved-state caches (e.g. tools/release/.cache)
 .cache/
 
+# rumdl ships a self-ignoring .rumdl_cache/.gitignore; belt-and-braces for a pre-1.0 tool
+.rumdl_cache/
+
 lit-ui-router-*.tgz
 **/specs/__screenshots__
 # vitest failure artifacts for colocated specs (apps/sample-app-shared)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Publish Pipeline](https://github.com/simshanith/lit-ui-router/actions/workflows/publish-npm.yml/badge.svg?event=push)](https://github.com/simshanith/lit-ui-router/actions/workflows/publish-npm.yml)
 [![Website](https://img.shields.io/website?url=https%3A%2F%2Flit-ui-router.dev)](https://lit-ui-router.dev)
 
-#### Published packages
+## Published packages
 
 | Package                                | npm                                                                                                                                            | GitHub Release                                                                                                                                                                                                                    | Published diff                                                                                                                                                                                                                                                                                                                      |
 | -------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -17,7 +17,7 @@
 | `ui-router-navigation-location-plugin` | [![npm](https://img.shields.io/npm/v/ui-router-navigation-location-plugin.svg)](https://npmx.dev/package/ui-router-navigation-location-plugin) | [![GitHub Release](https://img.shields.io/github/v/release/simshanith/lit-ui-router?filter=ui-router-navigation-location-plugin@*)](https://github.com/simshanith/lit-ui-router/releases/?q=ui-router-navigation-location-plugin) | [![ui-router-navigation-location-plugin published diff](https://img.shields.io/github/check-runs/simshanith/lit-ui-router/main?nameFilter=published-diff%20%28ui-router-navigation-location-plugin%29&label=published-diff)](https://github.com/simshanith/lit-ui-router/actions/workflows/release-signals.yml?query=branch%3Amain) |
 | `ui-router-server`                     | [![npm](https://img.shields.io/npm/v/ui-router-server.svg)](https://npmx.dev/package/ui-router-server)                                         | [![GitHub Release](https://img.shields.io/github/v/release/simshanith/lit-ui-router?filter=ui-router-server@*)](https://github.com/simshanith/lit-ui-router/releases/?q=ui-router-server)                                         | [![ui-router-server published diff](https://img.shields.io/github/check-runs/simshanith/lit-ui-router/main?nameFilter=published-diff%20%28ui-router-server%29&label=published-diff)](https://github.com/simshanith/lit-ui-router/actions/workflows/release-signals.yml?query=branch%3Amain)                                         |
 
-##### Legend
+### Legend
 
 | Badge                                                                        | Meaning                                     |
 | ---------------------------------------------------------------------------- | ------------------------------------------- |
@@ -55,7 +55,7 @@ application states in a transaction-like manner.
 
 The UI-Router package is distributed using [npm](https://www.npmjs.com/), the node package manager.
 
-```
+```bash
 npm install lit-ui-router
 ```
 

--- a/REMOTE_CACHE.md
+++ b/REMOTE_CACHE.md
@@ -1,6 +1,6 @@
 # Turborepo Remote Cache
 
-https://adirishi.github.io/turborepo-remote-cache-cloudflare/
+<https://adirishi.github.io/turborepo-remote-cache-cloudflare/>
 
 Deployed to a Cloudflare Worker at a `*.workers.dev` URL. The URL is kept out of
 this public repo (a public endpoint invites free-tier request exhaustion); it

--- a/TURBO.md
+++ b/TURBO.md
@@ -32,7 +32,7 @@ npm run dev
 
 The root `turbo.json` defines shared task configurations inherited by all workspaces:
 
-```
+```text
 ci:pull_request
 ├── build
 ├── test
@@ -208,7 +208,7 @@ The GitHub Actions workflow (`.github/workflows/build-test.yml`) runs the CI pip
 
 Manual dispatch of the workflow has two deflake inputs: `force` (`TURBO_FORCE`) bypasses the turbo cache, and `mainGraph` runs the `ci:main` superset on demand — combine them to deflake the full main graph without pushing a commit (tagging stays push-only). Dispatch takes a ref, so this is also how you run the main graph against an arbitrary branch. CI also sets `CYPRESS_video: 'false'` (passed through un-hashed, so it never affects cache validity); local runs keep video recording.
 
-#### Smoke-testing the main graph before merge
+### Smoke-testing the main graph before merge
 
 The main-only guards (`test:engines`, `check:pack`, the full `dts-backtest` matrix) run after merge, so a break in them surfaces on main rather than on the PR. Two ways to pull that signal forward:
 

--- a/apps/sample-app-lit-mobx/README.md
+++ b/apps/sample-app-lit-mobx/README.md
@@ -1,4 +1,4 @@
-## UI-Router 1.0 Lit Sample Application — MobX variant
+# UI-Router 1.0 Lit Sample Application — MobX variant
 
 This is the [MobX](https://mobx.js.org) variant of the [vanilla sample app](../sample-app-lit-vanilla/): the same
 non-trivial ui-router lit application, with reactivity handled by
@@ -33,7 +33,7 @@ This sample app is intended to demonstrate a non-trivial ui-router lit applicati
 
 ---
 
-### Visualizer
+## Visualizer
 
 We're using the [State and Transition Visualizer](http://github.com/ui-router/visualizer) to visually represent
 the current state tree, as well as the transitions between states. Explore how transitions work by hovering
@@ -43,7 +43,7 @@ Note how states are _entered_ when they were previously not active, _exited_ and
 and how parent states whose parameters did not change are _retained_. Each of these (_exited, entered, retained_)
 correspond to a Transition Hook.
 
-### Structure
+## Structure
 
 The application is written in TypeScript, and utilizes ES6 modules.
 
@@ -61,7 +61,7 @@ There are many ways to structure a ui-router app. We aren't super opinionated on
   - States export themselves
   - The `router.config.ts` imports all states and registers them with the `stateRegistry`
 
-### UI-Router Patterns
+## UI-Router Patterns
 
 - Defining custom, app-specific global behaviors
   - Add metadata to a state, or state tree

--- a/apps/sample-app-lit-vanilla/README.md
+++ b/apps/sample-app-lit-vanilla/README.md
@@ -1,6 +1,6 @@
-## UI-Router 1.0 Lit Sample Application — vanilla variant
+# UI-Router 1.0 Lit Sample Application — vanilla variant
 
-https://github.simloovoo.com/lit-ui-router/#/mymessages/inbox/5648b50cc586cac4aed6836f
+<https://github.simloovoo.com/lit-ui-router/#/mymessages/inbox/5648b50cc586cac4aed6836f>
 
 This is the zero-dependency variant of the sample app, using `lit-ui-router`'s
 `TransitionController` for reactivity. See [`apps/README.md`](../README.md) for the
@@ -19,7 +19,7 @@ This sample app is intended to demonstrate a non-trivial ui-router lit applicati
 
 ---
 
-### Visualizer
+## Visualizer
 
 We're using the [State and Transition Visualizer](http://github.com/ui-router/visualizer) to visually represent
 the current state tree, as well as the transitions between states. Explore how transitions work by hovering
@@ -29,7 +29,7 @@ Note how states are _entered_ when they were previously not active, _exited_ and
 and how parent states whose parameters did not change are _retained_. Each of these (_exited, entered, retained_)
 correspond to a Transition Hook.
 
-### Structure
+## Structure
 
 The application is written in TypeScript, and utilizes ES6 modules.
 
@@ -47,7 +47,7 @@ There are many ways to structure a ui-router app. We aren't super opinionated on
   - States export themselves
   - The `router.config.ts` imports all states and registers them with the `stateRegistry`
 
-### UI-Router Patterns
+## UI-Router Patterns
 
 - Defining custom, app-specific global behaviors
   - Add metadata to a state, or state tree

--- a/apps/sample-app-shared/public/static/data/README.md
+++ b/apps/sample-app-shared/public/static/data/README.md
@@ -1,15 +1,15 @@
-## Contents
+# Contents
 
 This directory contains the fake data used by the fake REST services.
 
-### Data
+## Data
 
 - _contacts.json_: The users' contacts (currently they share the contact list)
 - _folders.json_: Folder list (and meta-data, such as columns to display for a folder)
 - _messages.json_: The users' messages
 - _corpora_: Directory containing markov chain seed corpora for generating styles of messages
 
-### Scripts
+## Scripts
 
 - _fetch.sh_: Fetches original contacts list and non-markov messages from json-generator.com
 - _generate.sh_: Fetches `jsmarkov` project and re-generates markov messages

--- a/examples/README.md
+++ b/examples/README.md
@@ -6,7 +6,7 @@ This folder contains standalone example projects demonstrating lit-ui-router usa
 
 Each example is a self-contained Vite + TypeScript project designed to run directly on [StackBlitz](https://stackblitz.com/). You can open any example in StackBlitz using the GitHub integration:
 
-```
+```text
 https://stackblitz.com/github/simshanith/lit-ui-router/tree/main/examples/<example-name>
 ```
 
@@ -72,7 +72,7 @@ pnpm --filter examples example:install:<example-name>
 
 Each example follows the same structure:
 
-```
+```text
 <example-name>/
 ├── index.html          # Entry HTML file
 ├── package.json        # Dependencies and scripts

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "format:toml": "mise run format_toml",
     "lint": "turbo run lint",
     "lint:actionlint": "mise run lint_actionlint",
+    "lint:markdown": "mise run lint_markdown",
     "lint:package-json": "eslint --format tap \"**/package.json\" pnpm-workspace.yaml",
     "lint:root": "oxlint --ignore-pattern apps --ignore-pattern tools --ignore-pattern docs --ignore-pattern packages --ignore-pattern examples .",
     "lint:shellcheck": "mise run lint_shellcheck",

--- a/tools/typedoc-plugin-lit-ui-router/README.md
+++ b/tools/typedoc-plugin-lit-ui-router/README.md
@@ -96,7 +96,7 @@ link is emitted.
 
 ## Symbol File Structure
 
-```
+```text
 src/symbols/
 ├── index.ts      # Combined exports
 ├── ui-router.ts  # UI-Router Core symbols (templated)

--- a/turbo.json
+++ b/turbo.json
@@ -83,6 +83,7 @@
       "with": [
         "//#lint:root",
         "//#lint:package-json",
+        "//#lint:markdown",
         "//#lint:workflows",
         "//#lint:templates",
         "//#check:patches",
@@ -165,6 +166,18 @@
         "eslint.repo-rules.ts",
         "pnpm-workspace.yaml",
         ".oxlintrc.json"
+      ]
+    },
+    // Content lint (not config plumbing, so deliberately not under
+    // //#lint:workflows): rumdl over every tracked .md. Its own cache group,
+    // disjoint from oxfmt's format group, which owns .md *formatting*.
+    "//#lint:markdown": {
+      "inputs": [
+        "**/*.md",
+        "!**/node_modules/**",
+        "$TURBO_ROOT$/.config/rumdl.toml",
+        "$TURBO_ROOT$/.config/mise/tasks/rumdl",
+        "$TURBO_ROOT$/.config/mise/mise.lock"
       ]
     },
     // Config-plumbing lint: one //# cache group per tool, aggregated by the


### PR DESCRIPTION
Wires [rumdl](https://github.com/rvben/rumdl) (markdownlint's rule set, in Rust) as a
Markdown lint gate, modeled directly on the taplo precedent: a mise file task fed an
explicit `git ls-files -- '*.md'` list (rumdl's own walker does not skip `node_modules`),
a thin `lint_markdown` alias, and its own `//#lint:markdown` turbo cache group joined to
the `lint` task's `with` list.

**Check only.** oxfmt keeps ownership of `.md` formatting; `rumdl fmt` is never wired to
a task. `oxfmt → rumdl fmt → oxfmt` does converge, but rumdl's autofixes are destructive
on VitePress (see below), so this PR adopts the linter and not the formatter.

Unlike taplo — which needs `TAPLO_CONFIG` in mise `[env]` — rumdl natively discovers
`.config/rumdl.toml`, so no env pointer is needed.

## Config

258 findings out of the box, 16 after `.config/rumdl.toml`. Disabled:

- **MD013** (line length 80) — oxfmt does not hard-wrap markdown prose, so the rule
  fights the formatter. 168 hits, all noise.
- **MD033** (inline HTML) — `docs/` is VitePress, where inline HTML is legitimate. 57 hits.
- **MD036** (emphasis as heading) — see the decision point below.
- **MD057** (relative link targets exist) — `docs/api/*` links point into
  `docs/api/reference`, typedoc output that is gitignored and absent at lint time.
  VitePress's own `ignoreDeadLinks`-gated build already checks these.

**The MD025/MD041 trap.** rumdl counts a VitePress frontmatter `title:` as an H1, so
every page carrying both `title:` and an `#` heading reads as a duplicate H1 — 17 files.
The `rumdl fmt` autofix for that demotes the *entire* heading tree, breaking the rendered
page title and every anchor. `front_matter_title = ""` is what makes the rule correct
here; it is load-bearing, not cosmetic.

## Reviewer decision points

1. **README heading levels (MD001).** `#### Published packages` → `##` and
   `##### Legend` → `###`. This visibly changes rendered heading sizes on the repo
   landing page. The old levels were a skip from `#` straight to `####`; the new ones are
   correct, but the visual change is real and worth a look.
2. **MD036 disabled rather than fixed.** The two hits are labels on sibling code samples
   in `docs/api/index.md` (`**Template with Route Parameters**`, `**Template with
   Resolved Data**`). Two of their four siblings escape the rule only because they carry
   a trailing parenthetical (`**Inline Template Function** (simplest)`), so promoting
   just the flagged pair would inject partial, inconsistent entries into the VitePress
   outline and sidebar. Disabling reads as the honest call; happy to flip it.

## Other fixes

- **MD040 ×5** — fence languages: `bash` for the npm install snippet, `text` for the four
  ASCII trees / bare-URL blocks. Tags chosen so oxfmt (which formats only tagged js/ts
  fences) leaves the contents alone; verified no fence content was rewritten.
- **MD034 ×2** — bare URLs wrapped in angle brackets.
- **MD041 ×3** — sample-app READMEs promoted to a top-level H1 (subheadings shifted up
  one level to keep MD001 satisfied).

## Stacking on #562

One finding is deliberately left untouched: `docs/introduction.md` MD051 (dead
`#nested-ui-view` anchor), which #562 already fixes. **This PR's gate is red on exactly
that one line until #562 lands.** Verified locally: with #562's one-line change applied,
`turbo run lint` is 43/43 green.

## Notes

- rumdl is pre-1.0 (0.2.55), so the pin matters — rule behavior and defaults can move
  between patch releases. `mise.lock` carries all 7 platform rows, checksums verified
  against the published `.sha256` assets.
- Deliberately **not** added to `lint_workflows`: that umbrella is CI/config plumbing
  (workflows, TOML, shell) backing a standalone `lint-workflows.yml` job. Markdown is
  content.
