### PR TITLE
build(mise): drop corepack, bootstrap pnpm with the aqua backend

### DIFF
--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -57,8 +57,12 @@ idiomatic_version_file_enable_tools = ["node"]
 "aqua:zizmorcore/zizmor" = "1.26.1"
 # Shell-script static analysis
 "aqua:koalaman/shellcheck" = "0.11.0"
-# mise-provided corepack: no npx per-invocation resolution, Node-25-proof
-"npm:corepack" = "0.35.0"
+# Bootstrap pnpm, not the version that runs: `packageManager` is the authority
+# and pnpm >=11.10 self-swaps to it. Must be the aqua backend — the npm `pnpm`
+# package is a placeholder whose `preinstall` hardlinks the real binary from an
+# optional platform dep, which neither corepack nor mise's aube installer runs.
+# Keep at or above 11.20.0: below that a pnpm-12 lockfile reads as outdated.
+"aqua:pnpm/pnpm" = "11.21.0"
 # shadows node's bundled npm; OIDC trusted publishing needs npm >= 11.5.1
 "npm:npm" = "12.0.1"
 # TOML formatter; oxfmt handles everything but .toml, so this owns the mise
@@ -68,24 +72,8 @@ idiomatic_version_file_enable_tools = ["node"]
 # .md, rumdl lints it. Pre-1.0, so the pin is load-bearing.
 "aqua:rvben/rumdl" = "0.2.55"
 
-# Provisioning tasks, not hooks: hooks warn-and-continue, task failures are
-# loud; and tool-only bumps (actionlint) skip the corepack ceremony.
 # snake_case names (bazel target convention); no colons in task names — mise
 # monorepo task addressing owns `:` (see the config_roots above).
-[tasks.corepack_enable]
-description = "Shim the corepack-managed package managers onto PATH"
-run = "corepack enable"
-
-[tasks.corepack_install]
-# Materializes the packageManager pin (sha512-verified) in corepack's cache.
-description = "Install the packageManager-pinned pnpm into the corepack cache"
-run = "corepack install"
-
-[tasks.corepack]
-# Virtual grouping task; the two legs are order-independent and may run
-# in parallel (enable writes shims, install populates COREPACK_HOME).
-description = "Provision the packageManager-pinned pnpm via corepack"
-depends = ["corepack_enable", "corepack_install"]
 
 [tasks.setup]
 # Bootstrap layer: the one step pnpm scripts can't own (no node_modules yet).
@@ -93,10 +81,10 @@ depends = ["corepack_enable", "corepack_install"]
 # pnpm auto-enables --frozen-lockfile when CI is set (ci-info detection),
 # so one task serves local (plain) and CI (frozen) alike.
 description = "Install workspace dependencies with the pnpm on PATH"
-# turbo_link_worktree is independent of corepack and no-ops everywhere but a
-# fresh worktree; it rides setup because that is the one step every new
-# checkout already runs.
-depends = ["corepack", "turbo_link_worktree"]
+# turbo_link_worktree no-ops everywhere but a fresh worktree; it rides setup
+# because that is the one step every new checkout already runs. No provisioning
+# leg: `mise install` puts the bootstrap pnpm on PATH by itself.
+depends = ["turbo_link_worktree"]
 usage = '''
 flag "--release" help="Scope the install to the @tools/release closure (tag-job)"
 '''

--- a/.config/mise/mise.lock
+++ b/.config/mise/mise.lock
@@ -78,6 +78,46 @@ checksum = "sha256:8a4e35ab0b331c85d73567b12f2a444df187f483e5079ceffa6bda1faa2e7
 url = "https://github.com/koalaman/shellcheck/releases/download/v0.11.0/shellcheck-v0.11.0.zip"
 url_api = "https://api.github.com/repos/koalaman/shellcheck/releases/assets/279056944"
 
