### PR TITLE
fix(sample-app): scope the uiSref href to links with assignHref

### DIFF
--- a/apps/sample-app-lit-mobx/src/app/main/NavHeader.ts
+++ b/apps/sample-app-lit-mobx/src/app/main/NavHeader.ts
@@ -57,12 +57,12 @@ export class NavHeader extends LitElement {
         </li>
         <li class="navbar-right">
           <button
-            ${uiSref('home')}
+            ${uiSref('home', {}, { assignHref: 'auto' })}
             style="margin-right: 5px"
             class="btn btn-primary fa fa-home"
           ></button>
           <button
-            ${uiSref('mymessages.compose')}
+            ${uiSref('mymessages.compose', {}, { assignHref: 'auto' })}
             style="margin-right: 15px"
             class="btn btn-primary"
           >

--- a/apps/sample-app-lit-vanilla/src/app/main/NavHeader.ts
+++ b/apps/sample-app-lit-vanilla/src/app/main/NavHeader.ts
@@ -49,12 +49,12 @@ export class NavHeader extends LitElement {
         </li>
         <li class="navbar-right">
           <button
-            ${uiSref('home')}
+            ${uiSref('home', {}, { assignHref: 'auto' })}
             style="margin-right: 5px"
             class="btn btn-primary fa fa-home"
           ></button>
           <button
-            ${uiSref('mymessages.compose')}
+            ${uiSref('mymessages.compose', {}, { assignHref: 'auto' })}
             style="margin-right: 15px"
             class="btn btn-primary"
           >

--- a/apps/sample-app-shared/src/app/contacts/ContactView.ts
+++ b/apps/sample-app-shared/src/app/contacts/ContactView.ts
@@ -27,13 +27,17 @@ export class ContactView extends LitElement {
     const { contact } = this;
     const composeButton = html`<button
       class="btn btn-primary"
-      ${uiSref('mymessages.compose', { message: { to: contact.email } })}
+      ${uiSref(
+        'mymessages.compose',
+        { message: { to: contact.email } },
+        { assignHref: 'auto' },
+      )}
     >
       <i class="fa fa-envelope"></i><span>Message</span>
     </button>`;
     const editContactButton = html`<button
       class="btn btn-primary"
-      ${uiSref('.edit')}
+      ${uiSref('.edit', {}, { assignHref: 'auto' })}
     >
       <i class="fa fa-pencil"></i><span>Edit Contact</span>
     </button>`;

--- a/apps/sample-app-shared/src/app/contacts/EditContact.ts
+++ b/apps/sample-app-shared/src/app/contacts/EditContact.ts
@@ -98,7 +98,10 @@ export class EditContact extends LitElement {
       ></sample-contact-form>
       <hr />
       <div>
-        <button ${uiSref('^')} class="btn btn-primary">
+        <button
+          ${uiSref('^', {}, { assignHref: 'auto' })}
+          class="btn btn-primary"
+        >
           <i class="fa fa-close"></i><span>Cancel</span>
         </button>
         <button class="btn btn-primary" @click=${this.saveContact}>

--- a/apps/sample-app-shared/src/app/main/Home.ts
+++ b/apps/sample-app-shared/src/app/main/Home.ts
@@ -4,17 +4,26 @@ import { uiSref } from 'lit-ui-router';
 export function home() {
   return html`<div>
     <div class="home buttons">
-      <button ${uiSref('mymessages')} class="btn btn-primary">
+      <button
+        ${uiSref('mymessages', {}, { assignHref: 'auto' })}
+        class="btn btn-primary"
+      >
         <h1><i class="fa fa-envelope"></i></h1>
         <h1>Messages</h1>
       </button>
 
-      <button ${uiSref('contacts')} class="btn btn-primary">
+      <button
+        ${uiSref('contacts', {}, { assignHref: 'auto' })}
+        class="btn btn-primary"
+      >
         <h1><i class="fa fa-users"></i></h1>
         <h1>Contacts</h1>
       </button>
 
-      <button ${uiSref('prefs')} class="btn btn-primary">
+      <button
+        ${uiSref('prefs', {}, { assignHref: 'auto' })}
+        class="btn btn-primary"
+      >
         <h1><i class="fa fa-cogs"></i></h1>
         <h1>Preferences</h1>
       </button>

--- a/apps/sample-app-shared/src/app/main/NotFound.ts
+++ b/apps/sample-app-shared/src/app/main/NotFound.ts
@@ -17,7 +17,10 @@ export default (props: UIViewInjectedProps<NotFoundResolves>) =>
     <p>
       No state matched the URL <code>${props.resolves.attemptedPath}</code>.
     </p>
-    <button ${uiSref('welcome')} class="btn btn-primary">
+    <button
+      ${uiSref('welcome', {}, { assignHref: 'auto' })}
+      class="btn btn-primary"
+    >
       <i class="fa fa-home"></i><span>Return to Welcome</span>
     </button>
   </div>`;

--- a/apps/sample-app-shared/src/app/main/Welcome.ts
+++ b/apps/sample-app-shared/src/app/main/Welcome.ts
@@ -20,13 +20,22 @@ export default () =>
       "password")
     </p>
     <div>
-      <button ${uiSref('mymessages')} class="btn btn-primary">
+      <button
+        ${uiSref('mymessages', {}, { assignHref: 'auto' })}
+        class="btn btn-primary"
+      >
         <i class="fa fa-envelope"></i><span>Messages</span>
       </button>
-      <button ${uiSref('contacts')} class="btn btn-primary">
+      <button
+        ${uiSref('contacts', {}, { assignHref: 'auto' })}
+        class="btn btn-primary"
+      >
         <i class="fa fa-users"></i><span>Contacts</span>
       </button>
-      <button ${uiSref('prefs')} class="btn btn-primary">
+      <button
+        ${uiSref('prefs', {}, { assignHref: 'auto' })}
+        class="btn btn-primary"
+      >
         <i class="fa fa-cogs"></i><span>Preferences</span>
       </button>
     </div>

--- a/apps/sample-app-shared/src/app/mymessages/MessageTable.ts
+++ b/apps/sample-app-shared/src/app/mymessages/MessageTable.ts
@@ -84,9 +84,11 @@ export class MessageTable extends LitElement {
       [...messages].sort(orderBy(sort)),
       ({ _id }) => _id,
       (message) =>
+        // a <tr> is neither a link by tag nor by role, so it takes no href
+        // under 'auto' and no aria-current by default — only the row class
         html`<tr
           ${uiSrefActive({ activeClasses: ['active'] })}
-          ${uiSref('.message', { messageId: message._id })}
+          ${uiSref('.message', { messageId: message._id }, { assignHref: 'auto' })}
         >
           ${visibleColumns.map(
             (column) =>


### PR DESCRIPTION
**Stacked on #590** — base it there. The option this uses does not exist on `main`.

#590 adds `assignHref` and warns, in lit's dev build, when a non-link receives an `href`. The sample apps are the largest source of those warnings. This annotates every one of them.

## What changed

Fifteen call sites take `{ assignHref: 'auto' }`. The nine anchor call sites are untouched — `'auto'` is already what they get.

| file | host | sites |
| --- | --- | --- |
| `main/Home.ts` | `<button>` | 3 |
| `main/Welcome.ts` | `<button>` | 3 |
| `main/NotFound.ts` | `<button>` | 1 |
| `contacts/ContactView.ts` | `<button>` | 2 |
| `contacts/EditContact.ts` | `<button>` | 1 |
| `mymessages/MessageTable.ts` | `<tr>` | 1 |
| `sample-app-lit-vanilla/main/NavHeader.ts` | `<button>` | 2 |
| `sample-app-lit-mobx/main/NavHeader.ts` | `<button>` | 2 |

`sample-app-shared` renders in both apps, so a running app carries 13 of the 15.

The `<tr>` is the interesting one, and it carries a short comment because it is the case both predicates have to agree on:

```ts
// a <tr> is neither a link by tag nor by role, so it takes no href
// under 'auto' and no aria-current by default — only the row class
html`<tr
  ${uiSrefActive({ activeClasses: ['active'] })}
  ${uiSref('.message', { messageId: message._id }, { assignHref: 'auto' })}
>
```

Tag-based (`href`) says no, role-based (`aria-current`, #556) says no. `href="/mymessages/inbox/3"` on a table row was exactly the inert attribute #577 exists to stop, and it was in our own sample app.

## Audit: which of these should become real links

Annotation now, conversion later — but the sweep is the moment to record which sites the conversion should actually touch, because "make them all anchors" is wrong.

**Convert (12).** Plain navigation to a URL-bearing state, nothing lost by being a link, and everything gained: link semantics in the a11y tree, copy-link, open-in-new-tab, and eligibility for `aria-current`.

- `Home.ts` ×3 and `Welcome.ts` ×3 — the same three top-level states (`mymessages`, `contacts`, `prefs`), rendered as primary navigation tiles
- `NotFound.ts` — "Return to Welcome"
- `ContactView.ts` `.edit` — "Edit Contact"
- `NavHeader.ts` ×2 in each app — the home icon and "New Message"

**Keep as buttons (3).** Each for its own reason, none of them stylistic:

- **`ContactView.ts` → `mymessages.compose`** — the strongest case. It passes `{ message: { to: contact.email } }`, and `states.ts` declares that parameter deliberately outside the URL ("Note the parameter does not appear in the URL"). `$state.href()` therefore resolves to a bare `/mymessages/compose`. As an anchor it would be a *lossy* link: cmd-click opens a compose form with no recipient, and copy-link hands someone a URL that silently drops the intent. A control whose state cannot be encoded in a URL is not a link. This is the case `assignHref: 'auto'` handles best — no href at all beats a wrong one.
- **`EditContact.ts` → `^`** — "Cancel", sitting in a row with Save and Delete. It navigates, but it reads as the abort half of a form action and converting one of three to an anchor would be worse on both looks and semantics.
- **`MessageTable.ts` → `<tr>`** — a row cannot be an anchor. If we want a real link here it is an `<a>` inside the first cell, which is a separate design change to the table.

**Not counted above:** #575 converts `ContactList`'s nested `<a><button>` into a single `<button ${uiSref('.new')}>`, which becomes a 16th non-link site. Whichever of the two PRs merges second picks it up — it belongs in the convert column.

So the eventual conversion is 12 controls, not "all the buttons", and it still needs a `.btn`/`.btn-primary` stylesheet first: those classes carry no styling in this app today (only `button.btn i + span`, for icon spacing), so anchors would lose the button look entirely.

## How this compares to the upstream ui-router sample apps

Our sample app is a port of the angularjs, react and angular ones, so the first question is whether this walks away from them. Checked all three from the clones.

**The markup does not diverge — it is identical in all four.** Every site annotated here is a `<button>` or `<tr>` in upstream too, in the same component, usually with the same comment above it:

| control | angularjs | react | angular 2+ | ours |
| --- | --- | --- | --- | --- |
| Home / Welcome tiles ×3 | `<button ui-sref>` | `<button>` in `<UISref>` | `<button uiSref>` | `<button ${uiSref}>` |
| ContactView "Message" | `<button>` | `<button>` | `<button>` | `<button>` |
| ContactView "Edit" | `<button>` | `<button>` | `<button>` | `<button>` |
| EditContact "Cancel" | `<button>` | `<button>` | `<button>` | `<button>` |
| NavHeader home / compose | `<button>` | `<button>` | `<button>` | `<button>` |
| message row | `<tr ui-sref>` | `<tr>` | `<tr uiSref>` | `<tr>` |
| contact list items | `<a>` | `<a>` | `<a>` | `<a>` |

So the port is faithful, including the parts worth keeping. What differs is the **rendered DOM**, and only because the four bindings disagree about where `href` goes:

| binding | `href` on a `<button uiSref>` |
| --- | --- |
| angularjs | **yes** — any element that is not a `FORM` |
| react | **yes** — `cloneElement(child, { href })` |
| angular 2+ | **no** — `AnchorUISref` has selector `a[uiSref]` |
| ours, on `main` | **yes** |
| ours, with this PR | **no** |

That is a 2–2 split, not a lone precedent, and this PR moves us onto angular 2+'s side of it. Angular's sample app keeps every one of these buttons *and* renders no `href` on them — which is exactly the state this PR reaches, arrived at by the binding's default rather than by annotation. #597 is where our default catches up.

Worth recording that the unconditional write is visibly wrong upstream too, not just in theory. React's nav tabs wrap the **list item**, not the anchor inside it:

```jsx
<UISrefActive class={'active'}><UISref to={'mymessages'}><li><a role="button">Messages</a></li></UISref></UISrefActive>
```

`cloneElement` puts the `href` on the `<li>`, so `sample-app-react` ships `<li href="/mymessages">` today, with the real anchor next to it carrying none. Our NavHeader already puts `uiSref` on the `<a>` and drops upstream's `role="button"`, so it needs no annotation at all — one of the nine link sites left alone here.

**The trade-off, accepted.** Fifteen call sites now carry `{ assignHref: 'auto' }` that have no counterpart in any upstream app, so a future diff against them shows noise that is ours. That is the cost of fixing the rendered DOM ahead of the default. It is temporary in shape: once #597 flips the default, every one of these annotations becomes redundant and gets swept back out, and the source returns to matching upstream line for line. The `<tr>` comment stays, because that one is genuinely explaining something.

## Verification

`turbo run typecheck lint build` across `sample-app-shared…`, `sample-app-lit-vanilla…` and `sample-app-lit-mobx…` — 74/74 tasks, including `lint:templates` (lit-analyzer) at 0 problems over 114 files.

Audited mechanically as well as by eye: every `${uiSref(` in `apps/` paired with its enclosing tag, checking that annotated ↔ non-link holds in both directions. 15 non-link sites, all annotated; 9 anchor sites, none annotated.

## Semver

None — sample apps only, no published package touched.
