### PR TITLE
build(mise): wrap the Workers Builds 1Password bootstrap in tasks

### DIFF
--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -169,6 +169,30 @@ run = "mise run taplo fmt --check"
 # .config/mise/tasks/ — their shell bodies were too large to sit inline. Every
 # other task here is a one- or two-liner and stays inline.
 
+# Both Cloudflare tasks wrap `op` over a gitignored file whose path is the only
+# thing worth memorizing; neither is required, since the check reads plain env.
+# `op` is intentionally not in [tools]: a pinned copy would shadow the system
+# one and lose its desktop-app/biometric integration.
+
+[tasks.cloudflare_login]
+# op inject, not a prompt like turbo_login: these creds have a canonical
+# 1Password home, so regenerate the dotenv rather than re-type it.
+description = "Regenerate .config/mise/cloudflare.local.env from 1Password"
+run = '''
+op inject -i "{{config_root}}/.config/mise/cloudflare.local.env.tmpl" -o "{{config_root}}/.config/mise/cloudflare.local.env"
+chmod 600 "{{config_root}}/.config/mise/cloudflare.local.env"
+'''
+
+[tasks.check_workers_builds]
+# The no-secrets-at-rest path: op run injects into this process only, so the
+# Edit-scoped token --apply needs never lands in a file. Skip it and run
+# `pnpm check:workers-builds` directly when cloudflare_login's dotenv is enough.
+description = "Diff the Workers Builds triggers, credentials injected by 1Password"
+usage = '''
+flag "--apply" help="PATCH drifted triggers — writes production deploy config, needs the Edit scope"
+'''
+run = 'op run --env-file "{{config_root}}/.config/mise/cloudflare.op.env" -- pnpm check:workers-builds ${usage_apply:+-- --apply}'
+
 [tasks.build]
 # env: TURBO_TOKEN/TURBO_API/TURBO_TEAM for remote cache (ambient turbo
 # config, not a flag).

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -54,32 +54,31 @@ Manual-only — never part of CI.
 Both belong in `.config/mise/cloudflare.local.env`, a gitignored dotenv that the checked-in
 `.config/mise/config.toml` loads via `[env] _.file` (the same mechanism as the
 [Remote Cache](./REMOTE_CACHE.md) credentials, but a separate file — `mise run turbo_login` rewrites
-that one). Hand-create it; no task writes it, and it is deliberately not symlinked into git worktrees,
-so run `check:workers-builds` from the owning checkout.
+that one). It is deliberately not symlinked into git worktrees, so run `check:workers-builds` from
+the owning checkout.
 
-From 1Password, keep a `cloudflare.local.env.tmpl` beside it holding `op://` references instead of
-values, and regenerate the dotenv rather than editing it:
+From 1Password, two mise tasks wrap `op` over gitignored files that hold `op://` references instead
+of values (no secrets, but the vault layout they encode is personal rather than repo config, so they
+stay untracked). Create whichever the chosen task needs:
 
-```sh
-op inject -i .config/mise/cloudflare.local.env.tmpl -o .config/mise/cloudflare.local.env
-chmod 600 .config/mise/cloudflare.local.env
-```
+| Task                                      | Reads                                    | Reference form | Token at rest    |
+| ----------------------------------------- | ---------------------------------------- | -------------- | ---------------- |
+| `mise run cloudflare_login`               | `.config/mise/cloudflare.local.env.tmpl` | `{{ op://… }}` | yes, `chmod 600` |
+| `mise run check_workers_builds [--apply]` | `.config/mise/cloudflare.op.env`         | bare `op://…`  | no               |
 
-The template is gitignored alongside the dotenv — it carries no secrets, but the vault layout it
-encodes is personal rather than repo config.
+`cloudflare_login` regenerates the dotenv above with `op inject`, so edit the template and re-run
+rather than editing the dotenv. `check_workers_builds` skips the dotenv entirely and runs the diff
+under `op run`, which injects into that process only — the path to prefer for `--apply`, whose
+**Edit**-scoped token is the one worth never writing to disk.
 
-To avoid an Edit-scoped token at rest entirely, skip the dotenv and run the check under `op run`,
-which injects into the child process only. It takes its own file, `.config/mise/cloudflare.op.env`
-(also gitignored), holding the same references _without_ the `{{ }}`:
-
-```sh
-op run --env-file .config/mise/cloudflare.op.env -- pnpm check:workers-builds
-```
-
-One path per method, because the two syntaxes are mutually exclusive: `op inject` substitutes
+One file per task, because the two syntaxes are mutually exclusive: `op inject` substitutes
 `{{ op://… }}` and passes a bare `op://…` through untouched, so pointing it at the `op run` file
 yields a dotenv of literal reference strings, surfacing as an auth failure from Cloudflare rather
 than as an error from `op`.
+
+Neither task is required — both only supply the two variables, so `pnpm check:workers-builds` with
+them already in the environment works the same. `op` is deliberately not a pinned `[tools]` entry: a
+mise-managed copy would shadow the system one and lose its desktop-app integration.
 
 ### Build Environment Variables
 


### PR DESCRIPTION
Follow-up to #579/#580, which documented the `op` commands but left the paths to be memorized.

| Task | Reads | Reference form | Token at rest |
| --- | --- | --- | --- |
| `mise run cloudflare_login` | `cloudflare.local.env.tmpl` | `{{ op://… }}` | yes, `chmod 600` |
| `mise run check_workers_builds [--apply]` | `cloudflare.op.env` | bare `op://…` | no |

Each task owns exactly one path, so the mutually exclusive `op` syntaxes can't be aimed at the wrong file — the failure mode #580 described (a dotenv of literal reference strings, surfacing as a Cloudflare auth error rather than an `op` error).

Both are inline one-and-two-liners, matching the convention that only `turbo_login`/`read_secret`/`turbo_link_worktree` are file-based.

**`op` is deliberately not a pinned `[tools]` entry.** A mise-managed copy would shadow the system `op` and lose its desktop-app/biometric integration, which is the thing that makes the prompt tolerable. The tasks assume `op` on `PATH` and fail with its own error if not.

**Neither task is required.** Both only supply `CLOUDFLARE_API_TOKEN`/`CLOUDFLARE_ACCOUNT_ID`, so `pnpm check:workers-builds` with those already in the environment behaves identically — this is ergonomics, not a new dependency.

## Verified

- Both tasks parse; `check_workers_builds --help` renders the `--apply` flag through the usage spec.
- `{{config_root}}` renders to an absolute path in the inline `run` (file-based tasks don't get templating; inline ones do).
- `--apply` plumbing reaches the CLI: `pnpm check:workers-builds -- --zzz` shows turbo spawning `pnpm run check --zzz`, so the flag lands on `workers-builds-triggers.ts` rather than being eaten by turbo.
- `lint_workflows`, `lint_markdown`, `format:check`, and taplo all clean.

Not verified: an end-to-end `op` run — it prompts for authorization, and I left every `op` invocation to the maintainer.

Incidental finding: `@tools/workers-builds#check` runs `cache bypass, force executing`, and turbo propagates the CLI's exit 2 rather than collapsing it to 1 for a single-task run. So the read-only diff is neither cached nor exit-code-flattened when invoked through the pnpm script.