### PR TITLE
fix(sample-app): collapse the nested New Contact link and button

### DIFF
--- a/apps/sample-app-shared/src/app/contacts/ContactList.ts
+++ b/apps/sample-app-shared/src/app/contacts/ContactList.ts
@@ -16,12 +16,13 @@ export class ContactList extends LitElement {
   }
 
   render() {
+    // One control, not an <a> wrapping a <button>: nesting them gave two tab
+    // stops and put interactive content inside a link, which the content model
+    // forbids. Matches the button-shaped navigation used elsewhere in the app.
     const newContact = html`
-      <a ${uiSref('.new')}>
-        <button class="btn btn-primary">
-          <i class="fa fa-pencil"></i><span>New Contact</span>
-        </button>
-      </a>
+      <button class="btn btn-primary" ${uiSref('.new')}>
+        <i class="fa fa-pencil"></i><span>New Contact</span>
+      </button>
     `;
     const contacts = repeat(
       this.contacts,


### PR DESCRIPTION
Found while tabbing through `/app/contacts` on a branch preview: the **New Contact** control took two tab stops.

Rebased onto current `main`, which now carries #588, #589 and #596.

## The bug

`ContactList.ts` rendered an `<a>` wrapping a `<button>`:

```html
<a ${uiSref('.new')}>
  <button class="btn btn-primary">…</button>
</a>
```

Both elements are focusable, so keyboard users stopped twice on one control — first on the anchor (which `uiSref` had given `href="/contacts/new"`), then on the button, which has no destination at all. It is also invalid markup: `<a>`'s content model forbids interactive content.

Collapsed to a single `<button>` carrying `uiSref`, matching the button-shaped navigation used in `Home`, `Welcome`, `NotFound`, `EditContact` and `ContactView`. One tab stop, no visual change.

## Modifier-click on the resulting button — twice mis-stated, now resolved upstream

This section has been wrong twice, so it is worth stating what is actually true on `main` today.

**First version.** I recorded the lost cmd/middle-click as an inherent consequence of using a button. That was wrong: it was our click handler bailing on any modifier in order to defer to native browser behaviour, on an element that has none to defer to. The click was dropped entirely — a dead control.

**Second version.** I then described it as a live bug blocking this PR. That is now stale. #589 landed the fix, and `main` scopes the guard:

```ts
// scoped to links: these guards hand the click back to the browser, and a
// non-link has nothing to hand it back to
if (isNativeLink(element) && (isModifiedClick(event) || opensOffApp(element))) return;
```

`isNativeLink` is false for a `<button>`, so the guard short-circuits and the click falls through to `$state.go` + `preventDefault`. **Nothing about this PR is blocked, and the control is not dead.**

**What is still true.** The button is not equivalent to the anchor. Cmd-click now navigates *in the same tab*: the click is handled rather than dropped, but the "open in a new tab" intent is silently discarded, because there is no `href` for the browser to open. That is inherent to button-shaped navigation, and it is the honest cost of this change — the tab-stop fix is worth it, and it is also the strongest remaining argument for converting these controls to links.

## The larger question this exposes, deliberately not fixed here

`uiSref` on `main` still writes `href` unconditionally, and most of this app applies it to a bare `<button>`, rendering `<button href="/home">` — an attribute that does nothing there. Navigation works via the click handler, but those controls have no link semantics: announced as "button" rather than "link", no copy-link, no new-tab, and never eligible for `aria-current` (which is link-only by default).

#590 adds the `assignHref` option for this, defaulting to `true` in 1.x with a dev-mode warning naming `'auto'` as the fix. **This button becomes one of those warning sites.** The annotation is a separate sweep over every non-link `uiSref` in the sample apps rather than a one-off here; whichever of the two merges second picks up this call site.

Converting the sample app's buttons to real links remains the eventual answer, deferred deliberately: `.btn`/`.btn-primary` carry no styling in this app (only `button.btn i + span` for icon spacing), so anchors would need a small stylesheet to keep the button look. That is one decision across the whole app, not a fix to smuggle into this PR.

Also worth noting: #557's `eslint-plugin-lit-a11y` would **not** have caught the nesting — it ships no nested-interactive rule, and `anchor-is-valid` only validates the href value.

## Verification

`turbo run typecheck lint build --filter=sample-app-shared...` — including `lint:templates` (lit-analyzer). Rebased clean onto `main` with no conflicts.