+[[tools."aqua:pnpm/pnpm"]]
+version = "11.21.0"
+backend = "aqua:pnpm/pnpm"
+
+[tools."aqua:pnpm/pnpm"."platforms.linux-arm64"]
+checksum = "sha256:64eb219b008f7a4c176d81fbce919c20b0b7e093e815cbb669d46e681451f43b"
+url = "https://github.com/pnpm/pnpm/releases/download/v11.21.0/pnpm-linux-arm64.tar.gz"
+url_api = "https://api.github.com/repos/pnpm/pnpm/releases/assets/507585528"
+provenance = "github-attestations"
+
+[tools."aqua:pnpm/pnpm"."platforms.linux-arm64-musl"]
+checksum = "sha256:43587a1f3d26ee009c640378ef377cac3531990579acf0f35646531b7832831d"
+url = "https://github.com/pnpm/pnpm/releases/download/v11.21.0/pnpm-linux-arm64-musl.tar.gz"
+url_api = "https://api.github.com/repos/pnpm/pnpm/releases/assets/507585511"
+provenance = "github-attestations"
+
+[tools."aqua:pnpm/pnpm"."platforms.linux-x64"]
+checksum = "sha256:aadc489ce4473c2af0fec06a5c19e113b5793d404eac49853c8153bf4b0d8263"
+url = "https://github.com/pnpm/pnpm/releases/download/v11.21.0/pnpm-linux-x64.tar.gz"
+url_api = "https://api.github.com/repos/pnpm/pnpm/releases/assets/507585503"
+provenance = "github-attestations"
+
+[tools."aqua:pnpm/pnpm"."platforms.linux-x64-musl"]
+checksum = "sha256:8cad0a4d20318c0445d992630ace51edc0853fd259573f50ee5d0216dce9b420"
+url = "https://github.com/pnpm/pnpm/releases/download/v11.21.0/pnpm-linux-x64-musl.tar.gz"
+url_api = "https://api.github.com/repos/pnpm/pnpm/releases/assets/507585524"
+provenance = "github-attestations"
+
+[tools."aqua:pnpm/pnpm"."platforms.macos-arm64"]
+checksum = "sha256:860a96978a79ca5132bdc247375f94150a3c98edbecbee36e9f8e0c9e2f7f056"
+url = "https://github.com/pnpm/pnpm/releases/download/v11.21.0/pnpm-darwin-arm64.tar.gz"
+url_api = "https://api.github.com/repos/pnpm/pnpm/releases/assets/507585526"
+provenance = "github-attestations"
+
+[tools."aqua:pnpm/pnpm"."platforms.windows-x64"]
+checksum = "sha256:6643043caa3b01c65c431039926a2af954326d5cefbdb4da7baceceb17f5051f"
+url = "https://github.com/pnpm/pnpm/releases/download/v11.21.0/pnpm-win32-x64.zip"
+url_api = "https://api.github.com/repos/pnpm/pnpm/releases/assets/507585516"
+provenance = "github-attestations"
+
 [[tools."aqua:rhysd/actionlint"]]
 version = "1.7.12"
 backend = "aqua:rhysd/actionlint"
@@ -85,36 +125,43 @@ backend = "aqua:rhysd/actionlint"
 [tools."aqua:rhysd/actionlint"."platforms.linux-arm64"]
 checksum = "sha256:325e971b6ba9bfa504672e29be93c24981eeb1c07576d730e9f7c8805afff0c6"
 url = "https://github.com/rhysd/actionlint/releases/download/v1.7.12/actionlint_1.7.12_linux_arm64.tar.gz"
+url_api = "https://api.github.com/repos/rhysd/actionlint/releases/assets/384924897"
 provenance = "github-attestations"
 
 [tools."aqua:rhysd/actionlint"."platforms.linux-arm64-musl"]
 checksum = "sha256:325e971b6ba9bfa504672e29be93c24981eeb1c07576d730e9f7c8805afff0c6"
 url = "https://github.com/rhysd/actionlint/releases/download/v1.7.12/actionlint_1.7.12_linux_arm64.tar.gz"
