### PR TITLE
ci(release-signals): report Workers Builds trigger drift as a third signal

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -140,3 +140,8 @@ jobs:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_REMOTE_CACHE_SIGNATURE_KEY: ${{ secrets.TURBO_REMOTE_CACHE_SIGNATURE_KEY }}
       TURBO_API: ${{ secrets.TURBO_API }}
+      # Secrets don't auto-propagate into a called workflow: without this the
+      # post-publish refresh would flip the workers-builds badge grey
+      # (unverifiable) after every release.
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/release-signals.yml
+++ b/.github/workflows/release-signals.yml
@@ -1,14 +1,28 @@
-# Non-gating release signals on main's head, reported as per-package check
-# runs: "published-diff (<pkg>)" (README badges read them via shields'
-# check-runs endpoint) and "peer-floor (<pkg>)". action_required renders
-# orange = a release/floor-bump is owed, never a CI failure — this job
-# succeeds whether or not any signal is orange.
+# Non-gating release signals on main's head, reported as check runs: the
+# per-package "published-diff (<pkg>)" and "peer-floor (<pkg>)", plus the
+# single "workers-builds (triggers)" (README badges read them all via shields'
+# check-runs endpoint). All three answer "does the outside world still match
+# main?" — npm artifacts, peer ranges, and the Cloudflare deploy pipeline that
+# ships lit-ui-router.dev. action_required renders orange = a release, a
+# floor-bump, or a dashboard apply is owed; neutral renders grey = the check
+# could not reach a verdict. Never a CI failure — this job succeeds whatever
+# the signals say.
 name: Release signals
 
 on:
   push:
+    # A merge to main IS the CD event: Cloudflare Workers Builds deploys
+    # lit-ui-router.dev on this same push, so the workers-builds signal
+    # verifies the trigger config at the moment it gets used. Unfiltered by
+    # paths — two API GETs, seconds.
     branches:
       - main
+  # Secondary sweep: catches dashboard-side edits and npm-side changes (a
+  # deprecate, an unpublish) during quiet periods, which no push would ever
+  # surface. Off-peak and off the hour — the top of the hour is GitHub's most
+  # congested cron slot.
+  schedule:
+    - cron: '17 7 * * 0'
   # Called by publish-npm.yml after a successful publish: release-it pushes
   # the bump commit before npm `latest` moves, so the push-triggered run sees
   # stale drift; the post-publish call flips the badge green. Calls always
@@ -25,6 +39,14 @@ on:
         # Remote cache endpoint; a secret (not a var) so the worker domain stays
         # out of public logs. Secrets don't auto-propagate into a called
         # workflow, so the caller must pass it; absent = local cache only.
+        required: false
+      CLOUDFLARE_API_TOKEN:
+        # Read-scoped ("Workers Builds Configuration: Read"), USER-scoped —
+        # account-owned tokens don't cover the Builds triggers API. Absent =
+        # the workers-builds signal reports neutral (grey), never a failure.
+        required: false
+      CLOUDFLARE_ACCOUNT_ID:
+        # A secret, not a var, so it stays out of public logs.
         required: false
   workflow_dispatch:
     inputs:
@@ -43,7 +65,13 @@ env:
 # workflow_call, which would split called refreshes from push refreshes.
 concurrency:
   group: release-signals
-  cancel-in-progress: true
+  # The scheduled sweep is the one run that must never cancel: a cron firing
+  # mid-publish would kill the post-publish workflow_call whose whole job is
+  # flipping the badges green. cancel-in-progress is read off the INCOMING
+  # run, so a sweep queues behind whatever holds the group (and re-checks with
+  # fresh data when it starts), while any later push/call run still cancels
+  # the queued sweep and does the same work.
+  cancel-in-progress: ${{ github.event_name != 'schedule' }}
 
 jobs:
   published_diff:
@@ -68,7 +96,9 @@ jobs:
       - name: Published diff
         run: mise run //tools/release:published_diff
         env:
-          # Empty on push and workflow_call runs = full set.
+          # Empty on push, schedule, and workflow_call runs = full set (the
+          # inputs context is null off workflow_dispatch, so this renders as
+          # the empty string the tool already treats as "all").
           PUBLISHED_DIFF_PACKAGES: ${{ inputs.packages }}
           TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
           TURBO_REMOTE_CACHE_SIGNATURE_KEY: ${{ secrets.TURBO_REMOTE_CACHE_SIGNATURE_KEY }}
@@ -90,3 +120,19 @@ jobs:
           TURBO_REMOTE_CACHE_SIGNATURE_KEY: ${{ secrets.TURBO_REMOTE_CACHE_SIGNATURE_KEY }}
           TURBO_API: ${{ secrets.TURBO_API }}
           TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+      # CD-pipeline signal (#280 Phase 1): the "workers-builds (triggers)"
+      # check run. Read-only diff of the live Cloudflare Workers Builds
+      # triggers against the repo-owned desired state — on a push to main it
+      # verifies the deploy config against the very build that push kicked
+      # off. Conclusions: success in sync, action_required on drift (the
+      # dashboard owes a manual --apply), neutral when the check itself could
+      # not run — a missing/expired token or a Cloudflare outage is an
+      # observer failure, not evidence of drift, and must not share a colour
+      # with it. Read scope only: CI never gets Edit, so #280's apply-on-merge
+      # phase stays unimplemented. Exits 0 on every path.
+      - name: Workers Builds trigger check run
+        run: mise run //tools/release:workers_builds_check_runs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/release-signals.yml
+++ b/.github/workflows/release-signals.yml
@@ -41,7 +41,8 @@ on:
         # workflow, so the caller must pass it; absent = local cache only.
         required: false
       CLOUDFLARE_API_TOKEN:
-        # Read-scoped ("Workers Builds Configuration: Read"), USER-scoped —
+        # Read-scoped ("Workers Scripts: Read" for the name -> tag lookup plus
+        # "Workers Builds Configuration: Read"), USER-scoped —
         # account-owned tokens don't cover the Builds triggers API. Absent =
         # the workers-builds signal reports neutral (grey), never a failure.
         required: false

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -48,8 +48,12 @@ The private [`tools/workers-builds`](./tools/workers-builds) package owns
 [`workers-builds-triggers.config.jsonc`](./tools/workers-builds/workers-builds-triggers.config.jsonc), which mirrors
 the dashboard values above, and diffs it against the live triggers: `pnpm check:workers-builds` is read-only
 (exit 1 on drift); `pnpm check:workers-builds -- --apply` updates.
