### PR TITLE
fix(turbo): make the format writers uncacheable

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -310,17 +310,15 @@
       "cache": false,
       "passThroughEnv": ["CODECOV_TOKEN", "CI", "GITHUB_*"]
     },
+    // WRITER. Rewrites its own inputs in place and declares no outputs, so a
+    // cache hit restores nothing and silently leaves the tree unformatted;
+    // uncacheable is the only correct setting. Not in any ci:* graph — the
+    // gate is format:check. Run it ALONE: oxfmt truncates in place, so any
+    // reader co-scheduled with it (lint:templates, test, format:check) can
+    // observe a 0-byte source file.
     "format": {
       "with": ["//#format:root", "//#format:toml"],
-      // explicit globs hash gitignored files too; dist/ and .cache/ mutate
-      // mid-graph and oxfmt (gitignore-aware) never reads them
-      "inputs": [
-        "**/*.{ts,js,mjs,cjs,json,jsonc,md,yml,yaml,html,vue}",
-        "!dist/**",
-        "!.cache/**",
-        ".oxfmtrc.json",
-        "$TURBO_ROOT$/.oxfmtrc.json"
-      ]
+      "cache": false
     },
     "format:check": {
       "with": ["//#format:check:root", "//#format:check:toml"],
@@ -332,22 +330,18 @@
         "$TURBO_ROOT$/.oxfmtrc.json"
       ]
     },
+    // WRITER, uncacheable for the same reason as `format` above.
     "//#format:root": {
-      "inputs": ["$TURBO_DEFAULT$"]
+      "cache": false
     },
     "//#format:check:root": {
       "inputs": ["$TURBO_DEFAULT$"]
     },
-    // taplo owns .toml; separate root task so its cache key tracks only .toml
-    // (plus the .taplo.toml scoping and taplo's pin), disjoint from oxfmt above.
+    // taplo owns .toml, disjoint from the oxfmt writers above. WRITER,
+    // uncacheable for the same reason as `format`. //#format:check:toml keeps
+    // the .toml-scoped cache key.
     "//#format:toml": {
-      "inputs": [
-        "**/*.toml",
-        "!**/node_modules/**",
-        "$TURBO_ROOT$/.config/taplo.toml",
-        "$TURBO_ROOT$/.config/mise/tasks/taplo",
-        "$TURBO_ROOT$/.config/mise/mise.lock"
-      ]
+      "cache": false
     },
     "//#format:check:toml": {
       "inputs": [


### PR DESCRIPTION
## Mechanism

`format`, `//#format:root` and `//#format:toml` are **writers that rewrite their own inputs in place and declare no `outputs`**. Turbo caches them anyway, so a cache hit restores nothing and the task is a **silent no-op** — turbo replays the success log while the tree stays unformatted.

Measured (before this change), `turbo run format --filter=sample-app-shared` with an unformatted marker line appended to `apps/sample-app-shared/src/app/global/Dialog.ts`:

```
run 1:  sample-app-shared:format: cache miss, executing 06b34d20b1301ce1
        sample-app-shared:format: Finished in 378ms on 55 files
        unformatted marker still present? 0      <- formatted, correct

(git checkout -- apps; re-append the same marker -> same input hash)

run 2:  sample-app-shared:format: cache hit, replaying logs 06b34d20b1301ce1
        sample-app-shared:format: Finished in 378ms on 55 files
        unformatted marker still present? 1      <- NOT formatted
```

After the change the same script reports `cache bypass` on both runs and the marker is gone both times. This is how `format` reports green and `format:check` then fails on the same tree.

## The co-scheduling hazard (documented, not "fixed")

The original report hypothesised that `format` racing reader tasks (`lint:templates`, `test`, `format:check`) in one graph corrupts reads. The **primitive is real** — oxfmt rewrites in place with a truncate-then-write, exposing a 0-byte window:

- A polling reader over a 640 KB file across 150 oxfmt rewrites observed **324 zero-length reads** (sizes seen: `0`, formatted, unformatted — never a partial).
- During one real `turbo run format lint:templates --force`, a watcher over every tracked `packages/*/src` + `apps/*/src` `.ts` caught **2 zero-byte sightings** (t=1231 ms, t=2544 ms).
- A 0-byte app source file reproduces the reported symptom **exactly**: emptying `apps/sample-app-shared/src/app/contacts/ContactList.ts` makes lit-analyzer print `✖ 1 problem in 1 file (1 error, 0 warnings)` — `no-unknown-tag-name` on `<sample-contact-list>` in `Contacts.ts`.

What I could **not** do is make the two windows overlap in the real graph: 23 instrumented runs of the combined commands never coincided — under `--force` lit-analyzer starts ~3 s after the last zero-byte write, because it waits on `build:types`. So the race is *possible*, its consequence is *proven*, but it is not the demonstrated cause of the three field reports. Notably, `cache: false` makes `format` always execute, which **widens** this window relative to today's behaviour — hence the constraint comment rather than silence.

## Trade-off chosen

**Chosen:** `cache: false` on the three writers, plus a one-line constraint comment stating `format` must be run alone. No CI cost: the `ci:*` graphs gate on `format:check`, never `format`. Local `pnpm run format` loses a bogus instant-cache-hit and takes ~2-4 s, which is the correct price for actually formatting.

**Rejected:**

- **`dependsOn` edge from readers to `format`.** Would make `turbo run lint` silently rewrite the working tree, and — fatally — a reader that depends on the formatter means `ci:pull_request` formats the tree and then `format:check` trivially passes. Destroys the gate.
- **`with`.** Co-scheduling, not sequencing — it re-creates the race rather than removing it.
- **Atomic writes in oxfmt.** `oxfmt --help` offers `--write`/`--check`/`--list-different` only; no temp-file-and-rename option, and the truncation is inside the binary.
- **A guard that fails `turbo run format <reader>`.** Turbo exposes no sibling-task list to a running task, so any guard would have to wrap the `turbo` shim itself — disproportionate for an invocation that appears in no CI graph.

## Verification

All runs on this branch, `--force` throughout so nothing is skipped:

- `turbo run format lint --filter=@tools/dts-backtest` — **5/5 green**
- `turbo run test typecheck lint format:check --filter=ui-router-server` — **5/5 green**
- `turbo run format` then `turbo run format:check` over the whole workspace — green, no diff
- The cache-hit probe above — writer now executes on both runs

## Residual risk

The oxfmt truncation window still exists; `turbo run format <reader>` remains an unsupported invocation that can, in principle, produce a spurious `lit-analyzer` or `vitest` failure. The comment says so; nothing enforces it.

Also worth noting for whoever chases the `ui-router-server` `test` flake (`Promise resolution is still pending but the event loop has already resolved` in `treeshake.test.ts` / `vite.test.ts`): that command contains **no writer task at all** — `format:check` is a reader — so it is a separate problem from this one and is not addressed here.
