### PR TITLE
build(workspace): declare oxlint and oxfmt in every package that runs them

### DIFF
--- a/apps/sample-app-lit-e2e/package.json
+++ b/apps/sample-app-lit-e2e/package.json
@@ -30,6 +30,7 @@
     "concurrently": "catalog:",
     "cypress": "catalog:",
     "oxfmt": "catalog:",
+    "oxlint": "catalog:",
     "start-server-and-test": "catalog:",
     "typescript": "catalog:typescript6-compat",
     "vite": "catalog:"

--- a/apps/sample-app-lit-e2e/package.json
+++ b/apps/sample-app-lit-e2e/package.json
@@ -33,6 +33,7 @@
     "oxlint": "catalog:",
     "start-server-and-test": "catalog:",
     "typescript": "catalog:typescript6-compat",
+    "typescript-7": "catalog:",
     "vite": "catalog:"
   }
 }

--- a/apps/sample-app-lit-mobx/package.json
+++ b/apps/sample-app-lit-mobx/package.json
@@ -27,6 +27,7 @@
     "@types/lodash": "catalog:",
     "@types/node": "catalog:",
     "oxfmt": "catalog:",
+    "oxlint": "catalog:",
     "typescript": "catalog:typescript6-compat",
     "vite": "catalog:",
     "wrangler": "catalog:"

--- a/apps/sample-app-lit-mobx/package.json
+++ b/apps/sample-app-lit-mobx/package.json
@@ -29,6 +29,7 @@
     "oxfmt": "catalog:",
     "oxlint": "catalog:",
     "typescript": "catalog:typescript6-compat",
+    "typescript-7": "catalog:",
     "vite": "catalog:",
     "wrangler": "catalog:"
   }

--- a/apps/sample-app-lit-vanilla/package.json
+++ b/apps/sample-app-lit-vanilla/package.json
@@ -28,6 +28,7 @@
     "oxfmt": "catalog:",
     "oxlint": "catalog:",
     "typescript": "catalog:typescript6-compat",
+    "typescript-7": "catalog:",
     "vite": "catalog:",
     "wrangler": "catalog:"
   }

--- a/apps/sample-app-lit-vanilla/package.json
+++ b/apps/sample-app-lit-vanilla/package.json
@@ -26,6 +26,7 @@
     "@types/lodash": "catalog:",
     "@types/node": "catalog:",
     "oxfmt": "catalog:",
+    "oxlint": "catalog:",
     "typescript": "catalog:typescript6-compat",
     "vite": "catalog:",
     "wrangler": "catalog:"

--- a/apps/sample-app-routes/package.json
+++ b/apps/sample-app-routes/package.json
@@ -21,6 +21,7 @@
     "@tools/wintercg-globals": "workspace:*",
     "@types/node": "catalog:",
     "oxfmt": "catalog:",
+    "oxlint": "catalog:",
     "typescript": "catalog:"
   }
 }

--- a/apps/sample-app-shared/package.json
+++ b/apps/sample-app-shared/package.json
@@ -36,6 +36,7 @@
     "@types/node": "catalog:",
     "@vitest/browser-playwright": "catalog:",
     "oxfmt": "catalog:",
+    "oxlint": "catalog:",
     "playwright": "catalog:",
     "typescript": "catalog:",
     "vite": "catalog:",

--- a/docs/package.json
+++ b/docs/package.json
@@ -36,6 +36,7 @@
     "lit-ui-router": "workspace:*",
     "lit-ui-router-mobx": "workspace:*",
     "oxfmt": "catalog:",
+    "oxlint": "catalog:",
     "typescript": "catalog:",
     "ui-router-navigation-location-plugin": "workspace:*",
     "vite": "catalog:",

--- a/examples/package.json
+++ b/examples/package.json
@@ -19,6 +19,8 @@
   },
   "devDependencies": {
     "concurrently": "catalog:",
+    "oxfmt": "catalog:",
+    "oxlint": "catalog:",
     "typescript": "catalog:"
   }
 }

