### PR TITLE
build: evaluate pnpm 12 rc as the mise-provisioned package manager

### DIFF
--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -60,9 +60,9 @@ idiomatic_version_file_enable_tools = ["node"]
 # Bootstrap pnpm, not the version that runs: `packageManager` is the authority
 # and pnpm >=11.10 self-swaps to it. Must be the aqua backend — the npm `pnpm`
 # package is a placeholder whose `preinstall` hardlinks the real binary from an
-# optional platform dep, which neither corepack nor mise's aube installer runs.
+# optional platform dep, which mise's aube installer does not run.
 # Held equal to `packageManager` during the pnpm 12 RC eval, so nothing swaps.
-"aqua:pnpm/pnpm" = "12.0.0-rc.5"
+"aqua:pnpm/pnpm" = "12.0.0-rc.6"
 # shadows node's bundled npm; OIDC trusted publishing needs npm >= 11.5.1
 "npm:npm" = "12.0.1"
 # TOML formatter; oxfmt handles everything but .toml, so this owns the mise

--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -62,7 +62,7 @@ idiomatic_version_file_enable_tools = ["node"]
 # package is a placeholder whose `preinstall` hardlinks the real binary from an
 # optional platform dep, which mise's aube installer does not run.
 # Held equal to `packageManager` during the pnpm 12 RC eval, so nothing swaps.
-"aqua:pnpm/pnpm" = "12.0.0-rc.6"
+"aqua:pnpm/pnpm" = "12.0.0-rc.7"
 # shadows node's bundled npm; OIDC trusted publishing needs npm >= 11.5.1
 "npm:npm" = "12.0.1"
 # TOML formatter; oxfmt handles everything but .toml, so this owns the mise

--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -61,8 +61,8 @@ idiomatic_version_file_enable_tools = ["node"]
 # and pnpm >=11.10 self-swaps to it. Must be the aqua backend — the npm `pnpm`
 # package is a placeholder whose `preinstall` hardlinks the real binary from an
 # optional platform dep, which neither corepack nor mise's aube installer runs.
-# Keep at or above 11.20.0: below that a pnpm-12 lockfile reads as outdated.
-"aqua:pnpm/pnpm" = "11.21.0"
+# Held equal to `packageManager` during the pnpm 12 RC eval, so nothing swaps.
+"aqua:pnpm/pnpm" = "12.0.0-rc.5"
 # shadows node's bundled npm; OIDC trusted publishing needs npm >= 11.5.1
 "npm:npm" = "12.0.1"
 # TOML formatter; oxfmt handles everything but .toml, so this owns the mise

--- a/.config/mise/mise.lock
+++ b/.config/mise/mise.lock
@@ -79,43 +79,43 @@ url = "https://github.com/koalaman/shellcheck/releases/download/v0.11.0/shellche
 url_api = "https://api.github.com/repos/koalaman/shellcheck/releases/assets/279056944"
 
 [[tools."aqua:pnpm/pnpm"]]
-version = "12.0.0-rc.5"
+version = "12.0.0-rc.6"
 backend = "aqua:pnpm/pnpm"
 
 [tools."aqua:pnpm/pnpm"."platforms.linux-arm64"]
-checksum = "sha256:aed4fcf012a429cd322a9efdbc7f3965585bb74d3f51bb829fb81d768b6f3ea5"
-url = "https://github.com/pnpm/pnpm/releases/download/v12.0.0-rc.5/pnpm-linux-arm64.tar.gz"
-url_api = "https://api.github.com/repos/pnpm/pnpm/releases/assets/513228474"
+checksum = "sha256:b00ba83f1bb5a3b01614e6be55e5842a0dd7f32889cf81ed5a4acf72a0c6d3fb"
+url = "https://github.com/pnpm/pnpm/releases/download/v12.0.0-rc.6/pnpm-linux-arm64.tar.gz"
+url_api = "https://api.github.com/repos/pnpm/pnpm/releases/assets/515896949"
 provenance = "github-attestations"
 
 [tools."aqua:pnpm/pnpm"."platforms.linux-arm64-musl"]
-checksum = "sha256:129d7277e4e903f2d1289e4a40fdc2dcb01a97cc72202b9cd224fc1c62dbc677"
-url = "https://github.com/pnpm/pnpm/releases/download/v12.0.0-rc.5/pnpm-linux-arm64-musl.tar.gz"
-url_api = "https://api.github.com/repos/pnpm/pnpm/releases/assets/513228476"
+checksum = "sha256:0fa257910f095d0cbe32f846066b70bb05a9a9916b39f2e179f7136bab8782ce"
+url = "https://github.com/pnpm/pnpm/releases/download/v12.0.0-rc.6/pnpm-linux-arm64-musl.tar.gz"
+url_api = "https://api.github.com/repos/pnpm/pnpm/releases/assets/515896954"
 provenance = "github-attestations"
 
 [tools."aqua:pnpm/pnpm"."platforms.linux-x64"]
-checksum = "sha256:4700faec7d7d89b4d45111b49c56be6ba7120d99a27d0a4dd56700d92b6d8c20"
-url = "https://github.com/pnpm/pnpm/releases/download/v12.0.0-rc.5/pnpm-linux-x64.tar.gz"
-url_api = "https://api.github.com/repos/pnpm/pnpm/releases/assets/513228479"
+checksum = "sha256:91a587656717af75003896010fd1e9a78cd050b489028fcab541be59f9d0d06c"
+url = "https://github.com/pnpm/pnpm/releases/download/v12.0.0-rc.6/pnpm-linux-x64.tar.gz"
+url_api = "https://api.github.com/repos/pnpm/pnpm/releases/assets/515896950"
 provenance = "github-attestations"
 
 [tools."aqua:pnpm/pnpm"."platforms.linux-x64-musl"]
-checksum = "sha256:e83d2b54084b389cf0ff60b221d0bf1a32216b065ee255b0e576dd2c56d5cb3a"
-url = "https://github.com/pnpm/pnpm/releases/download/v12.0.0-rc.5/pnpm-linux-x64-musl.tar.gz"
-url_api = "https://api.github.com/repos/pnpm/pnpm/releases/assets/513228478"
+checksum = "sha256:0ce13add3547313494ff77e8ba75d4bc17f1995684413a599395c52a6f81165e"
+url = "https://github.com/pnpm/pnpm/releases/download/v12.0.0-rc.6/pnpm-linux-x64-musl.tar.gz"
+url_api = "https://api.github.com/repos/pnpm/pnpm/releases/assets/515896957"
 provenance = "github-attestations"
 
 [tools."aqua:pnpm/pnpm"."platforms.macos-arm64"]
-checksum = "sha256:028a6f439c609506b9d0ae2236150dd9a1421ad208651eb8f0b19341069d09fa"
-url = "https://github.com/pnpm/pnpm/releases/download/v12.0.0-rc.5/pnpm-darwin-arm64.tar.gz"
-url_api = "https://api.github.com/repos/pnpm/pnpm/releases/assets/513228475"
+checksum = "sha256:3d053af03a1f489863ee20b6a6b2149e19c313e2203e92731280ebcbd120d11a"
+url = "https://github.com/pnpm/pnpm/releases/download/v12.0.0-rc.6/pnpm-darwin-arm64.tar.gz"
+url_api = "https://api.github.com/repos/pnpm/pnpm/releases/assets/515896956"
 provenance = "github-attestations"
 
 [tools."aqua:pnpm/pnpm"."platforms.windows-x64"]
-checksum = "sha256:ea1bd2e84c0ba8ed991f848412321db486567e3dd5eb3347df10965eed48b8d8"
-url = "https://github.com/pnpm/pnpm/releases/download/v12.0.0-rc.5/pnpm-win32-x64.zip"
-url_api = "https://api.github.com/repos/pnpm/pnpm/releases/assets/513228472"
+checksum = "sha256:9c193cd78684223d1ccabd80ac60e8a5432758da7afd1e86e472d8a08ae6722a"
+url = "https://github.com/pnpm/pnpm/releases/download/v12.0.0-rc.6/pnpm-win32-x64.zip"
+url_api = "https://api.github.com/repos/pnpm/pnpm/releases/assets/515896952"
 provenance = "github-attestations"
 
 [[tools."aqua:rhysd/actionlint"]]

--- a/.config/mise/mise.lock
+++ b/.config/mise/mise.lock
@@ -79,43 +79,43 @@ url = "https://github.com/koalaman/shellcheck/releases/download/v0.11.0/shellche
 url_api = "https://api.github.com/repos/koalaman/shellcheck/releases/assets/279056944"
 
 [[tools."aqua:pnpm/pnpm"]]
