### PR TITLE
build(workers-builds): move the Cloudflare build command into a repo script

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -37,25 +37,34 @@ See: [Wrangler Commands](https://developers.cloudflare.com/workers/wrangler/comm
 
 ### Build & Deploy Commands
 
-| Environment                                                                                             | Build                                                                | Deploy                         |
-| ------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- | ------------------------------ |
-| Production                                                                                              | `npx pnpm@11.21.0 install --frozen-lockfile && npx turbo docs#build` | `npx wrangler deploy`          |
-| Preview ([Versions](https://developers.cloudflare.com/workers/configuration/versions-and-deployments/)) | `npx pnpm@11.21.0 install --frozen-lockfile && npx turbo docs#build` | `npx wrangler versions upload` |
+| Environment                                                                                             | Build                                        | Deploy                         |
+| ------------------------------------------------------------------------------------------------------- | -------------------------------------------- | ------------------------------ |
+| Production                                                                                              | `./tools/workers-builds/cloudflare-build.sh` | `npx wrangler deploy`          |
+| Preview ([Versions](https://developers.cloudflare.com/workers/configuration/versions-and-deployments/)) | `./tools/workers-builds/cloudflare-build.sh` | `npx wrangler versions upload` |
 
-The build command owns the dependency install because Workers Builds provisions pnpm with
+The build command is a **repo script, not the steps themselves**
+([`cloudflare-build.sh`](./tools/workers-builds/cloudflare-build.sh)). A trigger holds one
+build command for every branch it matches, so inlining the steps means a branch cannot
+change them — and a package-manager change is exactly a branch that needs to. Pinning the
+path instead lets the script differ per branch while the declared value stays constant, so
+divergence never reads as drift and never needs an `--apply` to test.
+
+The script owns the dependency install because Workers Builds provisions pnpm with
 corepack, which cannot install a pnpm-12 `packageManager` pin at all — the npm package is
 a wrapper whose real binary is materialized by a `preinstall` hook out of an optional
 platform dependency, and corepack runs neither lifecycle scripts nor optional
 dependencies. So `SKIP_DEPENDENCY_INSTALL=1` turns off Cloudflare's install step and npx
 bootstraps the last pnpm 11 instead — no preinstall hook, so npx handles it — which then
-reads `packageManager` and self-swaps to whatever the branch pins. Every later command
-goes through npx as well, because the unusable corepack `pnpm` shim stays first on `PATH`.
+reads `packageManager` and self-swaps to whatever the branch pins. `npx pnpm@11.21.0` is a
+**bootstrap floor**, not the version that runs: it needs to be at or above 11.20.0 to read
+a pnpm-12 lockfile, and `packageManager` decides the rest.
 
-`npx pnpm@11.21.0` is a **bootstrap floor**, not the version that runs: it needs to be at
-or above 11.20.0 to read a pnpm-12 lockfile, and `packageManager` decides the rest.
+npx covers only the commands the script names. Anything turbo spawns resolves `pnpm` from
+`PATH`, where the unusable corepack shim still sits — which is why a pnpm-12 branch fails
+in turbo even with the install fixed, and why that branch needs its own bootstrap here.
 
-These three move together — the commands and the variable are one state. Apply and verify
-preview before production.
+`build_command` and `SKIP_DEPENDENCY_INSTALL` are one state. Apply and verify preview
+before production.
 
 ### Dashboard as Code
 
@@ -145,8 +154,8 @@ and leaves every other variable on the trigger untouched.
 
 **Declared** (plaintext, committed, `--apply` writes them):
 
-- `SKIP_DEPENDENCY_INSTALL=1` — **required.** Hands the dependency install to the build
-  command, per [Build & Deploy Commands](#build--deploy-commands). Without it Cloudflare
+- `SKIP_DEPENDENCY_INSTALL=1` — **required.** Hands the dependency install to
+  `cloudflare-build.sh`, per [Build & Deploy Commands](#build--deploy-commands). Without it Cloudflare
   runs its own corepack-provisioned `pnpm install` first and the build fails there;
   deleting it in the dashboard breaks every deploy.
 - `CYPRESS_INSTALL_BINARY=0` — the Cypress binary belongs to the e2e suite, which a docs

--- a/tools/workers-builds/cloudflare-build.sh
+++ b/tools/workers-builds/cloudflare-build.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+#
+# The Cloudflare Workers Builds build command, kept in the repo so it can
+# differ per branch: the dashboard holds one value for every branch at once,
+# and a package-manager change needs a different bootstrap on its branch than
+# main has. The trigger config pins the path, not the steps, so branch
+# divergence never reads as drift.
+#
+# Runs from the repo root under SKIP_DEPENDENCY_INSTALL=1 — Cloudflare's own
+# install step is off, so installing is this script's job (see DEPLOY.md).
+set -euo pipefail
+
+# Bootstrap floor, not the version that runs: >=11.20.0 to read a pnpm-12
+# lockfile, then `packageManager` self-swaps. Via npx because the corepack
+# `pnpm` on PATH cannot materialize a pnpm-12 pin.
+npx pnpm@11.21.0 install --frozen-lockfile
+
+# npx again: turbo is a workspace devDependency, not on PATH before the install.
+npx turbo docs#build

--- a/tools/workers-builds/workers-builds-triggers.config.jsonc
+++ b/tools/workers-builds/workers-builds-triggers.config.jsonc
@@ -4,19 +4,19 @@
 // vars (TURBO_* cache config and secrets, VITE_*) stay dashboard-managed
 {
   "productionBranch": "main",
-  // The build command owns the install, so SKIP_DEPENDENCY_INSTALL=1 is required:
-  // Workers Builds provisions pnpm with corepack, which cannot install a pnpm-12
-  // `packageManager` pin at all (the npm package is a wrapper whose real binary a
-  // `preinstall` hook materializes from an optional platform dependency, and corepack
-  // runs neither). npx bootstraps the last pnpm 11 instead, which reads
-  // `packageManager` and self-swaps. Every command uses npx because the unusable
-  // corepack `pnpm` shim stays first on PATH.
+  // The build command is a repo script, not the steps themselves: the dashboard
+  // holds one value for every branch, and a package-manager change needs a
+  // different bootstrap on its branch than main has. Pinning the path lets a
+  // branch diverge without that reading as drift. The steps and why the install
+  // moved out of Cloudflare's hands live in cloudflare-build.sh.
+  // SKIP_DEPENDENCY_INSTALL=1 is what hands the install to that script; without
+  // it Cloudflare runs its own corepack-provisioned `pnpm install` first.
   // CYPRESS_INSTALL_BINARY=0 and HUSKY=0 skip install work a docs deploy never
   // uses: the Cypress binary (download + unzip, ~15s) belongs to the e2e suite,
   // and the husky git hooks to a developer checkout. Both mirror what
   // `mise run setup` and the CI workflows already set.
   "production": {
-    "build_command": "npx pnpm@11.21.0 install --frozen-lockfile && npx turbo docs#build",
+    "build_command": "./tools/workers-builds/cloudflare-build.sh",
     "deploy_command": "npx wrangler deploy",
     "environment_variables": {
       "SKIP_DEPENDENCY_INSTALL": "1",
@@ -25,7 +25,7 @@
     },
   },
   "preview": {
-    "build_command": "npx pnpm@11.21.0 install --frozen-lockfile && npx turbo docs#build",
+    "build_command": "./tools/workers-builds/cloudflare-build.sh",
     "deploy_command": "npx wrangler versions upload",
     "environment_variables": {
       "SKIP_DEPENDENCY_INSTALL": "1",

--- a/tools/workers-builds/workers-builds-triggers.fixtures.json
+++ b/tools/workers-builds/workers-builds-triggers.fixtures.json
@@ -4,7 +4,7 @@
     "production": {
       "trigger_uuid": "prod-uuid",
       "trigger_name": "Deploy production",
-      "build_command": "npx pnpm@11.21.0 install --frozen-lockfile && npx turbo docs#build",
+      "build_command": "./tools/workers-builds/cloudflare-build.sh",
       "deploy_command": "npx wrangler deploy",
       "branch_includes": ["main"],
       "branch_excludes": [],
@@ -22,7 +22,7 @@
     "preview": {
       "trigger_uuid": "preview-uuid",
       "trigger_name": "Preview",
-      "build_command": "npx pnpm@11.21.0 install --frozen-lockfile && npx turbo docs#build",
+      "build_command": "./tools/workers-builds/cloudflare-build.sh",
       "deploy_command": "npx wrangler versions upload",
       "branch_includes": ["*"],
       "branch_excludes": ["main"],

--- a/tools/workers-builds/workers-builds-triggers.test.ts
+++ b/tools/workers-builds/workers-builds-triggers.test.ts
@@ -78,15 +78,24 @@ describe('desiredStateFromConfig', () => {
   });
 
   // SKIP_DEPENDENCY_INSTALL=1 is only safe while the build command installs.
-  it('pairs the skipped install with an install in every build command', () => {
+  // The command is a repo script now, so follow the path and read the steps —
+  // otherwise the indirection would hide a build command that stopped
+  // installing, which is the one failure this pairing exists to catch.
+  it('pairs the skipped install with an install in every build command', async () => {
     for (const kind of ['production', 'preview'] as const) {
       assert.equal(
         desired[kind].environment_variables?.SKIP_DEPENDENCY_INSTALL,
         '1',
       );
+      const command = desired[kind].build_command ?? '';
+      assert.match(command, /^\.\/tools\/workers-builds\/[\w-]+\.sh$/);
+      const script = await readFile(
+        join(import.meta.dirname, '..', '..', command),
+        'utf8',
+      );
       assert.match(
-        desired[kind].build_command ?? '',
-        /^npx pnpm@\d+\.\d+\.\d+ install --frozen-lockfile &&/,
+        script,
+        /^npx pnpm@\d+\.\d+\.\d+ install --frozen-lockfile$/m,
       );
     }
   });


### PR DESCRIPTION
A Workers Builds trigger holds **one** build command for every branch it matches. That makes the steps unchangeable per branch — and #566 is exactly a branch that needs to change them: pnpm 12 fails in turbo because turbo spawns package scripts through the corepack `pnpm` on `PATH`, so that branch needs a different bootstrap than `main` does.

Pinning the *path* instead of the steps fixes that. The script differs per branch, the declared value stays constant, and branch divergence never reads as drift or needs an `--apply` to test.

```diff
- "build_command": "npx pnpm@11.21.0 install --frozen-lockfile && npx turbo docs#build"
+ "build_command": "./tools/workers-builds/cloudflare-build.sh"
```

No behaviour change on `main` — the script runs the same two commands, in the same order, that the dashboard runs today.

## Changes

- **`tools/workers-builds/cloudflare-build.sh`** (new, `100755`) — the two steps, with the corepack/bootstrap-floor rationale that used to live in a config comment. Colocated with the config that declares it, so the contract and the thing it points at sit together. Picked up automatically by the shellcheck gate (shebang scan over `*.sh`), verified passing.
- **`workers-builds-triggers.config.jsonc`** / **`.fixtures.json`** — both triggers point at the script.
- **`workers-builds-triggers.test.ts`** — see below.
- **`DEPLOY.md`** — the command table, why the indirection exists, and a new paragraph on the limit of `npx` (it covers only the commands the script names; turbo's children still resolve `pnpm` from `PATH`).

## The guard follows the indirection

`SKIP_DEPENDENCY_INSTALL=1` is only safe while the build command installs, and one test exists to hold that pairing. With the steps behind a path, asserting on the command string would assert nothing — so the test now resolves the path and reads the script:

```ts
const command = desired[kind].build_command ?? '';
assert.match(command, /^\.\/tools\/workers-builds\/[\w-]+\.sh$/);
const script = await readFile(join(import.meta.dirname, '..', '..', command), 'utf8');
assert.match(script, /^npx pnpm@\d+\.\d+\.\d+ install --frozen-lockfile$/m);
```

**Probed, not assumed:** replacing the install line in the script with something else drops the suite to 20 pass / 1 fail. The indirection cannot hide a build command that stopped installing.

## Verification

- `turbo run test lint typecheck --filter=@tools/workers-builds` — 17/17 tasks, **21/21 tests**
- `turbo run format` clean, `mise run lint_shellcheck` clean, `mise run lint_markdown` clean, 38 files
- Committed mode is `100755`, so the `./`-prefixed command is directly executable
- Live read-only `check:workers-builds` shows exactly the two `build_command` values drifting and nothing else

## Merge order matters, and it is the reverse of last time

**Merge first, then `--apply`.** The new command names a file that must exist in the branch being built, so applying early would break the preview build of every branch that does not yet have the script — the opposite hazard from #585, where applying first was correct because the variables were inert until declared.

Leaving `main` un-applied in the meantime is safe: the dashboard keeps running the old inline command, which still works and produces an identical build.

One consequence worth stating: once applied, **every open PR needs a rebase onto `main` before its preview build will pass**, since older branches have no `cloudflare-build.sh`. That is #566, #575, #557, #556, #424 today. Production is unaffected either way.
