### PR TITLE
build(mise): pick the credential source in check_workers_builds

### DIFF
--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -165,13 +165,15 @@ run = "mise run taplo fmt --check"
 # invocation, not release logic, and at the root config_root turbo already
 # runs from the workspace root.
 
-# turbo_login, read_secret, turbo_link_worktree and cloudflare_item_create are
-# file-based tasks under .config/mise/tasks/ — their shell bodies were too large
-# to sit inline. Every other task here is a one- or two-liner and stays inline.
+# turbo_login, read_secret, turbo_link_worktree, cloudflare_item_create and
+# check_workers_builds are file-based tasks under .config/mise/tasks/ — their
+# shell bodies were too large to sit inline. Every other task here is a one- or
+# two-liner and stays inline.
 
 # The Cloudflare tasks wrap `op` over gitignored files whose paths are the only
 # thing worth memorizing; none is required, since the check reads plain env.
-# cloudflare_item_create bootstraps those files and the item they point at.
+# cloudflare_item_create bootstraps those files and the item they point at, and
+# check_workers_builds picks its credential source from which one exists.
 # `op` is intentionally not in [tools]: a pinned copy would shadow the system
 # one and lose its desktop-app/biometric integration.
 
@@ -183,16 +185,6 @@ run = '''
 op inject -i "{{config_root}}/.config/mise/cloudflare.local.env.tmpl" -o "{{config_root}}/.config/mise/cloudflare.local.env"
 chmod 600 "{{config_root}}/.config/mise/cloudflare.local.env"
 '''
-
-[tasks.check_workers_builds]
-# The no-secrets-at-rest path: op run injects into this process only, so the
-# Edit-scoped token --apply needs never lands in a file. Skip it and run
-# `pnpm check:workers-builds` directly when cloudflare_login's dotenv is enough.
-description = "Diff the Workers Builds triggers, credentials injected by 1Password"
-usage = '''
-flag "--apply" help="PATCH drifted triggers — writes production deploy config, needs the Edit scope"
-'''
-run = 'op run --env-file "{{config_root}}/.config/mise/cloudflare.op.env" -- pnpm check:workers-builds ${usage_apply:+-- --apply}'
 
 [tasks.build]
 # env: TURBO_TOKEN/TURBO_API/TURBO_TEAM for remote cache (ambient turbo

--- a/.config/mise/tasks/check_workers_builds
+++ b/.config/mise/tasks/check_workers_builds
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+#MISE description="Diff the Workers Builds triggers, credentials injected by 1Password"
+#
+# Two ways to hold the Cloudflare credentials, and this task picks whichever is
+# already in place rather than making the caller remember:
+#   cloudflare.local.env exists -> mise's [env] _.file already loaded it into
+#     this task's environment, so run the check directly. Wrapping it in op run
+#     would re-resolve the same two variables and prompt for authorization on
+#     every invocation, for values the process already has.
+#   otherwise -> op run --env-file, which injects into this process only. The
+#     no-secrets-at-rest path, and the one to prefer for --apply.
+# Deleting cloudflare.local.env is what switches back; the warning below says so.
+#USAGE flag "--apply" help="PATCH drifted triggers — writes production deploy config, needs the Edit scope"
+set -euo pipefail
+
+dir="${MISE_CONFIG_ROOT}/.config/mise"
+dotenv="$dir/cloudflare.local.env"
+openv="$dir/cloudflare.op.env"
+
+# Built as one array so the empty-flag case never expands an empty array.
+cmd=(pnpm check:workers-builds)
+if [ -n "${usage_apply:-}" ]; then
+  cmd+=(-- --apply)
+fi
+
+if [ -e "$dotenv" ]; then
+  echo "check_workers_builds: $dotenv exists, so mise has already put CLOUDFLARE_API_TOKEN and CLOUDFLARE_ACCOUNT_ID in this task's environment — skipping op run (it would prompt for authorization to resolve values this process already holds)." >&2
+  echo "check_workers_builds: the token in that file is the one being used. Delete it to run under 'op run' instead, which keeps no token at rest." >&2
+  exec "${cmd[@]}"
+fi
+
+if ! [ -e "$openv" ]; then
+  echo "check_workers_builds: neither $dotenv nor $openv exists; run 'mise run cloudflare_item_create' to bootstrap them" >&2
+  exit 1
+fi
+
+exec op run --env-file "$openv" -- "${cmd[@]}"

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -77,11 +77,11 @@ From 1Password, two mise tasks wrap `op` over gitignored files that hold `op://`
 of values (no secrets, but the vault layout they encode is personal rather than repo config, so they
 stay untracked). A third task creates both files and the item they point at:
 
