### PR TITLE
build(mise): bootstrap the Workers Builds 1Password item

### DIFF
--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -153,12 +153,13 @@ run = "mise run taplo fmt --check"
 # invocation, not release logic, and at the root config_root turbo already
 # runs from the workspace root.
 
-# turbo_login, read_secret and turbo_link_worktree are file-based tasks under
-# .config/mise/tasks/ — their shell bodies were too large to sit inline. Every
-# other task here is a one- or two-liner and stays inline.
+# turbo_login, read_secret, turbo_link_worktree and cloudflare_item_create are
+# file-based tasks under .config/mise/tasks/ — their shell bodies were too large
+# to sit inline. Every other task here is a one- or two-liner and stays inline.
 
-# Both Cloudflare tasks wrap `op` over a gitignored file whose path is the only
-# thing worth memorizing; neither is required, since the check reads plain env.
+# The Cloudflare tasks wrap `op` over gitignored files whose paths are the only
+# thing worth memorizing; none is required, since the check reads plain env.
+# cloudflare_item_create bootstraps those files and the item they point at.
 # `op` is intentionally not in [tools]: a pinned copy would shadow the system
 # one and lose its desktop-app/biometric integration.
 

--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -153,13 +153,15 @@ run = "mise run taplo fmt --check"
 # invocation, not release logic, and at the root config_root turbo already
 # runs from the workspace root.
 
-# turbo_login, read_secret, turbo_link_worktree and cloudflare_item_create are
-# file-based tasks under .config/mise/tasks/ — their shell bodies were too large
-# to sit inline. Every other task here is a one- or two-liner and stays inline.
+# turbo_login, read_secret, turbo_link_worktree, cloudflare_item_create and
+# check_workers_builds are file-based tasks under .config/mise/tasks/ — their
+# shell bodies were too large to sit inline. Every other task here is a one- or
+# two-liner and stays inline.
 
 # The Cloudflare tasks wrap `op` over gitignored files whose paths are the only
 # thing worth memorizing; none is required, since the check reads plain env.
-# cloudflare_item_create bootstraps those files and the item they point at.
+# cloudflare_item_create bootstraps those files and the item they point at, and
+# check_workers_builds picks its credential source from which one exists.
 # `op` is intentionally not in [tools]: a pinned copy would shadow the system
 # one and lose its desktop-app/biometric integration.
 
@@ -171,16 +173,6 @@ run = '''
 op inject -i "{{config_root}}/.config/mise/cloudflare.local.env.tmpl" -o "{{config_root}}/.config/mise/cloudflare.local.env"
 chmod 600 "{{config_root}}/.config/mise/cloudflare.local.env"
 '''
-
-[tasks.check_workers_builds]
-# The no-secrets-at-rest path: op run injects into this process only, so the
-# Edit-scoped token --apply needs never lands in a file. Skip it and run
-# `pnpm check:workers-builds` directly when cloudflare_login's dotenv is enough.
-description = "Diff the Workers Builds triggers, credentials injected by 1Password"
-usage = '''
-flag "--apply" help="PATCH drifted triggers — writes production deploy config, needs the Edit scope"
-'''
-run = 'op run --env-file "{{config_root}}/.config/mise/cloudflare.op.env" -- pnpm check:workers-builds ${usage_apply:+-- --apply}'
 
 [tasks.build]
 # env: TURBO_TOKEN/TURBO_API/TURBO_TEAM for remote cache (ambient turbo