+url_api = "https://api.github.com/repos/rhysd/actionlint/releases/assets/384924897"
 provenance = "github-attestations"
 
 [tools."aqua:rhysd/actionlint"."platforms.linux-x64"]
 checksum = "sha256:8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8"
 url = "https://github.com/rhysd/actionlint/releases/download/v1.7.12/actionlint_1.7.12_linux_amd64.tar.gz"
+url_api = "https://api.github.com/repos/rhysd/actionlint/releases/assets/384924896"
 provenance = "github-attestations"
 
 [tools."aqua:rhysd/actionlint"."platforms.linux-x64-musl"]
 checksum = "sha256:8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8"
 url = "https://github.com/rhysd/actionlint/releases/download/v1.7.12/actionlint_1.7.12_linux_amd64.tar.gz"
+url_api = "https://api.github.com/repos/rhysd/actionlint/releases/assets/384924896"
 provenance = "github-attestations"
 
 [tools."aqua:rhysd/actionlint"."platforms.macos-arm64"]
 checksum = "sha256:aba9ced2dee8d27fecca3dc7feb1a7f9a52caefa1eb46f3271ea66b6e0e6953f"
 url = "https://github.com/rhysd/actionlint/releases/download/v1.7.12/actionlint_1.7.12_darwin_arm64.tar.gz"
+url_api = "https://api.github.com/repos/rhysd/actionlint/releases/assets/384924893"
 provenance = "github-attestations"
 
 [tools."aqua:rhysd/actionlint"."platforms.macos-x64"]
 checksum = "sha256:5b44c3bc2255115c9b69e30efc0fecdf498fdb63c5d58e17084fd5f16324c644"
 url = "https://github.com/rhysd/actionlint/releases/download/v1.7.12/actionlint_1.7.12_darwin_amd64.tar.gz"
+url_api = "https://api.github.com/repos/rhysd/actionlint/releases/assets/384924880"
 provenance = "github-attestations"
 
 [tools."aqua:rhysd/actionlint"."platforms.windows-x64"]
 checksum = "sha256:6e7241b51e6817ea6a047693d8e6fed13b31819c9a0dd6c5a726e1592d22f6e9"
 url = "https://github.com/rhysd/actionlint/releases/download/v1.7.12/actionlint_1.7.12_windows_amd64.zip"
+url_api = "https://api.github.com/repos/rhysd/actionlint/releases/assets/384924919"
 provenance = "github-attestations"
 
 [[tools."aqua:rvben/rumdl"]]
@@ -209,6 +256,7 @@ backend = "aqua:zizmorcore/zizmor"
 [tools."aqua:zizmorcore/zizmor"."platforms.linux-arm64"]
 checksum = "sha256:711f5af366b299128f9a04b1470e37d990b41fbd21f14a1a4148d25004a83762"
 url = "https://github.com/zizmorcore/zizmor/releases/download/v1.26.1/zizmor-aarch64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/zizmorcore/zizmor/releases/assets/453417983"
 provenance = "github-attestations"
 
 [tools."aqua:zizmorcore/zizmor"."platforms.linux-arm64-musl"]
@@ -219,6 +267,7 @@ provenance = "github-attestations"
 [tools."aqua:zizmorcore/zizmor"."platforms.linux-x64"]
 checksum = "sha256:8556289a64e7aaf2400cd516f61a471aa91c5902cc56ad96a82fd12f90c2ef73"
 url = "https://github.com/zizmorcore/zizmor/releases/download/v1.26.1/zizmor-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/zizmorcore/zizmor/releases/assets/453417985"
 provenance = "github-attestations"
 
 [tools."aqua:zizmorcore/zizmor"."platforms.linux-x64-musl"]
