### PR TITLE
Release 0.1.1

### DIFF
--- a/packages/ui-router-server/package.json
+++ b/packages/ui-router-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ui-router-server",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Server-side UI-Router state matching for Connect, Vite, Hono, and fetch handlers",
   "homepage": "https://lit-ui-router.dev/packages/server",
   "bugs": {


### PR DESCRIPTION
### Bug Fixes

* **ui-router-server:** keep the merged query ahead of a redirect fragment ([#567](https://github.com/simshanith/lit-ui-router/issues/567)) ([83dac32](https://github.com/simshanith/lit-ui-router/commit/83dac32a0b2cb364146ff836d3555a6d92552d64))

### Code Refactoring

* **compat:** read catalogs via the pnpm SDK, split the lit2 lane ([#525](https://github.com/simshanith/lit-ui-router/issues/525)) ([9c17b2b](https://github.com/simshanith/lit-ui-router/commit/9c17b2b128416ee0e58215c71d65b6c5a7325c5f))

### Build System

* **ui-router-server:** opt into runtime globals via tsconfig types ([#540](https://github.com/simshanith/lit-ui-router/issues/540)) ([a440fe6](https://github.com/simshanith/lit-ui-router/commit/a440fe69f90d756c0eaa63ef73c389ea977ad950))
