### PR TITLE
ci: report the failing tasks of a red turbo run in their own step

### DIFF
--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -189,14 +189,16 @@ run = 'turbo run "${usage_package_name?}#build"'
 # the env itself (no CLI flags), plus WRANGLER_LOG for the underlying
 # tasks. TURBO_FORCE is the build-test deflake input: a truthy value
 # forces a cache-bypassing rerun, ""/"false" respect the cache.
+# --summarize writes .turbo/runs/<id>.json (gitignored), which the
+# error_summary task reads on failure. It changes nothing about what runs.
 description = "Run the pull-request CI pipeline via turbo"
-run = "turbo run ci --ui=stream --log-order=stream"
+run = "turbo run ci --ui=stream --log-order=stream --summarize"
 
 [tasks.ci_main]
 # Superset of `ci` (same env contract): adds the main-only guard tasks
 # (@tools/release#check:pack, @tools/dts-backtest#test:matrix) to the graph.
 description = "Run the main-push CI pipeline via turbo"
-run = "turbo run ci:main --ui=stream --log-order=stream"
+run = "turbo run ci:main --ui=stream --log-order=stream --summarize"
 
 [tasks.codecov_bundle]
 # env: CODECOV_TOKEN plus the ambient TURBO_* remote-cache config.

--- a/.github/workflows/build-test-run.yml
+++ b/.github/workflows/build-test-run.yml
@@ -143,6 +143,17 @@ jobs:
           # Cypress video off in CI (configs keep video:true for local runs);
           # the cypressVideo dispatch input re-enables it for debugging.
           CYPRESS_video: ${{ inputs.cypressVideo == true }}
+      - name: Error summary
+        # Skip-to-the-good-parts for a red run: reads the `--summarize`
+        # artifact the ci/ci_main step just wrote, and republishes only the
+        # tasks that really failed — turbo's stream also prints ELIFECYCLE for
+        # every task it CANCELLED, which the run summary omits entirely.
+        #
+        # Placed before codecov_bundle so no later `turbo run` can be the
+        # newest summary in .turbo/runs, and it fails open: a broken reporter
+        # warns, never adds a second red step over the real failure.
+        if: ${{ failure() }}
+        run: mise run //tools/build_and_test:error_summary
       - name: Upload Codecov bundle stats
         run: mise run codecov_bundle
         env:

--- a/tools/build_and_test/mise.toml
+++ b/tools/build_and_test/mise.toml
@@ -2,8 +2,10 @@
 # (monorepo task addressing; the root config declares tools/* as
 # config_roots). Tasks run from THIS directory, so run lines are
 # src/-relative. Same inputs/secrets contract as tools/release/mise.toml:
-# inputs arrive via step `env:` blocks and secrets stay in workflow step env
-# (never mise [env]). Unlike release, this file carries an [env] block — the
+# a task's inputs are env-backed usage flags (`mise run <task> --help` is the
+# contract) that workflow step `env:` blocks satisfy as-is, and secrets stay in
+# workflow step env (never mise [env]). Runner output targets — GITHUB_OUTPUT,
+# GITHUB_STEP_SUMMARY — aren't expressible in usage and stay per-task comments. Unlike release, this file carries an [env] block — the
 # _.path below — whose effect on a shell that merely cd's in here is a harmless
 # duplicate (see its note).
 # Tasks assume node_modules exists: build-test.yml runs `mise run setup` as a
@@ -35,14 +37,17 @@ description = "Decide whether this branch-head push needs its own CI run"
 run = "./src/branch-ci-gate.ts"
 
 [tasks.error_summary]
-# env: GITHUB_STEP_SUMMARY (runner file; prints when unset), TURBO_RUNS_DIR.
-# Reads the newest `.turbo/runs/*.json` — so `ci`/`ci_main` must pass
-# `--summarize` — and republishes only the tasks that really failed.
-# Runs from the repo root, not this directory: the summary's `logFile` paths
-# are repo-root-relative. Same direct-exec reason as `xvfb` above.
+# env: GITHUB_STEP_SUMMARY (runner output file; prints to stdout when unset) —
+# an output target, so it stays a comment like the GITHUB_OUTPUT tasks below.
+# Republishes only the tasks that really failed. Runs from the repo root, not
+# this directory: the summary's `logFile` paths are repo-root-relative, and so
+# is the --runs-dir default. Same direct-exec reason as `xvfb` above.
 description = "Report the failing tasks of a red turbo run to the step summary and stdout"
 dir = "{{config_root}}/../.."
-run = "./tools/build_and_test/src/error-summary.ts"
+usage = '''
+flag "--runs-dir <runs_dir>" help="Where `turbo --summarize` writes run summaries; the newest one is this report's input" default=".turbo/runs" env="TURBO_RUNS_DIR"
+'''
+run = 'TURBO_RUNS_DIR="${usage_runs_dir?}" ./tools/build_and_test/src/error-summary.ts'
 
 [tasks.playwright_version]
 # env: GITHUB_OUTPUT (step-output target). One task per browser tool so each

--- a/tools/build_and_test/mise.toml
+++ b/tools/build_and_test/mise.toml
@@ -34,6 +34,16 @@ run = "./src/start-xvfb.ts"
 description = "Decide whether this branch-head push needs its own CI run"
 run = "./src/branch-ci-gate.ts"
 
+[tasks.error_summary]
+# env: GITHUB_STEP_SUMMARY (runner file; prints when unset), TURBO_RUNS_DIR.
+# Reads the newest `.turbo/runs/*.json` — so `ci`/`ci_main` must pass
+# `--summarize` — and republishes only the tasks that really failed.
+# Runs from the repo root, not this directory: the summary's `logFile` paths
+# are repo-root-relative. Same direct-exec reason as `xvfb` above.
+description = "Report the failing tasks of a red turbo run to the step summary and stdout"
+dir = "{{config_root}}/../.."
+run = "./tools/build_and_test/src/error-summary.ts"
+
 [tasks.playwright_version]
 # env: GITHUB_OUTPUT (step-output target). One task per browser tool so each
 # cache step derives its key alone.