--- a/packages/lit-ui-router-mobx/package.json
+++ b/packages/lit-ui-router-mobx/package.json
@@ -81,6 +81,7 @@
     "mobx": "catalog:",
     "mobx-6": "catalog:mobx6-compat",
     "oxfmt": "catalog:",
+    "oxlint": "catalog:",
     "release-it": "catalog:",
     "rimraf": "catalog:",
     "typedoc": "catalog:",

--- a/packages/lit-ui-router-mobx/package.json
+++ b/packages/lit-ui-router-mobx/package.json
@@ -88,6 +88,7 @@
     "typedoc-plugin-markdown": "catalog:",
     "typedoc-vitepress-theme": "catalog:",
     "typescript": "catalog:typescript6-compat",
+    "typescript-7": "catalog:",
     "vitest": "catalog:"
   },
   "peerDependencies": {

--- a/packages/lit-ui-router/package.json
+++ b/packages/lit-ui-router/package.json
@@ -92,6 +92,7 @@
     "lit-2": "catalog:lit2-compat",
     "oxc-project-runtime": "catalog:",
     "oxfmt": "catalog:",
+    "oxlint": "catalog:",
     "playwright": "catalog:",
     "release-it": "catalog:",
     "rimraf": "catalog:",

--- a/packages/lit-ui-router/package.json
+++ b/packages/lit-ui-router/package.json
@@ -100,6 +100,7 @@
     "typedoc-plugin-markdown": "catalog:",
     "typedoc-vitepress-theme": "catalog:",
     "typescript": "catalog:typescript6-compat",
+    "typescript-7": "catalog:",
     "vitest": "catalog:"
   },
   "peerDependencies": {

--- a/packages/navigation-location-plugin/package.json
+++ b/packages/navigation-location-plugin/package.json
@@ -70,6 +70,7 @@
     "@vitest/coverage-v8": "catalog:",
     "happy-dom": "catalog:",
     "oxfmt": "catalog:",
+    "oxlint": "catalog:",
     "playwright": "catalog:",
     "release-it": "catalog:",
     "rimraf": "catalog:",

--- a/packages/navigation-location-plugin/package.json
+++ b/packages/navigation-location-plugin/package.json
@@ -78,6 +78,7 @@
     "typedoc-plugin-markdown": "catalog:",
     "typedoc-vitepress-theme": "catalog:",
     "typescript": "catalog:typescript6-compat",
+    "typescript-7": "catalog:",
     "vitest": "catalog:"
   },
   "peerDependencies": {

--- a/packages/ui-router-server/package.json
+++ b/packages/ui-router-server/package.json
@@ -90,6 +90,7 @@
     "@uirouter/core": "catalog:",
     "hono": "catalog:",
     "oxfmt": "catalog:",
+    "oxlint": "catalog:",
     "release-it": "catalog:",
     "rimraf": "catalog:",
     "typedoc": "catalog:",

--- a/packages/ui-router-server/package.json
+++ b/packages/ui-router-server/package.json
@@ -97,6 +97,7 @@
     "typedoc-plugin-markdown": "catalog:",
     "typedoc-vitepress-theme": "catalog:",
     "typescript": "catalog:typescript6-compat",
+    "typescript-7": "catalog:",
     "vite": "catalog:"
   },
   "peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -385,6 +385,9 @@ importers:
       typescript:
         specifier: catalog:typescript6-compat
         version: '@typescript/typescript6@6.0.2'
+      typescript-7:
+        specifier: 'catalog:'
+        version: typescript@7.0.2
       vite:
         specifier: 'catalog:'
         version: 8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)
@@ -434,6 +437,9 @@ importers:
       typescript:
         specifier: catalog:typescript6-compat
         version: '@typescript/typescript6@6.0.2'
+      typescript-7:
+        specifier: 'catalog:'
+        version: typescript@7.0.2
       vite:
         specifier: 'catalog:'
         version: 8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)
@@ -480,6 +486,9 @@ importers:
       typescript:
         specifier: catalog:typescript6-compat
         version: '@typescript/typescript6@6.0.2'
