### PR TITLE
build: onboard CodeRabbit with a repo-scoped review config

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -18,8 +18,9 @@ reviews:
 
   auto_review:
     enabled: true
-    # Nearly all work here lands through long-lived draft PRs.
-    drafts: true
+    # Work here sits in draft for a long time. Review on "ready for review",
+    # not on every WIP push; `@coderabbitai review` pulls one in early.
+    drafts: false
     base_branches:
       - main
 

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,118 @@
+# yaml-language-server: $schema=https://storage.googleapis.com/coderabbit_public_assets/schema.v2.json
+#
+# Review behaviour for CodeRabbit. Read from the PR's own branch, so a PR may
+# tune its own review. Static analysis this repo already gates in CI is turned
+# off below — CodeRabbit is here for semantic review, not a second linter.
+language: en-US
+
+tone_instructions: >-
+  Direct and technical. Skip praise and restating the diff. Flag a concern once,
+  with the failing case. Defer to the repo's existing conventions over general
+  best practice.
+
+reviews:
+  profile: chill
+  request_changes_workflow: false
+  high_level_summary: true
+  poem: false
+
+  auto_review:
+    enabled: true
+    # Nearly all work here lands through long-lived draft PRs.
+    drafts: true
+    base_branches:
+      - main
+
+  path_filters:
+    - '!pnpm-lock.yaml'
+    - '!examples/*/package-lock.json'
+    - '!.config/mise/mise.lock'
+    - '!**/dist/**'
+    - '!apps/sample-app-shared/public/static/data/corpora/**'
+
+  path_instructions:
+    - path: packages/*/src/**/*.ts
+      instructions: >-
+        Published library source. Anything reaching the emitted `dist/*.d.ts`
+        must compile under TypeScript 5.0 — implementation-only use of newer
+        syntax is fine, but a construct like `NoInfer<T>` in an exported
+        signature breaks the floor. `lit` and `@uirouter/core` are peer
+        dependencies resolved to one shared singleton; never import a second
+        copy or promote either to a runtime dependency. Do not add runtime
+        dependencies to these packages without calling it out explicitly.
+        Comments state a constraint the code cannot show, in one line, or are
+        omitted.
+
+    - path: packages/lit-ui-router/src/**/*.ts
+      instructions: >-
+        Lit reactive controllers and directives. Check disconnect/reconnect
+        teardown: every subscription or transition hook registered on connect
+        must be released on disconnect, and re-registered on reconnect.
+        Element-part directives do not render under @lit-labs/ssr, so any
+        behaviour that must survive SSR belongs in an attribute position.
+
+    - path: '**/*.spec.ts'
+      instructions: >-
+        Lit re-render specs must build their markup from a single shared
+        template factory. Two separate `html` tagged literals produce two
+        templates, so Lit discards and recreates the directive instead of
+        updating it, and the assertion silently stops testing re-render.
+
+    - path: .github/workflows/**
+      instructions: >-
+        A skipped required check reports as passing to branch protection, so
+        weigh whether a new condition can silently degrade a gate. Prefer
+        maintained off-the-shelf actions over bespoke shell.
+
+    - path: tools/**
+      instructions: >-
+        Internal build tooling, never published. Judge it on whether it fails
+        loudly and reproducibly, not on API polish.
+
+    - path: '**/turbo.json'
+      instructions: >-
+        Task `inputs` must over-approximate. Enumerated globs go stale and
+        produce false cache hits; prefer `$TURBO_DEFAULT$`. A task that writes
+        files in place must be marked uncacheable, or a cache hit turns it into
+        a silent no-op.
+
+  pre_merge_checks:
+    # The Semantic PR workflow already enforces the Conventional Commit title.
+    title:
+      mode: 'off'
+    description:
+      mode: warning
+    docstrings:
+      mode: 'off'
+
+  # Every tool below is already a hard gate in `mise run ci`; leaving them on
+  # duplicates CI as advisory PR comments. Secret scanning is the exception —
+  # nothing in this repo covers it.
+  tools:
+    oxc:
+      enabled: false
+    biome:
+      enabled: false
+    eslint:
+      enabled: false
+    actionlint:
+      enabled: false
+    zizmor:
+      enabled: false
+    shellcheck:
+      enabled: false
+    markdownlint:
+      enabled: false
+    yamllint:
+      enabled: false
+    gitleaks:
+      enabled: true
+
+chat:
+  auto_reply: true
+
+knowledge_base:
+  learnings:
+    scope: local
+  code_guidelines:
+    enabled: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,6 +85,11 @@ repo already gates (oxlint, ESLint, actionlint, zizmor, shellcheck, rumdl,
 yamllint) are switched off there to avoid a second, weaker copy of CI; secret
 scanning is left on because nothing else covers it.
 
