### PR TITLE
docs(deploy): give the op run env-file its own gitignored path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,11 +46,14 @@ certs/
 # config.toml `_.file` dotenvs: turbo.local.env (written by turbo_login —
 # remote-cache creds + the sensitive worker domain) and the hand-created
 # cloudflare.local.env (Workers Builds API token + account id).
-# The .tmpl siblings hold `op://` secret references rather than secrets, but stay
+# The 1Password sources hold `op://` references rather than secrets, but stay
 # untracked too: the vault layout they encode is per-maintainer, not repo config.
+# One path per method — *.local.env.tmpl is `op inject` input (braced references,
+# output is the dotenv above), *.op.env is `op run --env-file` input (bare ones).
 .config/mise/**/*.local.toml
 .config/mise/**/*.local.env
 .config/mise/**/*.local.env.tmpl
+.config/mise/**/*.op.env
 mise.local.toml
 mise.*.local.toml
 

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -66,15 +66,20 @@ chmod 600 .config/mise/cloudflare.local.env
 ```
 
 The template is gitignored alongside the dotenv — it carries no secrets, but the vault layout it
-encodes is personal rather than repo config. To avoid an Edit-scoped token at rest entirely, drop
-the `{{ }}` around each reference and run the check under `op run` instead, which injects into the
-child process only:
+encodes is personal rather than repo config.
+
+To avoid an Edit-scoped token at rest entirely, skip the dotenv and run the check under `op run`,
+which injects into the child process only. It takes its own file, `.config/mise/cloudflare.op.env`
+(also gitignored), holding the same references _without_ the `{{ }}`:
 
 ```sh
-op run --env-file .config/mise/cloudflare.local.env.tmpl -- pnpm check:workers-builds
+op run --env-file .config/mise/cloudflare.op.env -- pnpm check:workers-builds
 ```
 
-The two syntaxes are mutually exclusive, so pick one per file.
+One path per method, because the two syntaxes are mutually exclusive: `op inject` substitutes
+`{{ op://… }}` and passes a bare `op://…` through untouched, so pointing it at the `op run` file
+yields a dotenv of literal reference strings, surfacing as an auth failure from Cloudflare rather
+than as an error from `op`.
 
 ### Build Environment Variables
 


### PR DESCRIPTION
Follow-up to #579, which documented both 1Password bootstraps against a single `cloudflare.local.env.tmpl`.

That conflated two things. `op inject` substitutes `{{ op://… }}` and passes a bare `op://…` through **untouched**, so aiming it at an `op run` file produces a dotenv of literal reference strings — which then surfaces as an auth failure from Cloudflare, not as an error from `op`. A quiet wrong-credential path, not a loud one.

One path per method instead:

| Path | Method | Contents |
| --- | --- | --- |
| `cloudflare.local.env` | mise `[env] _.file` | real values |
| `cloudflare.local.env.tmpl` | `op inject -o` source | `{{ op://… }}` |
| `cloudflare.op.env` | `op run --env-file` | bare `op://…` |

`*.op.env` gitignored alongside the others — no secrets in it, but the same per-maintainer vault layout.

Worth noting mise never loads the new file by accident: `_.file` names the exact path `cloudflare.local.env`, so a sibling in that directory is inert regardless of extension. The hazard the separate path guards is a human pointing the wrong tool at the wrong file, not mise.

Docs + gitignore only.