-Requires `CLOUDFLARE_API_TOKEN` (user-scoped, **Workers Builds Configuration: Edit**) and `CLOUDFLARE_ACCOUNT_ID`.
-Manual-only — never part of CI.
+Requires `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID`. The token must be **user-scoped** — account-owned
+tokens do not cover the Workers Builds API — with **Workers Builds Configuration: Read** for the diff and
+**Edit** only for `--apply`.
+
+Applying is manual-only: `--apply` writes production deploy configuration, and no automation holds an
+Edit-scoped token.
 
 Both belong in `.config/mise/cloudflare.local.env`, a gitignored dotenv that the checked-in
 `.config/mise/config.toml` loads via `[env] _.file` (the same mechanism as the
@@ -79,6 +83,28 @@ than as an error from `op`.
 Neither task is required — both only supply the two variables, so `pnpm check:workers-builds` with
 them already in the environment works the same. `op` is deliberately not a pinned `[tools]` entry: a
 mise-managed copy would shadow the system one and lose its desktop-app integration.
+
+#### CD-pipeline verification signal
+
+[`release-signals.yml`](./.github/workflows/release-signals.yml) runs the same read-only diff on every push to
+`main` — the push that Workers Builds deploys from — plus a weekly sweep, and reports it as the
+`workers-builds (triggers)` check run alongside its `published-diff` and `peer-floor` siblings. It is
+non-gating: green in sync, orange (`action_required`) on drift, grey (`neutral`) when the check could not run.
+It never applies; resolving drift is still a local `--apply`.
+
+Two repository secrets drive it. Both are optional — absent, the signal reports grey rather than failing:
+
+| Secret                  | Value                                                                                                       |
+| ----------------------- | ----------------------------------------------------------------------------------------------------------- |
+| `CLOUDFLARE_API_TOKEN`  | A **user-scoped** API token with **Workers Builds Configuration: Read**. CI must never hold the Edit scope. |
+| `CLOUDFLARE_ACCOUNT_ID` | The Cloudflare account ID. A secret rather than a variable so it stays out of public logs.                  |
+
+Rotation is manual: mint a replacement in the Cloudflare dashboard under **My Profile → API Tokens** (user
+tokens, not **Manage Account → API Tokens**), update the repository secret, and revoke the old one. A stale
+token shows up as the grey `workers-builds (triggers)` badge, not a red run.
+
+`publish-npm.yml` forwards both into its post-publish `workflow_call`; secrets do not auto-propagate, and
+without that the badge would go grey after every release.
 
 ### Build Environment Variables
 

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -49,8 +49,9 @@ The private [`tools/workers-builds`](./tools/workers-builds) package owns
 the dashboard values above, and diffs it against the live triggers: `pnpm check:workers-builds` is read-only
 (exit 1 on drift); `pnpm check:workers-builds -- --apply` updates.
 Requires `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID`. The token must be **user-scoped** — account-owned
-tokens do not cover the Workers Builds API — with **Workers Builds Configuration: Read** for the diff and
-**Edit** only for `--apply`.
+tokens do not cover the Workers Builds API — and carry two permissions: **Workers Scripts: Read**, which
+resolves the worker name to the tag the triggers endpoint is keyed by, and **Workers Builds Configuration:
+Read** for the diff itself, raised to **Edit** only for `--apply`.
 
 Applying is manual-only: `--apply` writes production deploy configuration, and no automation holds an
 Edit-scoped token.
@@ -94,10 +95,10 @@ It never applies; resolving drift is still a local `--apply`.
 
 Two repository secrets drive it. Both are optional — absent, the signal reports grey rather than failing:
 
-| Secret                  | Value                                                                                                       |
-| ----------------------- | ----------------------------------------------------------------------------------------------------------- |
-| `CLOUDFLARE_API_TOKEN`  | A **user-scoped** API token with **Workers Builds Configuration: Read**. CI must never hold the Edit scope. |
-| `CLOUDFLARE_ACCOUNT_ID` | The Cloudflare account ID. A secret rather than a variable so it stays out of public logs.                  |
+| Secret                  | Value                                                                                                                                                                                                              |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `CLOUDFLARE_API_TOKEN`  | A **user-scoped** API token with **Workers Scripts: Read** and **Workers Builds Configuration: Read** — both, or the run 403s on the tag lookup before it reaches the triggers. CI must never hold the Edit scope. |
+| `CLOUDFLARE_ACCOUNT_ID` | The Cloudflare account ID. A secret rather than a variable so it stays out of public logs.                                                                                                                         |
 
 Rotation is manual: mint a replacement in the Cloudflare dashboard under **My Profile → API Tokens** (user
 tokens, not **Manage Account → API Tokens**), update the repository secret, and revoke the old one. A stale

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![codecov](https://codecov.io/gh/simshanith/lit-ui-router/branch/main/graph/badge.svg)](https://codecov.io/gh/simshanith/lit-ui-router)
 [![Publish Pipeline](https://github.com/simshanith/lit-ui-router/actions/workflows/publish-npm.yml/badge.svg?event=push)](https://github.com/simshanith/lit-ui-router/actions/workflows/publish-npm.yml)
 [![Website](https://img.shields.io/website?url=https%3A%2F%2Flit-ui-router.dev)](https://lit-ui-router.dev)
+[![workers-builds trigger drift](https://img.shields.io/github/check-runs/simshanith/lit-ui-router/main?nameFilter=workers-builds%20%28triggers%29&label=workers-builds)](https://github.com/simshanith/lit-ui-router/actions/workflows/release-signals.yml?query=branch%3Amain)
 
 ## Published packages
 
@@ -23,6 +24,17 @@
 | ---------------------------------------------------------------------------- | ------------------------------------------- |
 | ![passing](https://img.shields.io/badge/published--diff-passing-brightgreen) | The npm release matches `main`              |
 | ![passing](https://img.shields.io/badge/published--diff-passing-orange)      | Unreleased ship-affecting changes on `main` |
+
+The `workers-builds` badge above is the same kind of signal for the deploy pipeline: it diffs the live
+Cloudflare Workers Builds triggers that ship [lit-ui-router.dev](https://lit-ui-router.dev) against the
+repo-owned [desired state](./tools/workers-builds/workers-builds-triggers.config.jsonc). See
+[DEPLOY.md](./DEPLOY.md#cd-pipeline-verification-signal).
+
+| Badge                                                                        | Meaning                                                                   |
+| ---------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| ![passing](https://img.shields.io/badge/workers--builds-passing-brightgreen) | The dashboard triggers match the repo config                              |
+| ![passing](https://img.shields.io/badge/workers--builds-passing-orange)      | The dashboard drifted — a manual `--apply` is owed                        |
+| ![neutral](https://img.shields.io/badge/workers--builds-neutral-lightgrey)   | Could not verify (no/expired token, API outage) — not a claim about drift |
 
 ---
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -562,7 +562,7 @@ importers:
         version: 8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)
       vite-plugin-checker:
         specifier: 'catalog:'
-        version: 0.14.5(eslint@10.8.1(jiti@2.7.0))(meow@13.2.0)(optionator@0.9.4)(oxlint@1.78.0(oxlint-tsgolint@7.0.2001))(typescript@7.0.2)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(vue-tsc@3.3.9(typescript@7.0.2))
+        version: 0.14.5(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))(meow@13.2.0)(optionator@0.9.4)(oxlint@1.78.0(oxlint-tsgolint@7.0.2001))(typescript@7.0.2)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(vue-tsc@3.3.9(typescript@7.0.2))
       vite-plugin-static-copy:
         specifier: 'catalog:'
         version: 4.1.1(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
@@ -626,7 +626,7 @@ importers:
         version: 4.1.1(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
       vitepress:
         specifier: 'catalog:'
-        version: 2.0.0-alpha.19(@types/node@24.13.3)(axios@1.18.1)(change-case@5.4.4)(esbuild@0.28.1)(jiti@2.7.0)(postcss@8.5.26)(typescript@7.0.2)(yaml@2.9.0)
+        version: 2.0.0-alpha.19(@types/node@24.13.3)(axios@1.18.1(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2))(change-case@5.4.4)(esbuild@0.28.1)(jiti@2.7.0)(postcss@8.5.26)(typescript@7.0.2)(yaml@2.9.0)
       wrangler:
         specifier: 'catalog:'
         version: 4.113.0
@@ -651,7 +651,7 @@ importers:
         version: 0.11.0
       '@release-it/conventional-changelog':
         specifier: 'catalog:'
-        version: 12.0.0(conventional-commits-filter@6.0.1)(conventional-commits-parser@7.1.0)(release-it@21.0.2(@types/node@24.13.3)(magicast@0.5.3))
+        version: 12.0.0(conventional-commits-filter@6.0.1)(conventional-commits-parser@7.1.0)(release-it@21.0.2(@types/node@24.13.3)(magicast@0.5.3)(supports-color@10.2.2))
       '@tools/bundle-probe':
         specifier: workspace:*
         version: link:../../tools/bundle-probe
@@ -705,7 +705,7 @@ importers:
         version: 1.62.1
       release-it:
         specifier: 'catalog:'
-        version: 21.0.2(@types/node@24.13.3)(magicast@0.5.3)(supports-color@8.1.1)
+        version: 21.0.2(@types/node@24.13.3)(magicast@0.5.3)(supports-color@10.2.2)
       rimraf:
         specifier: 'catalog:'
         version: 6.1.3
@@ -729,7 +729,7 @@ importers:
     devDependencies:
       '@release-it/conventional-changelog':
         specifier: 'catalog:'
-        version: 12.0.0(conventional-commits-filter@6.0.1)(conventional-commits-parser@7.1.0)(release-it@21.0.2(@types/node@24.13.3)(magicast@0.5.3))
+        version: 12.0.0(conventional-commits-filter@6.0.1)(conventional-commits-parser@7.1.0)(release-it@21.0.2(@types/node@24.13.3)(magicast@0.5.3)(supports-color@10.2.2))
       '@tools/bundle-probe':
         specifier: workspace:*
         version: link:../../tools/bundle-probe
@@ -786,7 +786,7 @@ importers:
         version: 0.63.0
       release-it:
         specifier: 'catalog:'
-        version: 21.0.2(@types/node@24.13.3)(magicast@0.5.3)(supports-color@8.1.1)
+        version: 21.0.2(@types/node@24.13.3)(magicast@0.5.3)(supports-color@10.2.2)
       rimraf:
         specifier: 'catalog:'
         version: 6.1.3
@@ -810,7 +810,7 @@ importers:
     devDependencies:
       '@release-it/conventional-changelog':
         specifier: 'catalog:'
-        version: 12.0.0(conventional-commits-filter@6.0.1)(conventional-commits-parser@7.1.0)(release-it@21.0.2(@types/node@24.13.3)(magicast@0.5.3))
+        version: 12.0.0(conventional-commits-filter@6.0.1)(conventional-commits-parser@7.1.0)(release-it@21.0.2(@types/node@24.13.3)(magicast@0.5.3)(supports-color@10.2.2))
       '@tools/bundle-probe':
         specifier: workspace:*
         version: link:../../tools/bundle-probe
@@ -849,7 +849,7 @@ importers:
         version: 1.62.1
       release-it:
         specifier: 'catalog:'
-        version: 21.0.2(@types/node@24.13.3)(magicast@0.5.3)(supports-color@8.1.1)
+        version: 21.0.2(@types/node@24.13.3)(magicast@0.5.3)(supports-color@10.2.2)
       rimraf:
         specifier: 'catalog:'
         version: 6.1.3
@@ -873,7 +873,7 @@ importers:
     devDependencies:
       '@release-it/conventional-changelog':
         specifier: 'catalog:'
-        version: 12.0.0(conventional-commits-filter@6.0.1)(conventional-commits-parser@7.1.0)(release-it@21.0.2(@types/node@24.13.3)(magicast@0.5.3))
+        version: 12.0.0(conventional-commits-filter@6.0.1)(conventional-commits-parser@7.1.0)(release-it@21.0.2(@types/node@24.13.3)(magicast@0.5.3)(supports-color@10.2.2))
       '@tools/bundle-probe':
         specifier: workspace:*
         version: link:../../tools/bundle-probe
@@ -906,7 +906,7 @@ importers:
         version: 0.63.0
       release-it:
         specifier: 'catalog:'
-        version: 21.0.2(@types/node@24.13.3)(magicast@0.5.3)(supports-color@8.1.1)
+        version: 21.0.2(@types/node@24.13.3)(magicast@0.5.3)(supports-color@10.2.2)
       rimraf:
         specifier: 'catalog:'
         version: 6.1.3
@@ -1127,6 +1127,9 @@ importers:
       '@tools/shared':
         specifier: workspace:*
         version: link:../shared
+      '@tools/workers-builds':
+        specifier: workspace:*
+        version: link:../workers-builds
       '@types/node':
         specifier: 'catalog:'
         version: 24.13.3
@@ -1141,7 +1144,7 @@ importers:
         version: link:../../packages/lit-ui-router-mobx
       pacote:
         specifier: 'catalog:'
-        version: 22.0.0(supports-color@8.1.1)
+        version: 22.0.0(supports-color@10.2.2)
       publint:
         specifier: 'catalog:'
         version: 0.3.23
@@ -3634,6 +3637,11 @@ packages:
 
   '@volar/typescript@2.4.28':
     resolution: {integrity: sha512-Ja6yvWrbis2QtN4ClAKreeUZPVYMARDYZl9LMEv1iQ1QdepB6wn0jTRxA9MftYmYa4DQ4k/DaSZpFPUfxl8giw==}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   '@vscode/web-custom-data@0.4.13':
     resolution: {integrity: sha512-2ZUIRfhofZ/npLlf872EBnPmn27Kt4M2UssmQIfnJvgGgMYZJ5fvtHEDnttBBf2hnVtBgNCqZMVHJA+wsFVqTA==}
@@ -7284,18 +7292,27 @@ snapshots:
   '@esbuild/win32-x64@0.28.2':
     optional: true
 
+  '@eslint-community/eslint-utils@4.9.1(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))':
+    dependencies:
+      eslint: 10.8.1(jiti@2.7.0)(supports-color@10.2.2)
+      eslint-visitor-keys: 3.4.3
+    optional: true
+
   '@eslint-community/eslint-utils@4.9.1(eslint@10.8.1(jiti@2.7.0)(supports-color@8.1.1))':
     dependencies:
       eslint: 10.8.1(jiti@2.7.0)(supports-color@8.1.1)
       eslint-visitor-keys: 3.4.3
 
-  '@eslint-community/eslint-utils@4.9.1(eslint@10.8.1(jiti@2.7.0))':
-    dependencies:
-      eslint: 10.8.1(jiti@2.7.0)
-      eslint-visitor-keys: 3.4.3
-    optional: true
-
   '@eslint-community/regexpp@4.12.2': {}
+
+  '@eslint/config-array@0.23.5(supports-color@10.2.2)':
+    dependencies:
+      '@eslint/object-schema': 3.0.5
+      debug: 4.4.3(supports-color@10.2.2)
+      minimatch: 10.2.5
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
 
   '@eslint/config-array@0.23.5(supports-color@8.1.1)':
     dependencies:
@@ -7655,13 +7672,13 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
-  '@npmcli/agent@5.0.2':
+  '@npmcli/agent@5.0.2(supports-color@10.2.2)':
     dependencies:
       agent-base: 9.0.0
-      http-proxy-agent: 9.1.0(supports-color@8.1.1)
-      https-proxy-agent: 9.1.0(supports-color@8.1.1)
+      http-proxy-agent: 9.1.0(supports-color@10.2.2)
+      https-proxy-agent: 9.1.0(supports-color@10.2.2)
       lru-cache: 11.5.1
-      socks-proxy-agent: 10.1.0
+      socks-proxy-agent: 10.1.0(supports-color@10.2.2)
     transitivePeerDependencies:
       - kerberos
       - supports-color
@@ -8228,7 +8245,7 @@ snapshots:
     dependencies:
       tinyexec: 1.2.4
 
-  '@release-it/conventional-changelog@12.0.0(conventional-commits-filter@6.0.1)(conventional-commits-parser@7.1.0)(release-it@21.0.2(@types/node@24.13.3)(magicast@0.5.3))':
+  '@release-it/conventional-changelog@12.0.0(conventional-commits-filter@6.0.1)(conventional-commits-parser@7.1.0)(release-it@21.0.2(@types/node@24.13.3)(magicast@0.5.3)(supports-color@10.2.2))':
     dependencies:
       '@conventional-changelog/git-client': 3.1.0(conventional-commits-filter@6.0.1)(conventional-commits-parser@7.1.0)
       concat-stream: 2.0.0
@@ -8236,7 +8253,7 @@ snapshots:
       conventional-changelog-angular: 9.2.1
       conventional-changelog-conventionalcommits: 10.2.1
       conventional-recommended-bump: 12.1.0
-      release-it: 21.0.2(@types/node@24.13.3)(magicast@0.5.3)(supports-color@8.1.1)
+      release-it: 21.0.2(@types/node@24.13.3)(magicast@0.5.3)(supports-color@10.2.2)
       semver: 7.8.5
     transitivePeerDependencies:
       - conventional-commits-filter
@@ -8359,13 +8376,13 @@ snapshots:
 
   '@sigstore/protobuf-specs@0.5.1': {}
 
-  '@sigstore/sign@5.0.0':
+  '@sigstore/sign@5.0.0(supports-color@10.2.2)':
     dependencies:
       '@gar/promise-retry': 1.0.3
       '@sigstore/bundle': 5.0.0
       '@sigstore/core': 4.0.1
       '@sigstore/protobuf-specs': 0.5.1
-      make-fetch-happen: 16.0.1
+      make-fetch-happen: 16.0.1(supports-color@10.2.2)
       proc-log: 7.0.0
     transitivePeerDependencies:
       - kerberos
@@ -8798,11 +8815,22 @@ snapshots:
 
   '@volar/source-map@2.4.28': {}
 
-  '@volar/typescript@2.4.28':
+  '@volar/typescript@2.4.28(typescript@6.0.3)':
     dependencies:
       '@volar/language-core': 2.4.28
       path-browserify: 1.0.1
       vscode-uri: 3.1.0
+    optionalDependencies:
+      typescript: 6.0.3
+
+  '@volar/typescript@2.4.28(typescript@7.0.2)':
+    dependencies:
+      '@volar/language-core': 2.4.28
+      path-browserify: 1.0.1
+      vscode-uri: 3.1.0
+    optionalDependencies:
+      typescript: 7.0.2
+    optional: true
 
   '@vscode/web-custom-data@0.4.13': {}
 
@@ -8892,13 +8920,13 @@ snapshots:
       '@vueuse/shared': 14.4.0(vue@3.5.41(typescript@7.0.2))
       vue: 3.5.41(typescript@7.0.2)
 
-  '@vueuse/integrations@14.4.0(axios@1.18.1)(change-case@5.4.4)(focus-trap@8.2.2)(vue@3.5.41(typescript@7.0.2))':
+  '@vueuse/integrations@14.4.0(axios@1.18.1(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2))(change-case@5.4.4)(focus-trap@8.2.2)(vue@3.5.41(typescript@7.0.2))':
     dependencies:
       '@vueuse/core': 14.4.0(vue@3.5.41(typescript@7.0.2))
       '@vueuse/shared': 14.4.0(vue@3.5.41(typescript@7.0.2))
       vue: 3.5.41(typescript@7.0.2)
     optionalDependencies:
-      axios: 1.18.1(debug@4.4.3(supports-color@8.1.1))
+      axios: 1.18.1(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
       change-case: 5.4.4
       focus-trap: 8.2.2
 
@@ -8951,7 +8979,14 @@ snapshots:
 
   acorn@8.17.0: {}
 
-  agent-base@6.0.2:
+  agent-base@6.0.2(supports-color@10.2.2):
+    dependencies:
+      debug: 4.4.3(supports-color@10.2.2)
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
+  agent-base@6.0.2(supports-color@8.1.1):
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
@@ -9042,11 +9077,22 @@ snapshots:
 
   aws4@1.13.2: {}
 
-  axios@1.18.1(debug@4.4.3(supports-color@8.1.1)):
+  axios@1.18.1(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2):
+    dependencies:
+      follow-redirects: 1.16.0(debug@4.4.3(supports-color@10.2.2))
+      form-data: 4.0.6
+      https-proxy-agent: 5.0.1(supports-color@10.2.2)
+      proxy-from-env: 2.1.0
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+    optional: true
+
+  axios@1.18.1(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
       follow-redirects: 1.16.0(debug@4.4.3(supports-color@8.1.1))
       form-data: 4.0.6
-      https-proxy-agent: 5.0.1
+      https-proxy-agent: 5.0.1(supports-color@8.1.1)
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
       - debug
@@ -9447,6 +9493,12 @@ snapshots:
     optionalDependencies:
       supports-color: 8.1.1
 
+  debug@4.4.3(supports-color@10.2.2):
+    dependencies:
+      ms: 2.1.3
+    optionalDependencies:
+      supports-color: 10.2.2
+
   debug@4.4.3(supports-color@8.1.1):
     dependencies:
       ms: 2.1.3
@@ -9700,11 +9752,11 @@ snapshots:
 
   eslint-visitor-keys@5.0.1: {}
 
-  eslint@10.8.1(jiti@2.7.0):
+  eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.8.1(jiti@2.7.0))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))
       '@eslint-community/regexpp': 4.12.2
-      '@eslint/config-array': 0.23.5(supports-color@8.1.1)
+      '@eslint/config-array': 0.23.5(supports-color@10.2.2)
       '@eslint/config-helpers': 0.7.0
       '@eslint/core': 1.2.1
       '@eslint/plugin-kit': 0.7.2
@@ -9714,7 +9766,7 @@ snapshots:
       '@types/estree': 1.0.9
       ajv: 6.15.0
       cross-spawn: 7.0.6
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@10.2.2)
       escape-string-regexp: 4.0.0
       eslint-scope: 9.1.2
       eslint-visitor-keys: 5.0.1
@@ -9936,6 +9988,11 @@ snapshots:
 
   focus-visible@5.2.1: {}
 
+  follow-redirects@1.16.0(debug@4.4.3(supports-color@10.2.2)):
+    optionalDependencies:
+      debug: 4.4.3(supports-color@10.2.2)
+    optional: true
+
   follow-redirects@1.16.0(debug@4.4.3(supports-color@8.1.1)):
     optionalDependencies:
       debug: 4.4.3(supports-color@8.1.1)
@@ -10130,6 +10187,15 @@ snapshots:
 
   http-cache-semantics@4.2.0: {}
 
+  http-proxy-agent@9.1.0(supports-color@10.2.2):
+    dependencies:
+      agent-base: 9.0.0
+      debug: 4.4.3(supports-color@10.2.2)
+      proxy-agent-negotiate: 1.1.0
+    transitivePeerDependencies:
+      - kerberos
+      - supports-color
+
   http-proxy-agent@9.1.0(supports-color@8.1.1):
     dependencies:
       agent-base: 9.0.0
@@ -10145,11 +10211,28 @@ snapshots:
       jsprim: 2.0.2
       sshpk: 1.18.0
 
-  https-proxy-agent@5.0.1:
+  https-proxy-agent@5.0.1(supports-color@10.2.2):
     dependencies:
-      agent-base: 6.0.2
+      agent-base: 6.0.2(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@10.2.2)
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
+  https-proxy-agent@5.0.1(supports-color@8.1.1):
+    dependencies:
+      agent-base: 6.0.2(supports-color@8.1.1)
       debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@9.1.0(supports-color@10.2.2):
+    dependencies:
+      agent-base: 9.0.0
+      debug: 4.4.3(supports-color@10.2.2)
+      proxy-agent-negotiate: 1.1.0
+    transitivePeerDependencies:
+      - kerberos
       - supports-color
 
   https-proxy-agent@9.1.0(supports-color@8.1.1):
@@ -10554,10 +10637,10 @@ snapshots:
     dependencies:
       semver: 7.8.5
 
-  make-fetch-happen@16.0.1:
+  make-fetch-happen@16.0.1(supports-color@10.2.2):
     dependencies:
       '@gar/promise-retry': 1.0.3
-      '@npmcli/agent': 5.0.2
+      '@npmcli/agent': 5.0.2(supports-color@10.2.2)
       '@npmcli/redact': 5.0.0
       cacache: 21.0.1
       http-cache-semantics: 4.2.0
@@ -10786,11 +10869,11 @@ snapshots:
       npm-package-arg: 14.0.0
       semver: 7.8.5
 
-  npm-registry-fetch@20.0.1:
+  npm-registry-fetch@20.0.1(supports-color@10.2.2):
     dependencies:
       '@npmcli/redact': 5.0.0
       jsonparse: 1.3.1
-      make-fetch-happen: 16.0.1
+      make-fetch-happen: 16.0.1(supports-color@10.2.2)
       minipass: 7.1.3
       minipass-fetch: 6.0.0
       minizlib: 3.1.0
@@ -11011,16 +11094,16 @@ snapshots:
 
   p-map@7.0.5: {}
 
-  pac-proxy-agent@9.1.0(supports-color@8.1.1):
+  pac-proxy-agent@9.1.0(supports-color@10.2.2):
     dependencies:
       agent-base: 9.0.0
       debug: 4.4.3(supports-color@8.1.1)
       get-uri: 8.0.1(supports-color@8.1.1)
-      http-proxy-agent: 9.1.0(supports-color@8.1.1)
-      https-proxy-agent: 9.1.0(supports-color@8.1.1)
+      http-proxy-agent: 9.1.0(supports-color@10.2.2)
+      https-proxy-agent: 9.1.0(supports-color@10.2.2)
       pac-resolver: 9.0.1(quickjs-wasi@2.2.0)
       quickjs-wasi: 2.2.0
-      socks-proxy-agent: 10.1.0
+      socks-proxy-agent: 10.1.0(supports-color@10.2.2)
     transitivePeerDependencies:
       - kerberos
       - supports-color
@@ -11042,7 +11125,7 @@ snapshots:
 
   package-manager-detector@1.8.0: {}
 
-  pacote@22.0.0(supports-color@8.1.1):
+  pacote@22.0.0(supports-color@10.2.2):
     dependencies:
       '@gar/promise-retry': 1.0.3
       '@npmcli/git': 8.0.0
@@ -11056,7 +11139,7 @@ snapshots:
       npm-package-arg: 14.0.0
       npm-packlist: 11.3.0
       npm-pick-manifest: 12.0.0
-      npm-registry-fetch: 20.0.1
+      npm-registry-fetch: 20.0.1(supports-color@10.2.2)
       proc-log: 7.0.0
       sigstore: 5.0.0(supports-color@8.1.1)
       ssri: 14.0.0
@@ -11188,16 +11271,16 @@ snapshots:
 
   proxy-agent-negotiate@1.1.0: {}
 
-  proxy-agent@8.0.2(supports-color@8.1.1):
+  proxy-agent@8.0.2(supports-color@10.2.2):
     dependencies:
       agent-base: 9.0.0
       debug: 4.4.3(supports-color@8.1.1)
       http-proxy-agent: 9.1.0(supports-color@8.1.1)
       https-proxy-agent: 9.1.0(supports-color@8.1.1)
       lru-cache: 7.18.3
-      pac-proxy-agent: 9.1.0(supports-color@8.1.1)
+      pac-proxy-agent: 9.1.0(supports-color@10.2.2)
       proxy-from-env: 2.1.0
-      socks-proxy-agent: 10.1.0
+      socks-proxy-agent: 10.1.0(supports-color@10.2.2)
     transitivePeerDependencies:
       - kerberos
       - supports-color
@@ -11263,7 +11346,7 @@ snapshots:
     dependencies:
       regex-utilities: 2.3.0
 
-  release-it@21.0.2(@types/node@24.13.3)(magicast@0.5.3)(supports-color@8.1.1):
+  release-it@21.0.2(@types/node@24.13.3)(magicast@0.5.3)(supports-color@10.2.2):
     dependencies:
       '@inquirer/prompts': 8.5.2(@types/node@24.13.3)
       '@octokit/rest': 22.0.1
@@ -11281,7 +11364,7 @@ snapshots:
       open: 11.0.0
       ora: 9.4.1
       os-name: 7.0.0
-      proxy-agent: 8.0.2(supports-color@8.1.1)
+      proxy-agent: 8.0.2(supports-color@10.2.2)
       semver: 7.8.5
       tinyglobby: 0.2.17
       undici: 7.29.0
@@ -11473,7 +11556,7 @@ snapshots:
       '@sigstore/bundle': 5.0.0
       '@sigstore/core': 4.0.1
       '@sigstore/protobuf-specs': 0.5.1
-      '@sigstore/sign': 5.0.0
+      '@sigstore/sign': 5.0.0(supports-color@10.2.2)
       '@sigstore/tuf': 5.0.0(supports-color@8.1.1)
       '@sigstore/verify': 4.1.0
     transitivePeerDependencies:
@@ -11500,10 +11583,10 @@ snapshots:
 
   smart-buffer@4.2.0: {}
 
-  socks-proxy-agent@10.1.0:
+  socks-proxy-agent@10.1.0(supports-color@10.2.2):
     dependencies:
       agent-base: 9.0.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@10.2.2)
       socks: 2.8.9
     transitivePeerDependencies:
       - supports-color
@@ -11579,7 +11662,7 @@ snapshots:
       execa: 5.1.1
       lazy-ass: 2.0.3
       tree-kill: 1.2.2
-      wait-on: 9.1.0(debug@4.4.3(supports-color@8.1.1))
+      wait-on: 9.1.0(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -11880,7 +11963,7 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite-plugin-checker@0.14.5(eslint@10.8.1(jiti@2.7.0))(meow@13.2.0)(optionator@0.9.4)(oxlint@1.78.0(oxlint-tsgolint@7.0.2001))(typescript@7.0.2)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(vue-tsc@3.3.9(typescript@7.0.2)):
+  vite-plugin-checker@0.14.5(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))(meow@13.2.0)(optionator@0.9.4)(oxlint@1.78.0(oxlint-tsgolint@7.0.2001))(typescript@7.0.2)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(vue-tsc@3.3.9(typescript@7.0.2)):
     dependencies:
       '@babel/code-frame': 7.29.7
       chokidar: 5.0.0
@@ -11891,7 +11974,7 @@ snapshots:
       tiny-invariant: 1.3.3
       vite: 8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)
     optionalDependencies:
-      eslint: 10.8.1(jiti@2.7.0)
+      eslint: 10.8.1(jiti@2.7.0)(supports-color@10.2.2)
       meow: 13.2.0
       optionator: 0.9.4
       oxlint: 1.78.0(oxlint-tsgolint@7.0.2001)
@@ -11934,7 +12017,7 @@ snapshots:
       jiti: 2.7.0
       yaml: 2.9.0
 
-  vitepress@2.0.0-alpha.19(@types/node@24.13.3)(axios@1.18.1)(change-case@5.4.4)(esbuild@0.28.1)(jiti@2.7.0)(postcss@8.5.26)(typescript@7.0.2)(yaml@2.9.0):
+  vitepress@2.0.0-alpha.19(@types/node@24.13.3)(axios@1.18.1(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2))(change-case@5.4.4)(esbuild@0.28.1)(jiti@2.7.0)(postcss@8.5.26)(typescript@7.0.2)(yaml@2.9.0):
     dependencies:
       '@docsearch/css': 4.7.0
       '@docsearch/js': 4.7.0
@@ -11948,7 +12031,7 @@ snapshots:
       '@vue/devtools-api': 8.2.1
       '@vue/shared': 3.5.40
       '@vueuse/core': 14.4.0(vue@3.5.41(typescript@7.0.2))
-      '@vueuse/integrations': 14.4.0(axios@1.18.1)(change-case@5.4.4)(focus-trap@8.2.2)(vue@3.5.41(typescript@7.0.2))
+      '@vueuse/integrations': 14.4.0(axios@1.18.1(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2))(change-case@5.4.4)(focus-trap@8.2.2)(vue@3.5.41(typescript@7.0.2))
       focus-trap: 8.2.2
       mark.js: 8.11.1
       minisearch: 7.2.0
@@ -12069,13 +12152,13 @@ snapshots:
 
   vue-tsc@3.3.9(typescript@6.0.3):
     dependencies:
-      '@volar/typescript': 2.4.28
+      '@volar/typescript': 2.4.28(typescript@6.0.3)
       '@vue/language-core': 3.3.9
       typescript: 6.0.3
 
   vue-tsc@3.3.9(typescript@7.0.2):
     dependencies:
-      '@volar/typescript': 2.4.28
+      '@volar/typescript': 2.4.28(typescript@7.0.2)
       '@vue/language-core': 3.3.9
       typescript: 7.0.2
     optional: true
@@ -12090,9 +12173,9 @@ snapshots:
     optionalDependencies:
       typescript: 7.0.2
 
-  wait-on@9.1.0(debug@4.4.3(supports-color@8.1.1)):
+  wait-on@9.1.0(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
-      axios: 1.18.1(debug@4.4.3(supports-color@8.1.1))
+      axios: 1.18.1(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
       joi: 18.2.3
       lodash: 4.18.1
       minimist: 1.2.8

--- a/tools/release/mise.toml
+++ b/tools/release/mise.toml
@@ -121,6 +121,16 @@ run = "node src/checks/publish-check-runs.ts"
 description = "Create per-package peer-floor check runs (merge-time signal, non-gating)"
 run = "node src/checks/peer-floor-check-runs.ts"
 
+[tasks.workers_builds_check_runs]
+# env: GH_TOKEN, GITHUB_REPOSITORY, CLOUDFLARE_API_TOKEN, CLOUDFLARE_ACCOUNT_ID.
+# CD-pipeline signal (#280 Phase 1): read-only diff of the live Cloudflare
+# Workers Builds triggers against the repo-owned desired state, reported as
+# one check run on the current HEAD. action_required on drift, neutral when
+# the credential/API failed — never a job failure. Read scope only; --apply
+# stays manual.
+description = "Create the workers-builds trigger-drift check run (CD signal, non-gating)"
+run = "node src/checks/workers-builds-check-runs.ts"
+
 [tasks.peer_floor_gate]
 # Tier-2 peer-floor gate: fails the bump of a package whose floor claim is
 # dishonest; no-ops for packages without the typecheck:peer-floor script.

--- a/tools/release/package.json
+++ b/tools/release/package.json
@@ -22,6 +22,7 @@
     "@pnpm/types": "catalog:",
     "@pnpm/workspace.project-manifest-reader": "catalog:",
     "@tools/shared": "workspace:*",
+    "@tools/workers-builds": "workspace:*",
     "@types/node": "catalog:",
     "@types/pacote": "catalog:",
     "lit-ui-router": "workspace:*",

--- a/tools/release/src/checks/publish-check-runs.core.ts
+++ b/tools/release/src/checks/publish-check-runs.core.ts
@@ -9,7 +9,10 @@ import type { PackageSummary } from './check-published-diff.core.ts';
 
 export type CheckRunPayload = {
   name: string;
-  conclusion: 'success' | 'action_required';
+  // Shared by every release signal. `neutral` (grey) is the observer-failed
+  // verdict — see workers-builds-check-runs.core.ts; `failure` stays unused
+  // because these signals never fail CI.
+  conclusion: 'success' | 'action_required' | 'neutral';
   title: string;
   summary: string;
 };

--- a/tools/release/src/checks/workers-builds-check-runs.core.ts
+++ b/tools/release/src/checks/workers-builds-check-runs.core.ts
@@ -1,0 +1,94 @@
+// Pure shaping for the workers-builds CD-pipeline signal: the
+// workers-builds-triggers CLI's exit code and console output in, one Checks
+// API payload out. Third member of the release-signals family (published-diff
+// for the npm artifacts, peer-floor for peer ranges, this for the deploy
+// pipeline that ships lit-ui-router.dev) — same vocabulary: action_required
+// renders orange ("the dashboard owes an apply"), never a CI failure, and
+// `failure` is deliberately unused.
+//
+// The exit-2 → `neutral` mapping is the load-bearing one: an expired token, a
+// missing secret, or a Cloudflare outage is a failure of the OBSERVER, not
+// evidence about the observed dashboard, so it must render grey rather than
+// share a colour with real drift. The IO (running the CLI, gh) lives in
+// ./workers-builds-check-runs.ts.
+
+import type { CheckRunPayload } from './publish-check-runs.core.ts';
+
+export type TriggerCheckResult = {
+  /** The CLI's exit code: 0 in sync, 1 drifted, 2 usage/API error. */
+  exitCode: number;
+  /** Combined stdout+stderr — the CLI's own report text. */
+  output: string;
+};
+
+/** The exact run name the README badge nameFilter must match. */
+export const WORKERS_BUILDS_CHECK_RUN_NAME = 'workers-builds (triggers)';
+
+/** Checks API output.summary caps at 65535 chars; leave room for the framing. */
+const MAX_REPORT_CHARS = 60_000;
+
+function reportBlock(output: string): string[] {
+  const text = output.trim();
+  if (text === '') return [];
+  const clipped =
+    text.length > MAX_REPORT_CHARS
+      ? `${text.slice(0, MAX_REPORT_CHARS)}\n… report truncated`
+      : text;
+  return ['', '```', clipped, '```'];
+}
+
+/** The CLI's verdict → its Checks API payload. */
+export function toWorkersBuildsCheckRun(
+  result: TriggerCheckResult,
+  repo: string,
+): CheckRunPayload {
+  const name = WORKERS_BUILDS_CHECK_RUN_NAME;
+  const configUrl = `https://github.com/${repo}/blob/main/tools/workers-builds/workers-builds-triggers.config.jsonc`;
+  if (result.exitCode === 0) {
+    return {
+      name,
+      conclusion: 'success',
+      title: 'dashboard triggers match the repo config',
+      summary: [
+        'The live Cloudflare Workers Builds triggers that deploy',
+        `lit-ui-router.dev match [workers-builds-triggers.config.jsonc](${configUrl}).`,
+        ...reportBlock(result.output),
+      ].join('\n'),
+    };
+  }
+  if (result.exitCode === 1) {
+    return {
+      name,
+      conclusion: 'action_required',
+      title: 'trigger drift: the dashboard no longer matches the repo config',
+      summary: [
+        'The live Workers Builds triggers drifted from',
+        `[workers-builds-triggers.config.jsonc](${configUrl}) — the deploy`,
+        'pipeline that ships lit-ui-router.dev is running configuration with',
+        'no PR trail.',
+        '',
+        'To resolve: decide which side is right. If the config is, run',
+        '`pnpm check:workers-builds -- --apply` from the owning checkout (it',
+        'needs the Edit-scoped user token, which CI deliberately does not',
+        'have). If the dashboard is, update the config in a PR. This run',
+        're-checks on the next push to `main` and flips green.',
+        ...reportBlock(result.output),
+      ].join('\n'),
+      // details_url: not settable — GitHub pins GITHUB_TOKEN-created check runs to their own page
+    };
+  }
+  return {
+    name,
+    conclusion: 'neutral',
+    title: 'could not verify — observer error, not a verdict on the dashboard',
+    summary: [
+      `The trigger check could not reach a verdict (exit ${result.exitCode}).`,
+      'A missing/expired `CLOUDFLARE_API_TOKEN` secret or a Cloudflare API',
+      'outage says nothing about whether the dashboard drifted, so this',
+      'renders grey rather than sharing a colour with real drift.',
+      '',
+      'See DEPLOY.md for the required secrets and the read-only token scope.',
+      ...reportBlock(result.output),
+    ].join('\n'),
+  };
+}

--- a/tools/release/src/checks/workers-builds-check-runs.test.ts
+++ b/tools/release/src/checks/workers-builds-check-runs.test.ts
@@ -1,0 +1,81 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { checkRunApiArgs } from './publish-check-runs.core.ts';
+import {
+  WORKERS_BUILDS_CHECK_RUN_NAME,
+  toWorkersBuildsCheckRun,
+} from './workers-builds-check-runs.core.ts';
+
+const REPO = 'simshanith/lit-ui-router';
+
+describe('toWorkersBuildsCheckRun', () => {
+  it('maps exit 0 to success', () => {
+    const payload = toWorkersBuildsCheckRun(
+      { exitCode: 0, output: 'worker: lit-ui-router (abc)\n\nin sync' },
+      REPO,
+    );
+    assert.equal(payload.name, WORKERS_BUILDS_CHECK_RUN_NAME);
+    assert.equal(payload.conclusion, 'success');
+    assert.match(payload.summary, /in sync/);
+  });
+
+  it('maps exit 1 to action_required, never failure', () => {
+    const payload = toWorkersBuildsCheckRun(
+      { exitCode: 1, output: 'build_command: "a" != "b"' },
+      REPO,
+    );
+    assert.equal(payload.conclusion, 'action_required');
+    assert.match(payload.title, /drift/);
+    assert.match(payload.summary, /build_command/);
+    // CI is read-only by design: the resolve path is a local --apply.
+    assert.match(payload.summary, /--apply/);
+  });
+
+  it('maps exit 2 to neutral so an observer failure never reads as drift', () => {
+    const missingSecret = toWorkersBuildsCheckRun(
+      { exitCode: 2, output: 'Missing required env: set CLOUDFLARE_API_TOKEN' },
+      REPO,
+    );
+    assert.equal(missingSecret.conclusion, 'neutral');
+    assert.match(missingSecret.title, /observer error/);
+    assert.match(missingSecret.summary, /CLOUDFLARE_API_TOKEN/);
+  });
+
+  it('treats any unexpected exit code as an observer failure', () => {
+    for (const exitCode of [3, 127, 137]) {
+      assert.equal(
+        toWorkersBuildsCheckRun({ exitCode, output: '' }, REPO).conclusion,
+        'neutral',
+      );
+    }
+  });
+
+  it('omits the report block when the CLI printed nothing', () => {
+    const payload = toWorkersBuildsCheckRun(
+      { exitCode: 2, output: '  ' },
+      REPO,
+    );
+    assert.doesNotMatch(payload.summary, /```/);
+  });
+
+  it('truncates a runaway report to stay under the Checks API summary cap', () => {
+    const payload = toWorkersBuildsCheckRun(
+      { exitCode: 1, output: 'x'.repeat(200_000) },
+      REPO,
+    );
+    assert.ok(payload.summary.length < 65_535);
+    assert.match(payload.summary, /report truncated/);
+  });
+
+  it('feeds the shared gh api argv builder', () => {
+    const payload = toWorkersBuildsCheckRun(
+      { exitCode: 0, output: 'ok' },
+      REPO,
+    );
+    const args = checkRunApiArgs(REPO, 'deadbeef', payload);
+    assert.deepEqual(args.slice(0, 2), ['api', `repos/${REPO}/check-runs`]);
+    assert.ok(args.includes(`name=${WORKERS_BUILDS_CHECK_RUN_NAME}`));
+    assert.ok(args.includes('conclusion=success'));
+  });
+});

--- a/tools/release/src/checks/workers-builds-check-runs.ts
+++ b/tools/release/src/checks/workers-builds-check-runs.ts
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+// CD-pipeline verification signal: run the read-only workers-builds-triggers
+// diff against the live Cloudflare API and report its verdict as one check
+// run on the current HEAD. Phase 1 of #280, non-gating — this exits 0 for
+// every verdict, including the CLI's exit 2 and a missing credential, so the
+// signal can never fail CI.
+//
+// The CLI is spawned directly rather than through turbo on purpose: turbo
+// collapses any task failure to its own exit 1, which would erase the 1-vs-2
+// distinction the conclusion mapping is built on. Shaping is pure and
+// unit-tested in ./workers-builds-check-runs.core.ts.
+
+import { fileURLToPath } from 'node:url';
+
+import { defaultExec } from '@tools/shared/exec.ts';
+import { ensureGh } from '@tools/shared/gh.ts';
+import { logWarning } from '@tools/shared/gha.ts';
+import { workspaceRoot } from '@tools/shared/workspace.ts';
+
+import { checkRunApiArgs } from './publish-check-runs.core.ts';
+import {
+  toWorkersBuildsCheckRun,
+  type TriggerCheckResult,
+} from './workers-builds-check-runs.core.ts';
+
+// Resolved through node so the @tools/workers-builds devDependency (declared
+// for exactly this, and to pull the package into `setup --release`'s install
+// closure) is what locates the CLI, not a hardcoded relative path.
+const CLI = fileURLToPath(
+  import.meta.resolve('@tools/workers-builds/workers-builds-triggers.ts'),
+);
+
+/** Run the CLI without letting a non-zero exit escape as a rejection. */
+async function runTriggerCheck(): Promise<TriggerCheckResult> {
+  try {
+    const { stdout, stderr } = await defaultExec('node', [CLI], {
+      cwd: workspaceRoot,
+    });
+    return { exitCode: 0, output: `${stdout}${stderr}` };
+  } catch (error: unknown) {
+    // execFile rejects with the child's code/stdout/stderr attached; anything
+    // else (spawn failure) is an observer error too, so it lands on 2.
+    const failure = error as {
+      code?: unknown;
+      stdout?: unknown;
+      stderr?: unknown;
+    };
+    const exitCode = typeof failure.code === 'number' ? failure.code : 2;
+    const stdout = typeof failure.stdout === 'string' ? failure.stdout : '';
+    const stderr =
+      typeof failure.stderr === 'string'
+        ? failure.stderr
+        : error instanceof Error
+          ? error.message
+          : String(error);
+    return { exitCode, output: `${stdout}${stderr}` };
+  }
+}
+
+async function main() {
+  const dryRun = process.argv.includes('--dry-run');
+  const repo = process.env.GITHUB_REPOSITORY ?? 'simshanith/lit-ui-router';
+  if (!process.env.GITHUB_REPOSITORY && !dryRun) {
+    throw new Error('GITHUB_REPOSITORY must be set (or pass --dry-run)');
+  }
+
+  const result = await runTriggerCheck();
+  console.log(`workers-builds-triggers exited ${result.exitCode}`);
+  console.log(result.output);
+
+  const payload = toWorkersBuildsCheckRun(result, repo);
+  if (dryRun) {
+    console.log(JSON.stringify(payload, null, 2));
+    return;
+  }
+  const { stdout } = await defaultExec('git', ['rev-parse', 'HEAD']);
+  const headSha = stdout.trim();
+  await ensureGh();
+  await defaultExec('gh', checkRunApiArgs(repo, headSha, payload));
+  console.log(
+    `created check run "${payload.name}" (${payload.conclusion}) on ${headSha}`,
+  );
+}
+
+main().catch((error: unknown) => {
+  // Even the reporting path stays non-gating: a gh outage must not turn a
+  // deploy-pipeline signal into a red CI run. A warning annotation surfaces
+  // it on the run summary instead of a non-zero exit.
+  logWarning(
+    `workers-builds check run not reported: ${error instanceof Error ? error.message : String(error)}`,
+  );
+});

--- a/tools/workers-builds/workers-builds-triggers.ts
+++ b/tools/workers-builds/workers-builds-triggers.ts
@@ -9,9 +9,15 @@
 //
 // Default is a read-only diff. --apply PATCHes drifted triggers, then re-GETs
 // to confirm. Exit codes: 0 in sync, 1 drifted (or drift remained after
-// --apply), 2 usage/API error. Token needs "Workers Builds Configuration:
-// Edit" (user-scoped). Never wire this into CI's task graph — it reads (and
-// with --apply, writes) production deploy configuration.
+// --apply), 2 usage/API error. Token must be USER-scoped (account-owned
+// tokens don't cover the Builds API): "Workers Builds Configuration: Read"
+// suffices for the diff, Edit is only for --apply.
+//
+// Never make this a turbo task-graph dependency: it hits the live API, so no
+// build/test/typecheck task may reach it. Running the default read-only diff
+// from CI is fine and intended — release-signals.yml reports it as a
+// non-gating check run (#280 Phase 1) using a read-scoped token; --apply,
+// which writes production deploy configuration, stays manual.
 //
 // This file is the IO shell: env, wrangler.jsonc, and the Cloudflare API
 // (https://developers.cloudflare.com/workers/ci-cd/builds/api-reference/).
@@ -118,7 +124,8 @@ async function main() {
   if (!token || !accountId) {
     console.error(
       'Missing required env: set CLOUDFLARE_API_TOKEN (user token with ' +
-        '"Workers Builds Configuration: Edit") and CLOUDFLARE_ACCOUNT_ID.',
+        '"Workers Builds Configuration: Read", Edit for --apply) and ' +
+        'CLOUDFLARE_ACCOUNT_ID.',
     );
     process.exitCode = 2;
     return;


### PR DESCRIPTION
Phase 1 of #280: a **non-gating CD-pipeline verification signal** for Cloudflare Workers Builds trigger drift,
added as a third check run inside the existing `release-signals.yml` rather than a standalone workflow.

`published-diff`, `peer-floor`, and now `workers-builds (triggers)` all answer the same question — *does the
outside world still match `main`?* — for the npm artifacts, the peer ranges, and the deploy pipeline that ships
lit-ui-router.dev. Same job, same machinery, same vocabulary.

### Conclusion mapping

The `workers-builds-triggers` CLI's exit codes become check-run conclusions:

| exit | conclusion        | badge  | meaning                                          |
| ---- | ----------------- | ------ | ------------------------------------------------ |
| 0    | `success`         | green  | the dashboard matches the repo config            |
| 1    | `action_required` | orange | drift — the dashboard owes a manual `--apply`    |
| 2 (or anything else) | `neutral` | grey | the check could not reach a verdict             |

The `neutral` lane is the load-bearing one. An expired token, an absent secret, or a Cloudflare outage is a
failure of the **observer**, not evidence about the observed system, and must never render the same as real
drift. `neutral` is new to `CheckRunPayload`; `failure` stays deliberately unused across all three signals.

The CLI is spawned directly rather than through turbo on purpose — turbo collapses any task failure to its own
exit 1, which would erase the 1-vs-2 distinction the whole mapping rests on.

### Deviation from #280

The issue says *"exit 1 on drift fails the run."* **This does not do that.** Non-gating is the requirement:
the step exits 0 on every path, including drift, a missing credential, and a `gh` outage while reporting (that
last one becomes a `::warning::` annotation instead of a non-zero exit). The issue text and the implementation
now disagree on this point by design; flagging it here so it is on the record.

Also out of scope by design: #280's **Phase 2 (apply-on-merge)**. That hands CI an Edit-scoped token over the
production build pipeline. CI gets **Read** only.

### Triggers, and the concurrency hazard

`push:` to `main` is the primary trigger and stays unfiltered by paths — a merge to `main` *is* the CD event
(Workers Builds deploys from that same push), so the signal verifies the trigger config at the moment it gets
used, and it costs two API GETs.

`schedule:` (weekly, `17 7 * * 0` — off-peak and off the top of the hour) is secondary: it catches
dashboard-side edits, and npm-side changes like a deprecate or unpublish, during quiet periods that no push
would ever surface. This is the repo's first scheduled workflow.

The hazard: the group is `release-signals` with `cancel-in-progress: true`, and `publish-npm.yml`'s
post-publish `workflow_call` exists specifically to flip badges green after a release. A cron firing mid-publish
could cancel it.

**Resolution** — one expression, no restructuring:

```yaml
concurrency:
  group: release-signals
  cancel-in-progress: ${{ github.event_name != 'schedule' }}
```

`cancel-in-progress` is read off the **incoming** run, so a scheduled sweep never cancels anything: it queues
behind whatever holds the group and re-checks with fresh data when it starts. Any later push or `workflow_call`
run still carries `true` and cancels the queued sweep, doing the same work itself. Keeping one group also
preserves the existing "one refresh at a time on main's head" property that a separate per-event group would
have broken — a sweep and a publish refresh writing the same check-run names concurrently is exactly what the
shared group prevents.

### `inputs.packages` on a scheduled run — not a bug

Checked, and it is fine. The `inputs` context is null off `workflow_dispatch`, so `${{ inputs.packages }}`
renders as the empty string on `schedule` exactly as it already does on `push`, and `scopePackages` treats
`undefined` / `''` / `' , '` identically as "the full set" (already unit-tested). Comment updated to say so
explicitly rather than leaving it implied. Nothing else in `published_diff` or `peer_floor_check_runs` reads
event-specific context; checkout is pinned to `ref: main` for every event.

### How the exit-0 guarantee was verified

- Ran the task with no credentials — the state the repo is actually in at merge time. Output: `neutral`,
  `EXIT=0`. That is the missing-secret path *and* the exit-2 path in one.
- Probed `promisify(execFile)`'s rejection shape to confirm the runner reads real exit codes: numeric `code`
  (1 and 2 verified, with `stdout`/`stderr` attached as strings) for a child that exits non-zero, and the
  string `'ENOENT'` for a spawn failure — which is non-numeric, so it falls through to `2` → `neutral`.
- The `main().catch` handler no longer sets `process.exitCode`; a `gh` failure logs a warning annotation.
- Unit tests cover every conclusion including exit codes 3 / 127 / 137, the empty-report case, and summary
  truncation against the Checks API's 65535-char cap.

### Secrets

Neither exists yet. Both are declared optional, and absent they yield grey — not red, not a failure.

| Secret                  | Scope                                                                    |
| ----------------------- | ------------------------------------------------------------------------ |
| `CLOUDFLARE_API_TOKEN`  | **User-scoped**, **Workers Builds Configuration: Read**. Never Edit.     |
| `CLOUDFLARE_ACCOUNT_ID` | A secret rather than a variable so it stays out of public logs.          |

`publish-npm.yml` forwards both into its `workflow_call` — secrets don't auto-propagate, and without that the
badge would flip grey after every release. Names, scope, and manual rotation are documented in `DEPLOY.md`.

### Also in here

`workers-builds-triggers.ts:12` said *"Never wire this into CI's task graph"*, which reads as "never run this
in CI at all" — a rule this PR would appear to break. Tightened to the real constraint: never a **turbo
task-graph dependency**; running the read-only diff from CI is fine and intended, `--apply` stays manual. Its
token-scope line now also distinguishes Read (diff) from Edit (`--apply`).

### Merge order

**Merge after #574**, which touches the same CLI (`environment_variables` management, dependency install moved
into `build_command`). This PR depends only on the CLI's exit-code contract, which #574 preserves, so the two
are compatible in either order — but #574 is the older change and should land first.

Auto-merge deliberately not armed: this touches the CD pipeline.

Refs #280.