+      typescript-7:
+        specifier: 'catalog:'
+        version: typescript@7.0.2
       vite:
         specifier: 'catalog:'
         version: 8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)
@@ -748,6 +757,9 @@ importers:
       typescript:
         specifier: catalog:typescript6-compat
         version: '@typescript/typescript6@6.0.2'
+      typescript-7:
+        specifier: 'catalog:'
+        version: typescript@7.0.2
       vitest:
         specifier: 'catalog:'
         version: 4.1.10(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.2)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(yaml@2.9.0))
@@ -832,6 +844,9 @@ importers:
       typescript:
         specifier: catalog:typescript6-compat
         version: '@typescript/typescript6@6.0.2'
+      typescript-7:
+        specifier: 'catalog:'
+        version: typescript@7.0.2
       vitest:
         specifier: 'catalog:'
         version: 4.1.10(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.2)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(yaml@2.9.0))
@@ -898,6 +913,9 @@ importers:
       typescript:
         specifier: catalog:typescript6-compat
         version: '@typescript/typescript6@6.0.2'
+      typescript-7:
+        specifier: 'catalog:'
+        version: typescript@7.0.2
       vitest:
         specifier: 'catalog:'
         version: 4.1.10(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.2)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(yaml@2.9.0))
@@ -958,6 +976,9 @@ importers:
       typescript:
         specifier: catalog:typescript6-compat
         version: '@typescript/typescript6@6.0.2'
+      typescript-7:
+        specifier: 'catalog:'
+        version: typescript@7.0.2
       vite:
         specifier: 'catalog:'
         version: 8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)
@@ -1292,6 +1313,9 @@ importers:
       typescript:
         specifier: catalog:typescript6-compat
         version: '@typescript/typescript6@6.0.2'
+      typescript-7:
+        specifier: 'catalog:'
+        version: typescript@7.0.2
 
   tools/vue-check:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -376,6 +376,9 @@ importers:
       oxfmt:
         specifier: 'catalog:'
         version: 0.63.0
+      oxlint:
+        specifier: 'catalog:'
+        version: 1.78.0(oxlint-tsgolint@7.0.2001)
       start-server-and-test:
         specifier: 'catalog:'
         version: 3.0.12(supports-color@8.1.1)
@@ -425,6 +428,9 @@ importers:
       oxfmt:
         specifier: 'catalog:'
         version: 0.63.0
+      oxlint:
+        specifier: 'catalog:'
+        version: 1.78.0(oxlint-tsgolint@7.0.2001)
       typescript:
         specifier: catalog:typescript6-compat
         version: '@typescript/typescript6@6.0.2'
@@ -468,6 +474,9 @@ importers:
       oxfmt:
         specifier: 'catalog:'
         version: 0.63.0
+      oxlint:
+        specifier: 'catalog:'
+        version: 1.78.0(oxlint-tsgolint@7.0.2001)
       typescript:
         specifier: catalog:typescript6-compat
         version: '@typescript/typescript6@6.0.2'
@@ -493,6 +502,9 @@ importers:
       oxfmt:
         specifier: 'catalog:'
         version: 0.63.0
+      oxlint:
+        specifier: 'catalog:'
+        version: 1.78.0(oxlint-tsgolint@7.0.2001)
       typescript:
         specifier: 'catalog:'
         version: 7.0.2
@@ -551,6 +563,9 @@ importers:
       oxfmt:
         specifier: 'catalog:'
         version: 0.63.0
+      oxlint:
+        specifier: 'catalog:'
+        version: 1.78.0(oxlint-tsgolint@7.0.2001)
       playwright:
         specifier: 'catalog:'
         version: 1.62.1
@@ -612,6 +627,9 @@ importers:
       oxfmt:
         specifier: 'catalog:'
         version: 0.63.0
+      oxlint:
+        specifier: 'catalog:'
+        version: 1.78.0(oxlint-tsgolint@7.0.2001)
       typescript:
         specifier: 'catalog:'
         version: 7.0.2
@@ -636,6 +654,12 @@ importers:
       concurrently:
         specifier: 'catalog:'
         version: 10.0.4
