### PR TITLE
feat(lit-ui-router): add uiSref assignHref to scope the href to links

### DIFF
--- a/apps/sample-app-lit-mobx/src/app/main/NavHeader.ts
+++ b/apps/sample-app-lit-mobx/src/app/main/NavHeader.ts
@@ -57,12 +57,12 @@ export class NavHeader extends LitElement {
         </li>
         <li class="navbar-right">
           <button
-            ${uiSref('home')}
+            ${uiSref('home', {}, { assignHref: 'auto' })}
             style="margin-right: 5px"
             class="btn btn-primary fa fa-home"
           ></button>
           <button
-            ${uiSref('mymessages.compose')}
+            ${uiSref('mymessages.compose', {}, { assignHref: 'auto' })}
             style="margin-right: 15px"
             class="btn btn-primary"
           >

--- a/apps/sample-app-lit-vanilla/src/app/main/NavHeader.ts
+++ b/apps/sample-app-lit-vanilla/src/app/main/NavHeader.ts
@@ -49,12 +49,12 @@ export class NavHeader extends LitElement {
         </li>
         <li class="navbar-right">
           <button
-            ${uiSref('home')}
+            ${uiSref('home', {}, { assignHref: 'auto' })}
             style="margin-right: 5px"
             class="btn btn-primary fa fa-home"
           ></button>
           <button
-            ${uiSref('mymessages.compose')}
+            ${uiSref('mymessages.compose', {}, { assignHref: 'auto' })}
             style="margin-right: 15px"
             class="btn btn-primary"
           >

--- a/apps/sample-app-shared/src/app/contacts/ContactView.ts
+++ b/apps/sample-app-shared/src/app/contacts/ContactView.ts
@@ -27,13 +27,17 @@ export class ContactView extends LitElement {
     const { contact } = this;
     const composeButton = html`<button
       class="btn btn-primary"
-      ${uiSref('mymessages.compose', { message: { to: contact.email } })}
+      ${uiSref(
+        'mymessages.compose',
+        { message: { to: contact.email } },
+        { assignHref: 'auto' },
+      )}
     >
       <i class="fa fa-envelope"></i><span>Message</span>
     </button>`;
     const editContactButton = html`<button
       class="btn btn-primary"
-      ${uiSref('.edit')}
+      ${uiSref('.edit', {}, { assignHref: 'auto' })}
     >
       <i class="fa fa-pencil"></i><span>Edit Contact</span>
     </button>`;

--- a/apps/sample-app-shared/src/app/contacts/EditContact.ts
+++ b/apps/sample-app-shared/src/app/contacts/EditContact.ts
@@ -98,7 +98,10 @@ export class EditContact extends LitElement {
       ></sample-contact-form>
       <hr />
       <div>
-        <button ${uiSref('^')} class="btn btn-primary">
+        <button
+          ${uiSref('^', {}, { assignHref: 'auto' })}
+          class="btn btn-primary"
+        >
           <i class="fa fa-close"></i><span>Cancel</span>
         </button>
         <button class="btn btn-primary" @click=${this.saveContact}>

--- a/apps/sample-app-shared/src/app/main/Home.ts
+++ b/apps/sample-app-shared/src/app/main/Home.ts
@@ -4,17 +4,26 @@ import { uiSref } from 'lit-ui-router';
 export function home() {
   return html`<div>
     <div class="home buttons">
-      <button ${uiSref('mymessages')} class="btn btn-primary">
+      <button
+        ${uiSref('mymessages', {}, { assignHref: 'auto' })}
+        class="btn btn-primary"
+      >
         <h1><i class="fa fa-envelope"></i></h1>
         <h1>Messages</h1>
       </button>
 
-      <button ${uiSref('contacts')} class="btn btn-primary">
+      <button
+        ${uiSref('contacts', {}, { assignHref: 'auto' })}
+        class="btn btn-primary"
+      >
         <h1><i class="fa fa-users"></i></h1>
         <h1>Contacts</h1>
       </button>
 
-      <button ${uiSref('prefs')} class="btn btn-primary">
+      <button
+        ${uiSref('prefs', {}, { assignHref: 'auto' })}
+        class="btn btn-primary"
+      >
         <h1><i class="fa fa-cogs"></i></h1>
         <h1>Preferences</h1>
       </button>

--- a/apps/sample-app-shared/src/app/main/NotFound.ts
+++ b/apps/sample-app-shared/src/app/main/NotFound.ts
@@ -17,7 +17,10 @@ export default (props: UIViewInjectedProps<NotFoundResolves>) =>
     <p>
       No state matched the URL <code>${props.resolves.attemptedPath}</code>.
     </p>
-    <button ${uiSref('welcome')} class="btn btn-primary">
+    <button
+      ${uiSref('welcome', {}, { assignHref: 'auto' })}
+      class="btn btn-primary"
+    >
       <i class="fa fa-home"></i><span>Return to Welcome</span>
     </button>
   </div>`;

--- a/apps/sample-app-shared/src/app/main/Welcome.ts
+++ b/apps/sample-app-shared/src/app/main/Welcome.ts
@@ -20,13 +20,22 @@ export default () =>
       "password")
     </p>
     <div>
-      <button ${uiSref('mymessages')} class="btn btn-primary">
+      <button
+        ${uiSref('mymessages', {}, { assignHref: 'auto' })}
+        class="btn btn-primary"
+      >
         <i class="fa fa-envelope"></i><span>Messages</span>
       </button>
-      <button ${uiSref('contacts')} class="btn btn-primary">
+      <button
+        ${uiSref('contacts', {}, { assignHref: 'auto' })}
+        class="btn btn-primary"
+      >
         <i class="fa fa-users"></i><span>Contacts</span>
       </button>
-      <button ${uiSref('prefs')} class="btn btn-primary">
+      <button
+        ${uiSref('prefs', {}, { assignHref: 'auto' })}
+        class="btn btn-primary"
+      >
         <i class="fa fa-cogs"></i><span>Preferences</span>
       </button>
     </div>

--- a/apps/sample-app-shared/src/app/mymessages/MessageTable.ts
+++ b/apps/sample-app-shared/src/app/mymessages/MessageTable.ts
@@ -84,9 +84,11 @@ export class MessageTable extends LitElement {
       [...messages].sort(orderBy(sort)),
       ({ _id }) => _id,
       (message) =>
+        // a <tr> is neither a link by tag nor by role, so it takes no href
+        // under 'auto' and no aria-current by default — only the row class
         html`<tr
           ${uiSrefActive({ activeClasses: ['active'] })}
-          ${uiSref('.message', { messageId: message._id })}
+          ${uiSref('.message', { messageId: message._id }, { assignHref: 'auto' })}
         >
           ${visibleColumns.map(
             (column) =>

--- a/docs/guides/unmatched-urls.md
+++ b/docs/guides/unmatched-urls.md
@@ -144,11 +144,19 @@ export default (props: UIViewInjectedProps<NotFoundResolves>) =>
     <p>
       No state matched the URL <code>${props.resolves.attemptedPath}</code>.
     </p>
-    <button ${uiSref('welcome')} class="btn btn-primary">
+    <button
+      ${uiSref('welcome', {}, { assignHref: 'auto' })}
+      class="btn btn-primary"
+    >
       Return to Welcome
     </button>
   </div>`;
 ```
+
+`<button>` has no `href` in HTML, so `assignHref: 'auto'` keeps the attribute
+off it. Clicking still navigates — the option governs the attribute only, never
+the click handler. The 1.x default is `true` (write it anywhere, with a console
+warning on a non-link); `'auto'` becomes the default in 2.0.
 
 ## Caveat: lazy-loaded future states
 

--- a/packages/lit-ui-router/src/specs/ui-sref.spec.ts
+++ b/packages/lit-ui-router/src/specs/ui-sref.spec.ts
@@ -478,6 +478,189 @@ describe('uiSref directive', () => {
     });
   });
 
+  describe('assignHref', () => {
+    const home: LitStateDeclaration[] = [{ name: 'home', url: '/home' }];
+
+    it('should write href to a non-link by default', async () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const wrapper = await setupWithTemplate(
+        home,
+        html`<button ${uiSref('home')}>Go</button>`,
+      );
+
+      expect(wrapper.querySelector('button')!.getAttribute('href')).toContain(
+        '/home',
+      );
+      // the 1.x default is unchanged behaviour, but it names the fix
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining("{ assignHref: 'auto' }"),
+      );
+      warn.mockRestore();
+    });
+
+    it('should warn once per element, not once per render', async () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      router = createTestRouter([{ name: 'user', url: '/user/:id' }]);
+
+      const uiRouter = document.createElement('ui-router');
+      uiRouter.uiRouter = router;
+      container.appendChild(uiRouter);
+      await waitForUpdate(uiRouter);
+
+      const wrapper = document.createElement('div');
+      uiRouter.appendChild(wrapper);
+
+      const link = (id: string) =>
+        html`<button ${uiSref('user', { id })}>Go</button>`;
+      render(link('1'), wrapper);
+      await tick(50);
+      render(link('2'), wrapper);
+      await tick(50);
+
+      expect(warn).toHaveBeenCalledTimes(1);
+      warn.mockRestore();
+    });
+
+    it('should not write href to a non-link under auto', async () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const wrapper = await setupWithTemplate(
+        home,
+        html`<button ${uiSref('home', {}, { assignHref: 'auto' })}>Go</button>`,
+      );
+
+      expect(wrapper.querySelector('button')!.hasAttribute('href')).toBe(false);
+      expect(warn).not.toHaveBeenCalled();
+      warn.mockRestore();
+    });
+
+    it('should still write href to an anchor under auto', async () => {
+      const wrapper = await setupWithTemplate(
+        home,
+        html`<a ${uiSref('home', {}, { assignHref: 'auto' })}>Link</a>`,
+      );
+
+      expect(wrapper.querySelector('a')!.getAttribute('href')).toContain(
+        '/home',
+      );
+    });
+
+    it('should write href to an SVG anchor under auto', async () => {
+      const wrapper = await setupWithTemplate(
+        home,
+        html`<svg><a ${uiSref('home', {}, { assignHref: 'auto' })}>x</a></svg>`,
+      );
+
+      // localName is 'a' for the SVG element too, so no namespace check
+      expect(wrapper.querySelector('svg a')!.getAttribute('href')).toContain(
+        '/home',
+      );
+    });
+
+    it('should never write href under false', async () => {
+      const wrapper = await setupWithTemplate(
+        home,
+        html`<a ${uiSref('home', {}, { assignHref: false })}>Link</a>`,
+      );
+
+      expect(wrapper.querySelector('a')!.hasAttribute('href')).toBe(false);
+    });
+
+    it('should still dispatch uiSrefTarget under false', async () => {
+      // the href is never written, so an href-keyed dispatch guard would
+      // suppress the event for every sref (the #588 split is what makes
+      // this option possible)
+      router = createTestRouter(home);
+
+      const uiRouter = document.createElement('ui-router');
+      uiRouter.uiRouter = router;
+      container.appendChild(uiRouter);
+      await waitForUpdate(uiRouter);
+
+      const wrapper = document.createElement('div');
+      uiRouter.appendChild(wrapper);
+
+      const eventSpy = vi.fn();
+      wrapper.addEventListener(UI_SREF_TARGET_EVENT, eventSpy);
+
+      render(
+        html`<a ${uiSref('home', {}, { assignHref: false })}>Link</a>`,
+        wrapper,
+      );
+      await tick(50);
+
+      expect(eventSpy).toHaveBeenCalled();
+    });
+
+    it('should remove an href it wrote when the option is flipped', async () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      router = createTestRouter(home);
+
+      const uiRouter = document.createElement('ui-router');
+      uiRouter.uiRouter = router;
+      container.appendChild(uiRouter);
+      await waitForUpdate(uiRouter);
+
+      const wrapper = document.createElement('div');
+      uiRouter.appendChild(wrapper);
+
+      const link = (assignHref: boolean | 'auto') =>
+        html`<button ${uiSref('home', {}, { assignHref })}>Go</button>`;
+
+      render(link(true), wrapper);
+      await tick(50);
+      expect(wrapper.querySelector('button')!.hasAttribute('href')).toBe(true);
+
+      render(link('auto'), wrapper);
+      await tick(50);
+      expect(wrapper.querySelector('button')!.hasAttribute('href')).toBe(false);
+      warn.mockRestore();
+    });
+
+    it('should leave an href it did not write alone', async () => {
+      const wrapper = await setupWithTemplate(
+        home,
+        html`<a ${uiSref('home', {}, { assignHref: false })} href="/authored"
+          >Link</a
+        >`,
+      );
+
+      expect(wrapper.querySelector('a')!.getAttribute('href')).toBe(
+        '/authored',
+      );
+    });
+
+    it('should still navigate on click under auto on a button', async () => {
+      // the option governs the href only; it is never the switch for clicks
+      const wrapper = await setupWithTemplate(
+        home,
+        html`<button ${uiSref('home', {}, { assignHref: 'auto' })}>Go</button>`,
+      );
+
+      const goSpy = vi.spyOn(router!.stateService, 'go');
+      await clickLocatedElement(wrapper.querySelector('button')!);
+      await tick();
+
+      expect(goSpy).toHaveBeenCalledWith('home', {}, expect.any(Object));
+    });
+
+    it('should not leak assignHref into the transition options', async () => {
+      const wrapper = await setupWithTemplate(
+        home,
+        html`<a ${uiSref('home', {}, { assignHref: true, reload: true })}
+          >Link</a
+        >`,
+      );
+
+      const goSpy = vi.spyOn(router!.stateService, 'go');
+      await clickLocatedElement(wrapper.querySelector('a')!);
+      await tick();
+
+      const options = goSpy.mock.calls[0][2]!;
+      expect(options).not.toHaveProperty('assignHref');
+      expect(options).toHaveProperty('reload', true);
+    });
+  });
+
   describe('descendant clicks (currentTarget)', () => {
     // event.target is the deepest node clicked, so every guard that reads an
     // attribute off it is dead whenever a link wraps its label

--- a/packages/lit-ui-router/src/specs/ui-sref.spec.ts
+++ b/packages/lit-ui-router/src/specs/ui-sref.spec.ts
@@ -521,6 +521,36 @@ describe('uiSref directive', () => {
       warn.mockRestore();
     });
 
+    it('should stay silent outside lit dev mode, but still write href', async () => {
+      // ReactiveElement.enableWarning exists only in lit's development build,
+      // which is what production consumers resolve away from
+      const enableWarning = UIRouterLitElement.enableWarning;
+      UIRouterLitElement.enableWarning = undefined;
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      try {
+        const wrapper = await setupWithTemplate(
+          home,
+          html`<button ${uiSref('home')}>Go</button>`,
+        );
+
+        expect(warn).not.toHaveBeenCalled();
+        // only the warning is gated; the 1.x default still assigns
+        expect(wrapper.querySelector('button')!.getAttribute('href')).toContain(
+          '/home',
+        );
+      } finally {
+        warn.mockRestore();
+        UIRouterLitElement.enableWarning = enableWarning;
+      }
+    });
+
+    it('should confirm the specs run against lit dev mode', () => {
+      // the guard above is only meaningful if the suite sees dev lit; without
+      // this, every warning spec could pass vacuously
+      expect(typeof UIRouterLitElement.enableWarning).toBe('function');
+    });
+
     it('should not write href to a non-link under auto', async () => {
       const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
       const wrapper = await setupWithTemplate(

--- a/packages/lit-ui-router/src/ui-sref.ts
+++ b/packages/lit-ui-router/src/ui-sref.ts
@@ -75,6 +75,45 @@ function sameTarget(a: TargetState | null, b: TargetState): boolean {
 }
 
 /**
+ * Directive options for {@link uiSref}, passed alongside the transition
+ * options in its third argument. These never reach `@uirouter/core`.
+ *
+ * @category types
+ */
+export interface UiSrefOptions {
+  /**
+   * Where the generated `href` is written.
+   *
+   * - `true` *(default in 1.x)* — always write it, whatever the element is.
+   *   This is the historical behaviour and the standing answer for a custom
+   *   element that declares its own `href`.
+   * - `'auto'` — write it only to elements the HTML spec gives an `href`:
+   *   `<a>`, `<area>`, and SVG `<a>`. This is the correct behaviour and
+   *   becomes the default in 2.0.
+   * - `false` — never write it; the app manages the attribute itself.
+   *
+   * Under `true`, a non-link that receives an `href` warns once and names
+   * `'auto'` as the fix.
+   *
+   * This option governs the `href` attribute **only**. Whether the click
+   * handler defers to native browser behaviour is decided by the element
+   * itself, never by this setting — see {@link isNativeLink}.
+   */
+  assignHref?: boolean | 'auto';
+}
+
+/**
+ * The third argument to {@link uiSref}: core's transition options plus this
+ * directive's own.
+ *
+ * @category types
+ */
+export type UiSrefTransitionOptions = TransitionOptions & UiSrefOptions;
+
+/** elements already warned about, so a re-render does not repeat itself */
+const warnedAssignHref = new WeakSet<Element>();
+
+/**
  * Whether the element navigates on its own. `localName` is lowercase for HTML
  * and SVG alike, so SVG `<a>` needs no namespace check.
  * @internal
@@ -132,8 +171,14 @@ export class UiSrefDirective extends AsyncDirective {
   uiRouter: UIRouterLit | undefined;
   parentView: UiView | null = null;
 
+  /** this directive's own options, stripped from the transition options */
+  uiSrefOptions: UiSrefOptions = {};
+
   href: string | null = null;
   targetState: TargetState | null = null;
+
+  /** whether the href currently on the element was written by us */
+  private _ownsHref = false;
 
   /** @internal */
   unsubscribe: (() => void) | undefined;
@@ -177,12 +222,20 @@ export class UiSrefDirective extends AsyncDirective {
     // core returns null from href() for a state whose navigable has no url
     this.href = $state.href(state, params, this.getOptions(options));
 
-    if (this.href !== this.element.getAttribute('href')) {
-      if (this.href) {
-        this.element.setAttribute('href', this.href);
-      } else {
-        this.element.removeAttribute('href');
+    if (this.shouldAssignHref()) {
+      if (this.href !== this.element.getAttribute('href')) {
+        if (this.href) {
+          this.element.setAttribute('href', this.href);
+          this._ownsHref = true;
+        } else {
+          this.element.removeAttribute('href');
+          this._ownsHref = false;
+        }
       }
+    } else if (this._ownsHref) {
+      // the option was flipped after we wrote one; leave author hrefs alone
+      this.element.removeAttribute('href');
+      this._ownsHref = false;
     }
 
     // the href is not the target: a url-less state has none, and non-url
@@ -191,6 +244,36 @@ export class UiSrefDirective extends AsyncDirective {
       this.element.dispatchEvent(uiSrefTargetEvent(this.targetState));
     }
     return noChange;
+  }
+
+  /**
+   * Whether this render writes the `href`, warning once per element when the
+   * 1.x default puts one on something that cannot use it.
+   * @internal
+   */
+  shouldAssignHref(): boolean {
+    const element = this.element!;
+    const { assignHref = true } = this.uiSrefOptions;
+
+    if (assignHref === 'auto') {
+      return isNativeLink(element);
+    }
+    if (!assignHref) {
+      return false;
+    }
+
+    if (
+      this.href !== null &&
+      !isNativeLink(element) &&
+      !warnedAssignHref.has(element)
+    ) {
+      warnedAssignHref.add(element);
+      console.warn(
+        `lit-ui-router: uiSref wrote href="${this.href}" to <${element.localName}>, which has no href in HTML. ` +
+          `Pass { assignHref: 'auto' } to write it only to links; 'auto' becomes the default in 2.0.`,
+      );
+    }
+    return true;
   }
 
   /** @internal */
@@ -209,6 +292,7 @@ export class UiSrefDirective extends AsyncDirective {
     this.element = null;
     this.targetState = null;
     this.href = null;
+    this._ownsHref = false;
     this.unsubscribe?.();
   }
 
@@ -246,12 +330,15 @@ export class UiSrefDirective extends AsyncDirective {
     [state, params = {}, options = {}]: [
       string,
       RawParams?,
-      TransitionOptions?,
+      UiSrefTransitionOptions?,
     ],
   ): typeof noChange {
+    // split the directive's own options out so they never reach core
+    const { assignHref, ...transitionOptions } = options;
     this.state = state;
     this.params = params;
-    this.options = options;
+    this.options = transitionOptions;
+    this.uiSrefOptions = { assignHref };
     const uiSrefElement = part.element as unknown as UiSrefElement;
     if (this.element !== uiSrefElement) {
       this.element = uiSrefElement;
@@ -298,7 +385,8 @@ export class UiSrefDirective extends AsyncDirective {
  * **Arguments:**
  * - `state` - The target state name (can be relative like `.child` or `^.sibling`)
  * - `params` - Optional state parameters (see [[RawParams]])
- * - `options` - Optional transition options (see [[TransitionOptions]])
+ * - `options` - Optional transition options (see [[TransitionOptions]]), plus
+ *   this directive's own (see {@link UiSrefOptions})
  *
  * @example Basic usage
  * ```ts
@@ -327,8 +415,16 @@ export class UiSrefDirective extends AsyncDirective {
  * html`<a ${uiSref('^.sibling')}>Go to Sibling</a>`
  * ```
  *
+ * @example On an element that is not a link
+ * ```ts
+ * // `<button>` has no href in HTML; 'auto' keeps the attribute off it.
+ * // Clicking still navigates — the option governs the href only.
+ * html`<button ${uiSref('.new', {}, { assignHref: 'auto' })}>New</button>`
+ * ```
+ *
  * @see [[RawParams]]
  * @see [[TransitionOptions]]
+ * @see {@link UiSrefOptions}
  * @see [[DirectiveResult]]
  *
  * @category directives
@@ -336,5 +432,5 @@ export class UiSrefDirective extends AsyncDirective {
 export const uiSref: (
   state: string,
   params?: RawParams,
-  options?: TransitionOptions,
+  options?: UiSrefTransitionOptions,
 ) => DirectiveResult<typeof UiSrefDirective> = directive(UiSrefDirective);

--- a/packages/lit-ui-router/src/ui-sref.ts
+++ b/packages/lit-ui-router/src/ui-sref.ts
@@ -114,6 +114,18 @@ export type UiSrefTransitionOptions = TransitionOptions & UiSrefOptions;
 const warnedAssignHref = new WeakSet<Element>();
 
 /**
+ * Whether lit resolved to its development build. `enableWarning` is inherited
+ * from `ReactiveElement`, which declares it optional precisely because it
+ * exists only in development — lit's own docs prescribe guarding on it. Same
+ * shape in lit 2 and 3, and typed optional in both builds' `.d.ts`, so this
+ * needs no cast. Read per call, so import order cannot matter.
+ * @internal
+ */
+function inLitDevMode(): boolean {
+  return typeof UIRouterLitElement.enableWarning === 'function';
+}
+
+/**
  * Whether the element navigates on its own. `localName` is lowercase for HTML
  * and SVG alike, so SVG `<a>` needs no namespace check.
  * @internal
@@ -247,8 +259,8 @@ export class UiSrefDirective extends AsyncDirective {
   }
 
   /**
-   * Whether this render writes the `href`, warning once per element when the
-   * 1.x default puts one on something that cannot use it.
+   * Whether this render writes the `href`, warning once per element under lit's
+   * dev build when the 1.x default puts one on something that cannot use it.
    * @internal
    */
   shouldAssignHref(): boolean {
@@ -263,6 +275,7 @@ export class UiSrefDirective extends AsyncDirective {
     }
 
     if (
+      inLitDevMode() &&
       this.href !== null &&
       !isNativeLink(element) &&
       !warnedAssignHref.has(element)


### PR DESCRIPTION
Fixes #577. **Stacked on #589** (which is stacked on #588) — base it there.

## The option

```ts
assignHref?: boolean | 'auto';   // default true in 1.x
```

Lives on `uiSref`'s **third argument**, alongside the transition options:

```ts
html`<button ${uiSref('.new', {}, { assignHref: 'auto' })}>New</button>`
```

| mode | behaviour |
| --- | --- |
| `true` *(1.x default)* | write it anywhere — unchanged behaviour, plus a one-time console warning when a non-link receives one, naming `'auto'` as the fix |
| `'auto'` | write it only to `<a>`, `<area>`, SVG `<a>`; the default in 2.0 |
| `false` | never write it |

Two type exports: `UiSrefOptions` (the directive's own options) and `UiSrefTransitionOptions` (`TransitionOptions & UiSrefOptions`, the third argument's type). Both flow through `pure.ts`'s `export *`; verified present in the emitted `dist/ui-sref.d.ts`.

## Design notes

**Where the option lives.** Merged into the existing third argument rather than added as a fourth positional, and `update()` destructures `{ assignHref, ...transitionOptions }` so the directive's own keys **never reach core**. A spec asserts `$state.go` receives `reload` but not `assignHref` — without the split, an unknown key would ride along into every transition's options.

**The predicate is shared with the click guard; the option is not.** `'auto'` reuses `isNativeLink` from #589 — one predicate for one question ("is this a link by tag"). What #576 rules out is the *option* becoming the switch for click behaviour, and it doesn't: a spec asserts a plain click on `<button assignHref: 'auto'>` still navigates. The JSDoc on `assignHref` says so explicitly, since that is exactly the coupling a later refactor would be tempted to introduce.

**Not the `aria-current` predicate.** Per the issue, `href` is tag-based and `aria-current` (#556) is role-based; `<div role="link">` legitimately takes the latter and never the former. `isNativeLink`'s doc comment records why, so they don't get unified later.

**Flipping the option at runtime removes the href — but only one we wrote.** A `_ownsHref` flag tracks whether the attribute is ours, so `assignHref: false` on `<a href="/authored">` leaves the author's value intact. Both directions have specs.

**Warn once per element**, via a `WeakSet`, so a re-rendering sref doesn't spam the console. Plain `console.warn` with the `lit-ui-router:` prefix, matching the existing registration warnings.

## Why #588 had to land first

Under `assignHref: false` the attribute is never written, so the old `render()` guard — which returned before dispatching whenever the computed href matched the attribute — would have compared `null` to `null` on every render and suppressed `uiSrefTargetEvent` for **every** sref, breaking `uiSrefActive` wholesale. #588 split that guard; a spec here asserts the event still fires under `assignHref: false`, which is the regression that would otherwise be invisible.

## Verification

50 specs in the file, 194 across the package, all green. Every branch mutation-tested:

| mutation | specs that fail |
| --- | --- |
| `'auto'` ignores the tag | auto-on-button, option-flip |
| `false` ignored | never-write, leave-authored-href-alone |
| drop the warning | default-writes-and-warns, warn-once |
| warn on every render | warn-once |
| don't strip the option | no-leak-into-transition-options |
| drop the flip cleanup | option-flip |

The SVG case has its own spec — `localName` is `'a'` for SVG and HTML alike, so it needs no namespace check, and the spec is what keeps that true.

For the sample-app half: `turbo run typecheck lint build` across `sample-app-shared…`, `sample-app-lit-vanilla…` and `sample-app-lit-mobx…` — 74/74 tasks, including `lint:templates` (lit-analyzer) at 0 problems over 114 files. Audited mechanically as well as by eye: every `${uiSref(` in `apps/` paired with its enclosing tag, checking that annotated ↔ non-link holds in both directions. 15 non-link sites all annotated, 9 anchor sites none annotated.

## Downstream: the sample apps, folded in

Originally this PR left the sample apps alone and pointed at a stacked follow-up. That follow-up is now **this commit** — the stack is collapsed, so what merges into `main` is the option and its consumers together, with no window in which the repo's own apps warn.

`docs/guides/unmatched-urls.md` — the one docs snippet that puts `uiSref` on a `<button>` — passes `'auto'`, with a short note on why.

**Fifteen sample-app call sites** take `{ assignHref: 'auto' }`. The nine anchor call sites are untouched; `'auto'` is already what they get.

| file | host | sites |
| --- | --- | --- |
| `main/Home.ts` | `<button>` | 3 |
| `main/Welcome.ts` | `<button>` | 3 |
| `main/NotFound.ts` | `<button>` | 1 |
| `contacts/ContactView.ts` | `<button>` | 2 |
| `contacts/EditContact.ts` | `<button>` | 1 |
| `mymessages/MessageTable.ts` | `<tr>` | 1 |
| `sample-app-lit-vanilla/main/NavHeader.ts` | `<button>` | 2 |
| `sample-app-lit-mobx/main/NavHeader.ts` | `<button>` | 2 |

`sample-app-shared` renders in both apps, so a running app carries 13 of the 15. (The earlier count of nine in this PR was an undercount — it missed `ContactView`, the `<tr>`, and both `NavHeader`s.)

The `<tr>` carries a short comment, because it is the case both predicates have to agree on:

```ts
// a <tr> is neither a link by tag nor by role, so it takes no href
// under 'auto' and no aria-current by default — only the row class
html`<tr
  ${uiSrefActive({ activeClasses: ['active'] })}
  ${uiSref('.message', { messageId: message._id }, { assignHref: 'auto' })}
>
```

Tag-based (`href`) says no, role-based (`aria-current`, #556) says no. `href="/mymessages/inbox/3"` on a table row was exactly the inert attribute #577 exists to stop, and it was in our own sample app.

**Annotation, not conversion.** Whether these controls should be real links is a separate visual decision — `.btn` carries no styling in this app, so anchors need a stylesheet first — and three of the fifteen should stay buttons on the merits regardless. #575 remains the separate markup fix, and adds a sixteenth site.

## Semver

Minor. Additive, default unchanged; the only new behaviour on existing code is the console warning.


---

## Update: the warning is now gated on lit's development build

Second commit. The warning previously fired in production builds, where nobody can act on it.

```ts
/**
 * Whether lit resolved to its development build. `enableWarning` is inherited
 * from `ReactiveElement`, which declares it optional precisely because it
 * exists only in development — lit's own docs prescribe guarding on it.
 */
function inLitDevMode(): boolean {
  return typeof UIRouterLitElement.enableWarning === 'function';
}
```

### Why this probe

lit declares `static enableWarning?: (warningKind: WarningKind) => void` — **optional in the types because it only exists in the development build** — and its docs prescribe exactly this guard (`ReactiveElement.enableWarning?.('migration')`). So it is public, documented API, and TypeScript already models the absence, meaning no cast.

It is declared **identically in all four `.d.ts` files** — development *and* production builds of `@lit/reactive-element` 1.6.3 (lit 2) and 2.1.2 (lit 3) — and absent from both production runtimes. One probe covers the whole `^2||^3` peer range with no version branching, which matters given the lit 2 compat lane.

No new import: `UIRouterLitElement` is already imported here and inherits the static from `ReactiveElement`.

### Rejected: delegate to lit's own warning registry

Letting `enableWarning`/`disableWarning` govern our warning would be the tidier story, but `WarningKind` is a **closed union**:

```ts
export type WarningKind = 'change-in-update' | 'migration' | 'async-perform-update';
```

Registering `'uisref-assign-href'` would mean casting to squat in lit's namespace, where a future release could add a colliding kind or start validating. Reusing lit's existing `'migration'` category fails differently — it is **off by default**, so the warning would never fire, defeating its role as the migration path for #597.

### Rejected: a dedicated opt-out

Unnecessary — the option is the opt-out. `assignHref: 'auto'` (the fix) and `false` both silence it.

### Verification

197 tests. Two new specs, mutation-tested — forcing `inLitDevMode()` to `true` fails **exactly one**:

- silent outside dev mode, but the `href` is **still written** — only the warning is gated, never the behaviour
- a guard asserting the suite really runs against dev lit, so the warning specs cannot pass vacuously

### Known limitation

This makes the warning **inert** in production, not **absent** — the string still ships (~250 bytes). Removing the bytes means publishing our own dev/prod builds behind the `development` export condition, which is what lit does and what its docs recommend to library authors. Not worth the build infrastructure for one warning today; worth filing if the set grows, and #556's `aria-current` takeover warning is queued behind this one.

## Audit: which of these should become real links

Annotation now, conversion later — but the sweep is the moment to record which sites the conversion should actually touch, because "make them all anchors" is wrong. Nothing in this section is implemented here.

**Convert (12).** Plain navigation to a URL-bearing state, nothing lost by being a link, and everything gained: link semantics in the a11y tree, copy-link, open-in-new-tab, and eligibility for `aria-current`.

- `Home.ts` ×3 and `Welcome.ts` ×3 — the same three top-level states (`mymessages`, `contacts`, `prefs`), rendered as primary navigation tiles
- `NotFound.ts` — "Return to Welcome"
- `ContactView.ts` `.edit` — "Edit Contact"
- `NavHeader.ts` ×2 in each app — the home icon and "New Message"

**Keep as buttons (3).** Each for its own reason, none of them stylistic:

- **`ContactView.ts` → `mymessages.compose`** — the strongest case. It passes `{ message: { to: contact.email } }`, and `states.ts` declares that parameter deliberately outside the URL ("Note the parameter does not appear in the URL"). `$state.href()` therefore resolves to a bare `/mymessages/compose`. As an anchor it would be a *lossy* link: cmd-click opens a compose form with no recipient, and copy-link hands someone a URL that silently drops the intent. A control whose state cannot be encoded in a URL is not a link. This is the case `assignHref: 'auto'` handles best — no href at all beats a wrong one.
- **`EditContact.ts` → `^`** — "Cancel", sitting in a row with Save and Delete. It navigates, but it reads as the abort half of a form action and converting one of three to an anchor would be worse on both looks and semantics.
- **`MessageTable.ts` → `<tr>`** — a row cannot be an anchor. If we want a real link here it is an `<a>` inside the first cell, which is a separate design change to the table.

**Not counted above:** #575 converts `ContactList`'s nested `<a><button>` into a single `<button ${uiSref('.new')}>`, which becomes a 16th non-link site. Whichever of this PR and #575 merges second picks it up — it belongs in the convert column.

So the eventual conversion is 12 controls, not "all the buttons".

The styling cost is smaller than I first estimated. `styles.css` has three rules an anchor would drop, all element-qualified rather than class-qualified:

```css
button.btn i + span    { margin-left: .75em }
.home.buttons button   { text-shadow: …; border: 3px solid; border-radius: 1em; padding: 2em }
.home.buttons button i { … }
```

That is the Home tiles' whole appearance plus icon spacing. Widening those three selectors to `:is(button, a)` covers it — no new stylesheet. `.btn`/`.btn-primary` themselves carry nothing in this app, and the nav tabs (`.navheader .nav-tabs li a`) and contact list (`.selectlist a`) already style anchors directly.

Still a visual change that wants a look at the running app, which is why it is not in this PR.

## How this compares to the upstream ui-router sample apps

Our sample app is a port of the angularjs, react and angular ones, so the first question is whether this walks away from them. Checked all three from the clones.

**The markup does not diverge — it is identical in all four.** Every site annotated here is a `<button>` or `<tr>` in upstream too, in the same component, usually with the same comment above it:

| control | angularjs | react | angular 2+ | ours |
| --- | --- | --- | --- | --- |
| Home / Welcome tiles ×3 | `<button ui-sref>` | `<button>` in `<UISref>` | `<button uiSref>` | `<button ${uiSref}>` |
| ContactView "Message" | `<button>` | `<button>` | `<button>` | `<button>` |
| ContactView "Edit" | `<button>` | `<button>` | `<button>` | `<button>` |
| EditContact "Cancel" | `<button>` | `<button>` | `<button>` | `<button>` |
| NavHeader home / compose | `<button>` | `<button>` | `<button>` | `<button>` |
| message row | `<tr ui-sref>` | `<tr>` | `<tr uiSref>` | `<tr>` |
| contact list items | `<a>` | `<a>` | `<a>` | `<a>` |

So the port is faithful, including the parts worth keeping. What differs is the **rendered DOM**, and only because the four bindings disagree about where `href` goes:

| binding | `href` on a `<button uiSref>` |
| --- | --- |
| angularjs | **yes** — any element that is not a `FORM` |
| react | **yes** — `cloneElement(child, { href })` |
| angular 2+ | **no** — `AnchorUISref` has selector `a[uiSref]` |
| ours, on `main` | **yes** |
| ours, with this PR | **no** |

That is a 2–2 split, not a lone precedent, and this PR moves us onto angular 2+'s side of it. Angular's sample app keeps every one of these buttons *and* renders no `href` on them — which is exactly the state this PR reaches, arrived at by the binding's default rather than by annotation. #597 is where our default catches up.

Worth recording that the unconditional write is visibly wrong upstream too, not just in theory. React's nav tabs wrap the **list item**, not the anchor inside it:

```jsx
<UISrefActive class={'active'}><UISref to={'mymessages'}><li><a role="button">Messages</a></li></UISref></UISrefActive>
```

`cloneElement` puts the `href` on the `<li>`, so `sample-app-react` ships `<li href="/mymessages">` today, with the real anchor next to it carrying none. Our NavHeader already puts `uiSref` on the `<a>` and drops upstream's `role="button"`, so it needs no annotation at all — one of the nine link sites left alone here.

**The trade-off, accepted.** Fifteen call sites now carry `{ assignHref: 'auto' }` that have no counterpart in any upstream app, so a future diff against them shows noise that is ours. That is the cost of fixing the rendered DOM ahead of the default. It is temporary in shape: once #597 flips the default, every one of these annotations becomes redundant and gets swept back out, and the source returns to matching upstream line for line. The `<tr>` comment stays, because that one is genuinely explaining something.