--- a/.config/mise/tasks/check_workers_builds
+++ b/.config/mise/tasks/check_workers_builds
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+#MISE description="Diff the Workers Builds triggers, credentials injected by 1Password"
+#
+# Two ways to hold the Cloudflare credentials, and this task picks whichever is
+# already in place rather than making the caller remember:
+#   cloudflare.local.env exists -> mise's [env] _.file already loaded it into
+#     this task's environment, so run the check directly. Wrapping it in op run
+#     would re-resolve the same two variables and prompt for authorization on
+#     every invocation, for values the process already has.
+#   otherwise -> op run --env-file, which injects into this process only. The
+#     no-secrets-at-rest path, and the one to prefer for --apply.
+# Deleting cloudflare.local.env is what switches back; the warning below says so.
+#USAGE flag "--apply" help="PATCH drifted triggers — writes production deploy config, needs the Edit scope"
+set -euo pipefail
+
+dir="${MISE_CONFIG_ROOT}/.config/mise"
+dotenv="$dir/cloudflare.local.env"
+openv="$dir/cloudflare.op.env"
+
+# Built as one array so the empty-flag case never expands an empty array.
+cmd=(pnpm check:workers-builds)
+if [ -n "${usage_apply:-}" ]; then
+  cmd+=(-- --apply)
+fi
+
+if [ -e "$dotenv" ]; then
+  echo "check_workers_builds: $dotenv exists, so mise has already put CLOUDFLARE_API_TOKEN and CLOUDFLARE_ACCOUNT_ID in this task's environment — skipping op run (it would prompt for authorization to resolve values this process already holds)." >&2
+  echo "check_workers_builds: the token in that file is the one being used. Delete it to run under 'op run' instead, which keeps no token at rest." >&2
+  exec "${cmd[@]}"
+fi
+
+if ! [ -e "$openv" ]; then
+  echo "check_workers_builds: neither $dotenv nor $openv exists; run 'mise run cloudflare_item_create' to bootstrap them" >&2
+  exit 1
+fi
+
+exec op run --env-file "$openv" -- "${cmd[@]}"

--- a/.config/mise/tasks/cloudflare_item_create
+++ b/.config/mise/tasks/cloudflare_item_create
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+#MISE description="Create the empty 1Password item behind the Workers Builds creds, plus its two op:// reference files"
+#
+# Bootstrap for cloudflare_login / check_workers_builds: both read a gitignored
+# reference file this task writes, pointed at an item it creates with EMPTY
+# fields. It never writes a value — the maintainer fills the two fields in
+# 1Password afterwards, so no credential crosses argv, history or this repo.
+#USAGE flag "--vault <vault>" help="1Password vault to create the item in" default="Private"
+#USAGE flag "--title <title>" help="Item title; it is also an op:// path segment, so keep it space-free" default="lit-ui-router-workers-builds"
+#USAGE flag "--force" help="Rewrite the two reference files if they already exist (never touches the item)"
+set -euo pipefail
+
+vault="${usage_vault:?}"
+title="${usage_title:?}"
+
+# File-based tasks are raw scripts: mise's {{config_root}} template does NOT
+# render here, so use the env var mise exports to every task.
+dir="${MISE_CONFIG_ROOT}/.config/mise"
+tmpl="$dir/cloudflare.local.env.tmpl"
+openv="$dir/cloudflare.op.env"
+
+command -v op >/dev/null 2>&1 || {
+  echo "cloudflare_item_create: no 'op' on PATH; install the 1Password CLI (deliberately not a pinned [tools] entry)" >&2
+  exit 1
+}
+
+# --force guards the files only; a pre-existing item is always left untouched,
+# because its fields may already hold a real token.
+if [ -z "${usage_force:-}" ]; then
+  for f in "$tmpl" "$openv"; do
+    if [ -e "$f" ]; then
+      echo "cloudflare_item_create: $f exists; re-run with --force to rewrite it" >&2
+      exit 1
+    fi
+  done
+fi
+
+if op item get "$title" --vault "$vault" >/dev/null 2>&1; then
+  echo "cloudflare_item_create: '$title' already exists in vault '$vault' — leaving the item untouched"
+else
+  # Secure Note: the one category with no built-in credential fields, so both
+  # names below are custom fields and the op:// path stays op://vault/item/NAME.
+  created="$(op item create \
+    --category "Secure Note" \
+    --vault "$vault" \
+    --title "$title" \
+    --format json \
+    'CLOUDFLARE_API_TOKEN[password]=' \
+    'CLOUDFLARE_ACCOUNT_ID[text]=')" || {
+    echo "cloudflare_item_create: 'op item create' failed; nothing was written. Empty field values may have been rejected — create '$title' by hand with the two empty fields, then re-run to get the reference files" >&2
+    exit 1
+  }
+  # Empty values are documented for built-in fields, not custom ones; if op
+  # dropped either field, stop before writing references that resolve to nothing.
+  for f in CLOUDFLARE_API_TOKEN CLOUDFLARE_ACCOUNT_ID; do
+    case "$created" in
+    *"\"$f\""*) ;;
+    *)
+      echo "cloudflare_item_create: created '$title' but it has no $f field — op dropped the empty value. Add it by hand (or delete the item and retry), then re-run" >&2
+      exit 1
+      ;;
+    esac
+  done
+  echo "cloudflare_item_create: created '$title' in vault '$vault' with two empty fields"
+fi
+
+# Two files, two syntaxes: op inject wants {{ op://… }}, op run --env-file wants
+# a bare reference. See DEPLOY.md — crossing them fails as a Cloudflare 401.
+ref="op://$vault/$title"
+cat >"$tmpl" <<EOF
+CLOUDFLARE_API_TOKEN={{ $ref/CLOUDFLARE_API_TOKEN }}
+CLOUDFLARE_ACCOUNT_ID={{ $ref/CLOUDFLARE_ACCOUNT_ID }}
+EOF
+cat >"$openv" <<EOF
+CLOUDFLARE_API_TOKEN=$ref/CLOUDFLARE_API_TOKEN
+CLOUDFLARE_ACCOUNT_ID=$ref/CLOUDFLARE_ACCOUNT_ID
+EOF
+echo "cloudflare_item_create: wrote $tmpl and $openv"
+
+cat <<EOF
+
+Next, by hand — this task never writes a credential:
+  1. Open '$title' in vault '$vault' and fill both fields:
+     CLOUDFLARE_API_TOKEN   user-scoped, needs Workers Builds Configuration: Edit
+     CLOUDFLARE_ACCOUNT_ID
+  2. mise run cloudflare_login        # or: mise run check_workers_builds
+EOF

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -80,12 +80,19 @@ the owning checkout.
 
 From 1Password, two mise tasks wrap `op` over gitignored files that hold `op://` references instead
 of values (no secrets, but the vault layout they encode is personal rather than repo config, so they
-stay untracked). Create whichever the chosen task needs:
+stay untracked). A third task creates both files and the item they point at:
 
