### PR TITLE
fix(lit-ui-router): correct the uiSref click guards

### DIFF
--- a/packages/lit-ui-router/src/specs/ui-sref.spec.ts
+++ b/packages/lit-ui-router/src/specs/ui-sref.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { html, render } from 'lit';
+import { html, render, TemplateResult } from 'lit';
 import { TargetState } from '@uirouter/core';
 
 import {
@@ -80,6 +80,30 @@ describe('uiSref directive', () => {
     await tick(50);
 
     return { anchor, uiRouter };
+  }
+
+  /** renders an arbitrary template inside a started router */
+  async function setupWithTemplate(
+    states: LitStateDeclaration[],
+    template: TemplateResult,
+  ): Promise<HTMLElement> {
+    router = createTestRouter(states);
+
+    const uiRouter = document.createElement('ui-router');
+    uiRouter.uiRouter = router;
+    container.appendChild(uiRouter);
+    await waitForUpdate(uiRouter);
+
+    const wrapper = document.createElement('div');
+    uiRouter.appendChild(wrapper);
+
+    render(template, wrapper);
+    await tick(50);
+
+    router.start();
+    await tick(50);
+
+    return wrapper;
   }
 
   describe('href generation', () => {
@@ -278,6 +302,44 @@ describe('uiSref directive', () => {
       ]);
     });
 
+    it('should ignore click with shift key', async () => {
+      const states: LitStateDeclaration[] = [{ name: 'home', url: '/home' }];
+      const { anchor } = await setupWithSref(states, 'home');
+
+      const goSpy = vi.spyOn(router!.stateService, 'go');
+      // shift-click opens the href in a new window
+      await clickLocatedElement(anchor, { modifiers: ['Shift'] });
+      await tick();
+
+      expect(goSpy).not.toHaveBeenCalled();
+      expect(suppression.events).toEqual([
+        expect.objectContaining({
+          type: 'click',
+          tag: 'a',
+          defaultPrevented: false,
+        }),
+      ]);
+    });
+
+    it('should ignore click with alt key', async () => {
+      const states: LitStateDeclaration[] = [{ name: 'home', url: '/home' }];
+      const { anchor } = await setupWithSref(states, 'home');
+
+      const goSpy = vi.spyOn(router!.stateService, 'go');
+      // alt-click downloads the href on most platforms
+      await clickLocatedElement(anchor, { modifiers: ['Alt'] });
+      await tick();
+
+      expect(goSpy).not.toHaveBeenCalled();
+      expect(suppression.events).toEqual([
+        expect.objectContaining({
+          type: 'click',
+          tag: 'a',
+          defaultPrevented: false,
+        }),
+      ]);
+    });
+
     it('should ignore middle button click', async () => {
       const states: LitStateDeclaration[] = [{ name: 'home', url: '/home' }];
       const { anchor } = await setupWithSref(states, 'home');
@@ -379,6 +441,168 @@ describe('uiSref directive', () => {
           defaultPrevented: false,
         }),
       ]);
+    });
+
+    it('should ignore click with rel="external noopener"', async () => {
+      // rel is a token list; an exact-string comparison misses every anchor
+      // that pairs external with another token
+      const wrapper = await setupWithTemplate(
+        [{ name: 'home', url: '/home' }],
+        html`<a ${uiSref('home')} rel="external noopener">Link</a>`,
+      );
+
+      const goSpy = vi.spyOn(router!.stateService, 'go');
+      await clickLocatedElement(wrapper.querySelector('a')!);
+      await tick();
+
+      expect(goSpy).not.toHaveBeenCalled();
+      expect(suppression.events).toEqual([
+        expect.objectContaining({ type: 'click', defaultPrevented: false }),
+      ]);
+    });
+
+    it('should ignore click on an anchor with download', async () => {
+      const wrapper = await setupWithTemplate(
+        [{ name: 'home', url: '/home' }],
+        html`<a ${uiSref('home')} download>Link</a>`,
+      );
+
+      const goSpy = vi.spyOn(router!.stateService, 'go');
+      await clickLocatedElement(wrapper.querySelector('a')!);
+      await tick();
+
+      expect(goSpy).not.toHaveBeenCalled();
+      expect(suppression.events).toEqual([
+        expect.objectContaining({ type: 'click', defaultPrevented: false }),
+      ]);
+    });
+  });
+
+  describe('descendant clicks (currentTarget)', () => {
+    // event.target is the deepest node clicked, so every guard that reads an
+    // attribute off it is dead whenever a link wraps its label
+
+    it('should ignore a descendant click on target="_blank"', async () => {
+      const wrapper = await setupWithTemplate(
+        [{ name: 'home', url: '/home' }],
+        html`<a ${uiSref('home')} target="_blank"><span>Link</span></a>`,
+      );
+
+      const goSpy = vi.spyOn(router!.stateService, 'go');
+      await clickLocatedElement(wrapper.querySelector('span')!);
+      await tick();
+
+      expect(goSpy).not.toHaveBeenCalled();
+      expect(suppression.events).toEqual([
+        expect.objectContaining({
+          type: 'click',
+          tag: 'span',
+          defaultPrevented: false,
+        }),
+      ]);
+    });
+
+    it('should ignore a descendant click on rel="external"', async () => {
+      const wrapper = await setupWithTemplate(
+        [{ name: 'home', url: '/home' }],
+        html`<a ${uiSref('home')} rel="external"><span>Link</span></a>`,
+      );
+
+      const goSpy = vi.spyOn(router!.stateService, 'go');
+      await clickLocatedElement(wrapper.querySelector('span')!);
+      await tick();
+
+      expect(goSpy).not.toHaveBeenCalled();
+      expect(suppression.events).toEqual([
+        expect.objectContaining({ type: 'click', defaultPrevented: false }),
+      ]);
+    });
+
+    it('should still navigate on a plain descendant click', async () => {
+      const wrapper = await setupWithTemplate(
+        [{ name: 'home', url: '/home' }],
+        html`<a ${uiSref('home')}><span>Link</span></a>`,
+      );
+
+      const goSpy = vi.spyOn(router!.stateService, 'go');
+      await clickLocatedElement(wrapper.querySelector('span')!);
+      await tick();
+
+      expect(goSpy).toHaveBeenCalledWith('home', {}, expect.any(Object));
+    });
+  });
+
+  describe('defaultPrevented', () => {
+    it('should not navigate when another handler cancelled the event', async () => {
+      const wrapper = await setupWithTemplate(
+        [{ name: 'home', url: '/home' }],
+        html`<a ${uiSref('home')}>Link</a>`,
+      );
+
+      // capture phase on an ancestor runs before the element's own listener,
+      // which is the only way a consumer can get in front of the router
+      wrapper.addEventListener('click', (event) => event.preventDefault(), {
+        capture: true,
+      });
+
+      const goSpy = vi.spyOn(router!.stateService, 'go');
+      await clickLocatedElement(wrapper.querySelector('a')!);
+      await tick();
+
+      expect(goSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('non-link elements', () => {
+    // the guards defer to native click behaviour; an element that has none
+    // has nothing to defer to, so bailing drops the click instead of
+    // handing it back to the browser
+
+    it('should navigate on a shift-click on a button', async () => {
+      const wrapper = await setupWithTemplate(
+        [{ name: 'home', url: '/home' }],
+        html`<button ${uiSref('home')}>Go</button>`,
+      );
+
+      const goSpy = vi.spyOn(router!.stateService, 'go');
+      await clickLocatedElement(wrapper.querySelector('button')!, {
+        modifiers: ['Shift'],
+      });
+      await tick();
+
+      expect(goSpy).toHaveBeenCalledWith('home', {}, expect.any(Object));
+    });
+
+    it('should navigate on a meta-click on a button', async () => {
+      const wrapper = await setupWithTemplate(
+        [{ name: 'home', url: '/home' }],
+        html`<button ${uiSref('home')}>Go</button>`,
+      );
+
+      const goSpy = vi.spyOn(router!.stateService, 'go');
+      await clickLocatedElement(wrapper.querySelector('button')!, {
+        modifiers: ['Meta'],
+      });
+      await tick();
+
+      expect(goSpy).toHaveBeenCalledWith('home', {}, expect.any(Object));
+    });
+
+    it('should still honour defaultPrevented on a button', async () => {
+      const wrapper = await setupWithTemplate(
+        [{ name: 'home', url: '/home' }],
+        html`<button ${uiSref('home')}>Go</button>`,
+      );
+
+      wrapper.addEventListener('click', (event) => event.preventDefault(), {
+        capture: true,
+      });
+
+      const goSpy = vi.spyOn(router!.stateService, 'go');
+      await clickLocatedElement(wrapper.querySelector('button')!);
+      await tick();
+
+      expect(goSpy).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/lit-ui-router/src/ui-sref.ts
+++ b/packages/lit-ui-router/src/ui-sref.ts
@@ -75,6 +75,41 @@ function sameTarget(a: TargetState | null, b: TargetState): boolean {
 }
 
 /**
+ * Whether the element navigates on its own. `localName` is lowercase for HTML
+ * and SVG alike, so SVG `<a>` needs no namespace check.
+ * @internal
+ */
+function isNativeLink(element: Element): boolean {
+  const tag = element.localName;
+  return tag === 'a' || tag === 'area';
+}
+
+/**
+ * Whether the click asked the browser for something other than a plain
+ * in-place navigation: a new tab/window, a download, or a non-primary button.
+ * @internal
+ */
+function isModifiedClick(event: MouseEvent): boolean {
+  const { button, ctrlKey, metaKey, shiftKey, altKey } = event;
+  return (
+    !isNumber(button) || !!button || ctrlKey || metaKey || shiftKey || altKey
+  );
+}
+
+/**
+ * Whether the element declares that its href leaves the app: `target="_blank"`
+ * or a `rel` token list containing `external`.
+ * @internal
+ */
+function opensOffApp(element: Element): boolean {
+  if (element.getAttribute('target') === '_blank') {
+    return true;
+  }
+  // rel is a token list: `rel="external noopener"` is still external
+  return (element.getAttribute('rel') ?? '').split(/\s+/).includes('external');
+}
+
+/**
  * Directive class that creates state-based navigation links.
  *
  * This directive is used internally by the {@link uiSref} directive function.
@@ -181,24 +216,26 @@ export class UiSrefDirective extends AsyncDirective {
     const { uiRouter: router, state, params } = this;
     const options = this.getOptions();
     const $state = router?.stateService;
-    if (!$state || !this.element?.isConnected) {
+    if (!$state || !this.element?.isConnected || !state) {
       return;
     }
-    const { button, ctrlKey, metaKey, target } = event;
-    const openInNewTab =
-      (target as Element).getAttribute('target') === '_blank';
-    const isExternal = (target as Element).getAttribute('rel') === 'external';
+
+    const element = event.currentTarget as Element;
+
+    // author signals, so unscoped: they apply whatever the element is
+    if (event.defaultPrevented || element.hasAttribute('download')) {
+      return;
+    }
+
+    // scoped to links: these guards hand the click back to the browser, and a
+    // non-link has nothing to hand it back to
     if (
-      openInNewTab ||
-      isExternal ||
-      button ||
-      !isNumber(button) ||
-      ctrlKey ||
-      metaKey ||
-      !state
+      isNativeLink(element) &&
+      (isModifiedClick(event) || opensOffApp(element))
     ) {
       return;
     }
+
     // fire-and-forget: @uirouter/core handles transition promise rejections
     void $state.go(state, params, options);
     event.preventDefault();


### PR DESCRIPTION
Fixes #576. **Stacked on #588** — base it there; the diff against `main` includes that commit.

## What changed

`onClick` now runs in three tiers rather than one flat boolean:

```ts
if (!$state || !this.element?.isConnected || !state) return;

const element = event.currentTarget as Element | null;   // 1
if (!element) return;

// author signals — apply on any element
if (event.defaultPrevented || element.hasAttribute('download')) return;   // 2

// native-deferral guards — only where there is native behaviour to defer to
if (isNativeLink(element) && (isModifiedClick(event) || opensOffApp(element))) return;   // 3

void $state.go(state, params, options);
event.preventDefault();
```

| # | change | note |
| --- | --- | --- |
| 1 | `event.target` → `event.currentTarget` | the guards were dead for any click on a descendant |
| 2 | `shiftKey` / `altKey` | new-window and download clicks were being swallowed |
| 3 | `defaultPrevented` | a consumer handler can finally cancel us |
| 4 | `rel` as a token list | `rel="external noopener"` is external |
| 5 | `download` bails | matching Next and SvelteKit |
| 6 | native-deferral guards scoped to links | a modifier-click on `<button ${uiSref}>` no longer dies |

Three small predicates carry it: `isNativeLink` (`localName` is `'a'`/`'area'` — lowercase for HTML and SVG alike, so SVG `<a>` needs no namespace check), `isModifiedClick`, `opensOffApp`.

### Two judgement calls worth reviewing

**`download` and `defaultPrevented` are deliberately *not* anchor-scoped.** They aren't deferrals to native behaviour — they are author signals ("I handled this", "this is a download"), so dropping the click is the intended outcome regardless of tag. This follows the split the issue identified in Next, and each has a spec on a `<button>` proving the scoping did not leak.

**`isNativeLink` is tag-only, not `hasAttribute('href')`.** Keying on the actual href would be the more precise reading of "would the browser have navigated" — an `<a>` for a url-less state has no href and therefore no native behaviour — but it would make #577's `assignHref: false` silently become the switch for click behaviour, which #577 explicitly rules out. Tag-only keeps the two questions separate at the cost of one edge: a modifier-click on an href-less `<a ${uiSref}>` still does nothing. Worth a follow-up, not worth coupling the switches.

## The middle-click half of point 6 does not reproduce

The issue asks for a spec asserting a **middle**-click on `<button ${uiSref}>` navigates. It cannot, and the guard is not why. Probed in Chrome:

```
middle click on <button uiSref>:  ["pointerup","mouseup","auxclick"]   went: 0
middle click on <a uiSref>:       ["auxclick"]
```

A middle click never delivers a `click` event — only `auxclick` — and we only listen for `click`, so the handler never runs at all. Point 6's premise ("`button` is truthy, the handler returns, nothing happens") holds for ctrl/meta/shift/alt, which do deliver `click`; for middle-click the click never arrives.

Making it work needs an `auxclick` listener, which is a behaviour expansion rather than a restoration — and middle-click on a `<button>` natively means autoscroll or X11 paste, not navigate. **Left out deliberately, not overlooked.** Happy to add it in a follow-up if you want the button shape to accept middle-click; I'd rather that be an explicit decision than a side effect here.

The modifier half is fixed and covered: shift-click and meta-click on a `<button ${uiSref}>` now navigate.

## Verification

39 specs in the file (up from 28), 183 across the package, all green. Every change is **mutation-tested individually** — reverted alone, each fails exactly its own specs and nothing else:

| mutation | specs that fail |
| --- | --- |
| `currentTarget` → `target` | both descendant-click specs |
| drop `shiftKey`/`altKey` | shift, alt |
| drop `defaultPrevented` | the anchor spec and the button spec |
| `rel` exact match | `rel="external noopener"` |
| drop `download` | download |
| unscope the guards | shift-click and meta-click on a button |

The descendant specs click a `<span>` inside the anchor, so they'd be inert written the obvious way. The "bail" specs keep the existing positive-proof pattern: `suppression.events` must show the click reaching default-action stage with `defaultPrevented: false`, proving we handed it back rather than merely not navigating.

## Semver

Per the issue: **minor**, not patch. Three of these change behaviour code could rely on — shift-click stops navigating in-app, a sibling handler can now cancel, and modifier-clicks on non-anchor srefs start navigating where they previously did nothing. All restore browser-standard behaviour, so not a major. The commit is typed `fix`; the increment is an explicit flag at release dispatch, so nothing infers a patch from it.