--- a/tools/build_and_test/package.json
+++ b/tools/build_and_test/package.json
@@ -2,9 +2,10 @@
   "name": "@tools/build_and_test",
   "version": "0.0.1",
   "private": true,
-  "description": "Owns the build-test workflow's step logic: the branch-head CI gate, the shared Xvfb display, and the Codecov bundle-stats upload",
+  "description": "Owns the build-test workflow's step logic: the branch-head CI gate, the shared Xvfb display, the failure error-summary report, and the Codecov bundle-stats upload",
   "bin": {
     "branch-ci-gate": "./src/branch-ci-gate.ts",
+    "error-summary": "./src/error-summary.ts",
     "start-xvfb": "./src/start-xvfb.ts",
     "upload-bundle-stats": "./src/upload-bundle-stats.ts"
   },

--- a/tools/build_and_test/src/error-summary.core.ts
+++ b/tools/build_and_test/src/error-summary.core.ts
@@ -1,0 +1,306 @@
+// Pure reporting logic for the CI error-summary step: turbo run summary in,
+// focused failure report out. The IO (locating the summary, reading log files,
+// writing the two output lanes) lives in ./error-summary.ts.
+//
+// The input is turbo's `--summarize` artifact, not its stdout. That choice is
+// the whole design: when turbo tears a run down, the in-flight tasks it kills
+// print `ELIFECYCLE Command failed` indistinguishably from the task that
+// actually failed, and the run summary omits them from `tasks[]` entirely. The
+// triage the stream cannot do, the summary has already done.
+
+/** Per-task execution record. turbo 2.10 carries no `status` — exitCode is it. */
+export interface TaskExecution {
+  startTime: number;
+  endTime: number;
+  exitCode?: number | null;
+  error?: string;
+}
+
+export interface SummaryTask {
+  taskId: string;
+  task: string;
+  package: string;
+  directory: string;
+  command: string;
+  /** Repo-root-relative; written as the task runs, so it survives the failure. */
+  logFile: string;
+  cache?: { status?: string };
+  execution?: TaskExecution;
+}
+
+export interface RunSummary {
+  id: string;
+  turboVersion: string;
+  execution: {
+    command: string;
+    success: number;
+    failed: number;
+    cached: number;
+    attempted: number;
+    startTime: number;
+    endTime: number;
+    exitCode: number;
+  };
+  tasks: SummaryTask[];
+}
+
+/** A failing task plus the excerpt of its log we chose to republish. */
+export interface FailureReport {
+  task: SummaryTask;
+  durationMs: number;
+  excerpt: Excerpt;
+}
+
+export interface Excerpt {
+  text: string;
+  /** Lines dropped from the middle, 0 when the log was published whole. */
+  omittedLines: number;
+}
+
+/**
+ * Typed boundary: turbo owns this schema, so assert the two fields the report
+ * cannot work without and cast. A shape change should fail loudly here rather
+ * than produce a silently empty report — the step runs only when CI is already
+ * red, and a blank summary there reads as "nothing to see".
+ */
+export function parseRunSummary(value: unknown): RunSummary {
+  const summary = value as RunSummary;
+  if (!Array.isArray(summary?.tasks)) {
+    throw new Error('turbo run summary has no tasks[] array');
+  }
+  if (typeof summary.execution?.exitCode !== 'number') {
+    throw new Error('turbo run summary has no execution.exitCode');
+  }
+  return summary;
+}
+
+/**
+ * The genuinely-failing tasks, oldest first. Cancelled tasks never reach here
+ * (turbo omits them), and a missing `execution` means the task never ran.
+ */
+export function failedTasks(summary: RunSummary): SummaryTask[] {
+  return summary.tasks
+    .filter((task) => {
+      const code = task.execution?.exitCode;
+      return typeof code === 'number' && code !== 0;
+    })
+    .sort(
+      (a, b) => (a.execution?.startTime ?? 0) - (b.execution?.startTime ?? 0),
+    );
+}
+
+// CSI + OSC sequences. Task logs hold raw tool output, which is coloured;
+// markdown code fences render the escapes literally, so they have to go.
+// Built from a string so no ESC byte sits in this file.
+const ESC = '\\u001B';
+const ANSI = new RegExp(
+  `${ESC}\\[[0-9;?]*[ -/]*[@-~]|${ESC}\\][^]*?(?:\\u0007|${ESC}\\\\)`,
+  'g',
+);
+
+export function stripAnsi(value: string): string {
+  return value.replaceAll(ANSI, '');
+}
+
+export interface ExcerptBudget {
+  /** Lines kept from the top when the log must be cut. */
+  headLines: number;
+  /** Lines kept from the bottom when the log must be cut. */
+  tailLines: number;
+  /** Hard cap after line selection; trimmed from the head, which is the less
+   *  informative end for every runner in this repo. */
+  maxBytes: number;
+}
+
+/**
+ * Defaults sized from the real spread of task logs (112 B for a lint task,
+ * 389 KB for the Cypress e2e suite): the common failure — typecheck, lint, a
+ * unit suite — fits whole, and only the e2e-class logs are ever cut.
+ *
+ * Tail-weighted because tsc, oxlint and node:test all put the verdict last.
+ * Cypress buries its failure mid-log behind a passing-suite preamble, which is
+ * why the head is kept too rather than tailing alone.
+ */
+export const DEFAULT_BUDGET: ExcerptBudget = {
+  headLines: 20,
+  tailLines: 80,
+  maxBytes: 16 * 1024,
+};
+
+export function excerptLog(raw: string, budget = DEFAULT_BUDGET): Excerpt {
+  const lines = stripAnsi(raw)
+    .split('\n')
+    // pnpm echoes `$ <script body>` as the first line; the report prints the
+    // reproduction commands itself, so the echo is duplication.
+    .filter((line, index) => !(index === 0 && line.startsWith('$ ')));
+
+  // pnpm's own epitaph, on every failing task. The exit code is already in
+  // the table and the headline; here it just pushes the real error up.
+  while (
+    lines.length > 0 &&
+    (lines.at(-1)?.trim() === '' ||
+      lines.at(-1)?.startsWith('[ELIFECYCLE]') === true)
+  ) {
+    lines.pop();
+  }
+
+  const keep = budget.headLines + budget.tailLines;
+  let omitted = 0;
+  let kept = lines;
+  if (lines.length > keep) {
+    omitted = lines.length - keep;
+    kept = [
+      ...lines.slice(0, budget.headLines),
+      `… ${omitted} lines omitted …`,
+      ...lines.slice(-budget.tailLines),
+    ];
+  }
+
+  let text = kept.join('\n');
+  if (Buffer.byteLength(text, 'utf8') > budget.maxBytes) {
+    // Trim from the head: the tail holds the verdict.
+    const buffer = Buffer.from(text, 'utf8');
+    text = buffer.subarray(buffer.length - budget.maxBytes).toString('utf8');
+    // The byte cut lands mid-line; drop the partial leader.
+    text = text.slice(text.indexOf('\n') + 1);
+    omitted = Math.max(omitted, 1);
+    text = `… head trimmed to ${budget.maxBytes} bytes …\n${text}`;
+  }
+  return { text, omittedLines: omitted };
+}
+
+/**
+ * How to re-run just this task locally. `--force` because the failure is not
+ * in the cache (turbo never caches a failure) but its dependencies are, and a
+ * reader chasing a flake wants the bypass anyway.
+ */
+export function turboReproduction(task: SummaryTask): string {
+  const filter = task.package === '//' ? '//' : task.package;
+  return `turbo run ${task.task} --filter=${filter} --force`;
+}
+
+/** The exact command turbo ran, and where. The literal repro, not a re-derivation. */
+export function directReproduction(task: SummaryTask): string {
+  const dir = task.directory === '' ? '.' : task.directory;
+  return `cd ${dir} && ${task.command}`;
+}
+
+function seconds(ms: number): string {
+  return `${(ms / 1000).toFixed(1)}s`;
+}
+
+export function buildReports(
+  summary: RunSummary,
+  logs: Map<string, string>,
+  budget = DEFAULT_BUDGET,
+): FailureReport[] {
+  return failedTasks(summary).map((task) => {
+    const exec = task.execution;
+    const raw = logs.get(task.taskId);
+    return {
+      task,
+      durationMs: (exec?.endTime ?? 0) - (exec?.startTime ?? 0),
+      excerpt:
+        raw === undefined
+          ? {
+              text: `(no log file at ${task.logFile})\n${exec?.error ?? ''}`.trim(),
+              omittedLines: 0,
+            }
+          : excerptLog(raw, budget),
+    };
+  });
+}
+
+/** One-line headline, reused by both output lanes and by the run annotation. */
+export function headline(
+  summary: RunSummary,
+  reports: FailureReport[],
+): string {
+  const { attempted, success, cached } = summary.execution;
+  const names = reports.map((report) => report.task.taskId).join(', ');
+  const what =
+    reports.length === 0 ? 'no task reported a non-zero exit' : names;
+  return `${reports.length} failing task${reports.length === 1 ? '' : 's'}: ${what} — ${success} succeeded, ${cached} cached, ${attempted} attempted`;
+}
+
+/** The `$GITHUB_STEP_SUMMARY` lane: rendered markdown on the run page. */
+export function summaryMarkdown(
+  summary: RunSummary,
+  reports: FailureReport[],
+): string {
+  const out: string[] = ['## CI failure summary', ''];
+
+  if (reports.length === 0) {
+    out.push(
+      `\`${summary.execution.command}\` exited ${summary.execution.exitCode}, but no task reported a non-zero exit.`,
+      '',
+      'That means the run died outside a task — a turbo-level error, a runner',
+      'timeout, or a cancellation. The full step log is the only source.',
+      '',
+    );
+    return `${out.join('\n')}\n`;
+  }
+
+  const { attempted, success, cached } = summary.execution;
+  out.push(
+    `\`${summary.execution.command}\` — **${reports.length} failing**, ${success} succeeded, ${cached} cached, of ${attempted} attempted.`,
+    '',
+    '| Task | Package | Exit | Time |',
+    '| --- | --- | ---: | ---: |',
+  );
+  for (const { task, durationMs } of reports) {
+    out.push(
+      `| \`${task.task}\` | \`${task.package}\` | ${task.execution?.exitCode} | ${seconds(durationMs)} |`,
+    );
+  }
+  out.push('');
+
+  for (const { task, excerpt } of reports) {
+    out.push(
+      `### \`${task.taskId}\``,
+      '',
+      'Reproduce:',
+      '',
+      '```sh',
+      turboReproduction(task),
+      '# or, exactly as CI ran it:',
+      directReproduction(task),
+      '```',
+      '',
+    );
+    if (excerpt.omittedLines > 0) {
+      out.push(
+        `<details><summary>Log excerpt — ${excerpt.omittedLines} lines omitted, full log in the step output</summary>`,
+        '',
+      );
+    }
+    out.push('```text', excerpt.text, '```', '');
+    if (excerpt.omittedLines > 0) out.push('</details>', '');
+  }
+  return `${out.join('\n')}\n`;
+}
+
+/**
+ * The stdout lane. A step summary never appears in the logs API, so an agent
+ * running `gh run view --log-failed` cannot see it — the same content has to
+ * be printed too. Grouped per task, and the headline lands outside every group
+ * so it is visible without expanding anything.
+ */
+export function stdoutReport(
+  summary: RunSummary,
+  reports: FailureReport[],
+): string[] {
+  const lines: string[] = [];
+  for (const { task, excerpt } of reports) {
+    lines.push(
+      `── ${task.taskId} (exit ${task.execution?.exitCode})`,
+      `   repro: ${turboReproduction(task)}`,
+      `   exact: ${directReproduction(task)}`,
+      '',
+      excerpt.text,
+      '',
+    );
+  }
+  lines.push(headline(summary, reports));
+  return lines;
+}

