### PR TITLE
fix(lit-ui-router): treat any target but _self as leaving the app

### DIFF
--- a/packages/lit-ui-router/src/specs/ui-sref.spec.ts
+++ b/packages/lit-ui-router/src/specs/ui-sref.spec.ts
@@ -476,6 +476,65 @@ describe('uiSref directive', () => {
         expect.objectContaining({ type: 'click', defaultPrevented: false }),
       ]);
     });
+
+    // any target but _self leaves this browsing context, so it is the
+    // browser's click, not ours
+    it.each([
+      ['_top', 'escapes an enclosing frame'],
+      ['_parent', 'escapes one level of framing'],
+      ['results', 'names a frame, or opens a window when none matches'],
+      ['_BLANK', 'browsing-context keywords are ASCII case-insensitive'],
+      [' _blank', 'untrimmed, so this is a frame named " _blank"'],
+    ])('should ignore click with target="%s" (%s)', async (target) => {
+      const wrapper = await setupWithTemplate(
+        [{ name: 'home', url: '/home' }],
+        html`<a ${uiSref('home')} target=${target}>Link</a>`,
+      );
+
+      const goSpy = vi.spyOn(router!.stateService, 'go');
+      await clickLocatedElement(wrapper.querySelector('a')!);
+      await tick();
+
+      expect(goSpy).not.toHaveBeenCalled();
+      expect(suppression.events).toEqual([
+        expect.objectContaining({ type: 'click', defaultPrevented: false }),
+      ]);
+    });
+
+    // guards the regression the widening could introduce: _self is this
+    // context, so it stays ours
+    it.each(['_self', '_SELF'])(
+      'should navigate on click with target="%s"',
+      async (target) => {
+        const wrapper = await setupWithTemplate(
+          [{ name: 'home', url: '/home' }],
+          html`<a ${uiSref('home')} target=${target}>Link</a>`,
+        );
+
+        const goSpy = vi.spyOn(router!.stateService, 'go');
+        await clickLocatedElement(wrapper.querySelector('a')!);
+        await tick();
+
+        expect(goSpy).toHaveBeenCalledWith('home', {}, expect.any(Object));
+      },
+    );
+
+    it('should navigate on a button carrying target="_top"', async () => {
+      // target means nothing on a button, so it must not suppress the click.
+      // set imperatively: it is invalid markup, which lit-analyzer rejects
+      const wrapper = await setupWithTemplate(
+        [{ name: 'home', url: '/home' }],
+        html`<button ${uiSref('home')}>Go</button>`,
+      );
+      const button = wrapper.querySelector('button')!;
+      button.setAttribute('target', '_top');
+
+      const goSpy = vi.spyOn(router!.stateService, 'go');
+      await clickLocatedElement(button);
+      await tick();
+
+      expect(goSpy).toHaveBeenCalledWith('home', {}, expect.any(Object));
+    });
   });
 
   describe('descendant clicks (currentTarget)', () => {

--- a/packages/lit-ui-router/src/ui-sref.ts
+++ b/packages/lit-ui-router/src/ui-sref.ts
@@ -97,12 +97,16 @@ function isModifiedClick(event: MouseEvent): boolean {
 }
 
 /**
- * Whether the element declares that its href leaves the app: `target="_blank"`
- * or a `rel` token list containing `external`.
+ * Whether the element declares that its href leaves this browsing context: a
+ * `target` other than `_self`, or a `rel` token list containing `external`.
  * @internal
  */
 function opensOffApp(element: Element): boolean {
-  if (element.getAttribute('target') === '_blank') {
+  const target = element.getAttribute('target');
+  // browsing-context keywords are ASCII case-insensitive; a name we do not
+  // recognise is a frame, which is equally not ours. untrimmed on purpose —
+  // the browser does not trim either, so `" _blank"` really is a frame name
+  if (target && target.toLowerCase() !== '_self') {
     return true;
   }
   // rel is a token list: `rel="external noopener"` is still external


### PR DESCRIPTION
Stacked on #589, sibling of #590 — both branch from `fix/uisref-click-guards`. Implements #592.

## The change

One swap inside `opensOffApp`, the guard #589 introduced:

```diff
-if (element.getAttribute('target') === '_blank') {
+const target = element.getAttribute('target');
+if (target && target.toLowerCase() !== '_self') {
   return true;
 }
```

#589 widened `rel` to a token list but deliberately left `target` alone, since `rel` was a defect in a guard already being touched while `target` is a behaviour change. This is that change, on its own.

## What was slipping through

| markup | browser does | we did |
| --- | --- | --- |
| `target="_top"` / `"_parent"` | escapes the enclosing frame | navigated in place |
| `target="results"` | targets that frame, or opens a window | navigated in place |
| `target="_BLANK"` | opens a new tab — keywords are ASCII case-insensitive | navigated in place |

`_top` and `_parent` are the ones with real markup behind them: an app embedded in an iframe whose "open full app" link must break out of it.

## Why not-`_self` rather than a better `_blank` match

Inverting is what Next, React Router, TanStack Router and SvelteKit all ship; `=== '_blank'` is shared only with `@uirouter/angular` and `@uirouter/react`. The split is ui-router-family vs everyone else, not old vs new. Vue Router sits between with `/\b_blank\b/i` — it reached for a regex rather than equality, which suggests the exact comparison was known-insufficient even to the binding that kept it.

`toLowerCase()` adds the case-insensitivity HTML requires and only Vue Router implements.

## `" _blank"` is not a trim case

Left untrimmed on purpose. The browser does not trim `target`, so `" _blank"` genuinely *is* a frame named `" _blank"` — not a sloppy `_blank`. It is still caught, as an unrecognised name rather than as a misspelling, which is the honest reading. Trimming would be us diverging from the browser to be helpful.

## Scope is unchanged

The swap stays inside `opensOffApp`, which #589 scoped to elements that navigate on their own. A `target` on a `<button>` still means nothing and must not suppress the click — pinned by a spec.

## Verification

8 new specs. Both arms mutation-tested independently:

- revert to `=== '_blank'` → **exactly the 5 ignore specs fail** (`_top`, `_parent`, `results`, `_BLANK`, `" _blank"`), `_self` and the button spec still pass
- drop the `_self` exemption (`if (target)`) → **exactly the 2 navigate specs fail**

192 tests passing, plus `lint`, `typecheck`, and lit-analyzer clean.

One spec sets `target` on the `<button>` imperatively rather than in the template: it is invalid markup, which lit-analyzer correctly rejects (`no-unknown-attribute`), and being invalid is the point of the case. Setting it after render tests the same guard without a suppression.

## Semver

Minor, same as #589 and #590 — a bug fix that changes behaviour code could rely on. Stacked, all three land in one minor bump.

Fixes #592
