### PR TITLE
test(dts-backtest): backtest ui-router-server's shipped .d.ts

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1000,6 +1000,9 @@ importers:
       '@uirouter/core':
         specifier: 'catalog:'
         version: 6.1.2
+      hono:
+        specifier: 'catalog:'
+        version: 4.13.1
       lit:
         specifier: 'catalog:'
         version: 3.3.3
@@ -1027,6 +1030,9 @@ importers:
       ui-router-navigation-location-plugin:
         specifier: workspace:*
         version: link:../../packages/navigation-location-plugin
+      ui-router-server:
+        specifier: workspace:*
+        version: link:../../packages/ui-router-server
 
   tools/happy-dom:
     devDependencies:

--- a/tools/dts-backtest/README.md
+++ b/tools/dts-backtest/README.md
@@ -7,8 +7,9 @@ upgraded without raising the `.d.ts` floor for consumers.
 ## What it checks
 
 `run.ts` typechecks the [consumer fixtures](./fixtures) — real-world usage
-of `lit-ui-router`, `lit-ui-router-mobx`, and
-`ui-router-navigation-location-plugin` — under a matrix of:
+of `lit-ui-router`, `lit-ui-router-mobx`,
+`ui-router-navigation-location-plugin`, and `ui-router-server` — under a
+matrix of:
 
 - **TypeScript versions**: the pinned floor (`typescript-5.0` → 5.0.4) and
   the repo's current catalog version. The 6.x leg rides the shared
@@ -20,7 +21,7 @@ The fixture compiles with `skipLibCheck: false`, so the packages' built
 `dist/*.d.ts` are themselves fully parsed **and** typechecked under each
 version — new declaration-emit syntax that an older TypeScript cannot handle
 fails the run. Diagnostics originating in third-party declarations (lit,
-mobx, `@uirouter/core`, `lib.dom`) are counted but tolerated, matching what
+mobx, `@uirouter/core`, hono, `lib.dom`) are counted but tolerated, matching what
 a consumer running `skipLibCheck: true` would experience while still holding
 our own declarations to the strict bar.
 

