### PR TITLE
fix(ui-router-server): keep the merged query ahead of a redirect fragment

### DIFF
--- a/packages/ui-router-server/src/index.ts
+++ b/packages/ui-router-server/src/index.ts
@@ -131,17 +131,24 @@ const toTarget = (to: string | RedirectTarget): RedirectTarget =>
  * default replacement for `location + url.search`, which yields `?a=1?b=2`.
  * Params the redirect target declared win; remaining request params are
  * appended (all values of multi-value keys). Accepts the incoming search
- * with or without the leading '?'. Operates on `pathname?search` strings as
- * produced in redirect verdicts (no fragment handling).
+ * with or without the leading '?'. Operates on `pathname?search#fragment`
+ * strings as produced in redirect verdicts: a fragment (which
+ * {@link matcher!format | format} emits for a `'#'` param value) is detached
+ * before the merge and re-appended after it, so the query keeps its place
+ * ahead of the fragment.
  */
 export function mergeSearch(location: string, incoming: string): string {
   const query = incoming.startsWith('?') ? incoming.substring(1) : incoming;
   if (!query) return location;
-  const cut = location.indexOf('?');
-  const pathname = cut === -1 ? location : location.substring(0, cut);
-  const target = new URLSearchParams(
-    cut === -1 ? '' : location.substring(cut + 1),
-  );
+  // Split the fragment off FIRST. It terminates the url, so a '?' after it is
+  // fragment text rather than a query — and merging into `pathname#frag` would
+  // otherwise append `?a=1` past the '#', where no agent will ever read it.
+  const hash = location.indexOf('#');
+  const fragment = hash === -1 ? '' : location.substring(hash);
+  const base = hash === -1 ? location : location.substring(0, hash);
+  const cut = base.indexOf('?');
+  const pathname = cut === -1 ? base : base.substring(0, cut);
+  const target = new URLSearchParams(cut === -1 ? '' : base.substring(cut + 1));
   const request = new URLSearchParams(query);
   const keys = new Set<string>();
   request.forEach((_value, key) => keys.add(key));
@@ -150,7 +157,7 @@ export function mergeSearch(location: string, incoming: string): string {
     for (const value of request.getAll(key)) target.append(key, value);
   }
   const merged = target.toString();
-  return merged ? `${pathname}?${merged}` : pathname;
+  return merged ? `${pathname}?${merged}${fragment}` : `${pathname}${fragment}`;
 }
 
 // --- Mount compilation (construction-time, strategy-independent) ---------

--- a/packages/ui-router-server/test/fetch.test.ts
+++ b/packages/ui-router-server/test/fetch.test.ts
@@ -90,6 +90,25 @@ describe('createFetchHandler', () => {
     assert.equal(res.headers.get('Location'), '/app/home?ref=email');
   });
 