+      oxfmt:
+        specifier: 'catalog:'
+        version: 0.63.0
+      oxlint:
+        specifier: 'catalog:'
+        version: 1.78.0(oxlint-tsgolint@7.0.2001)
       typescript:
         specifier: 'catalog:'
         version: 7.0.2
@@ -700,6 +724,9 @@ importers:
       oxfmt:
         specifier: 'catalog:'
         version: 0.63.0
+      oxlint:
+        specifier: 'catalog:'
+        version: 1.78.0(oxlint-tsgolint@7.0.2001)
       playwright:
         specifier: 'catalog:'
         version: 1.62.1
@@ -784,6 +811,9 @@ importers:
       oxfmt:
         specifier: 'catalog:'
         version: 0.63.0
+      oxlint:
+        specifier: 'catalog:'
+        version: 1.78.0(oxlint-tsgolint@7.0.2001)
       release-it:
         specifier: 'catalog:'
         version: 21.0.2(@types/node@24.13.3)(magicast@0.5.3)(supports-color@10.2.2)
@@ -844,6 +874,9 @@ importers:
       oxfmt:
         specifier: 'catalog:'
         version: 0.63.0
+      oxlint:
+        specifier: 'catalog:'
+        version: 1.78.0(oxlint-tsgolint@7.0.2001)
       playwright:
         specifier: 'catalog:'
         version: 1.62.1
@@ -904,6 +937,9 @@ importers:
       oxfmt:
         specifier: 'catalog:'
         version: 0.63.0
+      oxlint:
+        specifier: 'catalog:'
+        version: 1.78.0(oxlint-tsgolint@7.0.2001)
       release-it:
         specifier: 'catalog:'
         version: 21.0.2(@types/node@24.13.3)(magicast@0.5.3)(supports-color@10.2.2)
@@ -937,6 +973,12 @@ importers:
       cypress:
         specifier: 'catalog:'
         version: 15.20.1
+      oxfmt:
+        specifier: 'catalog:'
+        version: 0.63.0
+      oxlint:
+        specifier: 'catalog:'
+        version: 1.78.0(oxlint-tsgolint@7.0.2001)
       playwright:
         specifier: 'catalog:'
         version: 1.62.1
@@ -964,6 +1006,9 @@ importers:
       oxfmt:
         specifier: 'catalog:'
         version: 0.63.0
+      oxlint:
+        specifier: 'catalog:'
+        version: 1.78.0(oxlint-tsgolint@7.0.2001)
       rolldown:
         specifier: 'catalog:'
         version: 1.2.3
@@ -985,6 +1030,9 @@ importers:
       oxfmt:
         specifier: 'catalog:'
         version: 0.63.0
+      oxlint:
+        specifier: 'catalog:'
+        version: 1.78.0(oxlint-tsgolint@7.0.2001)
       semver:
         specifier: 'catalog:'
         version: 7.8.5
@@ -1015,6 +1063,12 @@ importers:
       mobx:
         specifier: 'catalog:'
         version: 7.0.0
+      oxfmt:
+        specifier: 'catalog:'
+        version: 0.63.0
+      oxlint:
+        specifier: 'catalog:'
+        version: 1.78.0(oxlint-tsgolint@7.0.2001)
       typescript-5.0:
         specifier: 'catalog:'
         version: typescript@5.0.4
@@ -1045,6 +1099,9 @@ importers:
       oxfmt:
         specifier: 'catalog:'
         version: 0.63.0
+      oxlint:
+        specifier: 'catalog:'
+        version: 1.78.0(oxlint-tsgolint@7.0.2001)
       typescript:
         specifier: 'catalog:'
         version: 7.0.2
@@ -1063,6 +1120,9 @@ importers:
       oxfmt:
         specifier: 'catalog:'
         version: 0.63.0
+      oxlint:
+        specifier: 'catalog:'
+        version: 1.78.0(oxlint-tsgolint@7.0.2001)
       typescript:
         specifier: 'catalog:'
         version: 7.0.2
@@ -1078,6 +1138,9 @@ importers:
       oxfmt:
         specifier: 'catalog:'
         version: 0.63.0
