### PR TITLE
perf(sample-apps): swap lodash for lodash-es to enable tree-shaking

### DIFF
--- a/apps/sample-app-lit-e2e/package.json
+++ b/apps/sample-app-lit-e2e/package.json
@@ -25,7 +25,7 @@
     "docs": "workspace:*"
   },
   "devDependencies": {
-    "@types/lodash": "catalog:",
+    "@types/lodash-es": "catalog:",
     "@types/node": "catalog:",
     "concurrently": "catalog:",
     "cypress": "catalog:",

--- a/apps/sample-app-lit-mobx/package.json
+++ b/apps/sample-app-lit-mobx/package.json
@@ -17,14 +17,14 @@
     "lit": "catalog:",
     "lit-ui-router": "workspace:*",
     "lit-ui-router-mobx": "workspace:*",
-    "lodash": "catalog:",
+    "lodash-es": "catalog:",
     "mobx": "catalog:",
     "sample-app-shared": "workspace:*"
   },
   "devDependencies": {
     "@tools/build_and_test": "workspace:*",
     "@types/dom-navigation": "catalog:",
-    "@types/lodash": "catalog:",
+    "@types/lodash-es": "catalog:",
     "@types/node": "catalog:",
     "oxfmt": "catalog:",
     "oxlint": "catalog:",

--- a/apps/sample-app-lit-mobx/src/app/mymessages/Compose.ts
+++ b/apps/sample-app-lit-mobx/src/app/mymessages/Compose.ts
@@ -1,7 +1,7 @@
 import { html, LitElement } from 'lit';
 import { customElement, state, property } from 'lit/decorators.js';
 import { compareStructural } from 'mobx';
-import { isEqual } from 'lodash';
+import { isEqual } from 'lodash-es';
 import { UIViewInjectedProps } from 'lit-ui-router';
 import { RouterReactionController } from 'lit-ui-router-mobx';
 

--- a/apps/sample-app-lit-vanilla/package.json
+++ b/apps/sample-app-lit-vanilla/package.json
@@ -17,13 +17,13 @@
     "@uirouter/core": "catalog:",
     "lit": "catalog:",
     "lit-ui-router": "workspace:*",
-    "lodash": "catalog:",
+    "lodash-es": "catalog:",
     "sample-app-shared": "workspace:*"
   },
   "devDependencies": {
     "@tools/build_and_test": "workspace:*",
     "@types/dom-navigation": "catalog:",
-    "@types/lodash": "catalog:",
+    "@types/lodash-es": "catalog:",
     "@types/node": "catalog:",
     "oxfmt": "catalog:",
     "oxlint": "catalog:",

--- a/apps/sample-app-lit-vanilla/src/app/mymessages/Compose.ts
+++ b/apps/sample-app-lit-vanilla/src/app/mymessages/Compose.ts
@@ -1,6 +1,6 @@
 import { html, LitElement } from 'lit';
 import { customElement, state, property } from 'lit/decorators.js';
-import { isEqual } from 'lodash';
+import { isEqual } from 'lodash-es';
 import { TransitionController, UIViewInjectedProps } from 'lit-ui-router';
 
 import { MessagesStorage } from 'sample-app-shared/app/global/dataSources.js';

--- a/apps/sample-app-shared/package.json
+++ b/apps/sample-app-shared/package.json
@@ -25,14 +25,14 @@
     "lit": "catalog:",
     "lit-dialog": "catalog:",
     "lit-ui-router": "workspace:*",
-    "lodash": "catalog:",
+    "lodash-es": "catalog:",
     "sample-app-routes": "workspace:*",
     "ui-router-navigation-location-plugin": "workspace:*"
   },
   "devDependencies": {
     "@tools/lit-test-env": "workspace:*",
     "@types/dom-navigation": "catalog:",
-    "@types/lodash": "catalog:",
+    "@types/lodash-es": "catalog:",
     "@types/node": "catalog:",
     "@vitest/browser-playwright": "catalog:",
     "oxfmt": "catalog:",

--- a/apps/sample-app-shared/src/app/contacts/ContactForm.ts
+++ b/apps/sample-app-shared/src/app/contacts/ContactForm.ts
@@ -1,6 +1,6 @@
 import { LitElement, html } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
-import { get, set } from 'lodash';
+import { get, set } from 'lodash-es';
 import { Contact } from './interface.js';
 
 const formInputs = [

--- a/apps/sample-app-shared/src/app/contacts/EditContact.ts
+++ b/apps/sample-app-shared/src/app/contacts/EditContact.ts
@@ -1,7 +1,7 @@
 import { LitElement, html } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import { UIViewInjectedProps, uiSref } from 'lit-ui-router';
-import { isEqual, cloneDeep } from 'lodash';
+import { isEqual, cloneDeep } from 'lodash-es';
 
 import './ContactList.js';
 import './ContactForm.js';

--- a/apps/sample-app-shared/src/app/mymessages/MessageTable.ts
+++ b/apps/sample-app-shared/src/app/mymessages/MessageTable.ts
@@ -2,7 +2,7 @@ import { html, LitElement } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { repeat } from 'lit/directives/repeat.js';
 import { uiSref, uiSrefActive } from 'lit-ui-router';
-import { isEqual } from 'lodash';
+import { isEqual } from 'lodash-es';
 
 import { orderBy } from './messageListUIService.js';
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,9 +54,9 @@ catalogs:
     '@types/dom-navigation':
       specifier: ^1.0.7
       version: 1.0.7
-    '@types/lodash':
-      specifier: ^4.17.25
-      version: 4.17.25
+    '@types/lodash-es':
+      specifier: ^4.17.12
+      version: 4.17.12
     '@types/node':
       specifier: ^24.13.3
       version: 24.13.3
@@ -135,7 +135,7 @@ catalogs:
     lit-dialog:
       specifier: ^2.0.1
       version: 2.0.1
-    lodash:
+    lodash-es:
       specifier: ^4.18.1
       version: 4.18.1
     mobx:
@@ -361,9 +361,9 @@ importers:
         specifier: workspace:*
         version: link:../../docs
     devDependencies:
-      '@types/lodash':
+      '@types/lodash-es':
         specifier: 'catalog:'
-        version: 4.17.25
+        version: 4.17.12
       '@types/node':
         specifier: 'catalog:'
         version: 24.13.3
@@ -406,7 +406,7 @@ importers:
       lit-ui-router-mobx:
         specifier: workspace:*
         version: link:../../packages/lit-ui-router-mobx
-      lodash:
+      lodash-es:
         specifier: 'catalog:'
         version: 4.18.1
       mobx:
@@ -422,9 +422,9 @@ importers:
       '@types/dom-navigation':
         specifier: 'catalog:'
         version: 1.0.7
-      '@types/lodash':
+      '@types/lodash-es':
         specifier: 'catalog:'
-        version: 4.17.25
+        version: 4.17.12
       '@types/node':
         specifier: 'catalog:'
         version: 24.13.3
@@ -458,7 +458,7 @@ importers:
       lit-ui-router:
         specifier: workspace:*
         version: link:../../packages/lit-ui-router
-      lodash:
+      lodash-es:
         specifier: 'catalog:'
         version: 4.18.1
       sample-app-shared:
@@ -471,9 +471,9 @@ importers:
       '@types/dom-navigation':
         specifier: 'catalog:'
         version: 1.0.7
-      '@types/lodash':
+      '@types/lodash-es':
         specifier: 'catalog:'
-        version: 4.17.25
+        version: 4.17.12
       '@types/node':
         specifier: 'catalog:'
         version: 24.13.3
@@ -544,7 +544,7 @@ importers:
       lit-ui-router:
         specifier: workspace:*
         version: link:../../packages/lit-ui-router
-      lodash:
+      lodash-es:
         specifier: 'catalog:'
         version: 4.18.1
       sample-app-routes:
@@ -560,9 +560,9 @@ importers:
       '@types/dom-navigation':
         specifier: 'catalog:'
         version: 1.0.7
-      '@types/lodash':
+      '@types/lodash-es':
         specifier: 'catalog:'
-        version: 4.17.25
+        version: 4.17.12
       '@types/node':
         specifier: 'catalog:'
         version: 24.13.3
@@ -3487,6 +3487,9 @@ packages:
   '@types/linkify-it@5.0.0':
     resolution: {integrity: sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==}
 
+  '@types/lodash-es@4.17.12':
+    resolution: {integrity: sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ==}
+
   '@types/lodash@4.17.25':
     resolution: {integrity: sha512-+K1NIO8I+F9/wNulfVvu23QYd0Pe9/OCqRrim4NoYIf1VoEDL90Ve4ClzpyqBLc7NpGGWRvYNCKZ1BE/Jpf8dQ==}
 
@@ -5395,6 +5398,9 @@ packages:
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
+
+  lodash-es@4.18.1:
+    resolution: {integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==}
 
   lodash.camelcase@4.3.0:
     resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
@@ -8650,6 +8656,10 @@ snapshots:
 
   '@types/linkify-it@5.0.0': {}
 
+  '@types/lodash-es@4.17.12':
+    dependencies:
+      '@types/lodash': 4.17.25
+
   '@types/lodash@4.17.25': {}
 
   '@types/markdown-it@14.1.2':
@@ -10708,6 +10718,8 @@ snapshots:
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
+
+  lodash-es@4.18.1: {}
 
   lodash.camelcase@4.3.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -24,7 +24,7 @@ catalog:
   '@release-it/conventional-changelog': ^12.0.0
   '@spectrum-web-components/icons-workflow': ^1.12.2
   '@types/dom-navigation': ^1.0.7
-  '@types/lodash': ^4.17.25
+  '@types/lodash-es': ^4.17.12
   '@types/node': ^24.13.3
   '@types/pacote': ^11.1.8
   '@types/semver': ^7.8.0
@@ -51,7 +51,7 @@ catalog:
   lit: ^3.3.3
   lit-analyzer: ^2.0.3
   lit-dialog: ^2.0.1
-  lodash: ^4.18.1
+  lodash-es: ^4.18.1
   mobx: ^7.0.0
   oxc-minify: 0.144.0
   oxc-transform: 0.144.0


### PR DESCRIPTION
## What

Swap `lodash` → `lodash-es` (and `@types/lodash` → `@types/lodash-es`) across the sample apps.

The CJS `lodash` build is opaque to rollup, so every sample app shipped the whole library in one chunk to get `isEqual`, `cloneDeep`, `get`, and `set`. `lodash-es` is the same implementation published as ESM, so rollup keeps only the reachable graph.

Deliberately **plain named imports** (`import { isEqual } from 'lodash-es'`) — no per-function deep imports (`lodash/isEqual`) and no vendoring. The ESM entry does the tree-shaking; deep imports would buy nothing and cost readability.

`structuredClone` was considered as a native replacement for `cloneDeep`, but rejected: it throws on functions/DOM nodes and does not preserve prototypes, and the app still needs `isEqual`/`get`/`set` regardless — so the lodash dependency would not actually go away. Plain `lodash-es` keeps runtime semantics byte-identical.

## Measured impact — `apps/sample-app-lit-vanilla`

Whole-library chunk, gone:

| | raw | gzip |
| --- | ---: | ---: |
| before — `assets/lodash-Ddu_G1VK.js` | 71.21 kB | 26.02 kB |
| after — `assets/isEqual-*.js` + lodash code folded into the contacts `states-*` chunk | 18.46 kB | 6.95 kB |

Whole-app JS totals:

| | raw | gzip |
| --- | ---: | ---: |
| before | 438.53 kB | 144.49 kB |
| after | 385.73 kB | 125.41 kB |
| delta | **−52.8 kB** | **−19.1 kB (−13.2%)** |

On disk in the pnpm store:

| | before | after |
| --- | ---: | ---: |
| runtime package | `lodash` 4.9 MB | `lodash-es` 2.6 MB |
| types package | `@types/lodash` 3.5 MB | `@types/lodash-es` 1.3 MB |

## Verification

`turbo run typecheck lint test --filter=sample-app-lit-{vanilla,mobx,e2e} --filter=sample-app-shared` — 53/53 tasks green, including all 5 Cypress e2e suites (29 specs each: vanilla, mobx, docs, hash, navigation).

`lodash` still resolves in the lockfile as a transitive dep of tooling; only the direct app dependencies moved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated sample applications to use ES module-compatible Lodash packages.
  * Updated corresponding TypeScript type definitions.
  * Preserved existing application behavior and functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->