### PR TITLE
docs(release): add the break-glass local publish runbook

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -12,6 +12,10 @@ The release process is automated through GitHub Actions with protected environme
 4. **Tag** - A green main CI run automatically tags the release
 5. **Publish** - Publish to NPM and create GitHub Release
 
+Every stage runs in GitHub Actions. Publishing from a workstation is a
+break-glass fallback for when the pipeline itself is unavailable — see
+[Emergency Local Publish](#emergency-local-publish-break-glass).
+
 ## Tag and Branch Conventions
 
 | Pattern                        | Purpose                    | Example                        |
@@ -262,6 +266,103 @@ Break the cycle by hand, once, before adding the package to any workflow list:
 
    Expect `latest` only. Anything else is a fossil from a `--tag` on the seed
    or from a prerelease bump; retire it — see [Dist-Tags](#dist-tags).
+
+### Emergency Local Publish (break glass)
+
+**CI is the blessed path. Publish from a workstation only when the pipeline
+itself is unavailable** — a GitHub Actions outage, a broken runner image, an
+expired trusted-publisher config — and the release cannot wait for it.
+
+This is written down so the fallback is ready to roll, not to make it routine.
+A local publish forfeits four guarantees the pipeline provides, and every one
+of them has to be replaced by hand:
+
+| CI provides                                         | Locally you must                                               |
+| --------------------------------------------------- | -------------------------------------------------------------- |
+| A fresh checkout — `dist` starts empty              | Clean `dist` yourself (see below); nothing else prunes it      |
+| OIDC trusted publishing — no long-lived token       | Use a real npm token, then revoke it afterwards                |
+| Build provenance attestation                        | Accept its absence — the release ships unattested              |
+| Cold-bake reconciliation against CI's verified pack | Accept a single unwitnessed ledger; there is no second opinion |
+
+The first row is the one that bites, because it fails silently. Every
+publishable package declares `files: ["dist/**", ...]`, and **no build task
+cleans `dist` first** — the emit tasks write over whatever is already there,
+and a Turbo cache restore extracts over the directory rather than pruning it.
+So any file the build once emitted and no longer does sits in `dist`
+indefinitely and packs into the tarball. A long-lived workspace accumulates
+these; CI never sees one.
+
+Observed 2026-08-15: `lit-ui-router-mobx` carried a month-old
+`dist/specs/test-utils.*` from before `tsconfig.src.json` excluded `src/specs`.
+It would have shipped.
+
+**Procedure:**
+
+1. **Start from a clean tree at the tag** — `git status` empty, the release tag
+   checked out. A scratch clone is strictly better than your working copy, and
+   removes the need for step 2.
+
+2. **Purge every `dist`** (gitignored, so this is always safe):
+
+   ```bash
+   git clean -xdf packages/*/dist
+   ```
+
+3. **Rebuild, then run the verification pack and the outbound gates.** These
+   read `@tools/release#pack:all`'s tarballs under `.cache/pack/` — the same
+   artifact CI's checks validate:
+
+   ```bash
+   turbo run build
+   turbo run @tools/release#pack:all --force
+   pnpm check:pack
+   turbo run check:exports
+   pnpm check:published-diff
+   ```
+
+   `--force` matters: `pack:all`'s cache key covers its file inputs, not the
+   package manager version or anything else about the local environment, so an
+   unforced run can hand back a tarball baked elsewhere.
+
+   In `check:published-diff`, anything reported as ship-affecting that you did
+   not intend to change is a stale artifact until proven otherwise — check
+   mtimes in `dist` before believing it.
+
+4. **Bake the publish tarball.** This is a _different_ artifact: a cold re-pack
+   from source through a restore-free staging copy, deliberately kept off the
+   turbo cache so no cached bytes can reach the registry. Never publish
+   `.cache/pack/`'s tarball, and never a bare `pnpm pack` — that skips the
+   publish-shape manifest strip.
+
+   ```bash
+   mise run //tools/release:pack --package-name <package> --package-dir <dir>
+   ```
+
+   Output: `tools/release/.cache/publish/<package>.tgz`.
+
+5. **Gate the manifest**, which catches `devDependencies`, `scripts`, and
+   unsubstituted `catalog:`/`workspace:` leaks:
+
+   ```bash
+   mise run //tools/release:check_tarball --tarball tools/release/.cache/publish/<package>.tgz
+   ```
+
+   If CI did manage to produce a verified pack for this commit, also run
+   `//tools/release:reconcile` — it balances this cold bake against that
+   remote-cached witness and is the one guarantee you can still get back. In a
+   full outage there is no witness, and you proceed on the bake alone.
+
+6. **Publish the cold-baked tarball**, not the directory:
+
+   ```bash
+   npm publish tools/release/.cache/publish/<package>.tgz
+   ```
+
+7. **Afterwards:** revoke the token, push the tag if it is not already on
+   origin, and re-run
+   [Release signals](https://github.com/simshanith/lit-ui-router/actions/workflows/release-signals.yml)
+   so the badges reflect the new `latest`. The GitHub Release is not created
+   for you — cut it by hand and attach the same tarball.
 
 ### Dist-Tags
 


### PR DESCRIPTION
CI is the blessed publish path and stays that way. But a pipeline outage should not be the moment anyone works out the fallback from first principles, so `RELEASE.md` now carries an **Emergency Local Publish (break glass)** section, sibling to the existing first-publish runbook.

It opens with what a workstation publish forfeits, each row paired with what has to replace it by hand:

| CI provides                                         | Locally you must                                          |
| --------------------------------------------------- | ---------------------------------------------------------- |
| A fresh checkout — `dist` starts empty              | Clean `dist` yourself; nothing else prunes it             |
| OIDC trusted publishing — no long-lived token       | Use a real npm token, then revoke it                      |
| Build provenance attestation                        | Accept its absence — the release ships unattested         |
| Cold-bake reconciliation against CI's verified pack | Accept a single unwitnessed ledger                        |

Then a seven-step procedure, and a pointer from the Overview so the section is findable before it is needed.

### Why the first row is the one that bites

Every publishable package declares `files: ["dist/**", ...]`, and **no build task cleans `dist` first** — the emit tasks write over what is already there, and a turbo cache restore extracts over the directory rather than pruning it. Anything the build once emitted and no longer does sits there indefinitely and packs.

Found live while verifying `published-diff` under pnpm 12 (#566): `lit-ui-router-mobx` was carrying a month-old `dist/specs/test-utils.*` from before `tsconfig.src.json` excluded `src/specs`. `check:published-diff` reported it correctly as ship-affecting drift against the published `0.5.0` — those files are absent from the registry tarball and `files` would have shipped them. Every other output in that directory was minutes old; only the orphans were stale.

Worth noting what that means for reading the report: a local `SHIPS CHANGES` that CI calls clean is stale `dist`, not release debt. Check mtimes before believing it. The check was catching non-hermetic drift, which is not a class it was designed for — it detects it for free by comparing the working tree's pack against the registry rather than against another local build.

### Documented rather than fixed

The hazard is a non-hermetic workspace, and CI is already hermetic — fresh checkout, empty `dist`. Real exposure is bounded to a local publish, which is exactly the break-glass path this section governs.

The build-side fix is also weaker than it looks: cleaning `outDir` in the emit tasks would only cover cache misses, since turbo's restore does not prune. Narrowing `files` off `dist/**` to explicit globs would be airtight, but it buys hermeticity that CI has by construction. Neither seemed worth the churn against a documented procedure.

### The trap the procedure exists to prevent

There are two tarballs and publishing the wrong one is easy:

- `@tools/release#pack:all` → `.cache/pack/` — what `check:pack`, `check:exports`, and `check:published-diff` read. It can be a turbo-cache-restored artifact, and is deliberately kept **off** the publish path.
- `//tools/release:pack` → `.cache/publish/` — a cold re-pack from source through a restore-free staging copy. No turbo task declares this path. This is the only thing that may reach the registry.

My own first draft of step 6 published `.cache/pack/`'s tarball, which would have defeated the reason that separation exists. The section now names both and says which is which.

It also notes that `//tools/release:reconcile` still works locally when CI did manage to produce a verified pack for the commit — the one forfeited guarantee that is sometimes recoverable. In a full outage there is no witness and you proceed on the bake alone.

Docs only — no behaviour change.