+      oxlint:
+        specifier: 'catalog:'
+        version: 1.78.0(oxlint-tsgolint@7.0.2001)
       typescript:
         specifier: 'catalog:'
         version: 7.0.2
@@ -1087,6 +1150,9 @@ importers:
       oxfmt:
         specifier: 'catalog:'
         version: 0.63.0
+      oxlint:
+        specifier: 'catalog:'
+        version: 1.78.0(oxlint-tsgolint@7.0.2001)
       typescript:
         specifier: 'catalog:'
         version: 7.0.2
@@ -1106,6 +1172,12 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.13.3
+      oxfmt:
+        specifier: 'catalog:'
+        version: 0.63.0
+      oxlint:
+        specifier: 'catalog:'
+        version: 1.78.0(oxlint-tsgolint@7.0.2001)
       typescript:
         specifier: 'catalog:'
         version: 7.0.2
@@ -1142,6 +1214,12 @@ importers:
       lit-ui-router-mobx:
         specifier: workspace:*
         version: link:../../packages/lit-ui-router-mobx
+      oxfmt:
+        specifier: 'catalog:'
+        version: 0.63.0
+      oxlint:
+        specifier: 'catalog:'
+        version: 1.78.0(oxlint-tsgolint@7.0.2001)
       pacote:
         specifier: 'catalog:'
         version: 22.0.0(supports-color@10.2.2)
@@ -1163,6 +1241,9 @@ importers:
       oxfmt:
         specifier: 'catalog:'
         version: 0.63.0
+      oxlint:
+        specifier: 'catalog:'
+        version: 1.78.0(oxlint-tsgolint@7.0.2001)
 
   tools/shared:
     devDependencies:
@@ -1181,6 +1262,12 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.13.3
+      oxfmt:
+        specifier: 'catalog:'
+        version: 0.63.0
+      oxlint:
+        specifier: 'catalog:'
+        version: 1.78.0(oxlint-tsgolint@7.0.2001)
       typescript:
         specifier: 'catalog:'
         version: 7.0.2
@@ -1193,6 +1280,12 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.13.3
+      oxfmt:
+        specifier: 'catalog:'
+        version: 0.63.0
+      oxlint:
+        specifier: 'catalog:'
+        version: 1.78.0(oxlint-tsgolint@7.0.2001)
       typedoc:
         specifier: 'catalog:'
         version: 0.28.20(@typescript/typescript6@6.0.2)
@@ -1206,6 +1299,12 @@ importers:
         specifier: workspace:*
         version: link:../shared
     devDependencies:
+      oxfmt:
+        specifier: 'catalog:'
+        version: 0.63.0
+      oxlint:
+        specifier: 'catalog:'
+        version: 1.78.0(oxlint-tsgolint@7.0.2001)
       typescript:
         specifier: catalog:typescript6
         version: 6.0.3
@@ -1218,6 +1317,9 @@ importers:
       oxfmt:
         specifier: 'catalog:'
         version: 0.63.0
+      oxlint:
+        specifier: 'catalog:'
+        version: 1.78.0(oxlint-tsgolint@7.0.2001)
       typescript:
         specifier: 'catalog:'
         version: 7.0.2
@@ -1230,6 +1332,12 @@ importers:
       jsonc-parser:
         specifier: 'catalog:'
         version: 3.3.1
+      oxfmt:
+        specifier: 'catalog:'
+        version: 0.63.0
+      oxlint:
+        specifier: 'catalog:'
+        version: 1.78.0(oxlint-tsgolint@7.0.2001)
       typescript:
         specifier: 'catalog:'
         version: 7.0.2

--- a/tools/build_and_test/package.json
+++ b/tools/build_and_test/package.json
@@ -20,6 +20,8 @@
     "@codecov/bundle-analyzer": "catalog:",
     "@types/node": "catalog:",
     "cypress": "catalog:",
+    "oxfmt": "catalog:",
+    "oxlint": "catalog:",
     "playwright": "catalog:",
     "typescript": "catalog:",
     "vite": "catalog:"

