### PR TITLE
build(mise): load Cloudflare Workers Builds creds from a gitignored dotenv

### DIFF
--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -30,7 +30,19 @@ TAPLO_CONFIG = "{{config_root}}/.config/taplo.toml"
 # NOT `{ …, redact = true }`: redaction wraps the task's stdio to mask secrets,
 # which clobbers a task reading its own stdin — it silently breaks
 # `printf … | mise run turbo_login --token-file -`. Verified on this mise.
-_.file = "{{config_root}}/.config/mise/turbo.local.env"
+# Cloudflare Workers Builds config (CLOUDFLARE_API_TOKEN, CLOUDFLARE_ACCOUNT_ID
+# for `pnpm check:workers-builds`) lives in a second dotenv, same shape and the
+# same redact trap. Separate from turbo's, not appended to it: `turbo_login`
+# *writes* turbo.local.env and would clobber anything else in it, and the two
+# have different lifecycles (the turbo bearer is shared and static, the CF token
+# is user-scoped and revocable). No task writes this one — hand-create it. It is
+# also NOT linked into git worktrees (see the turbo_link_worktree task, which is
+# turbo-only): `check:workers-builds` is manual-only and never part of CI, so
+# run it from the owning checkout.
+_.file = [
+  "{{config_root}}/.config/mise/turbo.local.env",
+  "{{config_root}}/.config/mise/cloudflare.local.env",
+]
 
 [settings]
 # read the node version from .nvmrc instead of pinning it here

--- a/.gitignore
+++ b/.gitignore
@@ -42,8 +42,10 @@ certs/
 .claude
 
 # mise local overrides (machine-local env, e.g. TURBO_TOKEN); load after the
-# checked-in config and win, so they stay untracked. *.local.env is the dotenv
-# turbo_login writes (remote-cache creds + the sensitive worker domain).
+# checked-in config and win, so they stay untracked. *.local.env covers the
+# config.toml `_.file` dotenvs: turbo.local.env (written by turbo_login —
+# remote-cache creds + the sensitive worker domain) and the hand-created
+# cloudflare.local.env (Workers Builds API token + account id).
 .config/mise/**/*.local.toml
 .config/mise/**/*.local.env
 mise.local.toml

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -51,6 +51,12 @@ the dashboard values above, and diffs it against the live triggers: `pnpm check:
 Requires `CLOUDFLARE_API_TOKEN` (user-scoped, **Workers Builds Configuration: Edit**) and `CLOUDFLARE_ACCOUNT_ID`.
 Manual-only — never part of CI.
 
+Both belong in `.config/mise/cloudflare.local.env`, a gitignored dotenv that the checked-in
+`.config/mise/config.toml` loads via `[env] _.file` (the same mechanism as the
+[Remote Cache](./REMOTE_CACHE.md) credentials, but a separate file — `mise run turbo_login` rewrites
+that one). Hand-create it; no task writes it, and it is deliberately not symlinked into git worktrees,
+so run `check:workers-builds` from the owning checkout.
+
 ### Build Environment Variables
 
 - `VITE_GOOGLE_ANALYTICS_TRACKING_ID`


### PR DESCRIPTION
## What

`.config/mise/config.toml`'s `[env] _.file` becomes an array with a second entry,
`{{config_root}}/.config/mise/cloudflare.local.env`, alongside the existing
`turbo.local.env`. The new file holds `CLOUDFLARE_API_TOKEN` (user-scoped,
**Workers Builds Configuration: Edit**) and `CLOUDFLARE_ACCOUNT_ID` for
`pnpm check:workers-builds` (and `-- --apply`).

```toml
_.file = [
  "{{config_root}}/.config/mise/turbo.local.env",
  "{{config_root}}/.config/mise/cloudflare.local.env",
]
```

`.gitignore`'s existing `.config/mise/**/*.local.env` already covers it —
verified with `git check-ignore -v`, no gitignore rule change, only a comment
correction now that two dotenvs share the glob.

## Why a second file, not an append to `turbo.local.env`

Captured in the config comment:

- `mise run turbo_login` **writes** `turbo.local.env`; anything else in it gets
  clobbered on the next rotation.
- Different lifecycles — the turbo bearer is shared and static, the CF token is
  user-scoped and revocable.

The comment also carries forward the two traps that apply equally to the new
entry: **not** `{ …, redact = true }` (redaction wraps task stdio and breaks a
task reading its own stdin), and — unlike turbo's — **no task writes this one**,
so it is hand-created.

## Worktree linking: deliberately not linked

Agreed with the plan after reading `turbo_link_worktree`. That task exists
because a credential-less worktree makes turbo *silently* degrade to local-only
on every single build — a constant, invisible tax. `check:workers-builds` has
neither property: it is manual-only, never in CI, and it fails **loudly** (a
missing token is an obvious error, not a silent downgrade). Extending the
symlink would spread a revocable dashboard-write token across every worktree for
a command run a handful of times a year. Run it from the owning checkout.

This is documented, not implicit — stated in the `_.file` comment and in
`DEPLOY.md`.

## Docs

`DEPLOY.md` "Dashboard as Code" (which already names both vars) gets a
three-sentence pointer: where the file lives, that it is the same `_.file`
mechanism as the remote-cache creds but a separate file, and the
hand-created/not-worktree-linked facts. Deliberately **not** duplicated into
`REMOTE_CACHE.md` — that document is turbo-specific end to end (rotation table,
`turbo_login`, signature keys), not a generic dotenv-convention home; DEPLOY.md
stays canonical for Cloudflare and links to REMOTE_CACHE.md for the mechanism.
`CONTRIBUTING.md` mentions neither `_.file` nor `.local.env`, so nothing there
needed a sibling. The "Build Environment Variables" section is untouched.

No `.example` sibling: `turbo.local.env` has none (`git ls-files .config/mise`
lists only `config.toml`, `mise.lock`, and `tasks/*`), so adding one would
invent a convention this repo does not have.

## No credentials committed

`cloudflare.local.env` is **not** created here — the file is gitignored and the
maintainer creates it by hand.

## Verification

- `mise --version` 2026.7.5 accepts an array `_.file`; confirmed empirically.
- With the CF file **absent** (the normal state): `mise env` exits 0, loads
  nothing extra, no warning — all `TURBO_*` still resolve.
- With a throwaway probe file present: the var is exported, and `git status`
  stayed clean (ignored). Probe removed.
- `turbo run lint typecheck` — 89/89 green.
- `turbo run format:check`, `mise run format_check_toml`, `mise run lint_toml` —
  green; `format_toml` (taplo) and `pnpm format:root` (oxfmt) both left the
  hand-written array shape unchanged.