+  // The other direction: the fragment belongs to the TARGET, not the request.
+  // Merging past it emitted `/app/home#section?ref=email`, where the agent
+  // reads `section?ref=email` as the fragment and the params never come back.
+  it('keeps the merged search ahead of a fragment the target declares', async () => {
+    const handler = createFetchHandler(
+      routerOf({
+        kind: 'redirect',
+        mount: '/app',
+        location: '/app/home#section',
+        status: 302,
+      }),
+      { serveShell: noShell },
+    );
+    const res = await handler(navigation('/app/old?ref=email'));
+    assert.ok(res);
+    assert.equal(res.status, 302);
+    assert.equal(res.headers.get('Location'), '/app/home?ref=email#section');
+  });
+
   it('serves a plain shell with a canonical Link, from a request rewritten to the shell path', async () => {
     const asset = new Response('<html>shell</html>', {
       status: 200,

--- a/packages/ui-router-server/test/index.test.ts
+++ b/packages/ui-router-server/test/index.test.ts
@@ -379,6 +379,14 @@ describe('mergeSearch', () => {
     assert.equal(mergeSearch('/a?p=1#b', '?p=9'), '/a?p=1#b');
   });
 
+  it('emits no stray "?" when the request search parses to no params', () => {
+    // Separators only: non-empty (so no early return) but zero entries, so the
+    // merge yields nothing. The location comes back whole — fragment included,
+    // which is the arm that re-appends it without a query.
+    assert.equal(mergeSearch('/a', '&'), '/a');
+    assert.equal(mergeSearch('/a#b', '&'), '/a#b');
+  });
+
   it('carries a fragment through a real redirect verdict', async () => {
     const router = createServerRouter({
       mounts: {

--- a/packages/ui-router-server/test/index.test.ts
+++ b/packages/ui-router-server/test/index.test.ts
@@ -348,4 +348,60 @@ describe('mergeSearch', () => {
       );
     }
   });
+
+  // A fragment reaches a location whenever the redirect target declares a '#'
+  // param, which format() documents and RedirectTarget.params accepts. The
+  // query has to land BEFORE it: '#' terminates the url, so anything appended
+  // past it is fragment text the server never gets back.
+  it('keeps the query ahead of a fragment', () => {
+    assert.equal(
+      mergeSearch('/app/new#section', '?a=1'),
+      '/app/new?a=1#section',
+    );
+  });
+
+  it('merges into a location carrying both a query and a fragment', () => {
+    // Regression: splitting on '?' alone parsed 'tab=x#section' as one value,
+    // so toString() percent-encoded the '#' into the query (tab=x%23section)
+    // and destroyed the fragment outright.
+    assert.equal(
+      mergeSearch('/app/new?tab=x#section', '?a=1'),
+      '/app/new?tab=x&a=1#section',
+    );
+  });
+
+  it('preserves a fragment that itself contains a question mark', () => {
+    assert.equal(mergeSearch('/a#b?c', 'q=1'), '/a?q=1#b?c');
+  });
+
+  it('leaves a fragment alone when there is nothing to merge', () => {
+    assert.equal(mergeSearch('/a#b', ''), '/a#b');
+    assert.equal(mergeSearch('/a?p=1#b', '?p=9'), '/a?p=1#b');
+  });
+
+  it('carries a fragment through a real redirect verdict', async () => {
+    const router = createServerRouter({
+      mounts: {
+        '/app': {
+          routes: [
+            { name: 'new', url: '/new' },
+            {
+              name: 'old',
+              url: '/old',
+              redirectTo: { state: 'new', params: { '#': 'section' } },
+            },
+          ],
+        },
+      },
+    });
+    const verdict = await router.resolve('/app/old');
+    assert.equal(verdict.kind, 'redirect');
+    if (verdict.kind === 'redirect') {
+      assert.equal(verdict.location, '/app/new#section');
+      assert.equal(
+        mergeSearch(verdict.location, '?a=1'),
+        '/app/new?a=1#section',
+      );
+    }
+  });
 });


### PR DESCRIPTION
`mergeSearch` split the redirect location on `'?'` alone and never considered `'#'`. Its docstring conceded "no fragment handling" — but a fragment *can* reach a location through documented public API, and when it does the merge corrupts the result.

## The bug

`format()` documents that `values['#']` appends a hash fragment, and `RedirectTarget.params` accepts arbitrary `RawParams`. So `redirectTo: { state: 'new', params: { '#': 'section' } }` is a supported spelling, and it produces a location carrying a fragment. Two failure modes:

```js
mergeSearch('/new#section',       '?a=1')  //  '/new#section?a=1'
mergeSearch('/new?tab=x#section', '?a=1')  //  '/new?tab=x%23section&a=1'
```

**The first is malformed.** `#` terminates the url, so an agent parses `section?a=1` as the fragment — `a=1` is never sent on the follow-up request. The params are silently swallowed.

**The second is worse than ordering.** `URLSearchParams` has no notion of fragments, so it parsed `tab=x#section` as a single value; `toString()` then percent-encoded the `#` into the query. `tab` becomes `"x#section"` and the fragment is destroyed outright.

It reproduces end to end, not just at the helper — this mount answers a live `302`:

```js
createServerRouter({ mounts: { '/app': { routes: [
  { name: 'new', url: '/new' },
  { name: 'old', url: '/old', redirectTo: { state: 'new', params: { '#': 'section' } } },
] } } })
// GET /app/old?a=1  ->  302  Location: /app/new#section?a=1
```

Silent param loss on a redirect is precisely the server/client-honesty guarantee this package sells, which is what makes this worth a patch rather than a documented limitation.

## The fix

Detach the fragment **before** merging, re-append it after. Three lines of restructuring; the merge logic itself is untouched.

Both adapters route through this one helper, so `./connect` and `./vite` inherit the fix along with `./fetch`.

## Why it survived

Fragments had **zero** coverage in either the index or fetch suite. The one existing test that mentions a fragment — `drops the fragment before merging the request search` — covers the *opposite* direction: the **request's** fragment, which servers never receive anyway. That one is unaffected and still passes; this PR adds the target-side coverage it was easy to mistake for.

## Verification

`turbo run test typecheck lint format:check --filter=ui-router-server` — **24/24 tasks, 432 tests**.

Mutation-tested rather than assumed: neutralizing the fragment split (`const hash = -1`) fails **6** tests across both suites —

```
✖ keeps the query ahead of a fragment
✖ merges into a location carrying both a query and a fragment
✖ preserves a fragment that itself contains a question mark
✖ leaves a fragment alone when there is nothing to merge
✖ carries a fragment through a real redirect verdict
✖ keeps the merged search ahead of a fragment the target declares   (adapter Location header)
```

— including the adapter-level assertion on the actual `Location` header, so the coverage isn't confined to the helper's unit surface.

## Semver

Patch. No signature change; the only observable difference is that a previously-corrupt url is now correct.

Refs #354.