--- a/tools/bundle-probe/package.json
+++ b/tools/bundle-probe/package.json
@@ -24,6 +24,7 @@
     "@types/node": "catalog:",
     "esbuild": "catalog:",
     "oxfmt": "catalog:",
+    "oxlint": "catalog:",
     "rolldown": "catalog:",
     "typescript": "catalog:"
   }

--- a/tools/compat-guards/package.json
+++ b/tools/compat-guards/package.json
@@ -22,6 +22,7 @@
     "@types/node": "catalog:",
     "@types/semver": "catalog:",
     "oxfmt": "catalog:",
+    "oxlint": "catalog:",
     "semver": "catalog:",
     "typescript": "catalog:"
   }

--- a/tools/dts-backtest/package.json
+++ b/tools/dts-backtest/package.json
@@ -19,6 +19,8 @@
     "lit-ui-router": "workspace:*",
     "lit-ui-router-mobx": "workspace:*",
     "mobx": "catalog:",
+    "oxfmt": "catalog:",
+    "oxlint": "catalog:",
     "typescript-5.0": "catalog:",
     "typescript-5.9": "catalog:",
     "typescript-6": "catalog:typescript6",

--- a/tools/happy-dom/package.json
+++ b/tools/happy-dom/package.json
@@ -18,6 +18,7 @@
     "@types/node": "catalog:",
     "happy-dom": "catalog:",
     "oxfmt": "catalog:",
+    "oxlint": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:"
   }

--- a/tools/lcov-rebase/package.json
+++ b/tools/lcov-rebase/package.json
@@ -21,6 +21,7 @@
     "@tools/shared": "workspace:*",
     "@types/node": "catalog:",
     "oxfmt": "catalog:",
+    "oxlint": "catalog:",
     "typescript": "catalog:"
   }
 }

--- a/tools/lit-template-lint/package.json
+++ b/tools/lit-template-lint/package.json
@@ -17,6 +17,7 @@
     "@types/node": "catalog:",
     "lit-analyzer": "catalog:",
     "oxfmt": "catalog:",
+    "oxlint": "catalog:",
     "typescript": "catalog:"
   }
 }

--- a/tools/lit-test-env/package.json
+++ b/tools/lit-test-env/package.json
@@ -15,6 +15,7 @@
   },
   "devDependencies": {
     "oxfmt": "catalog:",
+    "oxlint": "catalog:",
     "typescript": "catalog:"
   }
 }

--- a/tools/oxc-emit/package.json
+++ b/tools/oxc-emit/package.json
@@ -20,6 +20,8 @@
   },
   "devDependencies": {
     "@types/node": "catalog:",
+    "oxfmt": "catalog:",
+    "oxlint": "catalog:",
     "typescript": "catalog:"
   }
 }

--- a/tools/release-config/package.json
+++ b/tools/release-config/package.json
@@ -13,6 +13,7 @@
     "lint": "oxlint ."
   },
   "devDependencies": {
-    "oxfmt": "catalog:"
+    "oxfmt": "catalog:",
+    "oxlint": "catalog:"
   }
 }

--- a/tools/release/package.json
+++ b/tools/release/package.json
@@ -27,6 +27,8 @@
     "@types/pacote": "catalog:",
     "lit-ui-router": "workspace:*",
     "lit-ui-router-mobx": "workspace:*",
+    "oxfmt": "catalog:",
+    "oxlint": "catalog:",
     "pacote": "catalog:",
     "publint": "catalog:",
     "typescript": "catalog:",

--- a/tools/shared/package.json
+++ b/tools/shared/package.json
@@ -28,6 +28,8 @@
     "@pnpm/workspace.projects-reader": "catalog:",
     "@pnpm/workspace.workspace-manifest-reader": "catalog:",
     "@types/node": "catalog:",
+    "oxfmt": "catalog:",
+    "oxlint": "catalog:",
     "typescript": "catalog:"
   }
 }

