### PR TITLE
build(workers-builds): declare CYPRESS_INSTALL_BINARY and HUSKY on both triggers

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -149,6 +149,11 @@ and leaves every other variable on the trigger untouched.
   command, per [Build & Deploy Commands](#build--deploy-commands). Without it Cloudflare
   runs its own corepack-provisioned `pnpm install` first and the build fails there;
   deleting it in the dashboard breaks every deploy.
+- `CYPRESS_INSTALL_BINARY=0` — the Cypress binary belongs to the e2e suite, which a docs
+  deploy never runs. Without it the install downloads and unzips it every build (~15s).
+  `mise run setup` sets the same thing locally.
+- `HUSKY=0` — the root `prepare` script installs git hooks, which mean nothing in a build
+  container. Matches the `env: HUSKY: 0` every CI workflow sets.
 
 **Unmanaged** (dashboard-only; listed in the diff output as `(unmanaged)`, never diffed or patched):
 

--- a/tools/workers-builds/workers-builds-triggers.config.jsonc
+++ b/tools/workers-builds/workers-builds-triggers.config.jsonc
@@ -11,11 +11,17 @@
   // runs neither). npx bootstraps the last pnpm 11 instead, which reads
   // `packageManager` and self-swaps. Every command uses npx because the unusable
   // corepack `pnpm` shim stays first on PATH.
+  // CYPRESS_INSTALL_BINARY=0 and HUSKY=0 skip install work a docs deploy never
+  // uses: the Cypress binary (download + unzip, ~15s) belongs to the e2e suite,
+  // and the husky git hooks to a developer checkout. Both mirror what
+  // `mise run setup` and the CI workflows already set.
   "production": {
     "build_command": "npx pnpm@11.21.0 install --frozen-lockfile && npx turbo docs#build",
     "deploy_command": "npx wrangler deploy",
     "environment_variables": {
       "SKIP_DEPENDENCY_INSTALL": "1",
+      "CYPRESS_INSTALL_BINARY": "0",
+      "HUSKY": "0",
     },
   },
   "preview": {
@@ -23,6 +29,8 @@
     "deploy_command": "npx wrangler versions upload",
     "environment_variables": {
       "SKIP_DEPENDENCY_INSTALL": "1",
+      "CYPRESS_INSTALL_BINARY": "0",
+      "HUSKY": "0",
     },
   },
 }