+Because the config is read from the PR branch, a PR can also disable its own
+review — including the `gitleaks` secret scan. Treat CodeRabbit as defence in
+depth, never as the secret-scanning floor: that belongs to GitHub's own secret
+scanning and push protection, which no PR can reach.
+
 Useful comment commands: `@coderabbitai review` for an incremental pass,
 `@coderabbitai full review` to re-review from scratch, `@coderabbitai pause` and
 `resume`, and `@coderabbitai configuration` to print the resolved settings.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,6 +73,23 @@ discussion (see the tool README).
 - A maintainer will review and run CI on your behalf
 - Ensure your changes pass local tests before submitting
 
+### Automated review
+
+[CodeRabbit](https://docs.coderabbit.ai) reviews every PR, including drafts. It
+is advisory — it posts no required status check, and nothing it says blocks a
+merge. `mise run ci` remains the gate.
+
+Its behaviour lives in [`.coderabbit.yaml`](./.coderabbit.yaml), read from the
+PR's own branch, so a PR may adjust its own review. The static analysers this
+repo already gates (oxlint, ESLint, actionlint, zizmor, shellcheck, rumdl,
+yamllint) are switched off there to avoid a second, weaker copy of CI; secret
+scanning is left on because nothing else covers it.
+
+Useful comment commands: `@coderabbitai review` for an incremental pass,
+`@coderabbitai full review` to re-review from scratch, `@coderabbitai pause` and
+`resume`, and `@coderabbitai configuration` to print the resolved settings.
+Replying to a review comment in plain English teaches it a durable convention.
+
 ## Commit conventions
 
 Every change lands on `main` as a **squash merge**, and the squash commit is

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,9 +75,11 @@ discussion (see the tool README).
 
 ### Automated review
 
-[CodeRabbit](https://docs.coderabbit.ai) reviews every PR, including drafts. It
-is advisory — it posts no required status check, and nothing it says blocks a
-merge. `mise run ci` remains the gate.
+[CodeRabbit](https://docs.coderabbit.ai) reviews a PR once it leaves draft, and
+re-reviews each push after that. Drafts are skipped on purpose — comment
+`@coderabbitai review` to pull one in early. It is advisory either way: no
+required status check, nothing it says blocks a merge. `mise run ci` remains the
+gate.
 
 Its behaviour lives in [`.coderabbit.yaml`](./.coderabbit.yaml), read from the
 PR's own branch, so a PR may adjust its own review. The static analysers this


### PR DESCRIPTION
Onboards the CodeRabbit trial onto this repo deliberately, rather than letting it run on defaults.

## Why the defaults review nothing

`reviews.auto_review.drafts` defaults to `false`, and all four open PRs here are drafts. Out of the box CodeRabbit would sit idle on this repo. `drafts: true` fixes that.

## Static analysis is off on purpose

oxlint, ESLint, actionlint, zizmor, shellcheck, rumdl and yamllint are already hard gates in `mise run ci`. Re-running them as advisory PR comments produces a weaker second opinion on ground CI already owns, and trains reviewers to skim bot output.

Two specifics worth recording:

- CodeRabbit's oxlint integration is keyed `oxc`, not `oxlint`, and only runs when Biome is disabled. `reviews.tools` has no `additionalProperties: false`, so `oxlint:` would validate clean against the published schema and silently do nothing.
- Its ESLint skips the run *entirely* when a config references plugins outside its curated allow-list, and disables type-aware rules. With `eslint-plugin-lit`/`-wc`/`-lit-a11y` incoming (#557), enabling it would most likely be a no-op that reads as coverage.

`gitleaks` stays on — secret scanning is the one thing CI does not cover.

## Path instructions

These encode what a reviewer cannot infer from a diff: the TypeScript 5.0 floor on emitted declarations, `lit` and `@uirouter/core` as one shared peer singleton, controller connect/disconnect teardown symmetry, element parts not rendering under `@lit-labs/ssr`, the shared-template-factory rule that keeps re-render specs from going inert, and the turbo `inputs`/cacheability traps.

Pre-merge title checks are off — the Semantic PR workflow already owns the Conventional Commit title.

## Verification

- Validated against `schema.v2.json`; mutation-tested the validator (a bogus top-level key is rejected) so the pass is meaningful.
- `oxfmt --check` clean. Confirmed by mutation that the root format glob really does cover this dotfile, so it cannot drift unchecked.
- `mise run lint_markdown` clean.

The config is advisory: no required status check, `request_changes_workflow: false`. `mise run ci` remains the gate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added guidance on automated pull request reviews, including available review commands, advisory behavior, and secret scanning.
  - Documented how review behavior is configured, including branch-specific settings and disabled overlapping checks.

- **Chores**
  - Added project configuration for automated review behavior, path-specific guidance, pre-merge checks, secret scanning, automatic replies, and local knowledge settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->