--- a/tools/typedoc-plugin-lit-ui-router/package.json
+++ b/tools/typedoc-plugin-lit-ui-router/package.json
@@ -27,6 +27,8 @@
   "devDependencies": {
     "@tools/oxc-emit": "workspace:*",
     "@types/node": "catalog:",
+    "oxfmt": "catalog:",
+    "oxlint": "catalog:",
     "typedoc": "catalog:",
     "typescript": "catalog:typescript6-compat"
   },

--- a/tools/typedoc-plugin-lit-ui-router/package.json
+++ b/tools/typedoc-plugin-lit-ui-router/package.json
@@ -30,7 +30,8 @@
     "oxfmt": "catalog:",
     "oxlint": "catalog:",
     "typedoc": "catalog:",
-    "typescript": "catalog:typescript6-compat"
+    "typescript": "catalog:typescript6-compat",
+    "typescript-7": "catalog:"
   },
   "peerDependencies": {
     "typedoc": "catalog:publishedPeer"

--- a/tools/vue-check/package.json
+++ b/tools/vue-check/package.json
@@ -16,6 +16,8 @@
     "@tools/shared": "workspace:*"
   },
   "devDependencies": {
+    "oxfmt": "catalog:",
+    "oxlint": "catalog:",
     "typescript": "catalog:typescript6",
     "vue-tsc": "catalog:"
   }

--- a/tools/wintercg-globals/package.json
+++ b/tools/wintercg-globals/package.json
@@ -18,6 +18,7 @@
   },
   "devDependencies": {
     "oxfmt": "catalog:",
+    "oxlint": "catalog:",
     "typescript": "catalog:"
   }
 }

--- a/tools/workers-builds/package.json
+++ b/tools/workers-builds/package.json
@@ -15,6 +15,8 @@
   "devDependencies": {
     "@types/node": "catalog:",
     "jsonc-parser": "catalog:",
+    "oxfmt": "catalog:",
+    "oxlint": "catalog:",
     "typescript": "catalog:",
     "valibot": "catalog:"
   }


### PR DESCRIPTION
## The defect class

A package's `scripts` entry invokes a binary the package does **not** declare in its own
`dependencies`/`devDependencies`. It works anyway because pnpm puts the root
`node_modules/.bin` on `PATH`, and the root declares the tool.

This is fragile in a specific way: a stale shim left behind in the package's *own*
`node_modules/.bin` shadows the root one, and pnpm will not overwrite or prune it. That is
exactly what bit `apps/sample-app-shared` — its `lint` script silently resolved to a
removed `oxlint@1.76.0` install directory until the shim was deleted by hand.

The audit found this is **not** limited to `sample-app-shared`. It is the workspace-wide
default:

- **`oxlint`** — declared *only* at the root. Every one of the 27 workspace packages has
  `"lint": "oxlint ."` and none of them declared it.
- **`oxfmt`** — declared in 18 packages, missing in 9 that run it.

## Why it was invisible

`lint` and `format:check` are cached turbo tasks. On any normal branch their inputs are
unchanged, so turbo **replays** the cached stdout instead of spawning the binary — the
resolution never happens, so a broken resolution cannot surface. Only a hash-busting change
to a package actually executes the task, which is why the failure appeared once, in one
package, seemingly at random. Nothing in CI resolves these binaries on a green run.

## Packages fixed

`+oxlint` (27):

| | |
|---|---|
| apps/sample-app-lit-e2e | tools/build_and_test |
| apps/sample-app-lit-mobx | tools/bundle-probe |
| apps/sample-app-lit-vanilla | tools/compat-guards |
| apps/sample-app-routes | tools/dts-backtest |
| apps/sample-app-shared | tools/happy-dom |
| docs | tools/lcov-rebase |
| examples | tools/lit-template-lint |
| packages/lit-ui-router | tools/lit-test-env |
| packages/lit-ui-router-mobx | tools/oxc-emit |
| packages/navigation-location-plugin | tools/release |
| packages/ui-router-server | tools/release-config |
| | tools/shared |
| | tools/typedoc-plugin-lit-ui-router |
| | tools/vue-check |
| | tools/wintercg-globals |
| | tools/workers-builds |