-| Task                                      | Reads / writes                                                                     | Reference form | Token at rest    |
-| ----------------------------------------- | ---------------------------------------------------------------------------------- | -------------- | ---------------- |
-| `mise run cloudflare_item_create`         | writes `.config/mise/cloudflare.local.env.tmpl` + `.config/mise/cloudflare.op.env` | both           | no               |
-| `mise run cloudflare_login`               | reads `.config/mise/cloudflare.local.env.tmpl`                                     | `{{ op://… }}` | yes, `chmod 600` |
-| `mise run check_workers_builds [--apply]` | reads `.config/mise/cloudflare.op.env`                                             | bare `op://…`  | no               |
+| Task                                      | Reads / writes                                                                      | Reference form | Token at rest               |
+| ----------------------------------------- | ----------------------------------------------------------------------------------- | -------------- | --------------------------- |
+| `mise run cloudflare_item_create`         | writes `.config/mise/cloudflare.local.env.tmpl` + `.config/mise/cloudflare.op.env`  | both           | no                          |
+| `mise run cloudflare_login`               | reads `.config/mise/cloudflare.local.env.tmpl`                                      | `{{ op://… }}` | yes, `chmod 600`            |
+| `mise run check_workers_builds [--apply]` | reads whichever exists: the dotenv (via mise) else `.config/mise/cloudflare.op.env` | bare `op://…`  | only if it found the dotenv |
 
 `cloudflare_item_create` is the one-time bootstrap: it creates a Secure Note (`--vault Private`,
 `--title lit-ui-router-workers-builds`) whose two fields are named after the variables and left
@@ -90,9 +90,16 @@ the task never writes a credential. It is idempotent on the item: an existing on
 and the two files are only rewritten with `--force`.
 
 `cloudflare_login` regenerates the dotenv above with `op inject`, so edit the template and re-run
-rather than editing the dotenv. `check_workers_builds` skips the dotenv entirely and runs the diff
-under `op run`, which injects into that process only — the path to prefer for `--apply`, whose
-**Edit**-scoped token is the one worth never writing to disk.
+rather than editing the dotenv.
+
+`check_workers_builds` picks its credential source rather than asking you to remember which one is
+set up. If `cloudflare.local.env` exists, mise's `[env] _.file` has already put both variables in the
+task's environment, so it runs the diff directly and warns that it did — wrapping that in `op run`
+would prompt for authorization on every invocation to re-resolve values the process already holds.
+With no dotenv it runs under `op run --env-file`, which injects into that process only: the
+no-secrets-at-rest path, and the one to prefer for `--apply`, whose **Edit**-scoped token is the one
+worth never writing to disk. Deleting the dotenv is what switches back — after an `--apply`, that is
+worth doing, since the file outlives the write it was created for.
 
 One file per task, because the two syntaxes are mutually exclusive: `op inject` substitutes
 `{{ op://… }}` and passes a bare `op://…` through untouched, so pointing it at the `op run` file


### PR DESCRIPTION
Stacked on #583 (base `build/mise-cloudflare-item-create`) — it edits the same comment block listing the file-based tasks.

`check_workers_builds` always wrapped the diff in `op run`, which prompts for 1Password authorization **on every invocation**. When `.config/mise/cloudflare.local.env` exists, that prompt buys nothing: mise's `[env] _.file` has already put `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` in the task's environment, so `op run` re-resolves two values the process already holds.

It also made every run ambiguous about which mechanism actually supplied the credentials — a green run proved the dotenv worked, `op run` worked, or both.

## Behaviour

| state | what runs | warning |
| --- | --- | --- |
| `cloudflare.local.env` exists | `pnpm check:workers-builds` directly | names the file, says the token in it is the one being used, and that deleting it switches to `op run` |
| no dotenv, `cloudflare.op.env` exists | `op run --env-file … -- pnpm check:workers-builds` | none — the no-secrets-at-rest path |
| neither | exit 1 | points at `mise run cloudflare_item_create` |

The warning is the point: the task picks a credential source, so it has to say which one it picked. Both lines go to stderr; `--apply` passes through either path.

## Why a file-based task

The conditional puts it past the one-or-two-liner bar that keeps tasks inline in `config.toml`, so it joins `turbo_login`, `read_secret`, `turbo_link_worktree` and `cloudflare_item_create` under `.config/mise/tasks/`. That also brings it under the `lint_shellcheck` gate. `{{config_root}}` does not render in a file-based task, so it reads `$MISE_CONFIG_ROOT` like its siblings.

The command is built as one array (`cmd=(pnpm check:workers-builds)`, `+=(-- --apply)`) rather than an array of flags, so the no-flag case never expands an empty array under `set -u`.

## Verification

Both paths exercised, no real `op` invoked at any point:

- **op path** — dotenv moved aside, a stub `op` first on `PATH`. Confirms the exact argv, including flag passthrough:
  ```
  STUB op run --env-file …/cloudflare.op.env -- pnpm check:workers-builds
  STUB op run --env-file …/cloudflare.op.env -- pnpm check:workers-builds -- --apply
  ```
- **dotenv path** — real live read-only run: both warnings printed, then `✓ Workers Builds triggers match the desired state`.

`bash -n`, `lint_shellcheck`, `lint_markdown`, `lint_workflows`, `turbo run format` all clean.

### Found while testing

The first dotenv-path run reported **drift** — because this branch was stacked on #583, which predated #574, so it diffed the live dashboard against the *old* desired state. Harmless read-only, but the same command with `--apply` from a stale branch would have silently reverted the dashboard. Both branches have since been rebased onto `main`, and the re-run is green.

Worth knowing generally: `--apply` writes whatever the working tree says, so it belongs on a checkout of current `main`, not a feature branch.

## Changes

- `.config/mise/tasks/check_workers_builds` — new, 0755, `#MISE description` + `#USAGE flag "--apply"`.
- `.config/mise/config.toml` — inline `[tasks.check_workers_builds]` removed; the file-based-task list and the Cloudflare block comment updated.
- `DEPLOY.md` — the task table's `Reads` and `Token at rest` cells now describe the branch, plus a paragraph on the selection rule and on deleting the dotenv after an `--apply`.