@@ -229,16 +278,19 @@ provenance = "github-attestations"
 [tools."aqua:zizmorcore/zizmor"."platforms.macos-arm64"]
 checksum = "sha256:68ab2b37836bbd44f6cfffcc102b9ffffbc20c5d67d84293dafb63bd2775a1da"
 url = "https://github.com/zizmorcore/zizmor/releases/download/v1.26.1/zizmor-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/zizmorcore/zizmor/releases/assets/453417984"
 provenance = "github-attestations"
 
 [tools."aqua:zizmorcore/zizmor"."platforms.macos-x64"]
 checksum = "sha256:2967414a561f8c1264121e8f723c3b5abcf3d1bf7ce5063114df99985dd75801"
 url = "https://github.com/zizmorcore/zizmor/releases/download/v1.26.1/zizmor-x86_64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/zizmorcore/zizmor/releases/assets/453417982"
 provenance = "github-attestations"
 
 [tools."aqua:zizmorcore/zizmor"."platforms.windows-x64"]
 checksum = "sha256:c6cea156935e3b9d36faeca4fd8f622d23f7a7578da26adb34e6456abd9beb9a"
 url = "https://github.com/zizmorcore/zizmor/releases/download/v1.26.1/zizmor-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/zizmorcore/zizmor/releases/assets/453417981"
 provenance = "github-attestations"
 
 [[tools.node]]
@@ -272,10 +324,6 @@ url = "https://nodejs.org/dist/v24.18.0/node-v24.18.0-darwin-x64.tar.gz"
 [tools.node."platforms.windows-x64"]
 checksum = "sha256:0ae68406b42d7725661da979b1403ec9926da205c6770827f33aac9d8f26e821"
 url = "https://nodejs.org/dist/v24.18.0/node-v24.18.0-win-x64.zip"
-
-[[tools."npm:corepack"]]
-version = "0.35.0"
-backend = "npm:corepack"
 
 [[tools."npm:npm"]]
 version = "12.0.1"

--- a/.github/workflows/deflake-e2e.yml
+++ b/.github/workflows/deflake-e2e.yml
@@ -84,7 +84,7 @@ jobs:
           DEFLAKE_RUNS: ${{ inputs.runs || 5 }}
           WRANGLER_LOG: warn
           CYPRESS_video: false
-        run: corepack pnpm --filter sample-app-lit-e2e run deflake
+        run: pnpm --filter sample-app-lit-e2e run deflake
       - name: Upload attempt logs
         # Not `failure()`: a green run can still hold near-miss logs (passed
         # with the crash signature), and those are the interesting ones.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,9 +7,8 @@ This repo uses [mise](https://mise.jdx.dev) to provision the toolchain used by c
 | Tool       | Provided by                                     | Pinned in                                                                |
 | ---------- | ----------------------------------------------- | ------------------------------------------------------------------------ |
 | node       | mise                                            | [`.nvmrc`](./.nvmrc)                                                     |