`+oxfmt` (9): `examples`, `tools/build_and_test`, `tools/dts-backtest`, `tools/oxc-emit`,
`tools/release`, `tools/shared`, `tools/typedoc-plugin-lit-ui-router`, `tools/vue-check`,
`tools/workers-builds`.

All declared as `"catalog:"`, matching how the 18 packages that already declared `oxfmt` do
it. `oxfmt` placed the keys; none were hand-placed.

## Second commit: `tsc` in the typescript6-compat packages

The first pass flagged this as unfixable and left it alone. It is fixable — by a second
alias, not a second `typescript` key.

The eight `catalog:typescript6-compat` packages (`sample-app-lit-e2e`, `sample-app-lit-mobx`,
`sample-app-lit-vanilla`, the four `packages/*`, `tools/typedoc-plugin-lit-ui-router`) alias
`typescript` to `@typescript/typescript6`, which ships a `tsc6` bin and no `tsc`. Their
`tsc -p … --noEmit` scripts were therefore resolving `tsc` from an ancestor
`node_modules/.bin` — the same undeclared-binary defect as the oxlint one, reached by a
different route.

The default catalog already carries `typescript-7: npm:typescript@^7.0.2`, and
`tools/dts-backtest` already consumes it as `"typescript-7": "catalog:"`. Declaring that
alias in the eight packages links a package-local `tsc` beside the existing `tsc6`:

```
$ ls packages/lit-ui-router/node_modules/.bin
tsc   tsc6   …
$ packages/lit-ui-router/node_modules/.bin/tsc --version    # Version 7.0.2
$ packages/lit-ui-router/node_modules/.bin/tsc6 --version   # Version 6.0.3
```

The `typescript` specifier is untouched, so the TS 6 JS API those packages import is
unchanged, and `tsc` resolves to 7.0.2 — the same binary that was already running. This
declares what ran; it does not change it. No new catalog entry: duplicating the pin into
`typescript6-compat` would create a second place for it to drift.

**Probed with an isolated PATH**, since this repo's own PATH carries several ancestor
`.bin` directories (worktrees included) that mask a removal — the first attempt at this
probe passed spuriously for exactly that reason:

```
new state (package .bin on PATH):           …/packages/lit-ui-router/node_modules/.bin/tsc
                                            TYPECHECK_OK
old state (no package .bin, no root .bin):  tsc: NOT FOUND
```

`turbo run typecheck lint --force` — 90/90, 0 cached. Lockfile additive (24 insertions,
0 deletions), every new entry resolving to the `typescript@7.0.2` already in the tree.

## Deliberately out of scope

- **`wrangler` in `sample-app-lit-e2e`** is a false positive:
  `pnpm --filter docs exec wrangler dev` resolves inside `docs`, which declares it.
- **`oxlint-tsgolint`** is not script-invoked; `oxlint` locates it by walking up
  `node_modules`. Left alone.

## Verification

`turbo run lint typecheck` — 90/90, **0 cached**, so every task actually executed against
the newly declared binaries:

```
   • Running lint, typecheck in 27 packages
 Tasks:    90 successful, 90 total
Cached:    0 cached, 90 total
  Time:    29.107s
```

`turbo run format:check` — 29/29 successful, 0 cached.
`pnpm run lint:package-json` (eslint-plugin-pnpm catalog enforcement) — 32/32 `ok`.

Each fixed package now resolves its own binary out of the current virtual store:

```
$ ls -l apps/sample-app-shared/node_modules/oxlint
apps/sample-app-shared/node_modules/oxlint ->
  ../../../node_modules/.pnpm/oxlint@1.78.0_oxlint-tsgolint@7.0.2001/node_modules/oxlint/

$ ls apps/sample-app-shared/node_modules/.bin/oxlint \
     packages/lit-ui-router/node_modules/.bin/oxlint \
     tools/shared/node_modules/.bin/oxfmt
```

A re-run of the audit reports zero remaining unresolved script binaries other than the
`wrangler` false positive described above.

The `pnpm-lock.yaml` diff is purely additive across both commits (108 + 24 insertions, 0
deletions) and touches no package-manager entries.