-| Task                                      | Reads                                    | Reference form | Token at rest    |
-| ----------------------------------------- | ---------------------------------------- | -------------- | ---------------- |
-| `mise run cloudflare_login`               | `.config/mise/cloudflare.local.env.tmpl` | `{{ op://… }}` | yes, `chmod 600` |
-| `mise run check_workers_builds [--apply]` | `.config/mise/cloudflare.op.env`         | bare `op://…`  | no               |
+| Task                                      | Reads / writes                                                                     | Reference form | Token at rest    |
+| ----------------------------------------- | ---------------------------------------------------------------------------------- | -------------- | ---------------- |
+| `mise run cloudflare_item_create`         | writes `.config/mise/cloudflare.local.env.tmpl` + `.config/mise/cloudflare.op.env` | both           | no               |
+| `mise run cloudflare_login`               | reads `.config/mise/cloudflare.local.env.tmpl`                                     | `{{ op://… }}` | yes, `chmod 600` |
+| `mise run check_workers_builds [--apply]` | reads `.config/mise/cloudflare.op.env`                                             | bare `op://…`  | no               |
+
+`cloudflare_item_create` is the one-time bootstrap: it creates a Secure Note (`--vault Private`,
+`--title lit-ui-router-workers-builds`) whose two fields are named after the variables and left
+**empty**, then writes both reference files pointed at it. Fill the fields in 1Password afterwards —
+the task never writes a credential. It is idempotent on the item: an existing one is left untouched,
+and the two files are only rewritten with `--force`.
 
 `cloudflare_login` regenerates the dotenv above with `op inject`, so edit the template and re-run
 rather than editing the dotenv. `check_workers_builds` skips the dotenv entirely and runs the diff
@@ -97,9 +104,9 @@ One file per task, because the two syntaxes are mutually exclusive: `op inject` 
 yields a dotenv of literal reference strings, surfacing as an auth failure from Cloudflare rather
 than as an error from `op`.
 
