### PR TITLE
refactor(lit-ui-router): bind core's untyped forEach at module scope

### DIFF
--- a/packages/lit-ui-router/src/core.ts
+++ b/packages/lit-ui-router/src/core.ts
@@ -24,6 +24,17 @@ import {
 } from './interface.js';
 
 /**
+ * `@uirouter/core` types `forEach` as `any` because it resolves to
+ * `angular.forEach || _forEach` at load time. Narrowed to the object-iteration
+ * form used here, where the callback receives `(value, key)`.
+ * @internal
+ */
+const forEachValue = forEach as <V>(
+  obj: Record<string, V>,
+  cb: (value: V, key: string) => void,
+) => void;
+
+/**
  * Internal counter for generating unique view config IDs.
  * @internal
  */
@@ -116,45 +127,43 @@ export function litViewsBuilder<
       $default: pick(state, ['component']),
     };
 
-  (
-    forEach as (
-      obj: object,
-      cb: (config: LitViewDeclaration<T>, name: string) => void,
-    ) => void
-  )(viewsObject, function (config: LitViewDeclaration<T>, name: string) {
-    let normalizedConfig: NormalizedLitViewDeclaration<T>;
-    name = name || '$default'; // Account for views: { "": { template... } }
-    if (isLitViewDeclarationTemplate<T>(config)) {
-      normalizedConfig = { component: config as LitViewDeclarationTemplate };
-    } else {
-      normalizedConfig = config as NormalizedLitViewDeclaration<T>;
-    }
-    if (Object.keys(normalizedConfig || {}).length === 0) return;
+  forEachValue(
+    viewsObject as Record<string, LitViewDeclaration<T>>,
+    function (config: LitViewDeclaration<T>, name: string) {
+      let normalizedConfig: NormalizedLitViewDeclaration<T>;
+      name = name || '$default'; // Account for views: { "": { template... } }
+      if (isLitViewDeclarationTemplate<T>(config)) {
+        normalizedConfig = { component: config as LitViewDeclarationTemplate };
+      } else {
+        normalizedConfig = config as NormalizedLitViewDeclaration<T>;
+      }
+      if (Object.keys(normalizedConfig || {}).length === 0) return;
 
-    normalizedConfig.$type = 'lit';
-    normalizedConfig.$context = state;
-    normalizedConfig.$name = name;
+      normalizedConfig.$type = 'lit';
+      normalizedConfig.$context = state;
+      normalizedConfig.$name = name;
 
-    const normalizedTarget = ViewService.normalizeUIViewTarget(
-      normalizedConfig.$context,
-      normalizedConfig.$name,
-    );
-    normalizedConfig.$uiViewName = normalizedTarget.uiViewName;
-    normalizedConfig.$uiViewContextAnchor =
-      normalizedTarget.uiViewContextAnchor;
+      const normalizedTarget = ViewService.normalizeUIViewTarget(
+        normalizedConfig.$context,
+        normalizedConfig.$name,
+      );
+      normalizedConfig.$uiViewName = normalizedTarget.uiViewName;
+      normalizedConfig.$uiViewContextAnchor =
+        normalizedTarget.uiViewContextAnchor;
 
-    if (isRoutedLitElement<T>(normalizedConfig.component)) {
-      const Component = normalizedConfig.component;
-      let component: InstanceType<RoutedLitElement<T>>;
-      normalizedConfig.component = (props: UIViewInjectedProps<T>) => {
-        component = (Component.sticky && component) || new Component(props);
-        component._uiViewProps = props;
-        return html`${component}`;
-      };
-    }
+      if (isRoutedLitElement<T>(normalizedConfig.component)) {
+        const Component = normalizedConfig.component;
+        let component: InstanceType<RoutedLitElement<T>>;
+        normalizedConfig.component = (props: UIViewInjectedProps<T>) => {
+          component = (Component.sticky && component) || new Component(props);
+          component._uiViewProps = props;
+          return html`${component}`;
+        };
+      }
 
-    views[name] = viewsObject[name] = normalizedConfig;
-  });
+      views[name] = viewsObject[name] = normalizedConfig;
+    },
+  );
   return views;
 }
 

--- a/packages/lit-ui-router/src/specs/uirouter-core-untyped.types.ts
+++ b/packages/lit-ui-router/src/specs/uirouter-core-untyped.types.ts
@@ -1,0 +1,28 @@
+import { equals, forEach, root } from '@uirouter/core';
+
+// Type-level canary — the compile is the assertion (package `typecheck`;
+// umbrella tsconfig covers src/specs); never executed.
+//
+// `@uirouter/core` assigns these at load time from an optional AngularJS
+// global (`common.js`: `exports.forEach = angular.forEach || _forEach`), so
+// its .d.ts declares them `any`. Each of our uses therefore binds a narrowed
+// signature at module scope, with the reason alongside it:
+//
+//   equals  -> packages/lit-ui-router/src/ui-sref.ts       (paramsEqual)
+//   forEach -> packages/lit-ui-router/src/core.ts          (forEachValue)
+//   root    -> packages/navigation-location-plugin/src/index.ts (globalRoot)
+//
+// Note `x satisfies SomeSignature` would be worthless here: `any` is
+// assignable to everything, so it can never fail. The assertion that has
+// teeth is the opposite one — that the symbol is *still* `any`. When core
+// starts typing one of these, its line below stops compiling, which is the
+// signal to delete the corresponding cast rather than carry it forever.
+
+/** `true` only for `any` — `1 & T` collapses to `any`, and `0 extends any`. */
+type IsAny<T> = 0 extends 1 & T ? true : false;
+
+export const coreStillShipsAny = {
+  equals: true satisfies IsAny<typeof equals>,
+  forEach: true satisfies IsAny<typeof forEach>,
+  root: true satisfies IsAny<typeof root>,
+};


