### PR TITLE
fix(lit-ui-router): dispatch uiSrefTarget on target change, not href change

### DIFF
--- a/packages/lit-ui-router/src/specs/ui-sref.spec.ts
+++ b/packages/lit-ui-router/src/specs/ui-sref.spec.ts
@@ -413,6 +413,98 @@ describe('uiSref directive', () => {
       expect(receivedTargetState).toBeDefined();
       expect(receivedTargetState?.name()).toBe('home');
     });
+
+    it('should dispatch for a state whose navigable has no url', async () => {
+      router = createTestRouter([{ name: 'abstract', abstract: true }]);
+
+      const uiRouter = document.createElement('ui-router');
+      uiRouter.uiRouter = router;
+      container.appendChild(uiRouter);
+      await waitForUpdate(uiRouter);
+
+      const wrapper = document.createElement('div');
+      uiRouter.appendChild(wrapper);
+
+      let receivedTargetState: TargetState | undefined;
+      wrapper.addEventListener(UI_SREF_TARGET_EVENT, ((
+        event: UiSrefTargetEvent,
+      ) => {
+        receivedTargetState = event.detail.targetState;
+      }) as EventListener);
+
+      // core returns null from href(): the old guard compared that to the
+      // absent attribute, matched, and returned before dispatching
+      render(html`<a ${uiSref('abstract')}>Link</a>`, wrapper);
+      await tick(50);
+
+      expect(receivedTargetState?.name()).toBe('abstract');
+    });
+
+    it('should dispatch when only a non-url param changes', async () => {
+      router = createTestRouter([
+        {
+          name: 'compose',
+          url: '/compose',
+          params: { message: { value: null, dynamic: true } },
+        },
+      ]);
+
+      const uiRouter = document.createElement('ui-router');
+      uiRouter.uiRouter = router;
+      container.appendChild(uiRouter);
+      await waitForUpdate(uiRouter);
+
+      const wrapper = document.createElement('div');
+      uiRouter.appendChild(wrapper);
+
+      // one template literal, so lit reuses the part and the directive
+      // instance; two literals would be two templates and a fresh element
+      const link = (message: string) =>
+        html`<a ${uiSref('compose', { message })}>Link</a>`;
+
+      render(link('a'), wrapper);
+      await tick(50);
+
+      const hrefBefore = wrapper.querySelector('a')!.getAttribute('href');
+
+      const eventSpy = vi.fn();
+      wrapper.addEventListener(UI_SREF_TARGET_EVENT, eventSpy);
+
+      render(link('b'), wrapper);
+      await tick(50);
+
+      // the param never reaches the url, so the old href-change guard held
+      expect(wrapper.querySelector('a')!.getAttribute('href')).toBe(hrefBefore);
+      expect(eventSpy).toHaveBeenCalled();
+      const { targetState } = (eventSpy.mock.calls[0][0] as UiSrefTargetEvent)
+        .detail;
+      expect(targetState.params().message).toBe('b');
+    });
+
+    it('should not re-dispatch when the target is unchanged', async () => {
+      router = createTestRouter([{ name: 'home', url: '/home' }]);
+
+      const uiRouter = document.createElement('ui-router');
+      uiRouter.uiRouter = router;
+      container.appendChild(uiRouter);
+      await waitForUpdate(uiRouter);
+
+      const wrapper = document.createElement('div');
+      uiRouter.appendChild(wrapper);
+
+      const link = () => html`<a ${uiSref('home')}>Link</a>`;
+
+      render(link(), wrapper);
+      await tick(50);
+
+      const eventSpy = vi.fn();
+      wrapper.addEventListener(UI_SREF_TARGET_EVENT, eventSpy);
+
+      render(link(), wrapper);
+      await tick(50);
+
+      expect(eventSpy).not.toHaveBeenCalled();
+    });
   });
 
   describe('uiSrefTargetEvent factory', () => {

--- a/packages/lit-ui-router/src/specs/ui-sref.spec.ts
+++ b/packages/lit-ui-router/src/specs/ui-sref.spec.ts
@@ -159,6 +159,32 @@ describe('uiSref directive', () => {
       const href = anchor.getAttribute('href');
       expect(href === null || href === '').toBe(true);
     });
+
+    it('should remove href when the target loses its url', async () => {
+      router = createTestRouter([
+        { name: 'home', url: '/home' },
+        { name: 'abstract', abstract: true },
+      ]);
+
+      const uiRouter = document.createElement('ui-router');
+      uiRouter.uiRouter = router;
+      container.appendChild(uiRouter);
+      await waitForUpdate(uiRouter);
+
+      const wrapper = document.createElement('div');
+      uiRouter.appendChild(wrapper);
+
+      // one literal, so the part and the directive instance are reused
+      const link = (state: string) => html`<a ${uiSref(state)}>Link</a>`;
+
+      render(link('home'), wrapper);
+      await tick(50);
+      expect(wrapper.querySelector('a')!.hasAttribute('href')).toBe(true);
+
+      render(link('abstract'), wrapper);
+      await tick(50);
+      expect(wrapper.querySelector('a')!.hasAttribute('href')).toBe(false);
+    });
   });
 
   describe('click navigation', () => {

--- a/packages/lit-ui-router/src/ui-sref.ts
+++ b/packages/lit-ui-router/src/ui-sref.ts
@@ -58,13 +58,19 @@ export function uiSrefTargetEvent(targetState: TargetState): UiSrefTargetEvent {
 }
 
 /**
+ * `@uirouter/core` types `equals` as `any` because it resolves to
+ * `angular.equals || _equals` at load time. The implementation is a deep
+ * structural compare (arrays, Date by `getTime`, RegExp by source, NaN).
+ * @internal
+ */
+const paramsEqual = equals as (a: RawParams, b: RawParams) => boolean;
+
+/**
  * Whether two target states name the same state with the same params.
  * `$state.target()` returns a fresh object every render, so identity is useless.
  * @internal
  */
 function sameTarget(a: TargetState | null, b: TargetState): boolean {
-  // core ships `equals` as `any`
-  const paramsEqual = equals as (x: RawParams, y: RawParams) => boolean;
   return !!a && a.name() === b.name() && paramsEqual(a.params(), b.params());
 }
 

--- a/packages/lit-ui-router/src/ui-sref.ts
+++ b/packages/lit-ui-router/src/ui-sref.ts
@@ -1,4 +1,5 @@
 import {
+  equals,
   extend,
   RawParams,
   TransitionOptions,
@@ -54,6 +55,17 @@ export function uiSrefTargetEvent(targetState: TargetState): UiSrefTargetEvent {
     composed: true,
     detail: { targetState },
   }) as UiSrefTargetEvent;
+}
+
+/**
+ * Whether two target states name the same state with the same params.
+ * `$state.target()` returns a fresh object every render, so identity is useless.
+ * @internal
+ */
+function sameTarget(a: TargetState | null, b: TargetState): boolean {
+  // core ships `equals` as `any`
+  const paramsEqual = equals as (x: RawParams, y: RawParams) => boolean;
+  return !!a && a.name() === b.name() && paramsEqual(a.params(), b.params());
 }
 
 /**
@@ -117,25 +129,26 @@ export class UiSrefDirective extends AsyncDirective {
       return noChange;
     }
 
-    this.element.targetState = this.targetState = $state.target(
-      state,
-      params,
-      this.getOptions(options),
-    );
+    const targetState = $state.target(state, params, this.getOptions(options));
+    const targetChanged = !sameTarget(this.targetState, targetState);
+    this.element.targetState = this.targetState = targetState;
 
+    // core returns null from href() for a state whose navigable has no url
     this.href = $state.href(state, params, this.getOptions(options));
 
-    if (this.href === this.element.getAttribute('href')) {
-      return noChange;
+    if (this.href !== this.element.getAttribute('href')) {
+      if (this.href) {
+        this.element.setAttribute('href', this.href);
+      } else {
+        this.element.removeAttribute('href');
+      }
     }
 
-    if (this.href) {
-      this.element.setAttribute('href', this.href);
-    } else {
-      this.element.removeAttribute('href');
+    // the href is not the target: a url-less state has none, and non-url
+    // params change the target without changing it
+    if (targetChanged) {
+      this.element.dispatchEvent(uiSrefTargetEvent(this.targetState));
     }
-
-    this.element.dispatchEvent(uiSrefTargetEvent(this.targetState));
     return noChange;
   }
 


### PR DESCRIPTION
Fixes the blocker both #576 and #577 record as "separate bug in `render()`, separate issue" — filed here as the PR that unblocks them.

## The bug

`ui-sref.ts:128` returned `noChange` when the computed href equalled the element's current `href` attribute, **before** dispatching `uiSrefTargetEvent`. A `uiSrefActive` with no state of its own learns its target only from that event (`ui-sref-active.ts:393-397`), so the guard silently withholds it in two cases:

- **A state whose navigable has no url.** Core returns `null` from `stateService.href()`, the attribute is absent, the two compare equal — the event never fires, ever.
- **A target that changes only in non-url params.** The href is identical by construction (`uiSref('mymessages.compose', { message })` in the sample app), so `uiSrefActive` retains a stale target indefinitely.

The guard conflated "the href changed" with "there is nothing to publish".

## The fix

Split it. The target state decides the dispatch; the href decides the attribute write.

```ts
const targetChanged = !sameTarget(this.targetState, targetState);
// … href written only when it differs
if (targetChanged) this.element.dispatchEvent(uiSrefTargetEvent(this.targetState));
```

`$state.target()` returns a fresh object every render, so `sameTarget` compares `name()` plus `params()` by value rather than identity. Identical re-renders therefore still dispatch nothing — the early return's one legitimate job is preserved without conflating it with the attribute.

## Why this lands first

#577 introduces `assignHref: false`, under which the attribute is **never written**. A naive implementation on top of the old guard would compare `null` to `null` on every render and suppress the event for *every* sref, not just url-less ones. The two concerns have to be separated before that option can exist.

## Verification

Three specs, all in `describe('uiSrefTarget event')`:

| spec | fails without the fix |
| --- | --- |
| dispatch for a state whose navigable has no url | ✅ |
| dispatch when only a non-url param changes | ✅ |
| no re-dispatch when the target is unchanged | — regression guard for the new dispatch path |

Mutation-tested: reverting `render()` alone fails exactly the first two, 26 others still pass.

One trap worth recording for future specs here — **two separate `` html`…` `` literals are two different lit templates**, so lit tears down the element and builds a fresh directive. A "re-render" written that way is not one, and a `prev === null` directive dispatches unconditionally, so the param spec passed for the wrong reason until it was rewritten against a single shared template factory.

## Semver

Patch. It only adds dispatches that were being withheld.