-Neither task is required — both only supply the two variables, so `pnpm check:workers-builds` with
-them already in the environment works the same. `op` is deliberately not a pinned `[tools]` entry: a
-mise-managed copy would shadow the system one and lose its desktop-app integration.
+None of the three is required — they only supply the two variables, so `pnpm check:workers-builds`
+with them already in the environment works the same. `op` is deliberately not a pinned `[tools]`
+entry: a mise-managed copy would shadow the system one and lose its desktop-app integration.
 
 #### CD-pipeline verification signal
 

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -82,11 +82,11 @@ From 1Password, two mise tasks wrap `op` over gitignored files that hold `op://`
 of values (no secrets, but the vault layout they encode is personal rather than repo config, so they
 stay untracked). A third task creates both files and the item they point at:
 
-| Task                                      | Reads / writes                                                                     | Reference form | Token at rest    |
-| ----------------------------------------- | ---------------------------------------------------------------------------------- | -------------- | ---------------- |
-| `mise run cloudflare_item_create`         | writes `.config/mise/cloudflare.local.env.tmpl` + `.config/mise/cloudflare.op.env` | both           | no               |
-| `mise run cloudflare_login`               | reads `.config/mise/cloudflare.local.env.tmpl`                                     | `{{ op://… }}` | yes, `chmod 600` |
-| `mise run check_workers_builds [--apply]` | reads `.config/mise/cloudflare.op.env`                                             | bare `op://…`  | no               |
+| Task                                      | Reads / writes                                                                      | Reference form | Token at rest               |
+| ----------------------------------------- | ----------------------------------------------------------------------------------- | -------------- | --------------------------- |
+| `mise run cloudflare_item_create`         | writes `.config/mise/cloudflare.local.env.tmpl` + `.config/mise/cloudflare.op.env`  | both           | no                          |
+| `mise run cloudflare_login`               | reads `.config/mise/cloudflare.local.env.tmpl`                                      | `{{ op://… }}` | yes, `chmod 600`            |
+| `mise run check_workers_builds [--apply]` | reads whichever exists: the dotenv (via mise) else `.config/mise/cloudflare.op.env` | bare `op://…`  | only if it found the dotenv |
 
 `cloudflare_item_create` is the one-time bootstrap: it creates a Secure Note (`--vault Private`,
 `--title lit-ui-router-workers-builds`) whose two fields are named after the variables and left
@@ -95,9 +95,16 @@ the task never writes a credential. It is idempotent on the item: an existing on
 and the two files are only rewritten with `--force`.
 
 `cloudflare_login` regenerates the dotenv above with `op inject`, so edit the template and re-run
-rather than editing the dotenv. `check_workers_builds` skips the dotenv entirely and runs the diff
-under `op run`, which injects into that process only — the path to prefer for `--apply`, whose
-**Edit**-scoped token is the one worth never writing to disk.
+rather than editing the dotenv.
+
+`check_workers_builds` picks its credential source rather than asking you to remember which one is
+set up. If `cloudflare.local.env` exists, mise's `[env] _.file` has already put both variables in the
+task's environment, so it runs the diff directly and warns that it did — wrapping that in `op run`
+would prompt for authorization on every invocation to re-resolve values the process already holds.
+With no dotenv it runs under `op run --env-file`, which injects into that process only: the
+no-secrets-at-rest path, and the one to prefer for `--apply`, whose **Edit**-scoped token is the one
+worth never writing to disk. Deleting the dotenv is what switches back — after an `--apply`, that is
+worth doing, since the file outlives the write it was created for.
 
 One file per task, because the two syntaxes are mutually exclusive: `op inject` substitutes
 `{{ op://… }}` and passes a bare `op://…` through untouched, so pointing it at the `op run` file


### PR DESCRIPTION
## What

Adds `mise run cloudflare_item_create` — the one-time bootstrap for the Cloudflare Workers Builds credential flow that #579/#580/#581 documented and wrapped but never automated.

It creates a 1Password item with `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` **empty**, then writes the two gitignored reference files that `cloudflare_login` and `check_workers_builds` read, and prints the one manual step left (fill the two fields in 1Password).

