### PR TITLE
feat(tools): manage declared build environment variables in workers-builds

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -46,7 +46,8 @@ See: [Wrangler Commands](https://developers.cloudflare.com/workers/wrangler/comm
 
 The private [`tools/workers-builds`](./tools/workers-builds) package owns
 [`workers-builds-triggers.config.jsonc`](./tools/workers-builds/workers-builds-triggers.config.jsonc), which mirrors
-the dashboard values above, and diffs it against the live triggers: `pnpm check:workers-builds` is read-only
+the dashboard values above plus the declared [build environment variables](#build-environment-variables),
+and diffs it against the live triggers: `pnpm check:workers-builds` is read-only
 (exit 1 on drift); `pnpm check:workers-builds -- --apply` updates.
 Requires `CLOUDFLARE_API_TOKEN` (user-scoped, **Workers Builds Configuration: Edit**) and `CLOUDFLARE_ACCOUNT_ID`.
 Manual-only — never part of CI.
@@ -82,8 +83,22 @@ mise-managed copy would shadow the system one and lose its desktop-app integrati
 
 ### Build Environment Variables
 
+Managed per key, not per map: `check:workers-builds` diffs only the keys declared in
+[`workers-builds-triggers.config.jsonc`](./tools/workers-builds/workers-builds-triggers.config.jsonc)
+and leaves every other variable on the trigger untouched.
+
+**Declared** (plaintext, committed, `--apply` writes them):
+
+- `SKIP_DEPENDENCY_INSTALL=1` — the build installs its own dependencies; deleting it breaks every deploy
+
+**Unmanaged** (dashboard-only; listed in the diff output as `(unmanaged)`, never diffed or patched):
+
 - `VITE_GOOGLE_ANALYTICS_TRACKING_ID`
 - `TURBO_`-prefixed [Remote Cache](./REMOTE_CACHE.md) variables and secrets
+
+Drift semantics for a declared key: a wrong or absent live value is drift and is patched; a key
+the dashboard has marked secret is reported and **not** overwritten, since the config holds
+plaintext only. Secrets therefore can never be committed here nor clobbered by `--apply`.
 
 ### Local Development
 

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -37,10 +37,25 @@ See: [Wrangler Commands](https://developers.cloudflare.com/workers/wrangler/comm
 
 ### Build & Deploy Commands
 
-| Environment                                                                                             | Build                  | Deploy                          |
-| ------------------------------------------------------------------------------------------------------- | ---------------------- | ------------------------------- |
-| Production                                                                                              | `npx turbo docs#build` | `pnpm wrangler deploy`          |
-| Preview ([Versions](https://developers.cloudflare.com/workers/configuration/versions-and-deployments/)) | `npx turbo docs#build` | `pnpm wrangler versions upload` |
+| Environment                                                                                             | Build                                                                | Deploy                         |
+| ------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- | ------------------------------ |
+| Production                                                                                              | `npx pnpm@11.21.0 install --frozen-lockfile && npx turbo docs#build` | `npx wrangler deploy`          |
+| Preview ([Versions](https://developers.cloudflare.com/workers/configuration/versions-and-deployments/)) | `npx pnpm@11.21.0 install --frozen-lockfile && npx turbo docs#build` | `npx wrangler versions upload` |
+
+The build command owns the dependency install because Workers Builds provisions pnpm with
+corepack, which cannot install a pnpm-12 `packageManager` pin at all — the npm package is
+a wrapper whose real binary is materialized by a `preinstall` hook out of an optional
+platform dependency, and corepack runs neither lifecycle scripts nor optional
+dependencies. So `SKIP_DEPENDENCY_INSTALL=1` turns off Cloudflare's install step and npx
+bootstraps the last pnpm 11 instead — no preinstall hook, so npx handles it — which then
+reads `packageManager` and self-swaps to whatever the branch pins. Every later command
+goes through npx as well, because the unusable corepack `pnpm` shim stays first on `PATH`.
+
+`npx pnpm@11.21.0` is a **bootstrap floor**, not the version that runs: it needs to be at
+or above 11.20.0 to read a pnpm-12 lockfile, and `packageManager` decides the rest.
+
+These three move together — the commands and the variable are one state. Apply and verify
+preview before production.
 
 ### Dashboard as Code
 
@@ -89,7 +104,10 @@ and leaves every other variable on the trigger untouched.
 
 **Declared** (plaintext, committed, `--apply` writes them):
 
-- `SKIP_DEPENDENCY_INSTALL=1` — the build installs its own dependencies; deleting it breaks every deploy
+- `SKIP_DEPENDENCY_INSTALL=1` — **required.** Hands the dependency install to the build
+  command, per [Build & Deploy Commands](#build--deploy-commands). Without it Cloudflare
+  runs its own corepack-provisioned `pnpm install` first and the build fails there;
+  deleting it in the dashboard breaks every deploy.
 
 **Unmanaged** (dashboard-only; listed in the diff output as `(unmanaged)`, never diffed or patched):
 

--- a/tools/workers-builds/workers-builds-triggers.config.jsonc
+++ b/tools/workers-builds/workers-builds-triggers.config.jsonc
@@ -1,13 +1,21 @@
 // Desired Workers Builds trigger configuration
 // `pnpm check:workers-builds --apply` updates Cloudflare
+// environment_variables: declared keys only, plaintext only — undeclared live
+// vars (TURBO_* cache config and secrets, VITE_*) stay dashboard-managed
 {
   "productionBranch": "main",
   "production": {
     "build_command": "npx turbo docs#build",
     "deploy_command": "pnpm wrangler deploy",
+    "environment_variables": {
+      "SKIP_DEPENDENCY_INSTALL": "1",
+    },
   },
   "preview": {
     "build_command": "npx turbo docs#build",
     "deploy_command": "pnpm wrangler versions upload",
+    "environment_variables": {
+      "SKIP_DEPENDENCY_INSTALL": "1",
+    },
   },
 }

--- a/tools/workers-builds/workers-builds-triggers.config.jsonc
+++ b/tools/workers-builds/workers-builds-triggers.config.jsonc
@@ -4,16 +4,23 @@
 // vars (TURBO_* cache config and secrets, VITE_*) stay dashboard-managed
 {
   "productionBranch": "main",
+  // The build command owns the install, so SKIP_DEPENDENCY_INSTALL=1 is required:
+  // Workers Builds provisions pnpm with corepack, which cannot install a pnpm-12
+  // `packageManager` pin at all (the npm package is a wrapper whose real binary a
+  // `preinstall` hook materializes from an optional platform dependency, and corepack
+  // runs neither). npx bootstraps the last pnpm 11 instead, which reads
+  // `packageManager` and self-swaps. Every command uses npx because the unusable
+  // corepack `pnpm` shim stays first on PATH.
   "production": {
-    "build_command": "npx turbo docs#build",
-    "deploy_command": "pnpm wrangler deploy",
+    "build_command": "npx pnpm@11.21.0 install --frozen-lockfile && npx turbo docs#build",
+    "deploy_command": "npx wrangler deploy",
     "environment_variables": {
       "SKIP_DEPENDENCY_INSTALL": "1",
     },
   },
   "preview": {
-    "build_command": "npx turbo docs#build",
-    "deploy_command": "pnpm wrangler versions upload",
+    "build_command": "npx pnpm@11.21.0 install --frozen-lockfile && npx turbo docs#build",
+    "deploy_command": "npx wrangler versions upload",
     "environment_variables": {
       "SKIP_DEPENDENCY_INSTALL": "1",
     },

--- a/tools/workers-builds/workers-builds-triggers.core.ts
+++ b/tools/workers-builds/workers-builds-triggers.core.ts
@@ -9,6 +9,13 @@ import * as v from 'valibot';
 // What the shell prints and exits on.
 export type Report = { ok: boolean; text: string };
 
+// One entry of a trigger's build environment-variable map. Cloudflare may
+// redact `value` when `is_secret` is true, so an absent value is not "empty".
+export type TriggerEnvironmentVariable = {
+  value?: string;
+  is_secret?: boolean;
+};
+
 // The trigger fields this check reads/writes; the API returns more, PATCH
 // accepts exactly these (https://developers.cloudflare.com/workers/ci-cd/builds/api-reference/).
 export type Trigger = {
@@ -19,9 +26,12 @@ export type Trigger = {
   root_directory?: string;
   branch_includes?: string[];
   branch_excludes?: string[];
+  environment_variables?: Record<string, TriggerEnvironmentVariable>;
 };
 
-// Fields a desired spec may pin; unpinned fields are shown but never drift.
+// Scalar fields a desired spec may pin; unpinned fields are shown but never
+// drift. environment_variables is pinned per key, not whole-field — see
+// describeEnvironment.
 export const PINNABLE_FIELDS = [
   'build_command',
   'deploy_command',
@@ -31,13 +41,18 @@ export type PinnableField = (typeof PINNABLE_FIELDS)[number];
 
 const nonEmptyString = v.pipe(v.string(), v.nonEmpty());
 
+// Shell-legal variable names only, so a typoed key is a config error too.
+const environmentKey = v.pipe(v.string(), v.regex(/^[A-Za-z_][A-Za-z0-9_]*$/));
+
 // strictObject: an unknown or typoed key throws rather than silently
 // un-pinning a field, since --apply writes this state to production.
 const DesiredTriggerSchema = v.strictObject({
   build_command: v.optional(nonEmptyString),
   deploy_command: v.optional(nonEmptyString),
   root_directory: v.optional(nonEmptyString),
-} satisfies Record<PinnableField, unknown>);
+  // Declared keys are plaintext by construction; secrets stay dashboard-only.
+  environment_variables: v.optional(v.record(environmentKey, nonEmptyString)),
+} satisfies Record<PinnableField | 'environment_variables', unknown>);
 
 const DesiredStateSchema = v.strictObject({
   productionBranch: nonEmptyString,
@@ -104,20 +119,77 @@ export function classifyTrigger(
     : 'preview';
 }
 
+// Body for PATCH /builds/triggers/{uuid}/environment_variables. Only declared
+// keys ever appear, so undeclared live vars survive whatever the API's merge
+// semantics are.
+export type EnvironmentPatch = Record<
+  string,
+  { value: string; is_secret: false }
+>;
+
 export type Drift = {
   trigger_uuid: string;
   kind: TriggerKind;
   // Exactly the body to PATCH /builds/triggers/{uuid} with.
   patch: Partial<Record<PinnableField, string>>;
+  environmentPatch: EnvironmentPatch;
 };
 
 export type DiffResult = { report: Report; drifts: Drift[] };
+
+const ENV_PAD = 34;
+
+// Per-key management: a declared key drifts on a wrong or absent live value; an
+// undeclared live key is listed as unmanaged and never diffed or patched. A
+// declared key that is live-secret is a conflict — reported, never overwritten.
+function describeEnvironment(
+  live: Record<string, TriggerEnvironmentVariable>,
+  declared: Record<string, string>,
+): { lines: string[]; patch: EnvironmentPatch; conflicts: string[] } {
+  const patch: EnvironmentPatch = {};
+  const conflicts: string[] = [];
+  const lines: string[] = [];
+  const liveKeys = Object.keys(live).sort();
+  if (liveKeys.length === 0 && Object.keys(declared).length === 0) {
+    return { lines, patch, conflicts };
+  }
+  lines.push('    environment_variables');
+  for (const [key, wanted] of Object.entries(declared)) {
+    const current = live[key];
+    if (current?.is_secret) {
+      conflicts.push(key);
+      lines.push(
+        `  ✗   ${key.padEnd(ENV_PAD)} (secret) — declared in config; refusing to overwrite`,
+      );
+    } else if (current?.value === wanted) {
+      lines.push(`  ✓   ${key.padEnd(ENV_PAD)} ${wanted}`);
+    } else {
+      patch[key] = { value: wanted, is_secret: false };
+      lines.push(
+        `  ✗   ${key.padEnd(ENV_PAD)} ${current?.value ?? '(absent)'}`,
+        `      ${' '.repeat(ENV_PAD)} wanted: ${wanted}`,
+      );
+    }
+  }
+  // Values omitted: an unmanaged var may hold a credential this tool prints.
+  for (const key of liveKeys.filter((key) => !(key in declared))) {
+    lines.push(
+      `      ${key.padEnd(ENV_PAD)} ${live[key]?.is_secret ? '(secret) ' : ''}(unmanaged)`,
+    );
+  }
+  return { lines, patch, conflicts };
+}
 
 function describeTrigger(
   trigger: Trigger,
   kind: TriggerKind,
   desired: DesiredTrigger,
-): { lines: string[]; patch: Drift['patch'] } {
+): {
+  lines: string[];
+  patch: Drift['patch'];
+  environmentPatch: EnvironmentPatch;
+  drift: boolean;
+} {
   const patch: Drift['patch'] = {};
   const lines = [
     `${kind} trigger ${trigger.trigger_uuid}` +
@@ -139,7 +211,20 @@ function describeTrigger(
       lines.push(`    ${' '.repeat(18)} wanted: ${wanted}`);
     }
   }
-  return { lines, patch };
+  const environment = describeEnvironment(
+    trigger.environment_variables ?? {},
+    desired.environment_variables ?? {},
+  );
+  lines.push(...environment.lines);
+  return {
+    lines,
+    patch,
+    environmentPatch: environment.patch,
+    drift:
+      Object.keys(patch).length > 0 ||
+      Object.keys(environment.patch).length > 0 ||
+      environment.conflicts.length > 0,
+  };
 }
 
 /** Diff live triggers against the desired state. */
@@ -150,18 +235,31 @@ export function diffTriggers(
   const drifts: Drift[] = [];
   const lines: string[] = [];
   const seen: Record<TriggerKind, number> = { production: 0, preview: 0 };
+  // A conflicted trigger fails the check without being patchable, so it counts
+  // here rather than in drifts.
+  let drifted = 0;
 
   for (const trigger of triggers) {
     const kind = classifyTrigger(trigger, desired.productionBranch);
     seen[kind] += 1;
-    const { lines: triggerLines, patch } = describeTrigger(
-      trigger,
-      kind,
-      desired[kind],
-    );
+    const {
+      lines: triggerLines,
+      patch,
+      environmentPatch,
+      drift,
+    } = describeTrigger(trigger, kind, desired[kind]);
     lines.push(...triggerLines, '');
-    if (Object.keys(patch).length > 0) {
-      drifts.push({ trigger_uuid: trigger.trigger_uuid, kind, patch });
+    if (drift) drifted += 1;
+    if (
+      Object.keys(patch).length > 0 ||
+      Object.keys(environmentPatch).length > 0
+    ) {
+      drifts.push({
+        trigger_uuid: trigger.trigger_uuid,
+        kind,
+        patch,
+        environmentPatch,
+      });
     }
   }
 
@@ -173,11 +271,11 @@ export function diffTriggers(
     lines.push(`  ✗ no ${kind} trigger found (create it in the dashboard)`, '');
   }
 
-  const ok = drifts.length === 0 && missing.length === 0;
+  const ok = drifted === 0 && missing.length === 0;
   lines.push(
     ok
       ? '✓ Workers Builds triggers match the desired state.'
-      : `✗ ${drifts.length + missing.length} trigger(s) drifted from the desired state.`,
+      : `✗ ${drifted + missing.length} trigger(s) drifted from the desired state.`,
   );
   return { report: { ok, text: lines.join('\n') }, drifts };
 }

--- a/tools/workers-builds/workers-builds-triggers.fixtures.json
+++ b/tools/workers-builds/workers-builds-triggers.fixtures.json
@@ -4,8 +4,8 @@
     "production": {
       "trigger_uuid": "prod-uuid",
       "trigger_name": "Deploy production",
-      "build_command": "npx turbo docs#build",
-      "deploy_command": "pnpm wrangler deploy",
+      "build_command": "npx pnpm@11.21.0 install --frozen-lockfile && npx turbo docs#build",
+      "deploy_command": "npx wrangler deploy",
       "branch_includes": ["main"],
       "branch_excludes": [],
       "environment_variables": {
@@ -20,8 +20,8 @@
     "preview": {
       "trigger_uuid": "preview-uuid",
       "trigger_name": "Preview",
-      "build_command": "npx turbo docs#build",
-      "deploy_command": "pnpm wrangler versions upload",
+      "build_command": "npx pnpm@11.21.0 install --frozen-lockfile && npx turbo docs#build",
+      "deploy_command": "npx wrangler versions upload",
       "branch_includes": ["*"],
       "branch_excludes": ["main"],
       "environment_variables": {
@@ -31,13 +31,13 @@
     }
   },
   "driftScenario": {
-    "driftedDeployCommand": "npx wrangler deploy",
+    "driftedDeployCommand": "pnpm wrangler versions upload",
     "expectedDrifts": [
       {
         "trigger_uuid": "preview-uuid",
         "kind": "preview",
         "patch": {
-          "deploy_command": "pnpm wrangler versions upload"
+          "deploy_command": "npx wrangler versions upload"
         },
         "environmentPatch": {}
       }

--- a/tools/workers-builds/workers-builds-triggers.fixtures.json
+++ b/tools/workers-builds/workers-builds-triggers.fixtures.json
@@ -1,5 +1,5 @@
 {
-  "$comment": "Fixtures for workers-builds-triggers.test.ts. `triggers` documents the shape GET /builds/workers/{tag}/triggers returns (matching the desired state in workers-builds-triggers.config.jsonc); `driftScenario` is one drifted preview trigger and the exact PATCH body the diff must emit for it.",
+  "$comment": "Fixtures for workers-builds-triggers.test.ts. `triggers` documents the shape GET /builds/workers/{tag}/triggers returns (matching the desired state in workers-builds-triggers.config.jsonc), including the environment_variables map with both declared and unmanaged keys and a redacted secret; `driftScenario` is one drifted preview trigger and the exact PATCH bodies the diff must emit for it.",
   "triggers": {
     "production": {
       "trigger_uuid": "prod-uuid",
@@ -7,7 +7,15 @@
       "build_command": "npx turbo docs#build",
       "deploy_command": "pnpm wrangler deploy",
       "branch_includes": ["main"],
-      "branch_excludes": []
+      "branch_excludes": [],
+      "environment_variables": {
+        "SKIP_DEPENDENCY_INSTALL": { "value": "1", "is_secret": false },
+        "VITE_GOOGLE_ANALYTICS_TRACKING_ID": {
+          "value": "G-XXXXXXXXXX",
+          "is_secret": false
+        },
+        "TURBO_TOKEN": { "is_secret": true }
+      }
     },
     "preview": {
       "trigger_uuid": "preview-uuid",
@@ -15,7 +23,11 @@
       "build_command": "npx turbo docs#build",
       "deploy_command": "pnpm wrangler versions upload",
       "branch_includes": ["*"],
-      "branch_excludes": ["main"]
+      "branch_excludes": ["main"],
+      "environment_variables": {
+        "SKIP_DEPENDENCY_INSTALL": { "value": "1", "is_secret": false },
+        "TURBO_TOKEN": { "is_secret": true }
+      }
     }
   },
   "driftScenario": {
@@ -26,7 +38,8 @@
         "kind": "preview",
         "patch": {
           "deploy_command": "pnpm wrangler versions upload"
-        }
+        },
+        "environmentPatch": {}
       }
     ]
   }

--- a/tools/workers-builds/workers-builds-triggers.test.ts
+++ b/tools/workers-builds/workers-builds-triggers.test.ts
@@ -38,6 +38,11 @@ const desired = desiredStateFromConfig(
   ),
 );
 
+const withEnvironment = (
+  trigger: Trigger,
+  environment_variables: NonNullable<Trigger['environment_variables']>,
+): Trigger => ({ ...trigger, environment_variables });
+
 describe('parseJsonc', () => {
   it('parses the repo wrangler.jsonc (comments + trailing commas)', async () => {
     const raw = await readFile(
@@ -101,6 +106,35 @@ describe('desiredStateFromConfig', () => {
       /production\.build_command: Invalid length/,
     );
   });
+
+  it('pins SKIP_DEPENDENCY_INSTALL on both triggers', () => {
+    assert.deepEqual(desired.production.environment_variables, {
+      SKIP_DEPENDENCY_INSTALL: '1',
+    });
+    assert.deepEqual(desired.preview.environment_variables, {
+      SKIP_DEPENDENCY_INSTALL: '1',
+    });
+  });
+
+  it('rejects invalid environment variable keys and values', () => {
+    const base = { productionBranch: 'main', preview: {} };
+    assert.throws(
+      () =>
+        desiredStateFromConfig({
+          ...base,
+          production: { environment_variables: { 'not-a-var': '1' } },
+        }),
+      /production\.environment_variables\.not-a-var: Invalid format/,
+    );
+    assert.throws(
+      () =>
+        desiredStateFromConfig({
+          ...base,
+          production: { environment_variables: { OK: 1 } },
+        }),
+      /production\.environment_variables\.OK: Invalid type/,
+    );
+  });
 });
 
 describe('workerNameFromConfig', () => {
@@ -158,6 +192,84 @@ describe('diffTriggers', () => {
     assert.equal(report.ok, true);
     assert.deepEqual(drifts, []);
     assert.match(report.text, /root_directory {5}\/docs \(not pinned\)/);
+  });
+
+  it('drifts on a declared environment variable with the wrong value', () => {
+    const drifted = withEnvironment(triggers.preview, {
+      SKIP_DEPENDENCY_INSTALL: { value: '0', is_secret: false },
+    });
+    const { report, drifts } = diffTriggers(
+      [triggers.production, drifted],
+      desired,
+    );
+    assert.equal(report.ok, false);
+    assert.deepEqual(drifts, [
+      {
+        trigger_uuid: 'preview-uuid',
+        kind: 'preview',
+        patch: {},
+        environmentPatch: {
+          SKIP_DEPENDENCY_INSTALL: { value: '1', is_secret: false },
+        },
+      },
+    ]);
+    assert.match(report.text, /wanted: 1/);
+  });
+
+  it('drifts on a declared environment variable missing from the trigger', () => {
+    const drifted = withEnvironment(triggers.preview, {});
+    const { report, drifts } = diffTriggers(
+      [triggers.production, drifted],
+      desired,
+    );
+    assert.equal(report.ok, false);
+    assert.deepEqual(drifts[0]?.environmentPatch, {
+      SKIP_DEPENDENCY_INSTALL: { value: '1', is_secret: false },
+    });
+    assert.match(report.text, /SKIP_DEPENDENCY_INSTALL {12}\(absent\)/);
+  });
+
+  it('reports undeclared environment variables as unmanaged, never drift', () => {
+    const extra = withEnvironment(triggers.preview, {
+      SKIP_DEPENDENCY_INSTALL: { value: '1', is_secret: false },
+      SOMETHING_ELSE: { value: 'dashboard-only', is_secret: false },
+      TURBO_TOKEN: { is_secret: true },
+    });
+    const { report, drifts } = diffTriggers(
+      [triggers.production, extra],
+      desired,
+    );
+    assert.equal(report.ok, true);
+    assert.deepEqual(drifts, []);
+    assert.match(report.text, /SOMETHING_ELSE +\(unmanaged\)/);
+    assert.match(report.text, /TURBO_TOKEN +\(secret\) \(unmanaged\)/);
+    // Values of unmanaged variables are never echoed.
+    assert.doesNotMatch(report.text, /dashboard-only/);
+  });
+
+  it('never patches unmanaged keys alongside a drifted declared key', () => {
+    const drifted = withEnvironment(triggers.preview, {
+      SOMETHING_ELSE: { value: 'dashboard-only', is_secret: false },
+      TURBO_TOKEN: { is_secret: true },
+    });
+    const { drifts } = diffTriggers([triggers.production, drifted], desired);
+    assert.deepEqual(Object.keys(drifts[0]?.environmentPatch ?? {}), [
+      'SKIP_DEPENDENCY_INSTALL',
+    ]);
+  });
+
+  it('refuses to overwrite a declared key that is live-secret', () => {
+    const conflicted = withEnvironment(triggers.preview, {
+      SKIP_DEPENDENCY_INSTALL: { is_secret: true },
+    });
+    const { report, drifts } = diffTriggers(
+      [triggers.production, conflicted],
+      desired,
+    );
+    assert.equal(report.ok, false);
+    assert.deepEqual(drifts, []);
+    assert.match(report.text, /refusing to overwrite/);
+    assert.match(report.text, /✗ 1 trigger\(s\) drifted/);
   });
 
   it('reports a missing trigger kind as unfixable drift', () => {

--- a/tools/workers-builds/workers-builds-triggers.test.ts
+++ b/tools/workers-builds/workers-builds-triggers.test.ts
@@ -60,11 +60,25 @@ describe('parseJsonc', () => {
 describe('desiredStateFromConfig', () => {
   it('accepts the real config (loaded above) with the dashboard values', () => {
     assert.equal(desired.productionBranch, 'main');
-    assert.equal(desired.production.deploy_command, 'pnpm wrangler deploy');
+    assert.equal(desired.production.deploy_command, 'npx wrangler deploy');
     assert.equal(
       desired.preview.deploy_command,
-      'pnpm wrangler versions upload',
+      'npx wrangler versions upload',
     );
+  });
+
+  // SKIP_DEPENDENCY_INSTALL=1 is only safe while the build command installs.
+  it('pairs the skipped install with an install in every build command', () => {
+    for (const kind of ['production', 'preview'] as const) {
+      assert.equal(
+        desired[kind].environment_variables?.SKIP_DEPENDENCY_INSTALL,
+        '1',
+      );
+      assert.match(
+        desired[kind].build_command ?? '',
+        /^npx pnpm@\d+\.\d+\.\d+ install --frozen-lockfile &&/,
+      );
+    }
   });
 
   it('rejects non-objects and unknown top-level keys', () => {
@@ -105,15 +119,6 @@ describe('desiredStateFromConfig', () => {
         desiredStateFromConfig({ ...base, production: { build_command: '' } }),
       /production\.build_command: Invalid length/,
     );
-  });
-
-  it('pins SKIP_DEPENDENCY_INSTALL on both triggers', () => {
-    assert.deepEqual(desired.production.environment_variables, {
-      SKIP_DEPENDENCY_INSTALL: '1',
-    });
-    assert.deepEqual(desired.preview.environment_variables, {
-      SKIP_DEPENDENCY_INSTALL: '1',
-    });
   });
 
   it('rejects invalid environment variable keys and values', () => {
@@ -180,7 +185,9 @@ describe('diffTriggers', () => {
     );
     assert.equal(report.ok, false);
     assert.deepEqual(drifts, driftScenario.expectedDrifts);
-    assert.match(report.text, /wanted: pnpm wrangler versions upload/);
+    assert.ok(
+      report.text.includes(`wanted: ${desired.preview.deploy_command}`),
+    );
   });
 
   it('never drifts on unpinned fields like root_directory', () => {

--- a/tools/workers-builds/workers-builds-triggers.ts
+++ b/tools/workers-builds/workers-builds-triggers.ts
@@ -99,15 +99,30 @@ async function workerTag(
   return script.tag;
 }
 
+// Build environment variables live on a sub-resource; the trigger list may or
+// may not inline them, so fetch only when it doesn't.
 async function getTriggers(
   token: string,
   accountId: string,
   tag: string,
 ): Promise<Trigger[]> {
-  return (await cf(
+  const triggers = (await cf(
     token,
     `/${accountId}/builds/workers/${tag}/triggers`,
   )) as Trigger[];
+  return Promise.all(
+    triggers.map(async (trigger) =>
+      trigger.environment_variables
+        ? trigger
+        : {
+            ...trigger,
+            environment_variables: (await cf(
+              token,
+              `/${accountId}/builds/triggers/${trigger.trigger_uuid}/environment_variables`,
+            )) as Trigger['environment_variables'],
+          },
+    ),
+  );
 }
 
 async function main() {
@@ -149,13 +164,26 @@ async function main() {
   }
 
   for (const drift of drifts) {
-    console.log(
-      `\nPATCHing ${drift.kind} trigger ${drift.trigger_uuid}: ${Object.keys(drift.patch).join(', ')}`,
-    );
-    await cf(token, `/${accountId}/builds/triggers/${drift.trigger_uuid}`, {
-      method: 'PATCH',
-      body: drift.patch,
-    });
+    if (Object.keys(drift.patch).length > 0) {
+      console.log(
+        `\nPATCHing ${drift.kind} trigger ${drift.trigger_uuid}: ${Object.keys(drift.patch).join(', ')}`,
+      );
+      await cf(token, `/${accountId}/builds/triggers/${drift.trigger_uuid}`, {
+        method: 'PATCH',
+        body: drift.patch,
+      });
+    }
+    // Declared keys only — undeclared live vars are never in this body.
+    if (Object.keys(drift.environmentPatch).length > 0) {
+      console.log(
+        `\nPATCHing ${drift.kind} trigger ${drift.trigger_uuid} environment_variables: ${Object.keys(drift.environmentPatch).join(', ')}`,
+      );
+      await cf(
+        token,
+        `/${accountId}/builds/triggers/${drift.trigger_uuid}/environment_variables`,
+        { method: 'PATCH', body: drift.environmentPatch },
+      );
+    }
   }
 
   // Re-read so the confirmation reflects what the API stored, not what we sent.


### PR DESCRIPTION
Closes #570.

`@tools/workers-builds` pinned three scalar trigger fields (`build_command`, `deploy_command`, `root_directory`). Build environment variables stayed dashboard-only and undiffed — including `SKIP_DEPENDENCY_INSTALL=1`, which the build genuinely depends on. Deleting it in the dashboard breaks every deploy today and `check:workers-builds` reports nothing. That is the bug this closes.

Two commits: the tool change, then the config change that makes the pinned state actually applyable.

## 1. Declared vs unmanaged

`environment_variables` is managed **per key**, not whole-field, because the same map holds values that must never be committed: `TURBO_TOKEN`, `TURBO_REMOTE_CACHE_SIGNATURE_KEY`, the rest of the `TURBO_*` cache config, and `VITE_GOOGLE_ANALYTICS_TRACKING_ID`.

| case | verdict |
| --- | --- |
| declared key, live value differs | drift → patched |
| declared key, absent live | drift → patched |
| declared key, live entry is `is_secret: true` | reported, **not** patched, check fails |
| undeclared key present live | not drift → listed as `(unmanaged)`, never touched |

This extends the existing "not pinned" idea (how `root_directory` already behaves) from whole-field down to per-key, rather than adding a parallel mechanism.

### Secret safety

Three properties, all test-covered:

1. The config schema accepts plaintext strings only — there is no way to express a secret, so none can be committed. Everything the tool writes goes out as `is_secret: false`.
2. The PATCH body for `/builds/triggers/{uuid}/environment_variables` contains **only declared, drifted keys**. Undeclared vars are never in the body, so they survive regardless of whether the API merges or replaces (the docs don't say, and this design makes it not matter — no read-modify-write race either).
3. A declared key the dashboard has marked secret is a conflict, not a drift: reported with `refusing to overwrite`, exit 1, never patched. Values of unmanaged vars are never echoed to stdout.

## 2. The install has to move with it

Declaring `SKIP_DEPENDENCY_INSTALL=1` while `build_command` is still bare `npx turbo docs#build` would leave `main` an **unapplyable half-state**: `--apply` would switch off Cloudflare's install step with nothing left to install dependencies, and production deploys would break. So both triggers also move the install into the build command:

```
npx pnpm@11.21.0 install --frozen-lockfile && npx turbo docs#build
npx wrangler deploy  /  npx wrangler versions upload
```

- `npx pnpm@11.21.0` is a **bootstrap floor**, not a version decision. `packageManager` remains the single authority: pnpm >= 11.10 reads it and self-swaps in either direction. Today `main` pins `pnpm@11.21.0`, so the bootstrap is an exact match and nothing swaps; on `ci-main/pnpm-12-rc-eval` the same command self-swaps up to `12.0.0-rc.5`. The floor only has to be recent enough to read the lockfile it finds — below 11.20.0 a pnpm-12 lockfile reads as outdated, which is why the pin is not simply `npx pnpm`.
- `pnpm wrangler …` → `npx wrangler …` because the corepack-provisioned `pnpm` shim stays first on `PATH` in the Workers Builds image and is unusable once the toolchain moves. A no-op on `main` today, a prerequisite for the next state.
- Production needs this regardless of #566 — the moment `main` pins pnpm 12, the old commands break. Landing it here decouples the two.

Command strings match `ci-main/pnpm-12-rc-eval` commit `add02f1` **verbatim**, so #566 de-conflicts rather than collides.

This is the Cloudflare-side half of the shape #582 adopts locally: one bootstrap pnpm that reads `packageManager` and self-swaps, replacing a provisioner that has to understand the pin itself. Neither PR depends on the other.

## Apply order

The commands and the variable are **one state** — apply them together, never separately, in either direction. `--apply` has no per-trigger flag (`workers-builds-triggers.ts` loops every drifted trigger), so a single run necessarily writes preview and production at once:

1. `pnpm check:workers-builds -- --apply` writes `SKIP_DEPENDENCY_INSTALL=1` and both command pairs across both triggers in one run.
2. Push any branch and confirm the preview build installs and the version uploads. Production is already rewritten at this point, but no production build runs until something lands on `main` — that gap is the verification window.
3. Then let a `main` build run against production.

Nothing breaks on merge — the config file is inert until `--apply`.

Also manual, and deliberately outside this tool's reach: `PNPM_VERSION` is set on both live triggers and is undeclared here, so it stays `(unmanaged)` forever. Once `SKIP_DEPENDENCY_INSTALL=1` lands it is inert (nothing installs for it to version) but misleading, and wants deleting in the dashboard by hand.

## Changes

- `workers-builds-triggers.core.ts` — `environment_variables` on `Trigger` and on the valibot `DesiredTriggerSchema` (`strictObject` preserved; keys must match `^[A-Za-z_][A-Za-z0-9_]*$`, values non-empty strings, so typos still fail loudly). New `describeEnvironment` and `Drift.environmentPatch`.
- `workers-builds-triggers.ts` — reads the env-var sub-resource when the trigger list doesn't inline it; `--apply` PATCHes the sub-resource separately from the scalar fields.
- `workers-builds-triggers.config.jsonc` — `SKIP_DEPENDENCY_INSTALL: "1"`, the install moved into both build commands, deploy commands to npx, and a terse trigger-level comment on why.
- Fixtures track the new command strings and document the env-var map shape including a redacted secret. 7 new tests (14 → 21), including one that asserts the skipped install is always paired with an install in the build command. No existing assertion weakened.
- `DEPLOY.md` — commands table updated with the rationale and the bootstrap-floor note; "Build Environment Variables" rewritten as a declared/unmanaged split with drift semantics, and `SKIP_DEPENDENCY_INSTALL` marked **required**.

## Verification

`turbo run lint typecheck test` green (111 tasks); `oxfmt` clean.

Rebased onto `main` (clean), which is also what makes the branch usable for the apply: it predated the `[env] _.file` entry for `.config/mise/cloudflare.local.env`, so credentials did not load in a checkout of the old head.

### Live read-only run

`pnpm check:workers-builds` against the real account, exit 1, no writes — the full drift this PR describes, and nothing else:

```
production trigger a40c7fbc… (Deploy default branch)
  ✗ build_command      npx turbo docs#build
                       wanted: npx pnpm@11.21.0 install --frozen-lockfile && npx turbo docs#build
  ✗ deploy_command     pnpm wrangler deploy
                       wanted: npx wrangler deploy
    environment_variables
  ✗   SKIP_DEPENDENCY_INSTALL            (absent)
                                         wanted: 1
      PNPM_VERSION                       (unmanaged)
      TURBO_TOKEN                        (secret) (unmanaged)
      …
✗ 2 trigger(s) drifted from the desired state.
```

Six field writes across the two triggers. `--apply` has **not** been run against live Cloudflare.

### Documented assumption, partly resolved

The published API reference confirms `PATCH`/`GET`/`DELETE` on `/builds/triggers/{uuid}/environment_variables` and the `{"KEY": {"value": …, "is_secret": …}}` body shape, but does not specify what `GET` returns for a secret, nor whether the trigger list inlines `environment_variables`.

The live run above settles the part that mattered: secret entries do come back flagged, and the tool classified all four `TURBO_*` secrets as `(secret) (unmanaged)` without echoing a value. The implementation stays correct either way — an `is_secret: true` entry is treated as unreadable whether `value` arrives redacted, absent, or masked, and the shell falls back to the sub-resource `GET` only when the trigger object has no inline map.