--- a/tools/workers-builds/workers-builds-triggers.fixtures.json
+++ b/tools/workers-builds/workers-builds-triggers.fixtures.json
@@ -10,6 +10,8 @@
       "branch_excludes": [],
       "environment_variables": {
         "SKIP_DEPENDENCY_INSTALL": { "value": "1", "is_secret": false },
+        "CYPRESS_INSTALL_BINARY": { "value": "0", "is_secret": false },
+        "HUSKY": { "value": "0", "is_secret": false },
         "VITE_GOOGLE_ANALYTICS_TRACKING_ID": {
           "value": "G-XXXXXXXXXX",
           "is_secret": false
@@ -26,6 +28,8 @@
       "branch_excludes": ["main"],
       "environment_variables": {
         "SKIP_DEPENDENCY_INSTALL": { "value": "1", "is_secret": false },
+        "CYPRESS_INSTALL_BINARY": { "value": "0", "is_secret": false },
+        "HUSKY": { "value": "0", "is_secret": false },
         "TURBO_TOKEN": { "is_secret": true }
       }
     }

--- a/tools/workers-builds/workers-builds-triggers.test.ts
+++ b/tools/workers-builds/workers-builds-triggers.test.ts
@@ -43,6 +43,16 @@ const withEnvironment = (
   environment_variables: NonNullable<Trigger['environment_variables']>,
 ): Trigger => ({ ...trigger, environment_variables });
 
+// Every declared preview key as the API would return it in sync. Derived from
+// the config rather than spelled out, so declaring another variable doesn't
+// turn each single-key scenario below into unrelated drift.
+const declaredPreviewLive: NonNullable<Trigger['environment_variables']> =
+  Object.fromEntries(
+    Object.entries(desired.preview.environment_variables ?? {}).map(
+      ([key, value]) => [key, { value, is_secret: false }],
+    ),
+  );
+
 describe('parseJsonc', () => {
   it('parses the repo wrangler.jsonc (comments + trailing commas)', async () => {
     const raw = await readFile(
@@ -203,6 +213,7 @@ describe('diffTriggers', () => {
 
   it('drifts on a declared environment variable with the wrong value', () => {
     const drifted = withEnvironment(triggers.preview, {
+      ...declaredPreviewLive,
       SKIP_DEPENDENCY_INSTALL: { value: '0', is_secret: false },
     });
     const { report, drifts } = diffTriggers(
@@ -230,15 +241,14 @@ describe('diffTriggers', () => {
       desired,
     );
     assert.equal(report.ok, false);
-    assert.deepEqual(drifts[0]?.environmentPatch, {
-      SKIP_DEPENDENCY_INSTALL: { value: '1', is_secret: false },
-    });
+    // Every declared key is absent, so every one is patched.
+    assert.deepEqual(drifts[0]?.environmentPatch, declaredPreviewLive);
     assert.match(report.text, /SKIP_DEPENDENCY_INSTALL {12}\(absent\)/);
   });
 
   it('reports undeclared environment variables as unmanaged, never drift', () => {
     const extra = withEnvironment(triggers.preview, {
-      SKIP_DEPENDENCY_INSTALL: { value: '1', is_secret: false },
+      ...declaredPreviewLive,
       SOMETHING_ELSE: { value: 'dashboard-only', is_secret: false },
       TURBO_TOKEN: { is_secret: true },
     });
@@ -260,13 +270,15 @@ describe('diffTriggers', () => {
       TURBO_TOKEN: { is_secret: true },
     });
     const { drifts } = diffTriggers([triggers.production, drifted], desired);
-    assert.deepEqual(Object.keys(drifts[0]?.environmentPatch ?? {}), [
-      'SKIP_DEPENDENCY_INSTALL',
-    ]);
+    assert.deepEqual(
+      Object.keys(drifts[0]?.environmentPatch ?? {}),
+      Object.keys(declaredPreviewLive),
+    );
   });
 
   it('refuses to overwrite a declared key that is live-secret', () => {
     const conflicted = withEnvironment(triggers.preview, {
+      ...declaredPreviewLive,
       SKIP_DEPENDENCY_INSTALL: { is_secret: true },
     });
     const { report, drifts } = diffTriggers(


### PR DESCRIPTION
Follow-up to #574, from reading the first production build log under the new config.

The docs deploy spends time on install work it never uses:

```
.../cypress@15.20.1 postinstall: Downloading Cypress
.../cypress@15.20.1 postinstall: Unzipping Cypress
. prepare$ husky
Done in 38.9s using pnpm v11.21.0
```

Cypress is roughly 15 of those 39 seconds — downloaded and unzipped on every production and preview build, for a suite the docs deploy never runs. `husky` installs git hooks into a build container that is thrown away.

Both are already switched off everywhere else: `mise run setup` sets `CYPRESS_INSTALL_BINARY=0`, and every CI workflow sets `env: HUSKY: 0`. Cloudflare was the one environment with no equivalent — until #574 made build environment variables declarable, this was not expressible in the repo at all.

## Changes

- `workers-builds-triggers.config.jsonc` — `CYPRESS_INSTALL_BINARY=0` and `HUSKY=0` on both triggers, with a comment on why each is safe to skip.
- `workers-builds-triggers.fixtures.json` — the live-in-sync fixture gains both keys.
- `workers-builds-triggers.test.ts` — see below.
- `DEPLOY.md` — both listed under **Declared**, with the reason and the local/CI counterpart each mirrors.

## Test change worth reviewing

The diff tests run against the real config, so every scenario that replaced a trigger's whole environment map hardcoded `SKIP_DEPENDENCY_INSTALL` as *the* declared key. Declaring two more turned five of those into unrelated drift — 9 failures, none of them a real defect.

Rather than spell out three keys in five places, the declared set is now derived from the config once:

```ts
const declaredPreviewLive = Object.fromEntries(
  Object.entries(desired.preview.environment_variables ?? {}).map(
    ([key, value]) => [key, { value, is_secret: false }],
  ),
);
```

Each scenario spreads that and overrides only the key under test, so "wrong value", "absent", "unmanaged", and "live-secret" stay single-variable scenarios. Declaring a fourth variable later will not touch this file.

Two assertions changed meaning rather than form, both deliberately:

- *drifts on a declared variable missing from the trigger* — the whole map is emptied, so the patch is now every declared key, asserted as `declaredPreviewLive` instead of one literal.
- *never patches unmanaged keys alongside a drifted declared key* — asserts the patch keys equal the declared keys, which is what the test was always about; the single-element literal was incidental.

No assertion was weakened: the unmanaged keys (`SOMETHING_ELSE`, `TURBO_TOKEN`) are still asserted absent from every patch, and the secret-refusal path is unchanged. 21/21 pass.

## Verification

`turbo run test lint typecheck --filter=@tools/workers-builds` green, 21/21. `turbo run format`, `lint_markdown` clean.

Live read-only `mise run check_workers_builds` against the real account shows exactly the intended delta and nothing else:

```
  ✓ build_command      npx pnpm@11.21.0 install --frozen-lockfile && npx turbo docs#build
  ✓ deploy_command     npx wrangler deploy
  ✓   SKIP_DEPENDENCY_INSTALL            1
  ✗   CYPRESS_INSTALL_BINARY             (absent)
  ✗   HUSKY                              (absent)
✗ 2 trigger(s) drifted from the desired state.
```

`--apply` has not been run. Merging changes nothing by itself — the config is inert until an apply, and this one is low-risk in both directions: if either variable turned out to be wrong, the build would install more than it needs, not less.
