### PR TITLE
docs: move the workers-builds badge legend into DEPLOY.md

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -1,5 +1,12 @@
 # Deploy Guide
 
+[![workers-builds trigger drift](https://img.shields.io/github/check-runs/simshanith/lit-ui-router/main?nameFilter=workers-builds%20%28triggers%29&label=workers-builds)](https://github.com/simshanith/lit-ui-router/actions/workflows/release-signals.yml?query=branch%3Amain)
+[![Website](https://img.shields.io/website?url=https%3A%2F%2Flit-ui-router.dev)](https://lit-ui-router.dev)
+
+Live state of the pipeline this guide describes: whether the Cloudflare dashboard still matches the
+repo config, and whether the site it deploys is up. See
+[CD-pipeline verification signal](#cd-pipeline-verification-signal) for what each colour means.
+
 ---
 
 <p align="center">
@@ -132,7 +139,7 @@ entry: a mise-managed copy would shadow the system one and lose its desktop-app 
 non-gating: green in sync, orange (`action_required`) on drift, grey (`neutral`) when the check could not run.
 It never applies; resolving drift is still a local `--apply`.
 
-The README carries the badge for it. It diffs the live Cloudflare Workers Builds triggers that ship
+The badge for it sits at the top of this file and in the README header. It diffs the live Cloudflare Workers Builds triggers that ship
 [lit-ui-router.dev](https://lit-ui-router.dev) against the repo-owned
 [desired state](./tools/workers-builds/workers-builds-triggers.config.jsonc):
 

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -132,6 +132,28 @@ entry: a mise-managed copy would shadow the system one and lose its desktop-app 
 non-gating: green in sync, orange (`action_required`) on drift, grey (`neutral`) when the check could not run.
 It never applies; resolving drift is still a local `--apply`.
 
+The README carries the badge for it. It diffs the live Cloudflare Workers Builds triggers that ship
+[lit-ui-router.dev](https://lit-ui-router.dev) against the repo-owned
+[desired state](./tools/workers-builds/workers-builds-triggers.config.jsonc):
+
+| Badge                                                                        | Meaning                                                                   |
+| ---------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| ![passing](https://img.shields.io/badge/workers--builds-passing-brightgreen) | The dashboard triggers match the repo config                              |
+| ![passing](https://img.shields.io/badge/workers--builds-passing-orange)      | The dashboard drifted — a manual `--apply` is owed                        |
+| ![neutral](https://img.shields.io/badge/workers--builds-neutral-lightgrey)   | Could not verify (no/expired token, API outage) — not a claim about drift |
+
+One ordering trap. When the value being applied names a file in the repo — as `build_command` does,
+pointing at [`cloudflare-build.sh`](./tools/workers-builds/cloudflare-build.sh) — the apply has to
+_follow_ the merge, or it breaks the preview build of every branch that does not have the file yet.
+But the push-triggered run fires seconds after that merge, so it necessarily reads the pre-apply
+dashboard: the badge goes orange on a dashboard that is about to become correct, and nothing
+re-triggers it afterwards. Finish the `--apply` with a re-dispatch, or it stays orange against a
+converged dashboard:
+
+```sh
+gh workflow run release-signals.yml --ref main
+```
+
 Two repository secrets drive it. Both are optional — absent, the signal reports grey rather than failing:
 
 | Secret                  | Value                                                                                                                                                                                                              |

--- a/README.md
+++ b/README.md
@@ -25,16 +25,10 @@
 | ![passing](https://img.shields.io/badge/published--diff-passing-brightgreen) | The npm release matches `main`              |
 | ![passing](https://img.shields.io/badge/published--diff-passing-orange)      | Unreleased ship-affecting changes on `main` |
 
-The `workers-builds` badge above is the same kind of signal for the deploy pipeline: it diffs the live
-Cloudflare Workers Builds triggers that ship [lit-ui-router.dev](https://lit-ui-router.dev) against the
-repo-owned [desired state](./tools/workers-builds/workers-builds-triggers.config.jsonc). See
-[DEPLOY.md](./DEPLOY.md#cd-pipeline-verification-signal).
-
-| Badge                                                                        | Meaning                                                                   |
-| ---------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
-| ![passing](https://img.shields.io/badge/workers--builds-passing-brightgreen) | The dashboard triggers match the repo config                              |
-| ![passing](https://img.shields.io/badge/workers--builds-passing-orange)      | The dashboard drifted — a manual `--apply` is owed                        |
-| ![neutral](https://img.shields.io/badge/workers--builds-neutral-lightgrey)   | Could not verify (no/expired token, API outage) — not a claim about drift |
+The `workers-builds` badge at the top is the same kind of signal for the deploy pipeline that ships
+[lit-ui-router.dev](https://lit-ui-router.dev) — see
+[CD-pipeline verification signal](./DEPLOY.md#cd-pipeline-verification-signal) for what it diffs and
+what each colour means.
 
 ---
 


### PR DESCRIPTION
The `workers-builds` badge now sits at the top of `DEPLOY.md` as well as in the README header — the page that explains the signal can show its current state instead of sending you back to the README. It is joined there by the website badge: is the deploy config in sync, and is the thing it deploys up. Its colour legend and the description of what it diffs move to [`DEPLOY.md#cd-pipeline-verification-signal`](./DEPLOY.md#cd-pipeline-verification-signal), where the rest of the pipeline is documented — they were sitting in the published-packages section next to an unrelated `published-diff` legend. The README keeps a one-line pointer to the section.

While moving it, documented an ordering trap that has now bitten once. When the value being applied names a file in the repo — as `build_command` does, pointing at `cloudflare-build.sh` — the `--apply` has to *follow* the merge, or it breaks the preview build of every branch that does not have the file yet. But `release-signals.yml` triggers on push to `main`, so its run fires seconds after that merge and necessarily reads the **pre-apply** dashboard. The badge goes orange on a dashboard that is about to become correct, and nothing re-triggers it afterwards.

That is what happened after #587: the badge sat orange reporting `build_command` drift on both triggers while the dashboard had already been applied and was serving the right value — #566's preview build only passes *because* the dashboard invokes the repo script. A bare re-dispatch flipped it to `dashboard triggers match the repo config` with no dashboard change in between.

So the section now ends with the step that closes the loop:

```sh
gh workflow run release-signals.yml --ref main
```

Docs only — no behaviour change.