--- a/tools/dts-backtest/fixtures/ui-router-server.ts
+++ b/tools/dts-backtest/fixtures/ui-router-server.ts
@@ -1,0 +1,171 @@
+import type { StateDeclaration } from '@uirouter/core';
+import type { MiddlewareHandler } from 'hono';
+import {
+  createServerRouter,
+  mergeSearch,
+  type MountConfig,
+  type RedirectRule,
+  type RouteDeclaration,
+  type ServerRouter,
+  type Verdict,
+} from 'ui-router-server';
+import {
+  createConnectMiddleware,
+  type ConnectAdapterOptions,
+  type ConnectMiddleware,
+} from 'ui-router-server/connect';
+import {
+  createFetchHandler,
+  type FetchAdapterOptions,
+  type FetchHandler,
+} from 'ui-router-server/fetch';
+import { serverRouterHono } from 'ui-router-server/hono';
+import {
+  compare,
+  exec,
+  format,
+  urlMatcherFactory,
+  type CompiledMatcher,
+  type UrlMatcherCompilerConfig,
+} from 'ui-router-server/matcher';
+import {
+  compileRedirects,
+  compileRoutes,
+  evaluateRedirects,
+  matchRoute,
+  type CompiledRoute,
+  type RedirectTable,
+  type RouteMatch,
+} from 'ui-router-server/redirects';
+import { createHeadlessRouter, onceSettled } from 'ui-router-server/simulate';
+import {
+  serverRouterPlugin,
+  type ServerRouterPlugin,
+} from 'ui-router-server/vite';
+
+const routes: RouteDeclaration[] = [
+  { name: 'app', url: '' },
+  { name: 'app.contacts', url: '/contacts' },
+  {
+    name: 'app.contacts.detail',
+    url: '/{id}',
+    params: { id: { squash: false } },
+  },
+  { name: 'app.legacy', url: '/people', redirectTo: 'app.contacts' },
+  { name: 'app.notFound' },
+];
+
+const rules: RedirectRule[] = [
+  { pattern: '/old/{id}', to: { state: 'app.contacts.detail' } },
+  { pattern: /^\/archive\//, to: 'app.contacts' },
+];
+
+const matcherConfig: UrlMatcherCompilerConfig = {
+  strict: false,
+  caseInsensitive: true,
+  decodeParams: true,
+  defaultSquashPolicy: false,
+};
+
+const mount: MountConfig = {
+  routes,
+  redirects: rules,
+  strategy: 'matcher',
+  config: matcherConfig,
+  otherwise: { state: 'app.notFound' },
+};
+
+const router: ServerRouter = createServerRouter({
+  mounts: { '/app': mount, '/admin': { routes, strategy: 'simulate' } },
+});
+
+// The verdict union must stay exhaustively narrowable by `kind` — the whole
+// point of the package's HTTP-honesty contract.
+export async function statusFor(pathname: string): Promise<number> {
+  const verdict: Verdict = await router.resolve(pathname);
+  if (verdict.kind === 'redirect') {
+    void mergeSearch(verdict.location, '?ref=nav');
+    void verdict.mount;
+    return verdict.status;
+  }
+  if (verdict.kind === 'shell') {
+    void verdict.mount;
+    return verdict.status ?? 200;
+  }
+  // `notFound` is the only arm whose `mount` is optional.
+  void verdict.mount?.length;
+  return 404;
+}
+
+// Matcher tier: the meta type parameter must flow through compile -> matcher.
+const { compile } = urlMatcherFactory(matcherConfig);
+const detail: CompiledMatcher<{ routeId: number }> = compile('/contacts/{id}', {
+  params: { id: 'default' },
+  meta: { routeId: 7 },
+});
+
+export function matcherRoundTrip(path: string): string | null {
+  const params = exec(detail, path);
+  if (params === null) return null;
+  void detail.meta.routeId;
+  void compare(detail, compile('/contacts/new'));
+  return format(detail, params);
+}
+
+// Redirect tier: data-only, no router instance.
+const table: RedirectTable = { routes, rules, config: matcherConfig };
+const compiled: CompiledRoute[] = compileRoutes(routes, matcherConfig);
+const evaluate: (pathname: string) => string | null = compileRedirects(table);
+
+export function redirectFor(pathname: string): string | null {
+  const match: RouteMatch | null = matchRoute(compiled, pathname);
+  void match?.state;
+  void match?.params;
+  return evaluate(pathname) ?? evaluateRedirects(table, pathname);
+}
+
+// Simulate tier: the headless core router.
+export async function simulate(states: StateDeclaration[]): Promise<boolean> {
+  return onceSettled(createHeadlessRouter(states));
+}
+
+// Adapters. Each options bag is spelled out so a widened/narrowed callback
+// signature surfaces here rather than at a consumer's build.
+const connectOptions: ConnectAdapterOptions = {
+  shellPath: (mountBase) => `${mountBase}/index.html`,
+  serveShell: (_mountBase, req, _res, next) => {
+    req.url = '/index.html';
+    next();
+  },
+  serveNotFound: (_mountBase, _req, res, _next) => {
+    res.writeHead(404, { 'content-type': 'text/plain' });
+    res.end('not found');
+  },
+  shouldHandle: (req) => req.method === 'GET',
+};
+
+export const middleware: ConnectMiddleware = createConnectMiddleware(
+  router,
+  connectOptions,
+);
+
+const fetchOptions: FetchAdapterOptions = {
+  shellPath: (mountBase) => mountBase,
+  serveShell: (_mountBase, request) => new Response(request.url),
+  // Promise-returning on purpose: the option's union accepts both arms.
+  serveNotFound: (_mountBase, _request) =>
+    Promise.resolve(new Response('not found', { status: 404 })),
+  shouldHandle: (request) => request.method === 'GET',
+};
+
+export const handler: FetchHandler = createFetchHandler(router, fetchOptions);
+
+export const honoMiddleware: MiddlewareHandler = serverRouterHono(
+  router,
+  fetchOptions,
+);
+
+export const plugin: ServerRouterPlugin = serverRouterPlugin(
+  router,
+  connectOptions,
+);

--- a/tools/dts-backtest/package.json
+++ b/tools/dts-backtest/package.json
@@ -14,6 +14,7 @@
   "devDependencies": {
     "@types/dom-navigation": "catalog:",
     "@uirouter/core": "catalog:",
+    "hono": "catalog:",
     "lit": "catalog:",
     "lit-ui-router": "workspace:*",
     "lit-ui-router-mobx": "workspace:*",
@@ -22,6 +23,7 @@
     "typescript-5.9": "catalog:",
     "typescript-6": "catalog:typescript6",
     "typescript-7": "catalog:",
-    "ui-router-navigation-location-plugin": "workspace:*"
+    "ui-router-navigation-location-plugin": "workspace:*",
+    "ui-router-server": "workspace:*"
   }
 }