-version = "11.21.0"
+version = "12.0.0-rc.5"
 backend = "aqua:pnpm/pnpm"
 
 [tools."aqua:pnpm/pnpm"."platforms.linux-arm64"]
-checksum = "sha256:64eb219b008f7a4c176d81fbce919c20b0b7e093e815cbb669d46e681451f43b"
-url = "https://github.com/pnpm/pnpm/releases/download/v11.21.0/pnpm-linux-arm64.tar.gz"
-url_api = "https://api.github.com/repos/pnpm/pnpm/releases/assets/507585528"
+checksum = "sha256:aed4fcf012a429cd322a9efdbc7f3965585bb74d3f51bb829fb81d768b6f3ea5"
+url = "https://github.com/pnpm/pnpm/releases/download/v12.0.0-rc.5/pnpm-linux-arm64.tar.gz"
+url_api = "https://api.github.com/repos/pnpm/pnpm/releases/assets/513228474"
 provenance = "github-attestations"
 
 [tools."aqua:pnpm/pnpm"."platforms.linux-arm64-musl"]
-checksum = "sha256:43587a1f3d26ee009c640378ef377cac3531990579acf0f35646531b7832831d"
-url = "https://github.com/pnpm/pnpm/releases/download/v11.21.0/pnpm-linux-arm64-musl.tar.gz"
-url_api = "https://api.github.com/repos/pnpm/pnpm/releases/assets/507585511"
+checksum = "sha256:129d7277e4e903f2d1289e4a40fdc2dcb01a97cc72202b9cd224fc1c62dbc677"
+url = "https://github.com/pnpm/pnpm/releases/download/v12.0.0-rc.5/pnpm-linux-arm64-musl.tar.gz"
+url_api = "https://api.github.com/repos/pnpm/pnpm/releases/assets/513228476"
 provenance = "github-attestations"
 
 [tools."aqua:pnpm/pnpm"."platforms.linux-x64"]
-checksum = "sha256:aadc489ce4473c2af0fec06a5c19e113b5793d404eac49853c8153bf4b0d8263"
-url = "https://github.com/pnpm/pnpm/releases/download/v11.21.0/pnpm-linux-x64.tar.gz"
-url_api = "https://api.github.com/repos/pnpm/pnpm/releases/assets/507585503"
+checksum = "sha256:4700faec7d7d89b4d45111b49c56be6ba7120d99a27d0a4dd56700d92b6d8c20"
+url = "https://github.com/pnpm/pnpm/releases/download/v12.0.0-rc.5/pnpm-linux-x64.tar.gz"
+url_api = "https://api.github.com/repos/pnpm/pnpm/releases/assets/513228479"
 provenance = "github-attestations"
 
 [tools."aqua:pnpm/pnpm"."platforms.linux-x64-musl"]
-checksum = "sha256:8cad0a4d20318c0445d992630ace51edc0853fd259573f50ee5d0216dce9b420"
-url = "https://github.com/pnpm/pnpm/releases/download/v11.21.0/pnpm-linux-x64-musl.tar.gz"
-url_api = "https://api.github.com/repos/pnpm/pnpm/releases/assets/507585524"
+checksum = "sha256:e83d2b54084b389cf0ff60b221d0bf1a32216b065ee255b0e576dd2c56d5cb3a"
+url = "https://github.com/pnpm/pnpm/releases/download/v12.0.0-rc.5/pnpm-linux-x64-musl.tar.gz"
+url_api = "https://api.github.com/repos/pnpm/pnpm/releases/assets/513228478"
 provenance = "github-attestations"
 
 [tools."aqua:pnpm/pnpm"."platforms.macos-arm64"]
-checksum = "sha256:860a96978a79ca5132bdc247375f94150a3c98edbecbee36e9f8e0c9e2f7f056"
-url = "https://github.com/pnpm/pnpm/releases/download/v11.21.0/pnpm-darwin-arm64.tar.gz"
-url_api = "https://api.github.com/repos/pnpm/pnpm/releases/assets/507585526"
+checksum = "sha256:028a6f439c609506b9d0ae2236150dd9a1421ad208651eb8f0b19341069d09fa"
+url = "https://github.com/pnpm/pnpm/releases/download/v12.0.0-rc.5/pnpm-darwin-arm64.tar.gz"
+url_api = "https://api.github.com/repos/pnpm/pnpm/releases/assets/513228475"
 provenance = "github-attestations"
 
 [tools."aqua:pnpm/pnpm"."platforms.windows-x64"]
-checksum = "sha256:6643043caa3b01c65c431039926a2af954326d5cefbdb4da7baceceb17f5051f"
-url = "https://github.com/pnpm/pnpm/releases/download/v11.21.0/pnpm-win32-x64.zip"
-url_api = "https://api.github.com/repos/pnpm/pnpm/releases/assets/507585516"
+checksum = "sha256:ea1bd2e84c0ba8ed991f848412321db486567e3dd5eb3347df10965eed48b8d8"
+url = "https://github.com/pnpm/pnpm/releases/download/v12.0.0-rc.5/pnpm-win32-x64.zip"
+url_api = "https://api.github.com/repos/pnpm/pnpm/releases/assets/513228472"
 provenance = "github-attestations"
 
 [[tools."aqua:rhysd/actionlint"]]

--- a/.config/mise/mise.lock
+++ b/.config/mise/mise.lock
@@ -79,43 +79,43 @@ url = "https://github.com/koalaman/shellcheck/releases/download/v0.11.0/shellche
 url_api = "https://api.github.com/repos/koalaman/shellcheck/releases/assets/279056944"
 
 [[tools."aqua:pnpm/pnpm"]]
-version = "12.0.0-rc.6"
+version = "12.0.0-rc.7"
 backend = "aqua:pnpm/pnpm"
 
 [tools."aqua:pnpm/pnpm"."platforms.linux-arm64"]
-checksum = "sha256:b00ba83f1bb5a3b01614e6be55e5842a0dd7f32889cf81ed5a4acf72a0c6d3fb"
-url = "https://github.com/pnpm/pnpm/releases/download/v12.0.0-rc.6/pnpm-linux-arm64.tar.gz"
-url_api = "https://api.github.com/repos/pnpm/pnpm/releases/assets/515896949"
+checksum = "sha256:6d31583bd708faef8eb6b1c3902a1a3e191dd25ce29e630fead9b38574bdf1e6"
+url = "https://github.com/pnpm/pnpm/releases/download/v12.0.0-rc.7/pnpm-linux-arm64.tar.gz"
+url_api = "https://api.github.com/repos/pnpm/pnpm/releases/assets/519309194"
 provenance = "github-attestations"
 
 [tools."aqua:pnpm/pnpm"."platforms.linux-arm64-musl"]
-checksum = "sha256:0fa257910f095d0cbe32f846066b70bb05a9a9916b39f2e179f7136bab8782ce"
-url = "https://github.com/pnpm/pnpm/releases/download/v12.0.0-rc.6/pnpm-linux-arm64-musl.tar.gz"
-url_api = "https://api.github.com/repos/pnpm/pnpm/releases/assets/515896954"
+checksum = "sha256:a86e7d600989037cb9a9f9323ec0bd328e4d7209ee854a887f9cd4e3391304ea"
+url = "https://github.com/pnpm/pnpm/releases/download/v12.0.0-rc.7/pnpm-linux-arm64-musl.tar.gz"
+url_api = "https://api.github.com/repos/pnpm/pnpm/releases/assets/519309196"
 provenance = "github-attestations"
 
 [tools."aqua:pnpm/pnpm"."platforms.linux-x64"]
-checksum = "sha256:91a587656717af75003896010fd1e9a78cd050b489028fcab541be59f9d0d06c"
-url = "https://github.com/pnpm/pnpm/releases/download/v12.0.0-rc.6/pnpm-linux-x64.tar.gz"
-url_api = "https://api.github.com/repos/pnpm/pnpm/releases/assets/515896950"
+checksum = "sha256:7870f46e4f7f9e6aab983ffe26a87945cebfa80c5683458169665ed423cf92bb"
+url = "https://github.com/pnpm/pnpm/releases/download/v12.0.0-rc.7/pnpm-linux-x64.tar.gz"
+url_api = "https://api.github.com/repos/pnpm/pnpm/releases/assets/519309197"
 provenance = "github-attestations"
 
 [tools."aqua:pnpm/pnpm"."platforms.linux-x64-musl"]
