### PR TITLE
docs(server): the alpha dist-tag is retired, not left over

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -239,7 +239,8 @@ Break the cycle by hand, once, before adding the package to any workflow list:
    accumulated came from exactly that: `lit-ui-router-mobx` seeded at
    `0.1.0-rc.0` under `next` (superseded by `0.1.0` twenty minutes later, tag
    stranded for five weeks), and `ui-router-server` at `0.0.1-alpha.1` under
-   `alpha`.
+   `alpha`. Both have since been retired — every package now carries `latest`
+   only, which is the steady state [Dist-Tags](#dist-tags) describes.
 
    The seed therefore holds `latest` until step 4 supersedes it. That is
    expected, and is why it should be a version nobody would want: short-lived

--- a/docs/packages/server.md
+++ b/docs/packages/server.md
@@ -93,9 +93,8 @@ Nothing else is required: `@uirouter/core` (only for
 [`simulate` mounts](#the-tiers)) and `hono` are **optional** peer
 dependencies, and every other adapter targets a host you already have.
 
-`latest` is the stable line (`0.1.0` today). The `alpha` dist-tag is left over
-from the pre-release seeds and points at an older build — install from
-`latest`.
+`latest` is the stable line (`0.1.0` today), and the only dist-tag — the
+pre-release seed tags have been retired.
 
 ## Quick start
 


### PR DESCRIPTION
`docs/packages/server.md` warned readers about a dist-tag that no longer exists:

> `latest` is the stable line (`0.1.0` today). The `alpha` dist-tag is left over from the pre-release seeds and points at an older build — install from `latest`.

That has stopped being true. Every published package in the repo now carries `latest` only:

```
lit-ui-router                        latest 1.9.0
lit-ui-router-mobx                   latest 0.5.0
ui-router-navigation-location-plugin latest 0.3.0
ui-router-server                     latest 0.1.0
```

which is precisely the steady state [RELEASE.md's Dist-Tags policy](../blob/main/RELEASE.md#dist-tags) calls for — "`latest` only in the steady state." So there was nothing left to retire; the docs had simply outlived the cleanup.

Warning readers off a channel that isn't there is worse than saying nothing: it implies a tag they might go hunting for, and invites `npm i ui-router-server@alpha` against a tag that would 404.

## Also: RELEASE.md's cautionary example

The first-publish section names both seed fossils as the example of what `--tag` on a seed costs:

> Both fossils this repo accumulated came from exactly that: `lit-ui-router-mobx` seeded at `0.1.0-rc.0` under `next` …, and `ui-router-server` at `0.0.1-alpha.1` under `alpha`.

Read cold, that leaves it genuinely ambiguous whether those tags are still live — the passage is about a trap, so a reader has no reason to assume it's been cleaned up. Added a clause saying both were retired and pointing at the policy section, so the example keeps its teaching value without doubling as a stale status report.

## Scope

Docs only — no package changes, no version implications. `turbo run format:check lint:root` — 30/30.
