### PR TITLE
docs(sample-app): make navigation controls real links

### DIFF
--- a/apps/sample-app-lit-e2e/src/integration/dialog.cy.js
+++ b/apps/sample-app-lit-e2e/src/integration/dialog.cy.js
@@ -32,7 +32,7 @@ describe('confirmation dialog', () => {
     visitWithFeatures('/contacts');
     cy.contains(name).click();
     cy.url().should('contain', id);
-    cy.get('button').contains('Edit Contact').click();
+    cy.get('a.btn').contains('Edit Contact').click();
     cy.url().should('contain', 'edit');
     cy.get('button').contains('Delete').click();
 

--- a/apps/sample-app-lit-e2e/src/integration/link_semantics.cy.js
+++ b/apps/sample-app-lit-e2e/src/integration/link_semantics.cy.js
@@ -16,6 +16,17 @@ describe('link semantics', () => {
 
   beforeEach(() => {
     warnings.length = 0;
+    // captures uiSref's assignHref warning, which only fires in lit's dev
+    // build. an event hook rather than visit's onBeforeLoad, so it composes
+    // with visitWithFeatures' own (which seeds the location plugin)
+    cy.on('window:before:load', (win) => {
+      const warn = win.console.warn;
+      win.console.warn = (...args) => {
+        warnings.push(args.join(' '));
+        warn.apply(win.console, args);
+      };
+    });
+
     const applyAppConfig = () => {
       window.sessionStorage.clear();
       window.sessionStorage.setItem('appConfig', appConfig);
@@ -38,18 +49,6 @@ describe('link semantics', () => {
       applyAppConfig();
     }
   });
-
-  /** capture uiSref's assignHref warning, which only fires in lit's dev build */
-  const collectWarnings = (win) => {
-    const warn = win.console.warn;
-    win.console.warn = (...args) => {
-      warnings.push(args.join(' '));
-      warn.apply(win.console, args);
-    };
-  };
-
-  const visitCollecting = (path) =>
-    cy.visit(path, { onBeforeLoad: collectWarnings });
 
   const expectNoAssignHrefWarning = () =>
     cy
@@ -124,15 +123,15 @@ describe('link semantics', () => {
   });
 
   it('logs no assignHref warning on any of these views', () => {
-    visitCollecting('/home');
+    visitWithFeatures('/home');
     cy.contains('Messages');
     expectNoAssignHrefWarning();
 
-    visitCollecting('/contacts');
+    visitWithFeatures('/contacts');
     cy.contains('New Contact');
     expectNoAssignHrefWarning();
 
-    visitCollecting('/mymessages');
+    visitWithFeatures('/mymessages');
     cy.get('table tbody tr').should('exist');
     expectNoAssignHrefWarning();
   });

--- a/apps/sample-app-lit-e2e/src/integration/link_semantics.cy.js
+++ b/apps/sample-app-lit-e2e/src/integration/link_semantics.cy.js
@@ -1,0 +1,139 @@
+import { visitWithFeatures } from '../support/e2e';
+
+const EMAIL_ADDRESS = 'myself@angular.dev';
+const CONTACT = 'Delia Hunter';
+
+/**
+ * Navigation controls are anchors and carry an href; plain actions, and the
+ * three controls that cannot be links, stay buttons and carry none.
+ *
+ * The button/anchor split is the point — asserting `contains(...)` alone would
+ * pass either way, so every assertion here names the element.
+ */
+describe('link semantics', () => {
+  let appConfig = null;
+  const warnings = [];
+
+  beforeEach(() => {
+    warnings.length = 0;
+    const applyAppConfig = () => {
+      window.sessionStorage.clear();
+      window.sessionStorage.setItem('appConfig', appConfig);
+    };
+
+    if (!appConfig) {
+      visitWithFeatures('/login');
+      cy.get('select')
+        .contains('myself')
+        .parent('select')
+        .select(EMAIL_ADDRESS);
+      cy.get('button').contains('Log in').click();
+      cy.url()
+        .should('include', '/home')
+        .then(() => {
+          appConfig = sessionStorage.getItem('appConfig');
+        })
+        .then(applyAppConfig);
+    } else {
+      applyAppConfig();
+    }
+  });
+
+  /** capture uiSref's assignHref warning, which only fires in lit's dev build */
+  const collectWarnings = (win) => {
+    const warn = win.console.warn;
+    win.console.warn = (...args) => {
+      warnings.push(args.join(' '));
+      warn.apply(win.console, args);
+    };
+  };
+
+  const visitCollecting = (path) =>
+    cy.visit(path, { onBeforeLoad: collectWarnings });
+
+  const expectNoAssignHrefWarning = () =>
+    cy
+      .wrap(warnings)
+      .should((all) => expect(all.join('\n')).not.to.contain('assignHref'));
+
+  it('renders the home tiles as anchors with hrefs', () => {
+    visitWithFeatures('/home');
+    ['Messages', 'Contacts', 'Preferences'].forEach((label) => {
+      // contains(selector, text) yields the anchor; get().contains(text)
+      // would narrow to the deepest descendant holding the text
+      cy.contains('a.btn', label).should('have.attr', 'href');
+    });
+    cy.get('.home.buttons button').should('not.exist');
+    cy.screenshot('home-tiles');
+  });
+
+  it('renders the welcome buttons as anchors with hrefs', () => {
+    visitWithFeatures('/welcome');
+    cy.contains('a.btn', 'Messages').should('have.attr', 'href');
+    cy.contains('a.btn', 'Contacts').should('have.attr', 'href');
+    cy.contains('a.btn', 'Preferences').should('have.attr', 'href');
+    cy.screenshot('welcome');
+  });
+
+  it('navigates on a plain click of a converted control', () => {
+    visitWithFeatures('/welcome');
+    cy.contains('a.btn', 'Contacts').click();
+    cy.url().should('include', '/contacts');
+  });
+
+  it('renders one New Contact control, an anchor with an href', () => {
+    visitWithFeatures('/contacts');
+    // the nested <a><button> gave two tab stops; there is one control now
+    cy.contains('a.btn', 'New Contact').should('have.attr', 'href');
+    cy.get('button').contains('New Contact').should('not.exist');
+    cy.screenshot('contact-list');
+  });
+
+  it('keeps Edit Contact an anchor and Message a button', () => {
+    visitWithFeatures('/contacts');
+    cy.contains(CONTACT).click();
+
+    cy.contains('a.btn', 'Edit Contact').should('have.attr', 'href');
+
+    // mymessages.compose takes a non-url `message` param, so an href here
+    // would be a lossy link — assignHref: 'auto' withholds it
+    // not.have.attr yields the attribute value, so re-query before clicking
+    cy.contains('button.btn', 'Message').should('not.have.attr', 'href');
+    cy.contains('button.btn', 'Message').click();
+    cy.url().should('include', '/compose');
+  });
+
+  it('keeps Cancel a button with no href, and it still navigates', () => {
+    visitWithFeatures('/contacts');
+    cy.contains(CONTACT).click();
+    cy.contains('a.btn', 'Edit Contact').click();
+    cy.url().should('include', 'edit');
+
+    cy.contains('button.btn', 'Cancel').should('not.have.attr', 'href');
+    cy.contains('button.btn', 'Cancel').click();
+    cy.url().should('not.include', 'edit');
+  });
+
+  it('keeps message rows as <tr> with no href, and they still navigate', () => {
+    visitWithFeatures('/mymessages');
+    cy.url().should('include', '/mymessages/inbox');
+    cy.get('table tbody tr').first().should('not.have.attr', 'href');
+    cy.get('table tbody tr').first().click();
+    cy.url().should('match', /\/inbox\/.+/);
+    cy.screenshot('message-list');
+  });
+
+  it('logs no assignHref warning on any of these views', () => {
+    visitCollecting('/home');
+    cy.contains('Messages');
+    expectNoAssignHrefWarning();
+
+    visitCollecting('/contacts');
+    cy.contains('New Contact');
+    expectNoAssignHrefWarning();
+
+    visitCollecting('/mymessages');
+    cy.get('table tbody tr').should('exist');
+    expectNoAssignHrefWarning();
+  });
+});

--- a/apps/sample-app-lit-e2e/src/integration/not_found.cy.js
+++ b/apps/sample-app-lit-e2e/src/integration/not_found.cy.js
@@ -46,7 +46,7 @@ describe('404 not found', () => {
     cy.contains('Welcome to the sample app!');
     syncUrl('/no/such/page');
     cy.contains('404 Page Not Found');
-    cy.get('button').contains('Return to Welcome').click();
+    cy.get('a.btn').contains('Return to Welcome').click();
     cy.url().should('include', '/welcome');
     cy.contains('Welcome to the sample app!');
   });

--- a/apps/sample-app-lit-e2e/src/integration/sample_app.cy.js
+++ b/apps/sample-app-lit-e2e/src/integration/sample_app.cy.js
@@ -13,16 +13,14 @@ describe('unauthenticated sample app', () => {
 
   it('renders home', () => {
     visitWithFeatures('/home');
-    cy.get('button.btn').contains('Messages');
-    cy.get('button.btn').contains('Contacts');
-    cy.get('button.btn').contains('Preferences');
+    // navigation controls are anchors, so they carry a real href
+    cy.contains('a.btn', 'Messages').should('have.attr', 'href');
+    cy.contains('a.btn', 'Contacts').should('have.attr', 'href');
+    cy.contains('a.btn', 'Preferences').should('have.attr', 'href');
   });
 
   it('asks for authentication', () => {
-    visitWithFeatures('/home')
-      .get('button.btn')
-      .contains('Preferences')
-      .click();
+    visitWithFeatures('/home').get('a.btn').contains('Preferences').click();
 
     cy.contains('Log In');
     cy.contains('Username');

--- a/apps/sample-app-lit-mobx/src/app/main/NavHeader.ts
+++ b/apps/sample-app-lit-mobx/src/app/main/NavHeader.ts
@@ -56,18 +56,18 @@ export class NavHeader extends LitElement {
           <a ${uiSref('prefs')}>Preferences</a>
         </li>
         <li class="navbar-right">
-          <button
-            ${uiSref('home', {}, { assignHref: 'auto' })}
+          <a
+            ${uiSref('home')}
             style="margin-right: 5px"
             class="btn btn-primary fa fa-home"
-          ></button>
-          <button
-            ${uiSref('mymessages.compose', {}, { assignHref: 'auto' })}
+          ></a>
+          <a
+            ${uiSref('mymessages.compose')}
             style="margin-right: 15px"
             class="btn btn-primary"
           >
             <i class="fa fa-envelope"></i> New Message
-          </button>
+          </a>
         </li>
 
         <li

--- a/apps/sample-app-lit-vanilla/src/app/main/NavHeader.ts
+++ b/apps/sample-app-lit-vanilla/src/app/main/NavHeader.ts
@@ -48,18 +48,18 @@ export class NavHeader extends LitElement {
           <a ${uiSref('prefs')}>Preferences</a>
         </li>
         <li class="navbar-right">
-          <button
-            ${uiSref('home', {}, { assignHref: 'auto' })}
+          <a
+            ${uiSref('home')}
             style="margin-right: 5px"
             class="btn btn-primary fa fa-home"
-          ></button>
-          <button
-            ${uiSref('mymessages.compose', {}, { assignHref: 'auto' })}
+          ></a>
+          <a
+            ${uiSref('mymessages.compose')}
             style="margin-right: 15px"
             class="btn btn-primary"
           >
             <i class="fa fa-envelope"></i> New Message
-          </button>
+          </a>
         </li>
 
         <li

--- a/apps/sample-app-shared/src/app/contacts/ContactList.ts
+++ b/apps/sample-app-shared/src/app/contacts/ContactList.ts
@@ -16,11 +16,11 @@ export class ContactList extends LitElement {
   }
 
   render() {
+    // one control, not an <a> wrapping a <button>: nesting them gave two tab
+    // stops, and <a>'s content model forbids interactive content
     const newContact = html`
-      <a ${uiSref('.new')}>
-        <button class="btn btn-primary">
-          <i class="fa fa-pencil"></i><span>New Contact</span>
-        </button>
+      <a ${uiSref('.new')} class="btn btn-primary">
+        <i class="fa fa-pencil"></i><span>New Contact</span>
       </a>
     `;
     const contacts = repeat(

--- a/apps/sample-app-shared/src/app/contacts/ContactView.ts
+++ b/apps/sample-app-shared/src/app/contacts/ContactView.ts
@@ -35,12 +35,12 @@ export class ContactView extends LitElement {
     >
       <i class="fa fa-envelope"></i><span>Message</span>
     </button>`;
-    const editContactButton = html`<button
+    const editContactButton = html`<a
       class="btn btn-primary"
-      ${uiSref('.edit', {}, { assignHref: 'auto' })}
+      ${uiSref('.edit')}
     >
       <i class="fa fa-pencil"></i><span>Edit Contact</span>
-    </button>`;
+    </a>`;
     return html`<div class="contact">
       <sample-contact-detail .contact=${contact}></sample-contact-detail>
       ${composeButton} ${editContactButton}

--- a/apps/sample-app-shared/src/app/main/Home.ts
+++ b/apps/sample-app-shared/src/app/main/Home.ts
@@ -4,29 +4,20 @@ import { uiSref } from 'lit-ui-router';
 export function home() {
   return html`<div>
     <div class="home buttons">
-      <button
-        ${uiSref('mymessages', {}, { assignHref: 'auto' })}
-        class="btn btn-primary"
-      >
+      <a ${uiSref('mymessages')} class="btn btn-primary">
         <h1><i class="fa fa-envelope"></i></h1>
         <h1>Messages</h1>
-      </button>
+      </a>
 
-      <button
-        ${uiSref('contacts', {}, { assignHref: 'auto' })}
-        class="btn btn-primary"
-      >
+      <a ${uiSref('contacts')} class="btn btn-primary">
         <h1><i class="fa fa-users"></i></h1>
         <h1>Contacts</h1>
-      </button>
+      </a>
 
-      <button
-        ${uiSref('prefs', {}, { assignHref: 'auto' })}
-        class="btn btn-primary"
-      >
+      <a ${uiSref('prefs')} class="btn btn-primary">
         <h1><i class="fa fa-cogs"></i></h1>
         <h1>Preferences</h1>
-      </button>
+      </a>
     </div>
   </div>`;
 }

--- a/apps/sample-app-shared/src/app/main/NotFound.ts
+++ b/apps/sample-app-shared/src/app/main/NotFound.ts
@@ -17,10 +17,7 @@ export default (props: UIViewInjectedProps<NotFoundResolves>) =>
     <p>
       No state matched the URL <code>${props.resolves.attemptedPath}</code>.
     </p>
-    <button
-      ${uiSref('welcome', {}, { assignHref: 'auto' })}
-      class="btn btn-primary"
-    >
+    <a ${uiSref('welcome')} class="btn btn-primary">
       <i class="fa fa-home"></i><span>Return to Welcome</span>
-    </button>
+    </a>
   </div>`;

--- a/apps/sample-app-shared/src/app/main/Welcome.ts
+++ b/apps/sample-app-shared/src/app/main/Welcome.ts
@@ -20,24 +20,15 @@ export default () =>
       "password")
     </p>
     <div>
-      <button
-        ${uiSref('mymessages', {}, { assignHref: 'auto' })}
-        class="btn btn-primary"
-      >
+      <a ${uiSref('mymessages')} class="btn btn-primary">
         <i class="fa fa-envelope"></i><span>Messages</span>
-      </button>
-      <button
-        ${uiSref('contacts', {}, { assignHref: 'auto' })}
-        class="btn btn-primary"
-      >
+      </a>
+      <a ${uiSref('contacts')} class="btn btn-primary">
         <i class="fa fa-users"></i><span>Contacts</span>
-      </button>
-      <button
-        ${uiSref('prefs', {}, { assignHref: 'auto' })}
-        class="btn btn-primary"
-      >
+      </a>
+      <a ${uiSref('prefs')} class="btn btn-primary">
         <i class="fa fa-cogs"></i><span>Preferences</span>
-      </button>
+      </a>
     </div>
     <h4>Patterns and Recipes</h4>
     <ul>

--- a/apps/sample-app-shared/src/styles.css
+++ b/apps/sample-app-shared/src/styles.css
@@ -31,7 +31,9 @@ api-docs {
   width: 100%;
 }
 
-button.btn i + span {
+/* navigation controls are anchors, plain actions are buttons; bootstrap styles
+   .btn on both, but these local rules were written element-qualified */
+:is(a, button).btn i + span {
   margin-left: 0.75em;
 }
 
@@ -65,7 +67,7 @@ button.btn i + span {
   height: 45%;
 }
 
-.home.buttons button {
+.home.buttons :is(a, button) {
   padding: 2em;
   margin: 0;
   border: 3px solid black;
@@ -73,7 +75,7 @@ button.btn i + span {
   text-shadow: 0.1em 0.1em 0.1em black;
 }
 
-.home.buttons button i {
+.home.buttons :is(a, button) i {
   padding: 0;
   margin: 0;
   text-shadow: 0.1em 0.1em 0.1em black;
@@ -85,6 +87,16 @@ button.btn i + span {
 
 .navheader .navbar-right {
   margin-right: 0;
+}
+
+/* bootstrap's `.nav > li > a` (display:block, tab padding) and the tab
+   border-radius below both claim any anchor in the tab list. these two are
+   button-shaped navigation sitting in it, not tabs — they were buttons, which
+   `li > a` never matched */
+.navheader .nav-tabs > li.navbar-right > a.btn {
+  display: inline-block;
+  padding: 6px 12px;
+  border-radius: 4px;
 }
 
 .navheader .nav-tabs li.active a:focus {
@@ -132,7 +144,15 @@ button.btn i + span {
   padding: 1.5em 0;
   background-color: #ddd;
 }
-.selectlist a {
+/* the button-shaped anchor keeps the row links' horizontal inset, which it
+   used to inherit as the padding of the anchor that wrapped it */
+.selectlist a.btn {
+  margin: 0 1.5em;
+}
+
+/* :not(.btn) because this list now holds a button-shaped anchor (New Contact)
+   as well as its plain row links, and this rule outranks bootstrap's .btn */
+.selectlist a:not(.btn) {
   display: block;
   color: black;
   padding: 0.15em 1.5em;


### PR DESCRIPTION
Based on `main`, which now carries #590. **Supersedes #575** — that PR's control is converted here, so it can be closed unmerged.

#590 stopped writing inert `href`s and annotated fifteen sample-app call sites with `{ assignHref: 'auto' }`. That shows a consumer what the warning asks for. This PR shows the other half: what a consumer does about it when the control really is a link.

## What changed

Twelve controls become anchors and drop the annotation; three keep it.

| control | now | why |
| --- | --- | --- |
| `Home` tiles ×3, `Welcome` ×3 | `<a class="btn btn-primary">` | plain navigation to a url-bearing state |
| `NotFound` "Return to Welcome" | `<a>` | same |
| `ContactView` "Edit Contact" | `<a>` | same |
| `NavHeader` home + New Message, in both apps | `<a>` | same |
| `ContactList` "New Contact" | `<a>` | same, and it was `<a><button>` — see below |
| `ContactView` "Message" | stays `<button>`, keeps `'auto'` | passes `{ message: { to } }`, which `states.ts` keeps out of the url; as an anchor it would be a **lossy** link — cmd-click opens a compose form with no recipient |
| `EditContact` "Cancel" | stays `<button>`, keeps `'auto'` | the abort half of a Save/Delete form action |
| `MessageTable` row | stays `<tr>`, keeps `'auto'` | a row cannot be an anchor |

`ContactList` also loses its `<a>` wrapping a `<button>`, which is #575: two tab stops for one control, and interactive content inside a link, which `<a>`'s content model forbids. That inherited from the upstream angularjs sample app in 2016 and rode into the react and angular ports — #575 has the lineage.

## Upstream ecosystem audit

Our sample app is a port, so the question for every control is whether we are diverging
from the ui-router ecosystem or converging with part of it. Checked all three upstream
apps at HEAD — `sample-app-angularjs` (`1c89ceb`), `sample-app-react` (`64ed979`),
`sample-app-angular` (`9263f04`, Angular v22).

**Authored markup is identical in all four apps at every site this PR touches.**

| control | angularjs | react | angular 2+ | here, after |
| --- | --- | --- | --- | --- |
| `Home` tiles ×3 | `<button class="btn btn-primary">` | same | same | **`<a>`** |
| `Welcome` ×3 | `<button class="btn btn-primary">` | same | same | **`<a>`** |
| `NavHeader` home + New Message | `<button class="btn btn-primary">` | same | same | **`<a>`** |
| `ContactList` "New Contact" | `<a ui-sref><button class="btn btn-primary">` | same | same | **`<a class="btn btn-primary">`** |
| `ContactView` "Edit Contact" | `<button class="btn btn-primary">` | same | same | **`<a>`** |
| `NotFound` "Return to Welcome" | — | — | — | **`<a>`** |
| `ContactView` "Message" | `<button>` | same | same | `<button>` |
| `EditContact` "Cancel" | `<button>` | same | same | `<button>` |
| `MessageTable` row | `<tr>` | same | same | `<tr>` |
| `NavHeader` tabs ×3 | `<li ui-sref-active><a ui-sref role="button">` | `<UISrefActive><UISref><li><a role="button">` | `<li uiSrefActive><a uiSref role="button">` | `<li ${uiSrefActive}><a ${uiSref}>` |

Four observations fall out of it.

**The three that stay buttons stay buttons everywhere.** Not a coincidence of ports —
angularjs and angular 2+ both carry the same authored comment on "Message" explaining
that the sref supplies a **non-url parameter**. That is the reason it cannot become a
link, written down by the upstream authors, and it is why the conversion stops at twelve.

**`<a>` wrapping `<button>` is unanimous, and it is the 2016 slip.** All three ship it for
"New Contact". It originates in angularjs `eb031c6` (2016-02-05) and was imported wholesale
by react and then angular. `<button ui-sref>` works fine in angularjs, so it bought nothing
there; it only became load-bearing in react, where `UISref` is
`cloneElement(children, { href })` and needs an anchor child to clone onto. We are the
first of the four to unwind it — that is #575's finding, and the conversion here does it.

**The react app has a live symptom of the same pressure.** `ContactList.jsx:29` ships
`<a href="asd">` — a placeholder that is still there, because the anchor exists to receive
a cloned href rather than to be a link. And `NavHeader.jsx:22` wraps the `<li>` rather than
the `<a>` inside it, so react ships `<li href="/mymessages">` today: an href on an element
that has no such attribute. Both are what an unconditional href write looks like in
practice, and both are the case #590's `'auto'` exists to stop.

**Upstream's tab links carry `role="button"` on an `<a>` that navigates.** All three do.
Our port already drops it, and this PR does not reintroduce it anywhere: the twelve
converted controls are plain anchors. An `<a>` with an href *is* a link, and relabelling it
as a button costs the affordances — status-bar preview, cmd-click, "Open in new tab" — the
conversion was for.

**So the divergence is narrower than "we differ from the ecosystem."** Authored markup:
identical everywhere before this PR. Rendered DOM: a 2–2 split, since angularjs and react
write href onto whatever the sref is on and angular 2+ does not (`AnchorUISref`'s selector
is `a[uiSref]`). #590 put us on angular 2+'s side of that split by default. This PR is the
second half — where upstream angular leaves a `<button uiSref>` as a button with no href,
we make the control a real link and get the href back for the right reason.

## The CSS, which is the reviewable part

Converting an element changes which selectors match it. Four rules were affected, and every one is a case of a `<button>` having quietly failed to match something written for anchors.

```css
button.btn i + span      →  :is(a, button).btn i + span
.home.buttons button     →  .home.buttons :is(a, button)
.home.buttons button i   →  .home.buttons :is(a, button) i
```

Those three are mechanical. The other two are not, and neither was visible without running the app:

**`.selectlist a` outranks bootstrap's `.btn`.** At `(0,1,1)` against `.btn`'s `(0,1,0)` it won on `display`, `padding`, `font-size` and `color`, so "New Contact" rendered as a full-width block in small black text. Now `:not(.btn)`, with the button-shaped anchor keeping the row inset it used to inherit as the wrapping anchor's own padding.

**Bootstrap's `.nav > li > a` claims anything in the tab list.** `display: block` plus tab padding, applied to the navheader's two controls the moment they stopped being buttons — they stacked and overflowed the header. A `<button>` never matched `li > a`, which is exactly why nobody had to think about it before. One scoped rule puts them back.

Both are the same lesson in different clothes: element-qualified selectors encode an assumption about markup, and converting the markup is when you find out.

## Verification

Before/after screenshots of `/home`, `/welcome`, `/contacts` and a contact view, captured by running each app and driving it with Cypress. The two CSS regressions above were both **found this way, not by review** — the first pass typechecked, linted and passed every existing spec while rendering visibly wrong. The final rendering is unchanged from the baseline.

- the full production-like e2e — 29/29 in **all four** location strategies (vanilla, mobx, hash, navigation), plus the 9 docs specs
- `turbo run typecheck lint build` across all three sample-app packages plus the e2e package — 83/83, including `lint:templates` (lit-analyzer)

The first push passed everything locally and failed CI in `[hash]` only: the warning test hooked `console.warn` through `cy.visit`'s `onBeforeLoad`, which meant it could not also use `visitWithFeatures`, so it never seeded the location plugin. Hooking `window:before:load` instead composes with the helper rather than replacing it. Worth knowing for any future spec that wants a window hook — the dev-server shortcut in the `verify` skill cannot catch this class, because hash mode needs its own wrangler-served mount.

New spec `link_semantics.cy.js`, 8 tests, pinning the split rather than just the labels — `contains('a.btn', …)`/`contains('button.btn', …)` so an element regression fails, plus `have.attr('href')` on the converted controls and `not.have.attr('href')` on the three that stayed. One test hooks `console.warn` and asserts no `assignHref` warning fires on any of these views.

Three existing specs selected on `button` for controls that are now anchors (`sample_app`, `not_found`, `dialog`) and are updated to `a.btn` — tightened to name the element rather than loosened to accept either.

## What this does not fix

Nothing in the sample apps demonstrates why `assignHref: true` exists. All twenty custom elements here are views and panels; none has an `href` property, so the escape hatch #597 says survives 2.0 has no consumer shown anywhere. After #597 flips the default, the three remaining `'auto'` annotations become redundant and get deleted, and the sample app will demonstrate nothing about the option at all.

One link-shaped element in `NavHeader` — the design-system `<my-nav-link href>` case #597 argues from — would cover it, and it is the one annotation that would survive 2.0. Deliberately not in this PR.

## Semver

None — sample apps and their e2e specs only, no published package touched.