-checksum = "sha256:0ce13add3547313494ff77e8ba75d4bc17f1995684413a599395c52a6f81165e"
-url = "https://github.com/pnpm/pnpm/releases/download/v12.0.0-rc.6/pnpm-linux-x64-musl.tar.gz"
-url_api = "https://api.github.com/repos/pnpm/pnpm/releases/assets/515896957"
+checksum = "sha256:e0b9dead3dfa30bab89f637c66cd90249dbfe9a9886fafa8ea7c327f6a866c54"
+url = "https://github.com/pnpm/pnpm/releases/download/v12.0.0-rc.7/pnpm-linux-x64-musl.tar.gz"
+url_api = "https://api.github.com/repos/pnpm/pnpm/releases/assets/519309190"
 provenance = "github-attestations"
 
 [tools."aqua:pnpm/pnpm"."platforms.macos-arm64"]
-checksum = "sha256:3d053af03a1f489863ee20b6a6b2149e19c313e2203e92731280ebcbd120d11a"
-url = "https://github.com/pnpm/pnpm/releases/download/v12.0.0-rc.6/pnpm-darwin-arm64.tar.gz"
-url_api = "https://api.github.com/repos/pnpm/pnpm/releases/assets/515896956"
+checksum = "sha256:6c3831e1ad90b35735c23e698d66b8633d058e5c5ca7daa13caab134fa77b90e"
+url = "https://github.com/pnpm/pnpm/releases/download/v12.0.0-rc.7/pnpm-darwin-arm64.tar.gz"
+url_api = "https://api.github.com/repos/pnpm/pnpm/releases/assets/519309195"
 provenance = "github-attestations"
 
 [tools."aqua:pnpm/pnpm"."platforms.windows-x64"]
-checksum = "sha256:9c193cd78684223d1ccabd80ac60e8a5432758da7afd1e86e472d8a08ae6722a"
-url = "https://github.com/pnpm/pnpm/releases/download/v12.0.0-rc.6/pnpm-win32-x64.zip"
-url_api = "https://api.github.com/repos/pnpm/pnpm/releases/assets/515896952"
+checksum = "sha256:0675932d30b246cd623c1ed1dc1a5162609f84da321eb5b775d44493aca2559b"
+url = "https://github.com/pnpm/pnpm/releases/download/v12.0.0-rc.7/pnpm-win32-x64.zip"
+url_api = "https://api.github.com/repos/pnpm/pnpm/releases/assets/519309193"
 provenance = "github-attestations"
 
 [[tools."aqua:rhysd/actionlint"]]

--- a/package.json
+++ b/package.json
@@ -65,5 +65,5 @@
   "engines": {
     "node": ">=24.18.0"
   },
-  "packageManager": "pnpm@12.0.0-rc.6"
+  "packageManager": "pnpm@12.0.0-rc.7"
 }

--- a/package.json
+++ b/package.json
@@ -65,5 +65,5 @@
   "engines": {
     "node": ">=24.18.0"
   },
-  "packageManager": "pnpm@12.0.0-rc.5"
+  "packageManager": "pnpm@12.0.0-rc.6"
 }

--- a/package.json
+++ b/package.json
@@ -65,5 +65,5 @@
   "engines": {
     "node": ">=24.18.0"
   },
-  "packageManager": "pnpm@12.0.0-rc.7"
+  "packageManager": "pnpm@12.0.0-rc.7+sha512.1d967069e7bb40beea4e2ebb5f4d6cfaab099119593cd2bfd26516f4c6e151a387d9b3a205f8d629264d6bd764b35e5bfdb38fa9cf798e625203353bc6fbb254"
 }

--- a/package.json
+++ b/package.json
@@ -65,5 +65,5 @@
   "engines": {
     "node": ">=24.18.0"
   },