--- a/tools/build_and_test/src/error-summary.core.ts
+++ b/tools/build_and_test/src/error-summary.core.ts
@@ -223,6 +223,33 @@ export function headline(
   return `${reports.length} failing task${reports.length === 1 ? '' : 's'}: ${what} — ${success} succeeded, ${cached} cached, ${attempted} attempted`;
 }
 
+/**
+ * A fence longer than the longest backtick run in `text`, so an excerpt that
+ * itself contains ``` cannot close the block and inject markdown into the
+ * summary. Log text is untrusted: a PR's own test output ends up in here.
+ */
+export function fenceFor(text: string): string {
+  let longest = 0;
+  for (const run of text.match(/`+/g) ?? [])
+    longest = Math.max(longest, run.length);
+  return '`'.repeat(Math.max(3, longest + 1));
+}
+
+/**
+ * Wraps stdout chunks in a `::stop-commands::` pair so the runner reads the
+ * republished logs as plain text. Same untrusted-text problem as `fenceFor`,
+ * different parser: on Actions a log line starting with `::` IS a workflow
+ * command, so an excerpt could forge annotations or stop command processing
+ * for the rest of the job. The token must be unguessable — a log that could
+ * predict it could emit the resume line itself and escape the guard.
+ *
+ * No token (running locally) leaves the chunks alone; nothing parses them.
+ */
+export function guardCommands(chunks: string[], token?: string): string[] {
+  if (token === undefined || token === '') return chunks;
+  return [`::stop-commands::${token}`, ...chunks, `::${token}::`];
+}
+
 /** The `$GITHUB_STEP_SUMMARY` lane: rendered markdown on the run page. */
 export function summaryMarkdown(
   summary: RunSummary,
@@ -274,7 +301,8 @@ export function summaryMarkdown(
         '',
       );
     }
-    out.push('```text', excerpt.text, '```', '');
+    const fence = fenceFor(excerpt.text);
+    out.push(`${fence}text`, excerpt.text, fence, '');
     if (excerpt.omittedLines > 0) out.push('</details>', '');
   }
   return `${out.join('\n')}\n`;

--- a/tools/build_and_test/src/error-summary.test.ts
+++ b/tools/build_and_test/src/error-summary.test.ts
@@ -1,0 +1,326 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+  type RunSummary,
+  type SummaryTask,
+  buildReports,
+  directReproduction,
+  excerptLog,
+  failedTasks,
+  headline,
+  parseRunSummary,
+  stdoutReport,
+  stripAnsi,
+  summaryMarkdown,
+  turboReproduction,
+} from './error-summary.core.ts';
+
+// The escape byte, spelled rather than embedded, so this file stays printable.
+const ESC = '\u001B';
+
+function task(over: Partial<SummaryTask> = {}): SummaryTask {
+  return {
+    taskId: 'lit-ui-router#typecheck:src',
+    task: 'typecheck:src',
+    package: 'lit-ui-router',
+    directory: 'packages/lit-ui-router',
+    command: 'tsc -p tsconfig.src.json --noEmit',
+    logFile: 'packages/lit-ui-router/.turbo/turbo-typecheck$colon$src.log',
+    cache: { status: 'MISS' },
+    execution: { startTime: 1_000, endTime: 8_000, exitCode: 1 },
+    ...over,
+  };
+}
+
+function summary(tasks: SummaryTask[], exitCode = 1): RunSummary {
+  return {
+    id: 'run-id',
+    turboVersion: '2.10.9',
+    execution: {
+      command: 'turbo run ci',
+      success: 61,
+      failed: tasks.filter((t) => (t.execution?.exitCode ?? 0) !== 0).length,
+      cached: 58,
+      attempted: 76,
+      startTime: 0,
+      endTime: 9_000,
+      exitCode,
+    },
+    tasks,
+  };
+}
+
+describe('parseRunSummary', () => {
+  it('rejects a summary with no tasks array', () => {
+    assert.throws(() => parseRunSummary({ execution: { exitCode: 1 } }), {
+      message: /no tasks\[\] array/,
+    });
+  });
+
+  it('rejects a summary with no execution.exitCode', () => {
+    assert.throws(() => parseRunSummary({ tasks: [] }), {
+      message: /no execution\.exitCode/,
+    });
+  });
+
+  it('accepts the real shape', () => {
+    const parsed = parseRunSummary(summary([task()]));
+    assert.equal(parsed.tasks.length, 1);
+  });
+});
+
+describe('failedTasks', () => {
+  // The whole point of reading the summary instead of the stream: turbo prints
+  // ELIFECYCLE for tasks it cancelled, and omits them from tasks[]. Anything
+  // present with exitCode 0 succeeded; anything absent was never run.
+  it('selects only non-zero exits, ignoring successes', () => {
+    const failing = failedTasks(
+      summary([
+        task({
+          taskId: 'a#lint',
+          execution: { startTime: 5, endTime: 6, exitCode: 0 },
+        }),
+        task({ taskId: 'b#typecheck' }),
+      ]),
+    );
+    assert.deepEqual(
+      failing.map((t) => t.taskId),
+      ['b#typecheck'],
+    );
+  });
+
+  it('ignores a task with no execution record', () => {
+    const failing = failedTasks(
+      summary([task({ taskId: 'c#build', execution: undefined })]),
+    );
+    assert.deepEqual(failing, []);
+  });
+
+  it('orders oldest-started first, so the earliest cause reads first', () => {
+    const failing = failedTasks(
+      summary([
+        task({
+          taskId: 'late',
+          execution: { startTime: 900, endTime: 950, exitCode: 1 },
+        }),
+        task({
+          taskId: 'early',
+          execution: { startTime: 100, endTime: 150, exitCode: 2 },
+        }),
+      ]),
+    );
+    assert.deepEqual(
+      failing.map((t) => t.taskId),
+      ['early', 'late'],
+    );
+  });
+});
+
+describe('stripAnsi', () => {
+  it('removes the SGR colouring turbo captures from tool output', () => {
+    assert.equal(
+      stripAnsi(`${ESC}[96msrc/core.ts${ESC}[0m:${ESC}[93m272${ESC}[0m`),
+      'src/core.ts:272',
+    );
+  });
+
+  it('leaves plain text untouched', () => {
+    assert.equal(stripAnsi('Found 2 errors.'), 'Found 2 errors.');
+  });
+});
+
+describe('excerptLog', () => {
+  it('publishes a short log whole', () => {
+    const { text, omittedLines } = excerptLog('one\ntwo\nthree');
+    assert.equal(text, 'one\ntwo\nthree');
+    assert.equal(omittedLines, 0);
+  });
+
+  it('drops the pnpm `$ <script>` echo, which the repro lines already say', () => {
+    const { text } = excerptLog(
+      '$ tsc -p tsconfig.src.json --noEmit\nerror TS2322',
+    );
+    assert.equal(text, 'error TS2322');
+  });
+
+  it('trims trailing blank lines', () => {
+    assert.equal(excerptLog('body\n\n\n').text, 'body');
+  });
+
+  it("drops pnpm's trailing ELIFECYCLE epitaph, which the exit column says", () => {
+    assert.equal(
+      excerptLog(
+        'Found 1 error in src/core.ts:272\n\n[ELIFECYCLE] Command failed with exit code 1.\n',
+      ).text,
+      'Found 1 error in src/core.ts:272',
+    );
+  });
+
+  it('elides the middle and says how much, keeping head and tail', () => {
+    const lines = Array.from({ length: 500 }, (_, i) => `line ${i}`);
+    const { text, omittedLines } = excerptLog(lines.join('\n'), {
+      headLines: 2,
+      tailLines: 3,
+      maxBytes: 1024,
+    });
+    assert.equal(omittedLines, 495);
+    assert.deepEqual(text.split('\n'), [
+      'line 0',
+      'line 1',
+      '… 495 lines omitted …',
+      'line 497',
+      'line 498',
+      'line 499',
+    ]);
+  });
+
+  it('enforces the byte cap from the head, because the verdict is at the tail', () => {
+    const lines = Array.from({ length: 50 }, (_, i) => `${i}`.repeat(40));
+    const { text, omittedLines } = excerptLog(lines.join('\n'), {
+      headLines: 50,
+      tailLines: 50,
+      maxBytes: 200,
+    });
+    assert.ok(Buffer.byteLength(text, 'utf8') <= 200 + 64);
+    assert.ok(text.startsWith('… head trimmed to 200 bytes …'));
+    assert.ok(text.endsWith('49'.repeat(40)), 'the last line survives');
+    assert.ok(omittedLines > 0);
+  });
+});
+
+describe('reproduction lines', () => {
+  it('filters a package task by its package name', () => {
+    assert.equal(
+      turboReproduction(task()),
+      'turbo run typecheck:src --filter=lit-ui-router --force',
+    );
+  });
+
+  it('filters a root task with //', () => {
+    assert.equal(
+      turboReproduction(task({ package: '//', task: 'lint:root' })),
+      'turbo run lint:root --filter=// --force',
+    );
+  });
+
+  it('gives the exact command and directory turbo used', () => {
+    assert.equal(
+      directReproduction(task()),
+      'cd packages/lit-ui-router && tsc -p tsconfig.src.json --noEmit',
+    );
+  });
+
+  it('uses . for a root task, whose directory is the empty string', () => {
+    assert.equal(
+      directReproduction(task({ directory: '', command: 'oxlint .' })),
+      'cd . && oxlint .',
+    );
+  });
+});
+
+describe('buildReports', () => {
+  it('pairs each failing task with its log excerpt and duration', () => {
+    const [report] = buildReports(
+      summary([task()]),
+      new Map([['lit-ui-router#typecheck:src', 'error TS2322: nope']]),
+    );
+    assert.equal(report.durationMs, 7_000);
+    assert.equal(report.excerpt.text, 'error TS2322: nope');
+  });
+
+  it('falls back to execution.error when the log file is missing', () => {
+    const [report] = buildReports(
+      summary([
+        task({
+          execution: {
+            startTime: 1,
+            endTime: 2,
+            exitCode: 1,
+            error: 'pnpm run typecheck:src exited (1)',
+          },
+        }),
+      ]),
+      new Map(),
+    );
+    assert.match(report.excerpt.text, /no log file at/);
+    assert.match(report.excerpt.text, /exited \(1\)/);
+  });
+});
+
+describe('headline', () => {
+  it('names the failing tasks and the graph size', () => {
+    const run = summary([task()]);
+    assert.equal(
+      headline(run, buildReports(run, new Map())),
+      '1 failing task: lit-ui-router#typecheck:src — 61 succeeded, 58 cached, 76 attempted',
+    );
+  });
+
+  it('says so plainly when the run died outside any task', () => {
+    const run = summary([]);
+    assert.match(headline(run, []), /no task reported a non-zero exit/);
+  });
+});
+
+describe('summaryMarkdown', () => {
+  it('leads with a table and gives each failure its repro block', () => {
+    const run = summary([task()]);
+    const markdown = summaryMarkdown(
+      run,
+      buildReports(
+        run,
+        new Map([['lit-ui-router#typecheck:src', 'error TS2322']]),
+      ),
+    );
+    assert.match(markdown, /^## CI failure summary/);
+    assert.match(
+      markdown,
+      /\| `typecheck:src` \| `lit-ui-router` \| 1 \| 7\.0s \|/,
+    );
+    assert.match(
+      markdown,
+      /turbo run typecheck:src --filter=lit-ui-router --force/,
+    );
+    assert.match(markdown, /error TS2322/);
+    // Short logs are not hidden behind a disclosure — that is the whole point.
+    assert.doesNotMatch(markdown, /<details>/);
+  });
+
+  it('hides a truncated excerpt behind a disclosure, labelled with the loss', () => {
+    const run = summary([task()]);
+    const long = Array.from({ length: 400 }, (_, i) => `line ${i}`).join('\n');
+    const markdown = summaryMarkdown(
+      run,
+      buildReports(run, new Map([['lit-ui-router#typecheck:src', long]])),
+    );
+    assert.match(markdown, /<details><summary>Log excerpt — 300 lines omitted/);
+  });
+
+  it('explains an exit with no failing task instead of rendering an empty report', () => {
+    const markdown = summaryMarkdown(summary([]), []);
+    assert.match(markdown, /no task reported a non-zero exit/);
+    assert.match(markdown, /died outside a task/);
+  });
+});
+
+describe('stdoutReport', () => {
+  // A step summary never reaches the logs API, so an agent running
+  // `gh run view --log-failed` sees only this lane.
+  it('prints the excerpt and both repro lines, headline last', () => {
+    const run = summary([task()]);
+    const lines = stdoutReport(
+      run,
+      buildReports(
+        run,
+        new Map([['lit-ui-router#typecheck:src', 'error TS2322']]),
+      ),
+    );
+    const text = lines.join('\n');
+    assert.match(text, /── lit-ui-router#typecheck:src \(exit 1\)/);
+    assert.match(text, /repro: turbo run typecheck:src/);
+    assert.match(text, /exact: cd packages\/lit-ui-router/);
+    assert.match(text, /error TS2322/);
+    assert.match(lines.at(-1) ?? '', /^1 failing task:/);
+  });
+});

--- a/tools/build_and_test/src/error-summary.test.ts
+++ b/tools/build_and_test/src/error-summary.test.ts
@@ -8,6 +8,8 @@ import {
   directReproduction,
   excerptLog,
   failedTasks,
+  fenceFor,
+  guardCommands,
   headline,
   parseRunSummary,
   stdoutReport,
@@ -322,5 +324,66 @@ describe('stdoutReport', () => {
     assert.match(text, /exact: cd packages\/lit-ui-router/);
     assert.match(text, /error TS2322/);
     assert.match(lines.at(-1) ?? '', /^1 failing task:/);
+  });
+});
+
+// Log text is untrusted — it is whatever a PR's own build printed. Both output
+// lanes embed it in a format with its own escape syntax.
+describe('untrusted log text', () => {
+  const hostile = [
+    '::error file=evil.ts,line=1::forged annotation',
+    '::stop-commands::attacker',
+    '```',
+    '</details><script>alert(1)</script>',
+  ].join('\n');
+
+  function hostileRun() {
+    const run = summary([task()]);
+    return {
+      run,
+      reports: buildReports(
+        run,
+        new Map([['lit-ui-router#typecheck:src', hostile]]),
+      ),
+    };
+  }
+
+  it('guardCommands leaves chunks alone with no token', () => {
+    assert.deepEqual(guardCommands(['a', 'b']), ['a', 'b']);
+    assert.deepEqual(guardCommands(['a'], ''), ['a']);
+  });
+
+  it('guardCommands brackets the chunks with a stop/resume pair', () => {
+    const out = guardCommands(['a', 'b'], 'tok');
+    assert.deepEqual(out, ['::stop-commands::tok', 'a', 'b', '::tok::']);
+  });
+
+  it('a `::` log line lands inside the guard, not before it', () => {
+    const { run, reports } = hostileRun();
+    const out = guardCommands(stdoutReport(run, reports), 'tok');
+    const forged = out.findIndex((chunk) =>
+      chunk.includes('forged annotation'),
+    );
+    assert.ok(forged > 0, 'the excerpt is emitted');
+    assert.equal(out.indexOf('::stop-commands::tok'), 0);
+    assert.equal(out.at(-1), '::tok::');
+    assert.ok(forged < out.length - 1, 'and lands before the resume line');
+  });
+
+  it('fenceFor outgrows the longest backtick run in the text', () => {
+    assert.equal(fenceFor('no backticks'), '```');
+    assert.equal(fenceFor('a ``` b'), '````');
+    assert.equal(fenceFor('a ````` b'), '``````');
+  });
+
+  it('summaryMarkdown fences an excerpt that contains a fence', () => {
+    const { run, reports } = hostileRun();
+    const markdown = summaryMarkdown(run, reports);
+    // The excerpt's own ``` must not be able to close the block we opened.
+    assert.match(markdown, /````text\n/);
+    assert.ok(
+      markdown.includes('</details><script>'),
+      'the excerpt is still reported verbatim',
+    );
   });
 });

--- a/tools/build_and_test/src/error-summary.ts
+++ b/tools/build_and_test/src/error-summary.ts
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+// Republishes the failing tasks of a red `turbo run` as a focused report, on
+// both lanes: `$GITHUB_STEP_SUMMARY` (rendered markdown, for humans reading the
+// run page) and stdout (for agents, which reach CI through the logs API and
+// never see a step summary).
+//
+// Input is the newest `.turbo/runs/*.json`, written by `--summarize` on the
+// `ci` / `ci_main` mise tasks. See error-summary.core.ts for why the summary,
+// not the stream, is the input.
+//
+// Fails open, always. It runs only when the job is already red; a second red
+// step here would be noise pointing at the reporter instead of the failure,
+// and an exception must never mask the real one. Every failure path warns and
+// exits 0.
+//
+// env: GITHUB_STEP_SUMMARY (runner file; printed when unset),
+//      TURBO_RUNS_DIR (override for tests and local reproduction).
+
+import { appendFile, readdir, readFile, stat } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import {
+  type FailureReport,
+  type RunSummary,
+  buildReports,
+  headline,
+  parseRunSummary,
+  stdoutReport,
+  summaryMarkdown,
+} from './error-summary.core.ts';
+
+const RUNS_DIR = process.env.TURBO_RUNS_DIR ?? '.turbo/runs';
+
+function onActions(): boolean {
+  return process.env.GITHUB_ACTIONS === 'true';
+}
+
+function warn(message: string): void {
+  console.log(
+    onActions() ? `::warning::${message.replaceAll('\n', '%0A')}` : message,
+  );
+}
+
+/**
+ * Newest summary by mtime. `--summarize` takes only true|false — no path — so
+ * recency is the only handle. In CI the job writes exactly one, but a local
+ * runs directory accumulates, hence the explicit exitCode check downstream
+ * rather than trusting recency to mean "the red one".
+ */
+async function newestSummary(): Promise<string | undefined> {
+  let names: string[];
+  try {
+    names = (await readdir(RUNS_DIR)).filter((name) => name.endsWith('.json'));
+  } catch {
+    return undefined;
+  }
+  let newest: { path: string; mtimeMs: number } | undefined;
+  for (const name of names) {
+    const path = join(RUNS_DIR, name);
+    const { mtimeMs } = await stat(path);
+    if (newest === undefined || mtimeMs > newest.mtimeMs) {
+      newest = { path, mtimeMs };
+    }
+  }
+  return newest?.path;
+}
+
+async function readLogs(summary: RunSummary): Promise<Map<string, string>> {
+  const logs = new Map<string, string>();
+  for (const task of summary.tasks) {
+    const code = task.execution?.exitCode;
+    if (typeof code !== 'number' || code === 0) continue;
+    try {
+      logs.set(task.taskId, await readFile(task.logFile, 'utf8'));
+    } catch {
+      // Left unset: buildReports renders the execution.error instead.
+    }
+  }
+  return logs;
+}
+
+async function publish(
+  summary: RunSummary,
+  reports: FailureReport[],
+): Promise<void> {
+  const line = headline(summary, reports);
+
+  // The stdout lane, ungrouped: an agent reading `gh run view --log-failed`
+  // gets the excerpts inline, and a human scanning the step sees the headline
+  // without expanding anything. Grouping is deliberately NOT used — a
+  // collapsed group is exactly the problem this step exists to solve.
+  for (const chunk of stdoutReport(summary, reports)) console.log(chunk);
+
+  const markdown = summaryMarkdown(summary, reports);
+  const file = process.env.GITHUB_STEP_SUMMARY;
+  if (file !== undefined && file !== '') {
+    await appendFile(file, markdown);
+  } else {
+    console.log(`\n${markdown}`);
+  }
+
+  // The annotation is the top-of-page pointer; the summary is the detail.
+  if (onActions() && reports.length > 0) {
+    console.log(`::error::${line.replaceAll('\n', '%0A')}`);
+  }
+}
+
+async function main(): Promise<void> {
+  const path = await newestSummary();
+  if (path === undefined) {
+    warn(
+      `no turbo run summary under ${RUNS_DIR} — the job failed before or outside the turbo run; read the full step log`,
+    );
+    return;
+  }
+
+  const summary = parseRunSummary(JSON.parse(await readFile(path, 'utf8')));
+  if (summary.execution.exitCode === 0) {
+    warn(
+      `newest turbo run summary (${path}) exited 0 — nothing to report; the failure is outside the turbo run`,
+    );
+    return;
+  }
+
+  const reports = buildReports(summary, await readLogs(summary));
+  await publish(summary, reports);
+}
+
+main().catch((error: unknown) => {
+  warn(
+    `error summary failed, the full step log is unaffected: ${
+      error instanceof Error ? error.message : String(error)
+    }`,
+  );
+});

--- a/tools/build_and_test/src/error-summary.ts
+++ b/tools/build_and_test/src/error-summary.ts
@@ -16,6 +16,7 @@
 // env: GITHUB_STEP_SUMMARY (runner file; printed when unset),
 //      TURBO_RUNS_DIR (override for tests and local reproduction).
 
+import { randomUUID } from 'node:crypto';
 import { appendFile, readdir, readFile, stat } from 'node:fs/promises';
 import { join } from 'node:path';
 
@@ -23,6 +24,7 @@ import {
   type FailureReport,
   type RunSummary,
   buildReports,
+  guardCommands,
   headline,
   parseRunSummary,
   stdoutReport,
@@ -33,6 +35,11 @@ const RUNS_DIR = process.env.TURBO_RUNS_DIR ?? '.turbo/runs';
 
 function onActions(): boolean {
   return process.env.GITHUB_ACTIONS === 'true';
+}
+
+/** Fresh per run: a log that could guess the token could escape the guard. */
+function commandToken(): string | undefined {
+  return onActions() ? randomUUID() : undefined;
 }
 
 function warn(message: string): void {
@@ -84,20 +91,22 @@ async function publish(
   reports: FailureReport[],
 ): Promise<void> {
   const line = headline(summary, reports);
+  const markdown = summaryMarkdown(summary, reports);
+  const file = process.env.GITHUB_STEP_SUMMARY;
+  const toFile = file !== undefined && file !== '';
 
   // The stdout lane, ungrouped: an agent reading `gh run view --log-failed`
   // gets the excerpts inline, and a human scanning the step sees the headline
   // without expanding anything. Grouping is deliberately NOT used — a
   // collapsed group is exactly the problem this step exists to solve.
-  for (const chunk of stdoutReport(summary, reports)) console.log(chunk);
+  const chunks = stdoutReport(summary, reports);
+  // The fallback prints the same untrusted excerpts, so it goes inside the guard.
+  if (!toFile) chunks.push(`\n${markdown}`);
+  for (const chunk of guardCommands(chunks, commandToken())) console.log(chunk);
 
-  const markdown = summaryMarkdown(summary, reports);
-  const file = process.env.GITHUB_STEP_SUMMARY;
-  if (file !== undefined && file !== '') {
-    await appendFile(file, markdown);
-  } else {
-    console.log(`\n${markdown}`);
-  }
+  // After the guard resumed: our own annotation has to be parsed. The step
+  // summary file is markdown, never scanned for commands, so it needs none.
+  if (toFile) await appendFile(file, markdown);
 
   // The annotation is the top-of-page pointer; the summary is the detail.
   if (onActions() && reports.length > 0) {


### PR DESCRIPTION
Design exploration for #607, as a working spike. Everything below was measured on this branch, not sketched.

## What lands

A new `Error summary` step in `build-test-run.yml`, gated `if: ${{ failure() }}`, placed after the two `ci`/`ci_main` steps and before `codecov_bundle` (so no later `turbo run` can be the newest summary). It runs `//tools/build_and_test:error_summary`, which reads the newest `.turbo/runs/*.json` and republishes only the tasks that actually failed.

`ci` and `ci_main` gain `--summarize`. That flag changes nothing about what runs — it writes one gitignored JSON file.

## The design decision: summary in, not stream in

An injected two-line type error, run through the real `--ui=stream --log-order=stream` shape, printed **four** `ELIFECYCLE Command failed` lines:

```text
lit-ui-router:docs:api:              [ELIFECYCLE] Command failed.
lit-ui-router:build:custom-elements: [ELIFECYCLE] Command failed.
//:lint:root:                        [ELIFECYCLE] Command failed.
lit-ui-router:typecheck:             ...TS2322... [ELIFECYCLE] Command failed with exit code 1.
```

Three are **cancellations** — in-flight tasks turbo killed on teardown. They are indistinguishable from the real failure in the stream and point at three packages that are fine. So the noise is actively misleading, not merely verbose.

The run summary has already done that triage: `tasks[]` held **62 entries against `attempted: 76`** — cancelled tasks are absent from the array entirely, and exactly one entry had `execution.exitCode !== 0`. No stdout scraping, no `ELIFECYCLE` heuristics, no ANSI-prefix attribution.

## Two lanes, because two audiences

- `$GITHUB_STEP_SUMMARY` — rendered markdown on the run page. Never appears in the logs API.
- **stdout** — the same content, ungrouped. An agent running `gh run view --log-failed` sees only this. Grouping is deliberately *not* used: a collapsed group is the problem this step exists to solve.

Plus a `::error::` headline annotation as the top-of-page pointer.

## Real output

From an actual failing run on this branch (`mise run //tools/build_and_test:error_summary`):

```text
── lit-ui-router#typecheck:lit2 (exit 1)
   repro: turbo run typecheck:lit2 --filter=lit-ui-router --force
   exact: cd packages/lit-ui-router && lit2-compat-guard && tsc -p tsconfig.lit2-compat.json --noEmit

lit2-compat-guard: lit-2 -> lit 2.8.0 within peer range ^2.0.0 || ^3.0.0
src/core.ts:272:14 - error TS2322: Type 'string' is not assignable to type 'number'.

272 export const __spikeTypeError: number = "not a number";
                 ~~~~~~~~~~~~~~~~

Found 1 error in src/core.ts:272

1 failing task: lit-ui-router#typecheck:lit2 — 16 succeeded, 34 cached, 68 attempted
```

Both reproduction lines are given: the `turbo run --filter` one, and the exact command in the exact directory — per the standing rule to reproduce the failing command before theorizing.

## Sizing, measured

Task logs span three orders of magnitude:

| Log | Bytes |
| --- | ---: |
| `tools/*/.turbo/turbo-lint.log` | 112 |
| `packages/lit-ui-router/.turbo/turbo-typecheck$colon$src.log` | 701 |
| `packages/ui-router-server/.turbo/turbo-test.log` | 36 882 |
| `apps/sample-app-lit-e2e/.turbo/turbo-test.log` | 389 355 |

So the common failure — typecheck, lint, a unit suite — is published **whole**, and only e2e-class logs are cut. Budget is 20 head + 80 tail lines, 16 KiB hard cap trimmed from the head (tsc, oxlint and node:test all put the verdict last; Cypress buries its failure mid-log behind a passing preamble, which is why the head is kept at all).

Run against the real 389 KB Cypress log: **389 355 B / 2 626 lines → 8 598 B / 101 lines**, with the `✓ e2e tests passed — 5/5 suites` verdict block intact. 45× reduction, signal preserved.

Truncated excerpts go behind a `<details>` labelled with the line count lost — no silent truncation.

## Fails open, always

The step runs only when the job is already red. A second red step here would point at the reporter instead of the failure, and an exception must never mask the real one. Every failure path warns and exits 0:

- no `.turbo/runs` → "the job failed before or outside the turbo run" (covers a Playwright/Cypress-install failure, where `failure()` still fires)
- newest summary exited 0 → says the failure is outside the turbo run
- a red run where no task reported non-zero → says so explicitly rather than rendering a blank report

## Verification

- `turbo run format lint typecheck test --filter=@tools/build_and_test` — **20/20 tasks green**, including `//:lint:templates`
- 26 new unit tests over `error-summary.core.ts`, all passing
- `lint:workflows`, `lint:actionlint`, `lint:zizmor`, `lint:toml`, `format:check:toml` — green on the changed workflow and TOML
- End-to-end: injected failure → real turbo run → real step output, shown above

## Open, for review

- **`--continue`.** Today the first failure cancels the graph, so the report covers the first failure(s) only; a reader who fixes it may hit a second on the next push. `--continue` makes the report complete at the cost of running the full graph on every red run. Not taken here — it changes what CI *runs*, which is out of scope for this PR.
- **Inline `::error file=,line=` annotations** — would place failures on the PR diff, but need per-tool location parsing (tsc, oxlint, vitest all differ). Deliberately deferred.
- **Budget defaults.** 20/80/16 KiB is fitted to the measurements above, not tuned against a real red CI run. Worth revisiting after the first few.

---

*Filed with Claude Code (claude-opus-5).*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added concise CI failure summaries with failed task details, relevant log excerpts, and reproduction commands.
  * Published failure reports to workflow summaries and logs while preserving the original job status.
  * Added handling for missing logs, truncated output, and failures without task-level details.

* **Bug Fixes**
  * Improved visibility into build and test failures.

* **Tests**
  * Added comprehensive coverage for failure detection, log formatting, truncation, fallback handling, and report generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->