### PR TITLE
docs(deploy): document the 1Password bootstrap for the Workers Builds creds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,8 +46,11 @@ certs/
 # config.toml `_.file` dotenvs: turbo.local.env (written by turbo_login —
 # remote-cache creds + the sensitive worker domain) and the hand-created
 # cloudflare.local.env (Workers Builds API token + account id).
+# The .tmpl siblings hold `op://` secret references rather than secrets, but stay
+# untracked too: the vault layout they encode is per-maintainer, not repo config.
 .config/mise/**/*.local.toml
 .config/mise/**/*.local.env
+.config/mise/**/*.local.env.tmpl
 mise.local.toml
 mise.*.local.toml
 

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -57,6 +57,25 @@ Both belong in `.config/mise/cloudflare.local.env`, a gitignored dotenv that the
 that one). Hand-create it; no task writes it, and it is deliberately not symlinked into git worktrees,
 so run `check:workers-builds` from the owning checkout.
 
+From 1Password, keep a `cloudflare.local.env.tmpl` beside it holding `op://` references instead of
+values, and regenerate the dotenv rather than editing it:
+
+```sh
+op inject -i .config/mise/cloudflare.local.env.tmpl -o .config/mise/cloudflare.local.env
+chmod 600 .config/mise/cloudflare.local.env
+```
+
+The template is gitignored alongside the dotenv — it carries no secrets, but the vault layout it
+encodes is personal rather than repo config. To avoid an Edit-scoped token at rest entirely, drop
+the `{{ }}` around each reference and run the check under `op run` instead, which injects into the
+child process only:
+
+```sh
+op run --env-file .config/mise/cloudflare.local.env.tmpl -- pnpm check:workers-builds
+```
+
+The two syntaxes are mutually exclusive, so pick one per file.
+
 ### Build Environment Variables
 
 - `VITE_GOOGLE_ANALYTICS_TRACKING_ID`


### PR DESCRIPTION
Follow-up to #573, which wired `.config/mise/cloudflare.local.env` into `_.file` but left it hand-created.

Adds a documented `op inject` bootstrap so the dotenv can be regenerated from 1Password rather than hand-edited, and gitignores the `*.local.env.tmpl` sibling that holds the `op://` references. The template carries no secrets, but the vault layout it encodes is per-maintainer rather than repo config — the same reason `REMOTE_CACHE.md` elides its item paths as `op://Private/…/token`.

Also documents `op run --env-file` as the alternative: it injects into the child process only, so the **Edit**-scoped production token never lands in a file at rest. The two syntaxes are mutually exclusive (`op inject` wants `{{ op://… }}`, `op run` wants a bare `op://…`), so the doc says to pick one per file rather than implying a single template serves both.

No task writes the dotenv — deliberately, matching #573's reasoning that `check:workers-builds` is manual-only and fails loudly, unlike the turbo creds whose absence degrades silently.

Docs + gitignore only; no code paths touched.