-  "packageManager": "pnpm@11.21.0+sha512.521705bce689924eac72f5a3587122f362689ef6571e55ba80076fd637c11132ecffada26fad4ea79c485bfddbfd3d5a2a5b05805a77e893de71ec8a6cca3bb1"
+  "packageManager": "pnpm@12.0.0-rc.5"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,3 +1,104 @@
+---
+lockfileVersion: '9.0'
+
+importers:
+
+  .:
+    configDependencies: {}
+    packageManagerDependencies:
+      pnpm:
+        specifier: 12.0.0-rc.5
+        version: 12.0.0-rc.5
+
+packages:
+
+  '@pnpm/exe.darwin-arm64@12.0.0-rc.5':
+    resolution: {integrity: sha512-CYNIBkLIcQ3dv9Bp4p8BUS9JMoQQM30ulEa72B8oqtgMweqraQ/60mnJut0iqflt6F9OSPgNJxTLmUVM0X/8ew==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@pnpm/exe.darwin-x64@12.0.0-rc.5':
+    resolution: {integrity: sha512-kJYD1EpisLlPrvIsA9SB40EAo0k/qPGioi56rMr9Us2pLTKNnzW6qyU/oeDDf9RcKDXWyjNsO9hHHVIfCS9BYA==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@pnpm/exe.linux-arm64-musl@12.0.0-rc.5':
+    resolution: {integrity: sha512-yQwz0Ahn62uRSjGT23drqshUWWIfwuZhq8uASp9JvsrRd/+xFG9K5hgyfW+Mhywlh2gWQ0tjQTbzJNdwvPzqUA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@pnpm/exe.linux-arm64@12.0.0-rc.5':
+    resolution: {integrity: sha512-/SlL2Or1dfiUJeAIusaWnwnQuoA2PwFqtbwFlvsihOfAaAZLw9P6mofu6VbWN/xB9OxLfGIXeElKUeY4PQehtw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@pnpm/exe.linux-x64-musl@12.0.0-rc.5':
+    resolution: {integrity: sha512-NkHve9TqSKqOQRjUx4w5niVuEojNHu2gy6s1rAvIWO4HEDC6g3Opn2toGLBYHO7xdzC/tL0iWQBJjhMBWCyq3g==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@pnpm/exe.linux-x64@12.0.0-rc.5':
+    resolution: {integrity: sha512-U7NiGcExYsbjItnntmB9aR84SA86MUCrpiB/rrK1aoNaTJHhZHXCusqkbYktZEd6PUTw0RA1SdBDrxpeQyLyKw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@pnpm/exe.win32-arm64@12.0.0-rc.5':
+    resolution: {integrity: sha512-j4W16YwEq2xJ01fw8hUCYme8UwRZHxMxUVF3DMUtr4+GxrMgqpjgHsWtlybRLVjVhXe4rTjNE7VIkrIvReuHpg==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@pnpm/exe.win32-x64@12.0.0-rc.5':
+    resolution: {integrity: sha512-IQrykr2gv9X6/hW2DgxyNNm7O2jl40xzDpgH2gAI0Z+A6gZaOn0BWBIAfv1j87W0yt1OC41I7qvgEPC9kO3dvQ==}
+    cpu: [x64]
+    os: [win32]
+
+  pnpm@12.0.0-rc.5:
+    resolution: {integrity: sha512-MvAerV1e6ufMdA5zy0am6ENHGiIWoGz8ADQEuViZJ1kVmoSW7xuCicO0BXICoqlUyX7p5jH+BN2HGzMYIi70Vg==}
+    engines: {node: '>=18.*'}
+    hasBin: true
+
+snapshots:
+
+  '@pnpm/exe.darwin-arm64@12.0.0-rc.5':
+    optional: true
+
+  '@pnpm/exe.darwin-x64@12.0.0-rc.5':
+    optional: true
+
+  '@pnpm/exe.linux-arm64-musl@12.0.0-rc.5':
+    optional: true
+
+  '@pnpm/exe.linux-arm64@12.0.0-rc.5':
+    optional: true
+
+  '@pnpm/exe.linux-x64-musl@12.0.0-rc.5':
+    optional: true
+
+  '@pnpm/exe.linux-x64@12.0.0-rc.5':
+    optional: true
+
+  '@pnpm/exe.win32-arm64@12.0.0-rc.5':
+    optional: true
+
+  '@pnpm/exe.win32-x64@12.0.0-rc.5':
+    optional: true
+
+  pnpm@12.0.0-rc.5:
+    optionalDependencies:
+      '@pnpm/exe.darwin-arm64': 12.0.0-rc.5
+      '@pnpm/exe.darwin-x64': 12.0.0-rc.5
+      '@pnpm/exe.linux-arm64': 12.0.0-rc.5
+      '@pnpm/exe.linux-arm64-musl': 12.0.0-rc.5
+      '@pnpm/exe.linux-x64': 12.0.0-rc.5
+      '@pnpm/exe.linux-x64-musl': 12.0.0-rc.5
+      '@pnpm/exe.win32-arm64': 12.0.0-rc.5
+      '@pnpm/exe.win32-x64': 12.0.0-rc.5
+
+---
 lockfileVersion: '9.0'
 
 settings:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,96 +7,96 @@ importers:
     configDependencies: {}
     packageManagerDependencies:
       pnpm:
-        specifier: 12.0.0-rc.6
-        version: 12.0.0-rc.6
+        specifier: 12.0.0-rc.7
+        version: 12.0.0-rc.7
 
 packages:
 
-  '@pnpm/exe.darwin-arm64@12.0.0-rc.6':
-    resolution: {integrity: sha512-m57z/dG0gzeh4rCApyLaHbaLh+4SwOiIoEQAyYUvY/YVVThBY4PrgJIE/0jxfNe9WeJR2cGO6W0ehiQ9LZ4csg==}
+  '@pnpm/exe.darwin-arm64@12.0.0-rc.7':
+    resolution: {integrity: sha512-IVRQGs1GB5YcVivwGewvdHkdCBrTYoInSnvJMslYa/BDTXDxQ352gVwpw0x7JvyfEKLrYcPQERxLBkPrjj2abA==}
     cpu: [arm64]
     os: [darwin]
 
-  '@pnpm/exe.darwin-x64@12.0.0-rc.6':
-    resolution: {integrity: sha512-Kqojv9k2hrAoUKEa+U2J1nMcYGZnxBnZ90Al7RMavfcKIDE13GdnWMaeiNKFBWoyPdYgtR2qCtwyjAprWSUstg==}
+  '@pnpm/exe.darwin-x64@12.0.0-rc.7':
+    resolution: {integrity: sha512-L1tyIoFaAyOFYKxIboJx3yaVhdzjW0kEtrgxqAIbYosCO97jdrd5uLDFhY7kh8UbdTNy5Je1mVj+6e7YOJmbzQ==}
     cpu: [x64]
     os: [darwin]
 
-  '@pnpm/exe.linux-arm64-musl@12.0.0-rc.6':
-    resolution: {integrity: sha512-FGeJUQ9Pralhzibl1o5QZUPhPIIWbomoeJG5Gm2HFFNEkvDWm+MwRw5eRnPdb+zyGtrXfQAc7eZtMgLQh/tuVg==}
+  '@pnpm/exe.linux-arm64-musl@12.0.0-rc.7':
+    resolution: {integrity: sha512-nDTlQXIwySKDkM9pkUazRs08xzdhZAdhBpd5afn/v/ECvcrSMPgGqDqDOY8xxchdv0BkX+OTjyEGZI3MYbSlSg==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@pnpm/exe.linux-arm64@12.0.0-rc.6':
-    resolution: {integrity: sha512-/S+hdo/9b8jOa74bpF7p+rTKUlqvsSLGLaCtNAyH+PjEKmTsbOKDinTeFM4MJK+6qEipigmrnSYrt66AwuT+CA==}
+  '@pnpm/exe.linux-arm64@12.0.0-rc.7':
+    resolution: {integrity: sha512-bs2dlLs+gVjs7gmM4zrhHC20ca20EAjluvkpBIoQJe+rf6gXEKtaMo7WcbnpsQChCEv3GhM//hVoRnbRZhR/jw==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@pnpm/exe.linux-x64-musl@12.0.0-rc.6':
-    resolution: {integrity: sha512-Sn88BvO6o1ChhP63qA/J96tWI+WBDtN57ZycUfl3ZV8n4ccmETYkWMRo4JaCexaMZI/b5U17neoBUo0MHZChHQ==}
+  '@pnpm/exe.linux-x64-musl@12.0.0-rc.7':
+    resolution: {integrity: sha512-fGdJQx0pXAbMYE36SiCHbHVvaOWyPKyBuVMlNTHU3XWfX94kiOx7pEzfAlODTYEFyk9vZABSLyyQZ2EvVSNKiA==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@pnpm/exe.linux-x64@12.0.0-rc.6':
-    resolution: {integrity: sha512-gCeOwlSLqMo0J/X4pH9yDH0GpZ+FAxHuFHGdedN7YKhCKxacUt+b4m74xSaBgSK2r4eHYR9bGCsLqSQ9ZaERTQ==}
+  '@pnpm/exe.linux-x64@12.0.0-rc.7':
+    resolution: {integrity: sha512-NZ16HBgXA6CPL4qCm5fku/C5paHZSLT243bG/27hCGysAXkN+ZJy+rZZKx6SKGUzVimi+9t0owPUNZ6XLSkWzQ==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@pnpm/exe.win32-arm64@12.0.0-rc.6':
-    resolution: {integrity: sha512-q7b2oxEcCBTBTh15qORCfCZfa3EHoNiIPdHJCS1Vs1tvv2qPys2AW9FpSwdPY6N9zb419CDQxb+Cwjfe2n/ZjQ==}
+  '@pnpm/exe.win32-arm64@12.0.0-rc.7':
+    resolution: {integrity: sha512-JKrB3taWXcN1OtZq95X5Sfe/Dk2JYkwgd+qXNmjK/RHpiS+G1pE45L5u77KXVhQQ8MoctLthK1CMA5TbXX3bIg==}
     cpu: [arm64]
     os: [win32]
 
-  '@pnpm/exe.win32-x64@12.0.0-rc.6':
-    resolution: {integrity: sha512-YBFLDcLgl60ssEeLJlBikCwK0LIjbmeVngA/0hu2MTvbbkV1GQcNlFKuVpG5OLW17PH5YGydIAbs0qEf0PQPiA==}
+  '@pnpm/exe.win32-x64@12.0.0-rc.7':
+    resolution: {integrity: sha512-AVEC3/Q+opA1npNqM+yqirXvufRpftoLwWs9OlRE7Euhx76FGHGkB72fi2VyNiFBkfovcwOfwOPM0h1geVFYaw==}
     cpu: [x64]
     os: [win32]
 
-  pnpm@12.0.0-rc.6:
-    resolution: {integrity: sha512-OSf85JwwVLflVB3HILzntOurB/RWL6b/zns5cgol5qdn12OEmE4iZcgAeZYT9/ecXEIun1ztybZs//0Iyjx3qQ==}
+  pnpm@12.0.0-rc.7:
+    resolution: {integrity: sha512-HZZwaee7QL7qTi67X01s+qsJkRlZPNK/0mUW9MbhUaOH2bOiBfjWKSZNa9dks15b/bOPqc95jmJSAzU7xvuyVA==}
     engines: {node: '>=18.*'}
     hasBin: true
 
 snapshots:
 
-  '@pnpm/exe.darwin-arm64@12.0.0-rc.6':
+  '@pnpm/exe.darwin-arm64@12.0.0-rc.7':
     optional: true
 
-  '@pnpm/exe.darwin-x64@12.0.0-rc.6':
+  '@pnpm/exe.darwin-x64@12.0.0-rc.7':
     optional: true
 
-  '@pnpm/exe.linux-arm64-musl@12.0.0-rc.6':
+  '@pnpm/exe.linux-arm64-musl@12.0.0-rc.7':
     optional: true
 
-  '@pnpm/exe.linux-arm64@12.0.0-rc.6':
+  '@pnpm/exe.linux-arm64@12.0.0-rc.7':
     optional: true
 
-  '@pnpm/exe.linux-x64-musl@12.0.0-rc.6':
+  '@pnpm/exe.linux-x64-musl@12.0.0-rc.7':
     optional: true
 
-  '@pnpm/exe.linux-x64@12.0.0-rc.6':
+  '@pnpm/exe.linux-x64@12.0.0-rc.7':
     optional: true
 
-  '@pnpm/exe.win32-arm64@12.0.0-rc.6':
+  '@pnpm/exe.win32-arm64@12.0.0-rc.7':
     optional: true
 
-  '@pnpm/exe.win32-x64@12.0.0-rc.6':
+  '@pnpm/exe.win32-x64@12.0.0-rc.7':
     optional: true
 
-  pnpm@12.0.0-rc.6:
+  pnpm@12.0.0-rc.7:
     optionalDependencies:
-      '@pnpm/exe.darwin-arm64': 12.0.0-rc.6
-      '@pnpm/exe.darwin-x64': 12.0.0-rc.6
-      '@pnpm/exe.linux-arm64': 12.0.0-rc.6
-      '@pnpm/exe.linux-arm64-musl': 12.0.0-rc.6
-      '@pnpm/exe.linux-x64': 12.0.0-rc.6
-      '@pnpm/exe.linux-x64-musl': 12.0.0-rc.6
-      '@pnpm/exe.win32-arm64': 12.0.0-rc.6
-      '@pnpm/exe.win32-x64': 12.0.0-rc.6
+      '@pnpm/exe.darwin-arm64': 12.0.0-rc.7
+      '@pnpm/exe.darwin-x64': 12.0.0-rc.7
+      '@pnpm/exe.linux-arm64': 12.0.0-rc.7
+      '@pnpm/exe.linux-arm64-musl': 12.0.0-rc.7
+      '@pnpm/exe.linux-x64': 12.0.0-rc.7
+      '@pnpm/exe.linux-x64-musl': 12.0.0-rc.7
+      '@pnpm/exe.win32-arm64': 12.0.0-rc.7
+      '@pnpm/exe.win32-x64': 12.0.0-rc.7
 
 ---
 lockfileVersion: '9.0'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,96 +7,96 @@ importers:
     configDependencies: {}
     packageManagerDependencies:
       pnpm:
-        specifier: 12.0.0-rc.5
-        version: 12.0.0-rc.5
+        specifier: 12.0.0-rc.6
+        version: 12.0.0-rc.6
 
 packages:
 
-  '@pnpm/exe.darwin-arm64@12.0.0-rc.5':
-    resolution: {integrity: sha512-CYNIBkLIcQ3dv9Bp4p8BUS9JMoQQM30ulEa72B8oqtgMweqraQ/60mnJut0iqflt6F9OSPgNJxTLmUVM0X/8ew==}
+  '@pnpm/exe.darwin-arm64@12.0.0-rc.6':
+    resolution: {integrity: sha512-m57z/dG0gzeh4rCApyLaHbaLh+4SwOiIoEQAyYUvY/YVVThBY4PrgJIE/0jxfNe9WeJR2cGO6W0ehiQ9LZ4csg==}
     cpu: [arm64]
     os: [darwin]
 
-  '@pnpm/exe.darwin-x64@12.0.0-rc.5':
-    resolution: {integrity: sha512-kJYD1EpisLlPrvIsA9SB40EAo0k/qPGioi56rMr9Us2pLTKNnzW6qyU/oeDDf9RcKDXWyjNsO9hHHVIfCS9BYA==}
+  '@pnpm/exe.darwin-x64@12.0.0-rc.6':
+    resolution: {integrity: sha512-Kqojv9k2hrAoUKEa+U2J1nMcYGZnxBnZ90Al7RMavfcKIDE13GdnWMaeiNKFBWoyPdYgtR2qCtwyjAprWSUstg==}
     cpu: [x64]
     os: [darwin]
 
-  '@pnpm/exe.linux-arm64-musl@12.0.0-rc.5':
-    resolution: {integrity: sha512-yQwz0Ahn62uRSjGT23drqshUWWIfwuZhq8uASp9JvsrRd/+xFG9K5hgyfW+Mhywlh2gWQ0tjQTbzJNdwvPzqUA==}
+  '@pnpm/exe.linux-arm64-musl@12.0.0-rc.6':
+    resolution: {integrity: sha512-FGeJUQ9Pralhzibl1o5QZUPhPIIWbomoeJG5Gm2HFFNEkvDWm+MwRw5eRnPdb+zyGtrXfQAc7eZtMgLQh/tuVg==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@pnpm/exe.linux-arm64@12.0.0-rc.5':
-    resolution: {integrity: sha512-/SlL2Or1dfiUJeAIusaWnwnQuoA2PwFqtbwFlvsihOfAaAZLw9P6mofu6VbWN/xB9OxLfGIXeElKUeY4PQehtw==}
+  '@pnpm/exe.linux-arm64@12.0.0-rc.6':
+    resolution: {integrity: sha512-/S+hdo/9b8jOa74bpF7p+rTKUlqvsSLGLaCtNAyH+PjEKmTsbOKDinTeFM4MJK+6qEipigmrnSYrt66AwuT+CA==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@pnpm/exe.linux-x64-musl@12.0.0-rc.5':
-    resolution: {integrity: sha512-NkHve9TqSKqOQRjUx4w5niVuEojNHu2gy6s1rAvIWO4HEDC6g3Opn2toGLBYHO7xdzC/tL0iWQBJjhMBWCyq3g==}
+  '@pnpm/exe.linux-x64-musl@12.0.0-rc.6':
+    resolution: {integrity: sha512-Sn88BvO6o1ChhP63qA/J96tWI+WBDtN57ZycUfl3ZV8n4ccmETYkWMRo4JaCexaMZI/b5U17neoBUo0MHZChHQ==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@pnpm/exe.linux-x64@12.0.0-rc.5':
-    resolution: {integrity: sha512-U7NiGcExYsbjItnntmB9aR84SA86MUCrpiB/rrK1aoNaTJHhZHXCusqkbYktZEd6PUTw0RA1SdBDrxpeQyLyKw==}
+  '@pnpm/exe.linux-x64@12.0.0-rc.6':
+    resolution: {integrity: sha512-gCeOwlSLqMo0J/X4pH9yDH0GpZ+FAxHuFHGdedN7YKhCKxacUt+b4m74xSaBgSK2r4eHYR9bGCsLqSQ9ZaERTQ==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@pnpm/exe.win32-arm64@12.0.0-rc.5':
-    resolution: {integrity: sha512-j4W16YwEq2xJ01fw8hUCYme8UwRZHxMxUVF3DMUtr4+GxrMgqpjgHsWtlybRLVjVhXe4rTjNE7VIkrIvReuHpg==}
+  '@pnpm/exe.win32-arm64@12.0.0-rc.6':
+    resolution: {integrity: sha512-q7b2oxEcCBTBTh15qORCfCZfa3EHoNiIPdHJCS1Vs1tvv2qPys2AW9FpSwdPY6N9zb419CDQxb+Cwjfe2n/ZjQ==}
     cpu: [arm64]
     os: [win32]
 
-  '@pnpm/exe.win32-x64@12.0.0-rc.5':
-    resolution: {integrity: sha512-IQrykr2gv9X6/hW2DgxyNNm7O2jl40xzDpgH2gAI0Z+A6gZaOn0BWBIAfv1j87W0yt1OC41I7qvgEPC9kO3dvQ==}
+  '@pnpm/exe.win32-x64@12.0.0-rc.6':
+    resolution: {integrity: sha512-YBFLDcLgl60ssEeLJlBikCwK0LIjbmeVngA/0hu2MTvbbkV1GQcNlFKuVpG5OLW17PH5YGydIAbs0qEf0PQPiA==}
     cpu: [x64]
     os: [win32]
 
-  pnpm@12.0.0-rc.5:
-    resolution: {integrity: sha512-MvAerV1e6ufMdA5zy0am6ENHGiIWoGz8ADQEuViZJ1kVmoSW7xuCicO0BXICoqlUyX7p5jH+BN2HGzMYIi70Vg==}
+  pnpm@12.0.0-rc.6:
+    resolution: {integrity: sha512-OSf85JwwVLflVB3HILzntOurB/RWL6b/zns5cgol5qdn12OEmE4iZcgAeZYT9/ecXEIun1ztybZs//0Iyjx3qQ==}
     engines: {node: '>=18.*'}
     hasBin: true
 
 snapshots:
 
-  '@pnpm/exe.darwin-arm64@12.0.0-rc.5':
+  '@pnpm/exe.darwin-arm64@12.0.0-rc.6':
     optional: true
 
-  '@pnpm/exe.darwin-x64@12.0.0-rc.5':
+  '@pnpm/exe.darwin-x64@12.0.0-rc.6':
     optional: true
 
-  '@pnpm/exe.linux-arm64-musl@12.0.0-rc.5':
+  '@pnpm/exe.linux-arm64-musl@12.0.0-rc.6':
     optional: true
 
-  '@pnpm/exe.linux-arm64@12.0.0-rc.5':
+  '@pnpm/exe.linux-arm64@12.0.0-rc.6':
     optional: true
 
-  '@pnpm/exe.linux-x64-musl@12.0.0-rc.5':
+  '@pnpm/exe.linux-x64-musl@12.0.0-rc.6':
     optional: true
 
-  '@pnpm/exe.linux-x64@12.0.0-rc.5':
+  '@pnpm/exe.linux-x64@12.0.0-rc.6':
     optional: true
 
-  '@pnpm/exe.win32-arm64@12.0.0-rc.5':
+  '@pnpm/exe.win32-arm64@12.0.0-rc.6':
     optional: true
 
-  '@pnpm/exe.win32-x64@12.0.0-rc.5':
+  '@pnpm/exe.win32-x64@12.0.0-rc.6':
     optional: true
 
-  pnpm@12.0.0-rc.5:
+  pnpm@12.0.0-rc.6:
     optionalDependencies:
-      '@pnpm/exe.darwin-arm64': 12.0.0-rc.5
-      '@pnpm/exe.darwin-x64': 12.0.0-rc.5
-      '@pnpm/exe.linux-arm64': 12.0.0-rc.5
-      '@pnpm/exe.linux-arm64-musl': 12.0.0-rc.5
-      '@pnpm/exe.linux-x64': 12.0.0-rc.5
-      '@pnpm/exe.linux-x64-musl': 12.0.0-rc.5
-      '@pnpm/exe.win32-arm64': 12.0.0-rc.5
-      '@pnpm/exe.win32-x64': 12.0.0-rc.5
+      '@pnpm/exe.darwin-arm64': 12.0.0-rc.6
+      '@pnpm/exe.darwin-x64': 12.0.0-rc.6
+      '@pnpm/exe.linux-arm64': 12.0.0-rc.6
+      '@pnpm/exe.linux-arm64-musl': 12.0.0-rc.6
+      '@pnpm/exe.linux-x64': 12.0.0-rc.6
+      '@pnpm/exe.linux-x64-musl': 12.0.0-rc.6
+      '@pnpm/exe.win32-arm64': 12.0.0-rc.6
+      '@pnpm/exe.win32-x64': 12.0.0-rc.6
 
 ---
 lockfileVersion: '9.0'

--- a/tools/workers-builds/cloudflare-build.sh
+++ b/tools/workers-builds/cloudflare-build.sh
@@ -16,11 +16,16 @@
 # replaced rather than bypassed.
 set -euo pipefail
 
-# npm's global bin is the same node bin dir the corepack shim sits in, so this
-# overwrites it. --allow-scripts is what makes it a pnpm 12 rather than the
-# wrapper's placeholder bin: the real binary is unpacked by a preinstall hook,
-# which npm 12 blocks by default. npm 11 ignores the unknown flag and runs the
-# hook anyway, so one command covers both.
+# npm's global bin is the same node bin dir the corepack shims sit in, and npm
+# refuses to overwrite a file it does not own (EEXIST), so clear them first
+# rather than reaching for --force.
+node_bin="$(dirname "$(command -v node)")"
+rm -f "$node_bin/pnpm" "$node_bin/pnpx"
+
+# --allow-scripts is what makes this a pnpm 12 rather than the wrapper's
+# placeholder bin: the real binary is unpacked by a preinstall hook, which npm
+# 12 blocks by default. npm 11 ignores the unknown flag and runs the hook
+# anyway, so one command covers both.
 npm install --global --allow-scripts=pnpm pnpm@12.0.0-rc.5
 
 pnpm install --frozen-lockfile

--- a/tools/workers-builds/cloudflare-build.sh
+++ b/tools/workers-builds/cloudflare-build.sh
@@ -12,8 +12,10 @@
 # This branch's copy diverges from main's, which is what the indirection is
 # for. npx covers only the commands named here; turbo spawns every package
 # script through the `pnpm` on PATH, which in the build image is corepack's
-# shim, and corepack cannot materialize a pnpm-12 pin. So the shim has to be
-# replaced rather than bypassed.
+# shim, and corepack could not materialize a pnpm-12 pin through rc.5. So the
+# shim is replaced rather than bypassed. rc.6 restored the bin entry points
+# corepack looks for, which may make this unnecessary — untested, and this path
+# is verified, so it stays until something forces the question.
 set -euo pipefail
 
 # npm's global bin is the same node bin dir the corepack shims sit in, and npm
@@ -28,7 +30,7 @@ rm -f "$npm_bin/pnpm" "$npm_bin/pnpx"
 # placeholder bin: the real binary is unpacked by a preinstall hook, which npm
 # 12 blocks by default. npm 11 ignores the unknown flag and runs the hook
 # anyway, so one command covers both.
-npm install --global --allow-scripts=pnpm pnpm@12.0.0-rc.5
+npm install --global --allow-scripts=pnpm pnpm@12.0.0-rc.6
 
 pnpm install --frozen-lockfile
 

--- a/tools/workers-builds/cloudflare-build.sh
+++ b/tools/workers-builds/cloudflare-build.sh
@@ -8,12 +8,22 @@
 #
 # Runs from the repo root under SKIP_DEPENDENCY_INSTALL=1 — Cloudflare's own
 # install step is off, so installing is this script's job (see DEPLOY.md).
+#
+# This branch's copy diverges from main's, which is what the indirection is
+# for. npx covers only the commands named here; turbo spawns every package
+# script through the `pnpm` on PATH, which in the build image is corepack's
+# shim, and corepack cannot materialize a pnpm-12 pin. So the shim has to be
+# replaced rather than bypassed.
 set -euo pipefail
 
-# Bootstrap floor, not the version that runs: >=11.20.0 to read a pnpm-12
-# lockfile, then `packageManager` self-swaps. Via npx because the corepack
-# `pnpm` on PATH cannot materialize a pnpm-12 pin.
-npx pnpm@11.21.0 install --frozen-lockfile
+# npm's global bin is the same node bin dir the corepack shim sits in, so this
+# overwrites it. --allow-scripts is what makes it a pnpm 12 rather than the
+# wrapper's placeholder bin: the real binary is unpacked by a preinstall hook,
+# which npm 12 blocks by default. npm 11 ignores the unknown flag and runs the
+# hook anyway, so one command covers both.
+npm install --global --allow-scripts=pnpm pnpm@12.0.0-rc.5
 
-# npx again: turbo is a workspace devDependency, not on PATH before the install.
+pnpm install --frozen-lockfile
+
+# turbo is a workspace devDependency, not on PATH.
 npx turbo docs#build

--- a/tools/workers-builds/cloudflare-build.sh
+++ b/tools/workers-builds/cloudflare-build.sh
@@ -30,7 +30,7 @@ rm -f "$npm_bin/pnpm" "$npm_bin/pnpx"
 # placeholder bin: the real binary is unpacked by a preinstall hook, which npm
 # 12 blocks by default. npm 11 ignores the unknown flag and runs the hook
 # anyway, so one command covers both.
-npm install --global --allow-scripts=pnpm pnpm@12.0.0-rc.6
+npm install --global --allow-scripts=pnpm pnpm@12.0.0-rc.7
 
 pnpm install --frozen-lockfile
 

--- a/tools/workers-builds/cloudflare-build.sh
+++ b/tools/workers-builds/cloudflare-build.sh
@@ -18,9 +18,11 @@ set -euo pipefail
 
 # npm's global bin is the same node bin dir the corepack shims sit in, and npm
 # refuses to overwrite a file it does not own (EEXIST), so clear them first
-# rather than reaching for --force.
-node_bin="$(dirname "$(command -v node)")"
-rm -f "$node_bin/pnpm" "$node_bin/pnpx"
+# rather than reaching for --force. Ask npm where it will write: asdf puts its
+# own shims on PATH, so `command -v node` resolves to ~/.asdf/shims, not the
+# installs/nodejs/<version>/bin the shims and the global install both land in.
+npm_bin="$(npm prefix -g)/bin"
+rm -f "$npm_bin/pnpm" "$npm_bin/pnpx"
 
 # --allow-scripts is what makes this a pnpm 12 rather than the wrapper's
 # placeholder bin: the real binary is unpacked by a preinstall hook, which npm

--- a/tools/workers-builds/workers-builds-triggers.test.ts
+++ b/tools/workers-builds/workers-builds-triggers.test.ts
@@ -93,10 +93,10 @@ describe('desiredStateFromConfig', () => {
         join(import.meta.dirname, '..', '..', command),
         'utf8',
       );
-      assert.match(
-        script,
-        /^npx pnpm@\d+\.\d+\.\d+ install --frozen-lockfile$/m,
-      );
+      // Command-agnostic on purpose: the bootstrap in front of the install is
+      // exactly what a branch is allowed to change. What must hold is that a
+      // frozen install happens at all.
+      assert.match(script, /^[^#\n]*\binstall --frozen-lockfile$/m);
     }
   });
 


### PR DESCRIPTION
Evaluation branch, **not for merge before pnpm 12.0.0 GA**. Flips the package manager to `12.0.0-rc.7` so the Rust rewrite runs against the full `ci:main` graph, while the rc is still cheap to abandon. Tracks each rc as it lands, so a regression surfaces against one prerelease rather than against GA.

**Status: all checks green** as of `0743150` (`12.0.0-rc.7`) — both the PR graph and the main graph, the latter at 159/159 tasks. Every blocker this branch turned up is resolved; what remains is waiting on GA.

`ci-main/` prefix, so every push here builds the main graph (`check:pack`, dts-backtest matrix) rather than the PR subset.

## Restacked — structural work has all landed on `main`

Everything structural this branch discovered has since landed on `main` as its own PR. What is left is the version flip:

| Was in this branch | Landed as |
| --- | --- |
| corepack retirement, `aqua:pnpm/pnpm` bootstrap | #582 |
| `SKIP_DEPENDENCY_INSTALL` + `npx pnpm@… install` in the build command | #582, declarable via #574 |
| Workers Builds env vars as code | #574, #585 |
| `PNPM_VERSION` dashboard variable | superseded — deleted, never needed |

What is left is the version flip plus the two things that are genuinely branch-local:

- **the flip** — `.config/mise/config.toml`, `.config/mise/mise.lock`, `package.json`, `pnpm-lock.yaml`
- **the Cloudflare bootstrap** — `tools/workers-builds/cloudflare-build.sh` and its guard test.
  #587 moved the build command into the repo precisely so a branch could diverge here without
  that reading as dashboard drift

The publint patch that used to sit here is **gone** — see below.

## The Cloudflare blocker: resolved

`Workers Builds: lit-ui-router` is **green on this branch** as of `34266e8`. The history below is
kept because it is what the fix is built on: the install step was fixed first, then turbo, then
two false starts on the shim removal.

`SKIP_DEPENDENCY_INSTALL=1` removes Cloudflare's own install, and `npx pnpm@11.21.0 install --frozen-lockfile` bootstraps a real pnpm (npx runs the `preinstall` hook that corepack won't), which then reads `packageManager` and self-swaps:

```
Detected the following tools from environment: pnpm@12.0.0-rc.5, nodejs@24.18.0
SKIP_DEPENDENCY_INSTALL is present in environment. Skipping automatic dependency installation.
Executing user build command: npx pnpm@11.21.0 install --frozen-lockfile && npx turbo docs#build
…
Done in 24.3s using pnpm v12.0.0-rc.5      ← install succeeds under pnpm 12
```

Then `npx turbo docs#build` fails, because turbo spawns each package script through the `pnpm` on `PATH` — which is corepack's shim in the asdf node bin dir, not the pnpm that just ran the install:

```
Error: Cannot find module '/opt/buildhome/.cache/node/corepack/v1/pnpm/12.0.0-rc.5/bin/pnpm.mjs'
docs#types:worker:  ERROR  command (/opt/buildhome/repo/docs)
  /opt/buildhome/.asdf/installs/nodejs/24.18.0/bin/pnpm run types:worker exited (1)

 Tasks:    7 successful, 15 total
Failed:    docs#types:worker, ui-router-server#build:js
```

The 7 that passed were cache hits, which replay without spawning anything. Every task that actually executes dies the same way. So `npx` fixes only the commands the build command itself names — turbo's own child processes still resolve `pnpm` from `PATH`.

Note this failure is a **preview** build. `main` is unaffected and `lit-ui-router.dev` deploys normally.

### The fix, now that the build command lives in the repo

#587 moved the build command into `tools/workers-builds/cloudflare-build.sh` and the
trigger pins the *path*, so this branch can change its own bootstrap without that reading
as drift. Two commits here do exactly that — this is the first branch to use the
indirection, and the reason it exists.

The script now replaces the corepack shim instead of bypassing it, and goes straight to
12.0.0-rc.5 rather than bootstrapping pnpm 11 and relying on a `packageManager` self-swap
— one less unverified step in that image:

```bash
node_bin="$(dirname "$(command -v node)")"
rm -f "$node_bin/pnpm" "$node_bin/pnpx"
npm install --global --allow-scripts=pnpm pnpm@12.0.0-rc.5
pnpm install --frozen-lockfile
npx turbo docs#build
```

Two details are load-bearing, both found by running it rather than reasoning about it:

- **`--allow-scripts`.** The pnpm 12 npm package is a wrapper whose real binary is
  unpacked by a `preinstall` hook, and npm 12 blocks install scripts by default — without
  the flag you get the placeholder bin, which exits with a shell syntax error. Verified
  locally both ways; npm 11.16.0 (what node 24.18.0 bundles, so what the build image has)
  ignores the unknown flag and runs the hook anyway, so one command covers both.
- **Removing the shims first.** npm will not overwrite a file it does not own. The first
  preview build stopped right there:

```
npm error code EEXIST
npm error path /opt/buildhome/.asdf/installs/nodejs/24.18.0/bin/pnpm
npm error File exists: /opt/buildhome/.asdf/installs/nodejs/24.18.0/bin/pnpm
```

  Resolved from `command -v node` rather than a hardcoded asdf path, so the script does
  not encode the image's layout. Preferred over npm's `--force`, which also disables the
  unrelated overwrite protections bundled under that flag.

## The publint blocker: resolved upstream, patch retired

**Current state: there is no patch.** `publint@0.3.24` / `@publint/pack@0.1.7` landed on
`main` in #631 and reads pnpm-12 tarballs natively, so this branch's rebase dropped
`53a5c45` outright and `check:exports` now reports `publint + attw clean` on all four
packages under a **stock** publint. The account below is kept for the record — it is how
the bug was found, filed, and carried while upstream caught up.

### How it got here

`@tools/release:check:exports` failed on this branch and passed on `main`:

```
Error: [publint] Unable to find package.json at package. If the `pack: { files }` option
is used, make sure the `pkgDir` is set to the root directory of the files.
```

Not a packaging defect — the tarballs are equivalent. Same 44 entries, same file set,
`package/package.json` present in both. What differs is the tar header format:

| packer | typeflag (regular file) | magic | publint |
| ------ | ----------------------- | ----- | ------- |
| pnpm 11.21.0 | `0x30` (`0`) | `ustar\0` + `00` | reads it |
| pnpm 12.0.0-rc.5 | `0x00` (NUL) | `ustar  \0` | throws |

The **typeflag** is what breaks it, not the magic — publint hand-rolls its tar parser
(`@publint/pack`, `src/shared/parse-tar.js`) and does `if (type === '\0') break`,
treating a NUL typeflag as end-of-archive. pnpm 12's *first* entry trips it, so zero
files are collected and the missing `package.json` is reported downstream. A NUL typeflag for a regular file is the pre-POSIX convention; npm and pnpm 11
both write `'0'`, and anything that parses tarballs strictly rejects the former. attw reads
either.

Confirmed by unpacking the pnpm 12 tarball and repacking the identical files with
`tar --format=ustar`:

```
pnpm12-pack:            THREW  [publint] Unable to find package.json at package…
pnpm11-pack:            OK  name=ui-router-server messages=0
pnpm12-repacked-posix:  OK  name=ui-router-server messages=0
```

### What was rejected, and what was done instead

Two workarounds were considered and both rejected. A shim normalizing the headers before
handing them to publint was written, verified green, and reverted: `check:exports` reads the
**raw** pack deliberately (#445, #449), so re-encoding the bytes under the gate defeats the
thing the gate exists to do. Disabling the check for the rollout was rejected too — it is the
outbound guard on the publish path, and a rollout is the worst moment for it to stop watching.

What landed instead is a `pnpm patch` carrying **publint/publint#253 verbatim** (`53a5c45`).
That is a different kind of thing from a workaround: it is the upstream fix arriving early, and
the provenance is checkable — the generated patch's pre- and post-image blob hashes,
`14e8a9a..17cbf28`, match that PR's own diff index line, so what runs here is byte-for-byte the
source under review upstream, not a reimplementation of it. The published `@publint/pack@0.1.6`
and publint's `master` carry an identical `parse-tar.js`, which is why it applies unmodified.

It also retires itself. When publint releases the fix the patch stops applying and the install
fails loudly, which is the signal to delete the entry — the failure mode of forgetting is a red
build, not silent dead code.

`check-patches` covers it automatically (4 patches verified against installs).

> One trap worth recording: `pnpm patch-commit` runs a full install, which re-resolved auto-peers
> across the lockfile — `supports-color` 8.1.1 → 10.2.2 through `sigstore`, `@sigstore/tuf`,
> `get-uri` and the proxy agents, 34 lines of unrelated drift. A clean-tree `pnpm install
> --lockfile-only` produces zero diff, so that churn was the patch flow, not pending drift.
> Regenerating from the committed lockfile gives the 3-line `patch_hash`-only diff that is here.
### Filed upstream

Neither side had this reported. Both are now filed:

- **publint/publint#252** — the parser bug. A NUL typeflag means *regular file*
  (POSIX.1-2017 `pax`; GNU tar's `AREGTYPE`), and end-of-archive is two all-zero
  512-byte blocks, not one zero byte at offset 156. publint is the non-conformant side.
- **publint/publint#253** — the fix, with a test that builds archives in-memory so the
  header bytes can be varied. Verified to fail without the change and pass with it.
- **pnpm/pnpm#13924** — the writer side. `crates/pack/src/tarball.rs` builds headers with
  `tar::Header::new_gnu()` and never calls `set_entry_type`, so the typeflag keeps its
  zero-filled value. Incidental rather than intended, and one line to fix. Filed as a
  compatibility report, not a conformance one — both encodings are legal.
- **pnpm/pnpm#13925** — that one line, opened by another contributor 30 minutes later and
  green on CI. The report handed over the file, the diagnosis and the literal
  `header.set_entry_type(tar::EntryType::Regular)`, so this is the issue being picked up
  rather than an independent fix. Nothing owed from here.

Evidence that the fix is the fix, posted to publint/publint#253: patchless `34266e8` fails all
four publishable packages, patched `53a5c45` reports `publint + attw clean`, with nothing else
changed between the two runs.

**Nothing here is blocked on upstream.** When #253 ships, drop the patch entry and the gate
stays green on the released version. Either fix alone is sufficient: once GA carries
pnpm/pnpm#13925 the tarballs parse under a stock publint, so the patch retires on whichever
lands first.

## Tracking the rc series (rc.7, `0743150`)

Each rc gets picked up as it lands rather than batched, so a regression surfaces against
one prerelease instead of arriving as one GA-sized jump. The flip is mechanical and the
same five files every time: the aqua bootstrap pin, all six `mise.lock` platform blocks,
`packageManager`, the resolved `packageManagerDependencies` doc in `pnpm-lock.yaml`, and
the Cloudflare bootstrap. Both the rc.6 and rc.7 lockfile diffs came out at 37 lines each
way, confined entirely to the pin plus the eight `@pnpm/exe.*` integrity hashes — zero
collateral drift either time.

rc.7 is green locally (install, 154/154 on the PR pipeline, `check:pack`, `check:exports`
publint + attw clean on 4 packages, `published-diff` clean against all four published
`latest`) and green in CI on the main graph at 159/159, Cloudflare preview included.

**The typeflag is still not fixed, and how that gets checked is worth recording.**
`pnpm/crates/pack/src/tarball.rs` at tag `v12.0.0-rc.7` still builds headers with
`tar::Header::new_gnu()` and never calls `set_entry_type`; pnpm/pnpm#13925 remains open.
Confirmed on the artifacts too — four rc.7-packed tarballs, typeflag `0x00` and magic
`ustar  ` + ` \0`, byte-identical in shape to rc.5 and rc.6. Note the crate path moved
under a `pnpm/` prefix during the rc.6 cycle, so a grep at the old path returns empty and
reads as *fixed* — the silent empty result is the trap, not the fix status. Check at the
tag, not from release notes.

**The other retirement condition fired, and the patch is now gone.** publint/publint#253
was merged and released as `@publint/pack@0.1.7` / `publint@0.3.24`, whose `parse-tar.js`
carries the accepted `type === '0' || type === '\0'` form. #631 took that bump onto
`main`, so rebasing this branch onto `main` dropped `53a5c45` (the patch commit) rather
than replaying it: `patches/@publint__pack.patch` is deleted, the `patchedDependencies`
entry with it, and the branch is back to six commits that are purely the version flip plus
the Cloudflare bootstrap.

That makes it a real test rather than a paperwork change — `check:exports`, forced with the
remote cache read-only so the tarballs are genuinely rc.7-packed, reports
`publint + attw clean (esm-only profile)` across all four packages with **no patch in the
tree**. The parser side of this bug is closed. pnpm/pnpm#13925 is now redundant here: nice
if GA carries it, but nothing on this branch waits for it.

Post-rebase the local pipeline is **158/158** (up from 154 with `main`'s task additions) and the
main graph is **163/163** in CI. `codecov/bundles` also came back to **0.0%** from 0.17%,
which retires that watch item — it was rebase drift, exactly as suspected, not the packer.
`published-diff` reports three packages clean and `lit-ui-router: SHIPS CHANGES vs 1.9.0`
— that is `main`'s unpublished 1.10.0 (#622) showing through, inherited by the rebase, not
a branch finding.

**Corepack works again as of rc.6** (pnpm/pnpm#13018): the published package ships
`bin/pnpm.mjs` and `bin/pnpx.mjs`, which fetch the pinned native binary on first use,
signature- and checksum-verified. That reverses the premise behind #582's move to the aqua
backend — but not the decision. Aqua needs no Node, does no first-use network fetch, and
`mise.lock` records sha256 plus `github-attestations` provenance for every platform
against corepack's single `+sha512`. The fix unblocks a road this repo left on its own
merits, so the comments asserting corepack *cannot* install pnpm 12 are narrowed to what
is still true rather than deleted, and `cloudflare-build.sh` keeps replacing the shim:
rc.6+ may well make that unnecessary, but that path is untested and the current one is
verified.

One number that resolved itself: `codecov/bundles` read 0.29% on rc.6 where recent PRs read
0.0%, and reads 0.17% on rc.7. A packer swap cannot change bundle contents, and the figure
moving without any bundle-affecting change confirms it is drift against a `main` that has
moved since this branch last rebased, not a finding.

### Why this holds for GA rather than merging green

This branch is green, so the merge gate is a judgement call rather than a blocker. The
remaining reason to wait is that the rc could still change its packing: `12.0.0-rc.7` is the
newest 12.x and pnpm/pnpm#13925 is unmerged, so the packer that produced these green runs is
not the packer GA will ship.

**Byte-identical packing is not a second gate, and does not need to be one.** Two findings,
measured rather than argued.

Byte-identical packing against pnpm 11 is unreachable by waiting. pnpm/pnpm#13925 fixes the
typeflag and stops there — the magic and version fields stay GNU (`ustar  ` + ` \0`) where npm
and pnpm 11 write `ustar\0` + `00`, and gzip framing is its own variable. `REPRODUCIBLE_MTIME`
guarantees a re-pack of unchanged sources is byte-identical *within* a packer, not across the
`tar-stream` → Rust `tar` swap.

But `published-diff` does not care, which is the part that actually mattered. It runs
`npm diff` over the two tarballs, and `npm diff` compares extracted file contents — archive
framing never reaches the comparison. Verified locally on this branch: a forced `pack:all`
under rc.5 produced four tarballs carrying the pnpm 12 shape (raw typeflag `0x00`, magic
`ustar  ` + ` \0`), and all four still report `clean` against their published pnpm-11-packed
`latest`.

```text
✓ published-diff check passed — 4 packages, no ship-affecting drift.
  lit-ui-router: clean vs 1.9.0
  lit-ui-router-mobx: clean vs 0.5.0
  ui-router-navigation-location-plugin: clean vs 0.3.0
  ui-router-server: clean vs 0.1.1
```

So the packer swap is invisible to the ship-affecting arbiter, and publishing under 12 does not
owe a release for framing alone. GA is the only gate.

Worth noting the run had to be forced with the remote cache read-only — `pack:all`'s cache key
does not include the pnpm version, so an unforced run returns pnpm-11-packed tarballs and
answers the wrong question.
## Open items before this could merge

- [ ] pnpm 12.0.0 GA (rc.7 is still the newest prerelease; `next-12`) — the sole merge gate,
  green CI notwithstanding
- [ ] `mise ls-remote pnpm` does not list 12.x — both backends filter prereleases, so the pin is hand-managed until GA flips it
- [ ] `aqua:pnpm/pnpm` has no `macos-x64` entry, though pnpm 12 ships an Intel build; check the aqua registry at GA if anyone needs it
- [x] Cloudflare: preview build green under pnpm 12 — shim removal + global install, verified on `34266e8`
- [x] Upstream: filed — publint/publint#252 + #253 (parser fix, the actual bug) and pnpm/pnpm#13924 (writer side)
- [x] Drop `patches/@publint__pack.patch` — **done**, dropped in the rebase onto `main`; `publint@0.3.24` / `@publint/pack@0.1.7` parses pnpm-12 tarballs unpatched
- [ ] pnpm/pnpm#13925 merged and in a GA build — no longer load-bearing here, the parser side already closed it
- [x] Confirm what a packer swap does to `published-diff` — **no effect**; `npm diff` compares file
  contents, not archive framing, and all 4 packages report clean when packed under rc.5
- [x] Cloudflare install step unblocked (#582, #574, #585) — `SKIP_DEPENDENCY_INSTALL` + npx bootstrap, self-swap confirmed
- [x] Full local suite green under rc.7, rebased on `main` — 158/158 on the PR pipeline
- [x] `build_and_test / run` **and** `build_and_test (branch) / run` green on `475e554` (rebased) — 14 pass, 2 skipping, main graph 163/163, Cloudflare preview green

## Not changed

`examples/*` `devEngines` blocks are `packageManager`-only with no `runtime` entry, so pnpm 12's project-aware global bins do not engage. `.nvmrc` + mise remains the sole Node authority.