--- a/tools/dts-backtest/run.ts
+++ b/tools/dts-backtest/run.ts
@@ -89,6 +89,7 @@ const PACKAGE_DIRS = [
   'lit-ui-router',
   'lit-ui-router-mobx',
   'navigation-location-plugin',
+  'ui-router-server',
 ].map((dir) => resolve(here, '..', '..', 'packages', dir, 'dist') + sep);
 
 // A file we cannot resolve is treated as ours: it means the compiler reported


### PR DESCRIPTION
Registers `ui-router-server` as dts-backtest's fourth package. This is the
last unchecked **publish-machinery** item on the #354 1.0 readiness gate —
the package has been published since 0.1.0 (2026-08-01) with its shipped
declarations never held to the TS 5.0 consumer floor the other three packages
are held to.

## Result first

**The package already clears the 5.0 floor unmodified.** No floor raise, no
declaration changes. The gap was coverage, not conformance — which is worth
stating plainly, because a green run on a newly added guard is exactly the
shape that gets mistaken for work having been done.

## The fixture is the first multi-entry one

The other three fixtures each import one entry. `ui-router-server` publishes
eight, so the fixture exercises all of them — root, `./matcher`,
`./redirects`, `./simulate`, `./connect`, `./fetch`, `./hono`, `./vite` —
which means a subpath's **exports map** is resolved under both `bundler` and
`NodeNext`, not just the root. That is the part a single-entry fixture cannot
reach, and the multi-entry typedoc setup (#474) has no equivalent guard.

## Why `hono` joins the devDeps

It is the only bare specifier the built declarations import besides
`@uirouter/core`:

```
from "@uirouter/core"   (4x)
from "hono"             (1x)   <- hono.d.ts, MiddlewareHandler
```

`./vite` types Vite's plugin surface **structurally** (`ViteMiddlewareServer`,
`ServerRouterPlugin`) and `./connect` types Node's http subset structurally
(`ConnectRequest`/`ConnectResponse`), so neither pulls its host framework into
the declarations. That is a deliberate property of the package worth noting:
only the Hono adapter has a real type dependency. Without `hono` installed,
its unresolved import would be reported **against our own declaration file**
(owned, not third-party) and fail the run for the wrong reason.

## Mutation-tested, not assumed green

Per the inert-gate lesson from #557 — a rule that is on, green, and inert
reads as coverage while contributing none — the guard was verified by breaking
the artifact it claims to protect:

| Mutation | Result |
| --- | --- |
| `NoInfer<>` appended to `dist/index.d.ts` | floor leg **only** fails, attributed to that file |
| `NoInfer<>` appended to `dist/url-matcher.d.ts` | floor leg **only** fails, attributed to that file |

Both fail at TS 5.0.4 and pass at 5.9 / 6.0 / 7.0, which is the correct
signature for a floor violation rather than a broken filter.

The **second** mutation is the one that matters. `url-matcher.d.ts` backs the
`./matcher` subpath, so it proves the subpath entries actually land in the
program — a fixture that imported only the root would still have gone green
on the first mutation while leaving seven entries unguarded.

Run.ts's existing `missing` guard gives a second, structural proof: it throws
if a registered `PACKAGE_DIRS` entry never appears in the program, so the
package cannot silently drop out of coverage later.

## Verification

`turbo run format:check lint lint:templates test test:matrix typecheck
--filter=@tools/dts-backtest --filter=ui-router-server` — **37/37 tasks**.
Full matrix green across TS 5.0.4 / 5.9.3 / 6.0.3 / 7.0.2 x `bundler` /
`NodeNext`, both harness self-tests included.

No turbo wiring was needed: `@tools/dts-backtest#test` already depends on
`^build`, and `^` reaches direct deps — which `ui-router-server` now is.

Refs #354.