-| corepack   | mise                                            | [`.config/mise/config.toml`](./.config/mise/config.toml)                 |
 | npm        | mise (shadows node's bundled npm)               | [`.config/mise/config.toml`](./.config/mise/config.toml)                 |
-| pnpm       | corepack                                        | `packageManager` in [`package.json`](./package.json) (+sha512 integrity) |
+| pnpm       | mise bootstraps, `packageManager` decides       | `packageManager` in [`package.json`](./package.json) (+sha512 integrity) |
 | turbo      | pnpm (`node_modules/.bin` on `PATH` via mise)   | [`pnpm-workspace.yaml`](./pnpm-workspace.yaml) catalog                   |
 | actionlint | mise (aqua backend, checksummed in `mise.lock`) | [`.config/mise/config.toml`](./.config/mise/config.toml)                 |
 | zizmor     | mise (aqua backend, checksummed in `mise.lock`) | [`.config/mise/config.toml`](./.config/mise/config.toml)                 |
@@ -17,12 +16,14 @@ This repo uses [mise](https://mise.jdx.dev) to provision the toolchain used by c
 ```bash
 # Install mise: https://mise.jdx.dev/getting-started.html
 mise trust
-mise install     # provisions node, corepack, npm, actionlint, zizmor
-mise run setup   # corepack-installs the pinned pnpm, then pnpm install
+mise install     # provisions node, pnpm, npm, actionlint, zizmor
+mise run setup   # pnpm install
 turbo build
 ```
 
-`mise install` provisions the pinned Node and corepack. `mise run setup` is the bootstrap layer pnpm scripts can't own (there is no `node_modules` yet): its `corepack` dependency task enables corepack and installs the `packageManager`-pinned pnpm, then `pnpm install` runs — frozen-lockfile automatically in CI. No separate `nvm use`, `pnpm add --global`, or global turbo needed. With mise active, `node_modules/.bin` is on `PATH`, so bare `turbo` (and every other workspace binary) runs the workspace-pinned version; everything after bootstrap belongs to turbo/pnpm scripts. mise-owned binaries (actionlint, zizmor) are invoked via mise tasks; package.json scripts delegate with `mise run`, never `mise exec`.
+`mise install` provisions the pinned Node and a bootstrap pnpm. `mise run setup` is the bootstrap layer pnpm scripts can't own (there is no `node_modules` yet): `pnpm install` runs — frozen-lockfile automatically in CI.
+
+The mise pin is a **bootstrap floor, not the version that runs**: pnpm ≥ 11.10 reads `packageManager` and swaps itself to it, so that field stays the single version authority for contributors, CI, and [Cloudflare Workers Builds](./DEPLOY.md) alike. corepack used to fill this role and no longer can — pnpm 12 ships as a native binary whose npm package is a placeholder, materialized by a `preinstall` hook that corepack does not run. The aqua backend fetches the release binary directly and records a checksum per platform in `mise.lock`, which is strictly more integrity than corepack's single `+sha512`. No separate `nvm use`, `pnpm add --global`, or global turbo needed. With mise active, `node_modules/.bin` is on `PATH`, so bare `turbo` (and every other workspace binary) runs the workspace-pinned version; everything after bootstrap belongs to turbo/pnpm scripts. mise-owned binaries (actionlint, zizmor) are invoked via mise tasks; package.json scripts delegate with `mise run`, never `mise exec`.
 
 pnpm's isolated `node_modules` means a workspace member's devDep binaries (`vitest`, `typedoc`, `vitepress`, …) live in that member's own `node_modules/.bin`, not the root one. When your shell is cd'd into a member directory, mise also puts that member's `.bin` first on `PATH`, so bare invocations resolve exactly as the member's own pnpm scripts would — including a member-local version shadowing the root one (e.g. `tools/vue-check`'s TypeScript 6 `tsc`). This only applies at the member's root directory, not its subdirectories; `pnpm run` inside the member works everywhere regardless. See [TURBO.md](./TURBO.md) for detailed turbo commands and workflows.
 

--- a/TURBO.md
+++ b/TURBO.md
@@ -200,7 +200,7 @@ turbo build --summarize
 The GitHub Actions workflow (`.github/workflows/build-test.yml`) runs the CI pipeline:
 
 1. **Checkout** - Clone repository
-2. **Setup** - mise installs Node.js (version pinned in `.nvmrc`) and corepack; `mise run setup` corepack-installs the `packageManager`-pinned pnpm, then installs dependencies
+2. **Setup** - mise installs Node.js (version pinned in `.nvmrc`) and a bootstrap pnpm that self-swaps to the `packageManager` pin; `mise run setup` installs dependencies
 3. **Install browsers** - Playwright and Cypress for e2e tests, restored from `actions/cache` keyed on the installed package versions
 4. **Build and Test** - PRs and branch pushes run `mise run ci` (turbo `ci:pull_request`); main pushes, `mainGraph` dispatches and `ci-main/` branches run `mise run ci_main` (turbo `ci:main`, adding the main-only guards)
 5. **Coverage reports** - Vitest coverage for PR comments, Codecov upload

--- a/apps/sample-app-lit-e2e/scripts/deflake-e2e.ts
+++ b/apps/sample-app-lit-e2e/scripts/deflake-e2e.ts
@@ -99,11 +99,9 @@ let inflight: ChildProcess | undefined;
 
 async function runAttempt(logFile: string): Promise<number> {
   const log = createWriteStream(logFile);
-  const child = spawn(
-    'corepack',
-    ['pnpm', '--filter', 'sample-app-lit-e2e', 'test'],
-    { stdio: ['ignore', 'pipe', 'pipe'] },
-  );
+  const child = spawn('pnpm', ['--filter', 'sample-app-lit-e2e', 'test'], {
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
   inflight = child;
   child.stdout.pipe(log);
   child.stderr.pipe(log);


### PR DESCRIPTION
Adopts locally the shape #574 already forces on Cloudflare: **a bootstrap pnpm that reads `packageManager` and self-swaps**, rather than a provisioner that has to understand the pin itself. Same mechanism in all three places — contributors, CI, Workers Builds.

## Why now

corepack **cannot** install pnpm 12, structurally. The npm `pnpm` package is a wrapper whose `bin/pnpm` is a placeholder text file; a `preinstall` hook hardlinks the real binary out of an `@pnpm/exe.<platform>` optionalDependency. corepack runs neither lifecycle scripts nor optional dependencies, so it installs the placeholder, **exits 0**, and the failure surfaces later as `Cannot find module …/bin/pnpm.mjs`.

That made the two branches mutually exclusive on one machine: the corepack shims live in a single shared install directory, main's `setup` re-enabled them via its `corepack` dependency task, and the pnpm-12 branch needed them gone. Removing corepack dissolves the conflict instead of managing it — no reconcile task, no per-worktree toggle.

## What changes

- `[tools]`: `npm:corepack` → `aqua:pnpm/pnpm = "11.21.0"`.
- Deletes `corepack_enable` / `corepack_install` / `corepack`; `setup` now depends only on `turbo_link_worktree`, since `mise install` puts pnpm on `PATH` by itself.
- `mise.lock` gains 6 platform entries for pnpm (matching the asset set aqua sees) and loses the corepack entry, via `mise lock`.
- `corepack pnpm …` → `pnpm …` in `deflake-e2e.yml` and `deflake-e2e.ts`. Checked the origin of that idiom first (#492) — it was the repo's convention at the time, not a workaround for anything.
- CONTRIBUTING toolchain table + bootstrap prose, TURBO.md CI description.

**11.21.0 is a bootstrap floor, not the version that runs.** It must stay ≥ 11.20.0 — below that, a pnpm-12 lockfile reads as outdated. `packageManager` remains the single version authority, so the #566 cutover becomes a one-line pin bump rather than a change of mechanism.

## Integrity

Not a downgrade: corepack verified one `+sha512` on the `packageManager` string, while `mise.lock` now records a sha256 **and** `provenance = "github-attestations"` per platform.

## Verified locally

- With the corepack shims removed, `which pnpm` resolves to the mise shim and reports `11.21.0`.
- `mise run setup` completes (`Done in 4.6s using pnpm v11.21.0`) with **zero** `pnpm-lock.yaml` drift.
- `turbo run lint --filter=//...` 16/16, `lint_workflows`, `lint_markdown`, `format:check`, taplo all green.
- `sample-app-lit-e2e` lint + typecheck green after the spawn change.

Not verifiable locally: that CI provisions correctly without the corepack leg — that's what this PR's own run proves.

## Follow-up

#566 rebases onto this and shrinks to the aqua pin, `packageManager`, and the lockfile.