### PR DESCRIPTION
Standalone off `main` — independent of the #588/#589/#590 stack, which does not touch `core.ts`.

## The change

`litViewsBuilder` wrapped its single `forEach` call in an inline function-type cast, so six lines of type noise sat in the call position:

```ts
(
  forEach as (
    obj: object,
    cb: (config: LitViewDeclaration<T>, name: string) => void,
  ) => void
)(viewsObject, function (config, name) { … });
```

Bound once at module scope instead, with the reason alongside it:

```ts
/**
 * `@uirouter/core` types `forEach` as `any` because it resolves to
 * `angular.forEach || _forEach` at load time. Narrowed to the object-iteration
 * form used here, where the callback receives `(value, key)`.
 */
const forEachValue = forEach as <V>(
  obj: Record<string, V>,
  cb: (value: V, key: string) => void,
) => void;
```

## Why `any`, and why the convention

Core's `common.js` assigns several exports at load time from an optional AngularJS global:

```js
exports.forEach = angular.forEach || _forEach;
exports.equals  = angular.equals  || _equals;
```

That runtime swap is why the `.d.ts` gives up and declares them `any`. It makes the cast the correct response rather than a workaround — but it should be written **once, at module scope, with the reason attached**, not inline at a call site.

That is already the established shape in this repo: `navigation-location-plugin/src/index.ts:18` does exactly this for `root`, and #588 now does it for `equals`. This PR is the third and last site, so all three untyped core symbols we import are handled the same way.

`extend` deliberately keeps its existing treatment — it is a different case. It is declared `typeof _extend`, whose *parameters* are typed and only whose return is `any`, so `extend(…) as TransitionOptions` is a legitimate return-type assertion rather than a workaround for an untyped callable.

## One design note

Relating `V` to the object rather than to the callback alone was not cosmetic — `no-unnecessary-type-parameters` correctly rejects a type parameter that appears once, since it cannot relate anything. Typing the object as `Record<string, V>` gives `V` a source to infer from, which satisfies the rule and removes the need for an explicit type argument at the call site. The remaining `viewsObject as Record<string, LitViewDeclaration<T>>` is arguably the more honest of the two casts anyway: it states the assumption the loop body immediately relies on.

## Verification

`lint`, `typecheck`, and the full package suite — **169 tests, unchanged**. No behaviour change; this is types and placement only.

Refs #588.


---

## Update: the linkage, and why it is not `satisfies` against the signature

Added `src/specs/uirouter-core-untyped.types.ts` — a typecheck-only canary, following the existing `typings-regressions.types.ts` precedent where the compile *is* the assertion.

**The catch worth knowing:** asserting each cast against its narrowed signature cannot work.

```ts
equals satisfies (a: RawParams, b: RawParams) => boolean   // ✅ always passes
```

`any` is assignable to everything, so that assertion can never fail — it is false confidence rather than a check. The version with teeth is the *opposite* one: assert the symbol is **still** `any`.

```ts
/** `true` only for `any` — `1 & T` collapses to `any`, and `0 extends any`. */
type IsAny<T> = 0 extends 1 & T ? true : false;

export const coreStillShipsAny = {
  equals: true satisfies IsAny<typeof equals>,
  forEach: true satisfies IsAny<typeof forEach>,
  root: true satisfies IsAny<typeof root>,
};
```

When core starts typing one of these, `IsAny` flips to `false`, `true satisfies false` stops compiling, and the failure names exactly which cast to delete. Otherwise these three casts outlive their reason silently and forever.

**Mutation-tested** — adding a properly-typed core symbol (`isNumber`) to the list fails typecheck with one error on that line, so the canary is not vacuous.

### Why one file rather than a shared types module

The thing that is genuinely shared here is **core's typing surface**, not our signatures — and both packages already depend on `@uirouter/core`. So the canary imports the symbols directly and speaks for the whole repo, including `navigation-location-plugin`'s `globalRoot`, with no cross-package import and nothing emitted. The file's comment lists all three call sites, so the convention has one discoverable home.

A shared types-only package was considered and rejected: it would add a devDependency to a published package for three type aliases, and by this repo's own graduation rule — own dependencies, own config, own turbo task — a pure-types module qualifies on none of them. The narrowed signatures also *should* differ per use (`forEach`'s object-iteration form is not its array form), so centralising them would be the wrong kind of sharing.