```console
$ mise run cloudflare_item_create --help
Create the empty 1Password item behind the Workers Builds creds, plus its two op:// reference files

Usage: //:cloudflare_item_create [FLAGS]

Flags:
  --vault <vault>  1Password vault to create the item in
  --title <title>  Item title; it is also an op:// path segment, so keep it
                   space-free
  --force          Rewrite the two reference files if they already exist (never
                   touches the item)
```

Defaults: `--vault Private`, `--title lit-ui-router-workers-builds`.

## The `op` invocation

```sh
op item create \
  --category "Secure Note" \
  --vault "$vault" \
  --title "$title" \
  --format json \
  'CLOUDFLARE_API_TOKEN[password]=' \
  'CLOUDFLARE_ACCOUNT_ID[text]='
```

Syntax from the 1Password CLI reference — assignment statements are `[<section>.]<field>[[<fieldType>]]=<value>`, and `password`/`text` are the `CONCEALED`/`STRING` custom field types. Secure Note is the category with no built-in credential fields, so both names land as top-level custom fields and the reference stays `op://<vault>/<item>/<NAME>`; the default title is space-free for the same reason.

## Design notes

- **Never writes a credential.** No value crosses argv, shell history, or this repo — the maintainer fills the fields in the 1Password UI.
- **Asymmetric idempotence, on purpose.** A pre-existing item is *always* left completely untouched, since its fields may already hold a live token; `--force` only governs rewriting the two reference files.
- **Empty values fail loudly, not halfway.** Empty values are documented for built-in fields but *not* for custom ones, and there is at least one community report of `op` rejecting an empty password at create time. So the create result is checked twice: a non-zero exit *and* a field missing from the returned JSON both abort before any reference file is written, each with a message naming what to finish by hand.
- File-based task (`$MISE_CONFIG_ROOT`, not `{{config_root}}`) because the body is well past the two-liner bar the other Cloudflare tasks sit at.

## Unverified, and why

**No `op` command was run at any point while building this.** Every `op` invocation triggers an interactive authorization prompt on the maintainer's desktop, so the task ships unverified against the live CLI. Concretely unverified:

- whether `op item create` accepts `FIELD[password]=` with an empty value for a **custom** field (the docs cover empty strings for built-in fields only) — this is the single most likely failure, and the guard above is what turns it into a clean abort instead of a half-created item;
- whether the item-exists probe (`op item get "$title" --vault "$vault"`) distinguishes not-found from an auth failure. It does not, by design: an auth failure falls through to the create, which then fails loudly with its own message.

No Cloudflare API call was made and no real credential was created or handled.

## Verified without `op`

- `mise run cloudflare_item_create --help` renders (above); the task parses and lists in `mise tasks ls`.
- `bash -n` clean; `mise run lint_shellcheck` green.
- Full script exercised end-to-end against a **local stub** named `op` in a throwaway `MISE_CONFIG_ROOT` — covering create, the two written files byte-for-byte, the no-`--force` refusal, and the existing-item path (stub asserts `item create` is never reached). Output:

  ```text
  CLOUDFLARE_API_TOKEN={{ op://Private/lit-ui-router-workers-builds/CLOUDFLARE_API_TOKEN }}
  CLOUDFLARE_ACCOUNT_ID={{ op://Private/lit-ui-router-workers-builds/CLOUDFLARE_ACCOUNT_ID }}
  ```

  ```text
  CLOUDFLARE_API_TOKEN=op://Private/lit-ui-router-workers-builds/CLOUDFLARE_API_TOKEN
  CLOUDFLARE_ACCOUNT_ID=op://Private/lit-ui-router-workers-builds/CLOUDFLARE_ACCOUNT_ID
  ```

- `mise run lint_workflows`, `mise run lint_markdown`, `turbo run format:check --filter=//...`, `mise run format_check_toml` — all green.

## Docs

`DEPLOY.md` "Dashboard as Code": the task table gains the new row (and a `Reads / writes` column, since this one writes), plus a paragraph on the bootstrap and its idempotence. `.config/mise/config.toml` comments updated for the third Cloudflare task and the file-based-task list.

Auto-merge deliberately not armed.
