### PR TITLE
docs: a design-system link example driving sp-link with uiSref

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -85,6 +85,7 @@ function makeSidebar() {
           link: '/guides/component-lifecycle',
         },
         { text: 'Reactive Components', link: '/guides/reactive-components' },
+        { text: 'Design System Links', link: '/guides/design-system-links' },
       ],
     },
     {

--- a/docs/.vitepress/theme/components/examples.ts
+++ b/docs/.vitepress/theme/components/examples.ts
@@ -11,6 +11,11 @@ export const EXAMPLES = {
     height: '920px',
     file: 'src/main.ts',
   },
+  'design-system-links': {
+    title: 'Design System Links',
+    height: '520px',
+    file: 'src/main.ts',
+  },
 } as const;
 
 export type ExampleName = keyof typeof EXAMPLES;

--- a/docs/.vitepress/vite.config.ts
+++ b/docs/.vitepress/vite.config.ts
@@ -4,9 +4,14 @@ import { mounts } from 'sample-app-routes';
 import { defineConfig, Plugin } from 'vite';
 import { viteStaticCopy } from 'vite-plugin-static-copy';
 
-// Tutorial examples embedded same-origin at /examples/<name>/; built by
+// Examples embedded same-origin at /examples/<name>/; built by
 // `examples#build:embeds` (hash routing, so no SPA fallback needed).
-const EMBEDDED_EXAMPLES = ['helloworld', 'hellosolarsystem', 'hellogalaxy'];
+const EMBEDDED_EXAMPLES = [
+  'helloworld',
+  'hellosolarsystem',
+  'hellogalaxy',
+  'design-system-links',
+];
 
 // The mount shells as the dev server serves them. Production (docs/worker)
 // serves each at its bare mount via Cloudflare's html_handling; the dev server

--- a/docs/guides/design-system-links.md
+++ b/docs/guides/design-system-links.md
@@ -1,0 +1,123 @@
+---
+title: Design System Links
+description: "Driving a design system's link component with uiSref, and why assignHref: true is the option for it"
+---
+
+# Design System Links
+
+Your design system almost certainly ships a link component —
+[`<sp-link>`](https://opensource.adobe.com/spectrum-web-components/components/link/),
+`<md-*>`, Shoelace's `<sl-...>`, or an in-house one. It is a custom element
+that declares its own `href` property and renders an anchor inside its shadow
+root. It is a link in every way that matters to a reader, and in no way that
+matters to `document.querySelector('a')`.
+
+[`uiSref`](/api/reference/directives/uiSref) drives it, but the `href` needs
+one option: **`assignHref: true`**.
+
+```ts
+html`<sp-link ${uiSref('components', {}, { assignHref: true })}
+  >Components</sp-link
+>`;
+```
+
+<LiveExample name="design-system-links" />
+
+## Why `'auto'` refuses it
+
+[`assignHref`](/api/reference/types/UiSrefOptions) decides where the
+generated `href` is written:
+
+| value    | behaviour                                                              |
+| -------- | ---------------------------------------------------------------------- |
+| `true`   | write it to whatever element carries the directive — the 1.x default   |
+| `'auto'` | write it only where HTML defines an `href`: `<a>`, `<area>`, SVG `<a>` |
+| `false`  | never write it; the app manages the attribute itself                   |
+
+`'auto'` tests the element's tag name, not its shape. A design-system link's
+`localName` is `sp-link`, not `a`, so `'auto'` skips it — deliberately. The
+rule it enforces is "no inert `href` on elements that cannot use one", and it
+has no way to tell a `<sp-link href>` that means it from a `<div>` that does
+not. `true` is the escape hatch for the elements that do mean it, which is why
+it survives the 2.0 default flip.
+
+The example above stages all three cases side by side and prints each
+element's live `href` attribute:
+
+- `<sp-link>` with `assignHref: true` — carries `href="#/components"`
+- `<sp-link>` with `assignHref: 'auto'` — no `href` attribute at all
+- `<a>` with `assignHref: 'auto'` — carries `href="#/tokens"`, because `'auto'`
+  writes to real anchors
+
+All three navigate on click. `assignHref` governs the attribute only; the
+click handler is never affected by it.
+
+## What the `href` buys you
+
+The `href` is not decoration on a link-shaped custom element. It is what makes
+the component behave like the link it renders:
+
+- the browser shows the target URL in the status bar on hover
+- middle-click and <kbd>Cmd</kbd>/<kbd>Ctrl</kbd>-click open a new tab
+- "Copy link address" produces a working URL
+- assistive technology announces a link, and
+  [`uiSrefActive`](/api/reference/directives/uiSrefActive) can mark it with
+  `aria-current`
+
+Most design-system link components forward `href` to their internal anchor, so
+writing the attribute on the host is enough for all of it.
+
+## Choosing the option
+
+| your element                                   | option                               |
+| ---------------------------------------------- | ------------------------------------ |
+| `<a>` / `<area>`                               | nothing — `'auto'` already writes it |
+| a custom element with its own `href`           | `assignHref: true`                   |
+| `<button>`, `<tr>`, `<div>` — no `href` at all | `assignHref: 'auto'`                 |
+| an element whose `href` you set yourself       | `assignHref: false`                  |
+
+For a control whose state cannot be encoded in a URL — a sref carrying
+non-URL parameters — no `href` beats a wrong one, whatever the element is.
+See [Unmatched URLs](./unmatched-urls) for the related case of routing a URL
+that matches no state.
+
+::: tip Under lit's development build
+`assignHref: true` on a non-anchor logs a one-time console warning naming
+`'auto'` as the fix, because it cannot know your element forwards `href`. The
+warning is gated to lit's dev build; production builds are silent. Pass
+`false` and set the property yourself if you would rather not see it.
+:::
+
+## Setting up the example
+
+The [example](https://github.com/simshanith/lit-ui-router/tree/main/examples/design-system-links)
+is a standalone Vite app that installs Spectrum Web Components from npm:
+
+```bash
+npm install @spectrum-web-components/link @spectrum-web-components/theme
+```
+
+```ts
+import '@spectrum-web-components/theme/sp-theme.js';
+import '@spectrum-web-components/theme/theme-light.js';
+import '@spectrum-web-components/theme/scale-medium.js';
+import '@spectrum-web-components/link/sp-link.js';
+```
+
+Spectrum's components need a theme ancestor, so the router lives inside one:
+
+```ts
+render(
+  html`
+    <sp-theme system="spectrum" color="light" scale="medium">
+      <ui-router .uiRouter=${router}>
+        <app-root></app-root>
+      </ui-router>
+    </sp-theme>
+  `,
+  document.getElementById('root')!,
+);
+```
+
+Nothing about the pairing is Spectrum-specific: any link-shaped custom element
+takes the same option.

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -32,6 +32,14 @@ client deployed across every point on the server-support spectrum.
 - [Component Lifecycle Hooks](./component-lifecycle) — `uiCanExit` for
   unsaved-changes prompts and `uiOnParamsChanged` for dynamic parameters
 
+## Links & Markup
+
+- [Design System Links](./design-system-links) — driving a design system's
+  link component (`<sp-link>`, `<md-*>`, an in-house one) with `uiSref`:
+  `assignHref: true` is the option for a custom element that declares its own
+  `href`, and `'auto'` scopes the attribute to real `<a>` elements, with a
+  live example contrasting all three cases
+
 ## Reactivity
 
 - [Reactive Components](./reactive-components) — keep components outside

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,6 @@
 # Examples
 
-This folder contains standalone example projects demonstrating lit-ui-router usage. The examples escalate in scope — start with **helloworld**, then work outward through the solar system and into the galaxy.
+This folder contains standalone example projects demonstrating lit-ui-router usage. The tutorial examples escalate in scope — start with **helloworld**, then work outward through the solar system and into the galaxy. **design-system-links** is not a tutorial rung: it is live documentation for one API surface, embedded in the guide that explains it.
 
 ## StackBlitz Integration
 
@@ -14,11 +14,12 @@ See [StackBlitz Tips & Best Practices](https://developer.stackblitz.com/guides/i
 
 ### Available Examples
 
-| Example              | Description                                                                                      | StackBlitz                                                                                         |
-| -------------------- | ------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------- |
-| **helloworld**       | Ultra-minimal starter: two states with `uiSref`/`uiSrefActive` navigation                        | [Open](https://stackblitz.com/github/simshanith/lit-ui-router/tree/main/examples/helloworld)       |
-| **hellosolarsystem** | Solar System tour: route parameters and async `resolve` data with a master/detail flow           | [Open](https://stackblitz.com/github/simshanith/lit-ui-router/tree/main/examples/hellosolarsystem) |
-| **hellogalaxy**      | Milky Way explorer: nested states and views, resolve inheritance, and a 3D model-viewer surprise | [Open](https://stackblitz.com/github/simshanith/lit-ui-router/tree/main/examples/hellogalaxy)      |
+| Example                 | Description                                                                                      | StackBlitz                                                                                            |
+| ----------------------- | ------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------- |
+| **helloworld**          | Ultra-minimal starter: two states with `uiSref`/`uiSrefActive` navigation                        | [Open](https://stackblitz.com/github/simshanith/lit-ui-router/tree/main/examples/helloworld)          |
+| **hellosolarsystem**    | Solar System tour: route parameters and async `resolve` data with a master/detail flow           | [Open](https://stackblitz.com/github/simshanith/lit-ui-router/tree/main/examples/hellosolarsystem)    |
+| **hellogalaxy**         | Milky Way explorer: nested states and views, resolve inheritance, and a 3D model-viewer surprise | [Open](https://stackblitz.com/github/simshanith/lit-ui-router/tree/main/examples/hellogalaxy)         |
+| **design-system-links** | `uiSref` driving a design-system link element (`<sp-link>`): `assignHref: true` vs `'auto'`      | [Open](https://stackblitz.com/github/simshanith/lit-ui-router/tree/main/examples/design-system-links) |
 
 ## What Each Example Teaches
 
@@ -49,6 +50,14 @@ A Milky Way explorer built on a real star catalog (Sirius, Vega, Polaris, Betelg
 - Resolve inheritance: the `star` resolve declares `deps: ['$transition$', 'stars']` on the parent state's resolved catalog
 - Relative sref targets (`.star`) for linking to child states
 - Sibling states: `galaxy.astronaut` renders a 3D model alongside the star explorer, lazy-loading model-viewer via a resolve
+
+### design-system-links
+
+Three links to two states, printing each element's live `href` attribute: an [`<sp-link>`](https://opensource.adobe.com/spectrum-web-components/components/link/) with `assignHref: true`, the same element with `'auto'`, and a plain `<a>` with `'auto'`. All three navigate; only the `href` differs. Embedded in the [Design System Links guide](https://lit-ui-router.dev/guides/design-system-links).
+
+- `assignHref: true` — the escape hatch for a custom element that declares its own `href`
+- `assignHref: 'auto'` — writes the attribute only to `<a>`, `<area>` and SVG `<a>`
+- Spectrum Web Components (`@spectrum-web-components/link` + `theme`) as a real published design system, npm-installed like every other example dependency
 
 ## Running Locally
 

--- a/examples/build-embeds.ts
+++ b/examples/build-embeds.ts
@@ -9,7 +9,12 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const root = dirname(fileURLToPath(import.meta.url));
-const EXAMPLES = ['helloworld', 'hellosolarsystem', 'hellogalaxy'];
+const EXAMPLES = [
+  'helloworld',
+  'hellosolarsystem',
+  'hellogalaxy',
+  'design-system-links',
+];
 
 for (const name of EXAMPLES) {
   const cwd = join(root, name);

--- a/examples/design-system-links/index.html
+++ b/examples/design-system-links/index.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Design System Links - lit-ui-router</title>
+    <style>
+      body {
+        font-family:
+          system-ui,
+          -apple-system,
+          sans-serif;
+        max-width: 800px;
+        margin: 32px auto;
+        padding: 0 20px;
+        color: #222;
+        background: #fff;
+      }
+      @media (max-width: 480px) {
+        body {
+          margin: 16px auto;
+          padding: 0 12px;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/examples/design-system-links/package-lock.json
+++ b/examples/design-system-links/package-lock.json
@@ -1,0 +1,1341 @@
+{
+  "name": "lit-ui-router-example-design-system-links",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "lit-ui-router-example-design-system-links",
+      "version": "0.0.0",
+      "dependencies": {
+        "@spectrum-web-components/link": "^1.12.2",
+        "@spectrum-web-components/theme": "^1.12.2",
+        "@uirouter/core": "^6.1.2",
+        "lit": "^3.3.3",
+        "lit-ui-router": "^1.9.0"
+      },
+      "devDependencies": {
+        "typescript": "^7.0.2",
+        "vite": "^8.2.1"
+      }
+    },
+    "node_modules/@lit-labs/observers": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@lit-labs/observers/-/observers-2.0.2.tgz",
+      "integrity": "sha512-eZb5+W9Cb0e/Y5m1DNxBSGTvGB2TAVTGMnTxL/IzFhPQEcZIAHewW1eVBhN8W07A5tirRaAmmF6fGL1V20p3gQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit/reactive-element": "^1.0.0 || ^2.0.0"
+      }
+    },
+    "node_modules/@lit-labs/ssr-dom-shim": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.6.0.tgz",
+      "integrity": "sha512-VHb0ALPMTlgKjM6yIxxoQNnpKyUKLD04VzeQdsiXkMqkvYlAHxq9glGLmgbb889/1GsohSOAjvQYoiBppXFqrQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@lit/reactive-element": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.2.tgz",
+      "integrity": "sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0"
+      }
+    },
+    "node_modules/@oxc-project/runtime": {
+      "version": "0.144.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/runtime/-/runtime-0.144.0.tgz",
+      "integrity": "sha512-Ps9oSujoaerkIY8SV7onfD6ldNL6oHlVaZDVuFftDX+JAV3ZqHVx5HMBBa9n0qNkig5K/WcgNbeD94rJrSwjQQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.144.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.144.0.tgz",
+      "integrity": "sha512-nuhZIOLuI6TFQ32I/WnUx+SCPY7SdSKwgnFHydAuoS1+Z4BRcaP+RRJmGzl9lw+0OFF7UmaESf7KQRXaNLHypg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.4.tgz",
+      "integrity": "sha512-jHC2cnyKz5xU2fhECtFl8OZ83cYNt13GZQD+0uMJ/X3o+ijmd56okHhTUwxVSHPx1IRVIJEZ1/1pPzeLCU6XKA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-Dc5mPD8F5F/FS8i01syd7FTF6yB2fVthH/TRkjwJkzUK6EpoxHtqvZQP5Zwq80/5z19TWYHIg1KOHboCgVx/aQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-fpDm4oBo6SqLvWUYCmFhdde3U9KH2fRNNMeAnAPAIwxRL345xutL0EtEUcuoxsoazdJGv/MuDBQHlCDrtbvqOg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.4.tgz",
+      "integrity": "sha512-rSJoreDE/HoIzoaib6MTp5jQtCTdMHKIvItAKT/ImS6Y6Ww76oUaeMyp4Vc/fAgd/ehji068IxetHXAnqUwN9A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.4.tgz",
+      "integrity": "sha512-/jm8OGHgn7oGaJu3i/qZI9spUGcJ+y/lk43ttQ/iO1tOd9NissG6o97bighBCiL+BKRngmcDuR6ikfwYdJmVuQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.4.tgz",
+      "integrity": "sha512-tIP06BeD9EqvECBrPZ+sqdPlYrT+aYaAiu1wYziVx5elRK/ftm33JxVDy2bXGbr6J0CrtirCkR87/X5a2euEng==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.4.tgz",
+      "integrity": "sha512-Ql1Q0EQqVThvn9VAVlwNzsUvbSFtCMGjLpRRi4pk5i7NZZ4n5ISiLMjHYtus4VQ2PvkSw24zyaCVsiS+sXPj1w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.4.tgz",
+      "integrity": "sha512-GjbjXD4XXfN19D0LZNbmiCBUoDiRACsYHr0yaIbbn8aFsXjHZifcYqu/W5Er5X2X990WjHXFrxarn5chzItorQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.4.tgz",
+      "integrity": "sha512-p5WR0NOwaRmJ/B1b6IjEFLLivwEsf3PrdBIhRbhTCQisbo2SvHHpG4ELB/+FgQNnB88LTOF86upmJmbvZdQ2lw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.4.tgz",
+      "integrity": "sha512-4/GyVjmhR+Tc6HLJvwc1sOhPqAZtySiSMesOZyX6JQ5XBxoTDEMKQzvo07NIK6nTon/SivlZqvhzvuVBNQhObQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.4.tgz",
+      "integrity": "sha512-l9eeLsCNvPpmSXUej0etw/J1eqV0Jj1D5G/xG6YTijmE6dkv6E2QezgWbTfQk63v952DPqrjOCoiqxq7Bw0YUQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.4.tgz",
+      "integrity": "sha512-e0F355MSTMm3+UOqtV3L24gFUp2N5m1f8L/7d56deik6va+AXdrt9F8LbzGpeWGWRbZEDq4m8NVnJDeBtf9DZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.4.tgz",
+      "integrity": "sha512-AWLi0uBRYh6QlE7OKhiz+phZC0qwtij2QZmhmOdsLdFn64m7oMpooE9ICE3lhm9xMb4SpDo2WbHcxX1iFLFtqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.4.tgz",
+      "integrity": "sha512-UwSDJOg3dqCAejWdxclJjCsh3Qq4vLYMDxmyHqo1btz3stK2VqgwNd3mm5tuIwzSlGIQ/1H9Hr+Zn09mrezNqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@spectrum-web-components/base": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@spectrum-web-components/base/-/base-1.12.2.tgz",
+      "integrity": "sha512-7vB3182FqJzRevafUWlFRw/bfM4ZjC+Mmh5Fh0mDmVcP/SohUowrmHsQns1fsQPi+/O8iMP8XbtT7sAFp6ejkA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lit": "^2.5.0 || ^3.1.3"
+      }
+    },
+    "node_modules/@spectrum-web-components/link": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@spectrum-web-components/link/-/link-1.12.2.tgz",
+      "integrity": "sha512-TPV4nPE/e+V0WZ1rPRAiq/9Zkok9A/tgL/wOORlB+3VNpZzg7k0QOvqrTkScNvlgGyVz6VfQJTmRO278vcLv8A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@spectrum-web-components/base": "1.12.2",
+        "@spectrum-web-components/shared": "1.12.2"
+      }
+    },
+    "node_modules/@spectrum-web-components/shared": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@spectrum-web-components/shared/-/shared-1.12.2.tgz",
+      "integrity": "sha512-1vRimMtdKllujoFPbuDoPP0eSHZJfExWld2jeqboMKjzNTDvBfoOIN3ZOz7ClOVyrJOQDJSP2htCVfDBYl72Ug==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@lit-labs/observers": "2.0.2",
+        "@spectrum-web-components/base": "1.12.2",
+        "focus-visible": "5.2.1"
+      }
+    },
+    "node_modules/@spectrum-web-components/styles": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@spectrum-web-components/styles/-/styles-1.12.2.tgz",
+      "integrity": "sha512-6vYe/VEbjJ4VDcOSbjxEZaKatwRdxp6yLgEf+qtlo7YOSTAM2016kr6MaqV3EbKXBsVJP8qe9j2hoq29MLGqyA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@spectrum-web-components/base": "1.12.2",
+        "lit": "^2.5.0 || ^3.1.3"
+      }
+    },
+    "node_modules/@spectrum-web-components/theme": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@spectrum-web-components/theme/-/theme-1.12.2.tgz",
+      "integrity": "sha512-JWzjsTybXBevJpFlH3HRD+MbssGu2K3/8hv0THU1Wy7khSxNIvfsCAg1Twjt9qTr7BNgw5gfCdMoMDj0qD7Ilg==",
+      "license": "ISC",
+      "dependencies": {
+        "@spectrum-web-components/base": "1.12.2",
+        "@spectrum-web-components/styles": "1.12.2"
+      }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT"
+    },
+    "node_modules/@typescript/typescript-aix-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz",
+      "integrity": "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-arm64/-/typescript-darwin-arm64-7.0.2.tgz",
+      "integrity": "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-x64/-/typescript-darwin-x64-7.0.2.tgz",
+      "integrity": "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-arm64/-/typescript-freebsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-x64/-/typescript-freebsd-x64-7.0.2.tgz",
+      "integrity": "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm/-/typescript-linux-arm-7.0.2.tgz",
+      "integrity": "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm64/-/typescript-linux-arm64-7.0.2.tgz",
+      "integrity": "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-loong64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-loong64/-/typescript-linux-loong64-7.0.2.tgz",
+      "integrity": "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-mips64el": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-mips64el/-/typescript-linux-mips64el-7.0.2.tgz",
+      "integrity": "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-ppc64/-/typescript-linux-ppc64-7.0.2.tgz",
+      "integrity": "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-riscv64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-riscv64/-/typescript-linux-riscv64-7.0.2.tgz",
+      "integrity": "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-s390x": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-s390x/-/typescript-linux-s390x-7.0.2.tgz",
+      "integrity": "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-x64/-/typescript-linux-x64-7.0.2.tgz",
+      "integrity": "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-arm64/-/typescript-netbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-x64/-/typescript-netbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-arm64/-/typescript-openbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-x64/-/typescript-openbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-sunos-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-sunos-x64/-/typescript-sunos-x64-7.0.2.tgz",
+      "integrity": "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-arm64/-/typescript-win32-arm64-7.0.2.tgz",
+      "integrity": "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-x64/-/typescript-win32-x64-7.0.2.tgz",
+      "integrity": "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@uirouter/core": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/@uirouter/core/-/core-6.1.2.tgz",
+      "integrity": "sha512-pYcg+cxVd9E9poC7AJf7ZrlQQrwAV6KVkiPvlbLJX5km+pBWrUOGQhdd87oIGc7/5iVQ7qSiAdl9QD+l55yegg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/focus-visible": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/focus-visible/-/focus-visible-5.2.1.tgz",
+      "integrity": "sha512-8Bx950VD1bWTQJEH/AM6SpEk+SU55aVnp4Ujhuuxy3eMEBCRwBnTBnVXr9YAPvZL3/CNjCa8u4IWfNmEO53whA==",
+      "license": "W3C"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lit": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.3.tgz",
+      "integrity": "sha512-fycuvZg/hkpozL00lm1pEJH5nN/lr9ZXd6mJI2HSN4+Bzc+LDNdEApJ6HFbPkdFNHLvOplIIuJvxkS4XUxqirw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit/reactive-element": "^2.1.0",
+        "lit-element": "^4.2.0",
+        "lit-html": "^3.3.0"
+      }
+    },
+    "node_modules/lit-element": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.2.2.tgz",
+      "integrity": "sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0",
+        "@lit/reactive-element": "^2.1.0",
+        "lit-html": "^3.3.0"
+      }
+    },
+    "node_modules/lit-html": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.3.tgz",
+      "integrity": "sha512-el8M6jK2o3RXBnrSHX3ZKrsN8zEV63pSExTO1wYJz7QndGYZ8353e2a5PPX+qHe2aGayfnchQmkAojaWAREOIA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
+      }
+    },
+    "node_modules/lit-ui-router": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/lit-ui-router/-/lit-ui-router-1.9.0.tgz",
+      "integrity": "sha512-pwnamYE4Hvpogcm1NdqmtwM3oN/Ndf1vj4xlYHqTo0NmmAosTWLrYOxkPQubeSxw48/WDq6gzYLHpacHIkJZnQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/runtime": ">=0.50.0"
+      },
+      "peerDependencies": {
+        "@uirouter/core": "^6.0.8",
+        "lit": "^2.0.0 || ^3.0.0"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.17",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.4.tgz",
+      "integrity": "sha512-rSr7irW0K7QRWzjdJXqZowkcRdDtjRduh43rBltnVKd0VFq839l1lJoDvGJb6gl7+4rTTCrPWu+YfujUL8Ug7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.144.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.2.4",
+        "@rolldown/binding-darwin-arm64": "1.2.4",
+        "@rolldown/binding-darwin-x64": "1.2.4",
+        "@rolldown/binding-freebsd-x64": "1.2.4",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.2.4",
+        "@rolldown/binding-linux-arm64-gnu": "1.2.4",
+        "@rolldown/binding-linux-arm64-musl": "1.2.4",
+        "@rolldown/binding-linux-ppc64-gnu": "1.2.4",
+        "@rolldown/binding-linux-s390x-gnu": "1.2.4",
+        "@rolldown/binding-linux-x64-gnu": "1.2.4",
+        "@rolldown/binding-linux-x64-musl": "1.2.4",
+        "@rolldown/binding-openharmony-arm64": "1.2.4",
+        "@rolldown/binding-win32-arm64-msvc": "1.2.4",
+        "@rolldown/binding-win32-x64-msvc": "1.2.4"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
+      "integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc"
+      },
+      "engines": {
+        "node": ">=16.20.0"
+      },
+      "optionalDependencies": {
+        "@typescript/typescript-aix-ppc64": "7.0.2",
+        "@typescript/typescript-darwin-arm64": "7.0.2",
+        "@typescript/typescript-darwin-x64": "7.0.2",
+        "@typescript/typescript-freebsd-arm64": "7.0.2",
+        "@typescript/typescript-freebsd-x64": "7.0.2",
+        "@typescript/typescript-linux-arm": "7.0.2",
+        "@typescript/typescript-linux-arm64": "7.0.2",
+        "@typescript/typescript-linux-loong64": "7.0.2",
+        "@typescript/typescript-linux-mips64el": "7.0.2",
+        "@typescript/typescript-linux-ppc64": "7.0.2",
+        "@typescript/typescript-linux-riscv64": "7.0.2",
+        "@typescript/typescript-linux-s390x": "7.0.2",
+        "@typescript/typescript-linux-x64": "7.0.2",
+        "@typescript/typescript-netbsd-arm64": "7.0.2",
+        "@typescript/typescript-netbsd-x64": "7.0.2",
+        "@typescript/typescript-openbsd-arm64": "7.0.2",
+        "@typescript/typescript-openbsd-x64": "7.0.2",
+        "@typescript/typescript-sunos-x64": "7.0.2",
+        "@typescript/typescript-win32-arm64": "7.0.2",
+        "@typescript/typescript-win32-x64": "7.0.2"
+      }
+    },
+    "node_modules/vite": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.1.tgz",
+      "integrity": "sha512-EU/eS7BH3XROHh2YnBefjM6DBKA6ZeMZEYQbj7NLWg5wHYlhB8B/Mayd5XsgWq+NFYccDOTemRpdETWR6Ka/lw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.33.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.25",
+        "rolldown": "~1.2.1",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.4.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/examples/design-system-links/package-lock.json
+++ b/examples/design-system-links/package-lock.json
@@ -12,7 +12,7 @@
         "@spectrum-web-components/theme": "^1.12.2",
         "@uirouter/core": "^6.1.2",
         "lit": "^3.3.3",
-        "lit-ui-router": "^1.9.0"
+        "lit-ui-router": "^1.10.0"
       },
       "devDependencies": {
         "typescript": "^7.0.2",
@@ -1084,9 +1084,9 @@
       }
     },
     "node_modules/lit-ui-router": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/lit-ui-router/-/lit-ui-router-1.9.0.tgz",
-      "integrity": "sha512-pwnamYE4Hvpogcm1NdqmtwM3oN/Ndf1vj4xlYHqTo0NmmAosTWLrYOxkPQubeSxw48/WDq6gzYLHpacHIkJZnQ==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/lit-ui-router/-/lit-ui-router-1.10.0.tgz",
+      "integrity": "sha512-SjnWTTU0EFMcU/Ce+U2+Dvlm2B72XsEE4ixZHc4fFKJra1YY2IGYx1B8RKl1XPqHsIjBQHaQACAXPVO+v1stxw==",
       "license": "MIT",
       "dependencies": {
         "@oxc-project/runtime": ">=0.50.0"

--- a/examples/design-system-links/package.json
+++ b/examples/design-system-links/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "lit-ui-router-example-design-system-links",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "vite build",
+    "dev": "vite",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@spectrum-web-components/link": "^1.12.2",
+    "@spectrum-web-components/theme": "^1.12.2",
+    "@uirouter/core": "^6.1.2",
+    "lit": "^3.3.3",
+    "lit-ui-router": "^1.10.0"
+  },
+  "devDependencies": {
+    "typescript": "^7.0.2",
+    "vite": "^8.2.1"
+  },
+  "devEngines": {
+    "packageManager": {
+      "name": "npm",
+      "onFail": "warn"
+    }
+  },
+  "allowScripts": {
+    "fsevents@2.3.3": true
+  }
+}

--- a/examples/design-system-links/src/main.ts
+++ b/examples/design-system-links/src/main.ts
@@ -1,0 +1,198 @@
+import { html, LitElement, css, render } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
+import { createRef, ref, Ref } from 'lit/directives/ref.js';
+import { hashLocationPlugin } from '@uirouter/core';
+import {
+  UIRouterLit,
+  uiSref,
+  uiSrefActive,
+  LitStateDeclaration,
+} from 'lit-ui-router';
+import '@spectrum-web-components/theme/sp-theme.js';
+import '@spectrum-web-components/theme/theme-light.js';
+import '@spectrum-web-components/theme/scale-medium.js';
+import '@spectrum-web-components/link/sp-link.js';
+
+/** each demo row reads its own live `href` back out of the DOM */
+type HrefRow = Ref<HTMLElement>;
+
+@customElement('app-root')
+export class AppRoot extends LitElement {
+  static styles = css`
+    :host {
+      display: block;
+    }
+    h3 {
+      margin: 0 0 4px;
+    }
+    p {
+      margin: 0 0 16px;
+      color: #4b4b4b;
+    }
+    .row {
+      display: grid;
+      grid-template-columns: 1fr auto;
+      align-items: baseline;
+      gap: 8px 16px;
+      padding: 10px 0;
+      border-top: 1px solid #e4e4e4;
+    }
+    .row:last-of-type {
+      border-bottom: 1px solid #e4e4e4;
+    }
+    .opt {
+      font-family: ui-monospace, monospace;
+      font-size: 13px;
+      color: #6b6b6b;
+    }
+    .href {
+      font-family: ui-monospace, monospace;
+      font-size: 13px;
+    }
+    .href.none {
+      color: #9a3b3b;
+    }
+    sp-link.active {
+      font-weight: 700;
+    }
+    a.active {
+      font-weight: 700;
+    }
+    ui-view {
+      display: block;
+      margin-top: 20px;
+    }
+  `;
+
+  private readonly rows: Record<
+    'assignTrue' | 'assignAuto' | 'anchorAuto',
+    HrefRow
+  > = {
+    assignTrue: createRef(),
+    assignAuto: createRef(),
+    anchorAuto: createRef(),
+  };
+
+  /** bumped whenever an observed href changes, to re-render the readouts */
+  @state() private hrefTick = 0;
+
+  private readonly observer = new MutationObserver(() => {
+    this.hrefTick += 1;
+  });
+
+  firstUpdated(): void {
+    for (const row of Object.values(this.rows)) {
+      const el = row.value;
+      if (el) {
+        this.observer.observe(el, {
+          attributes: true,
+          attributeFilter: ['href'],
+        });
+      }
+    }
+    this.hrefTick += 1;
+  }
+
+  disconnectedCallback(): void {
+    super.disconnectedCallback();
+    this.observer.disconnect();
+  }
+
+  private readout(row: HrefRow) {
+    // read through the tick so lit re-evaluates when the attribute changes
+    void this.hrefTick;
+    const href = row.value?.getAttribute('href') ?? null;
+    return href === null
+      ? html`<span class="href none">no href attribute</span>`
+      : html`<span class="href">href="${href}"</span>`;
+  }
+
+  render() {
+    const { assignTrue, assignAuto, anchorAuto } = this.rows;
+    return html`
+      <h3>uiSref and a design-system link element</h3>
+      <p>
+        <code>&lt;sp-link&gt;</code> declares its own <code>href</code>, but its
+        tag name is not <code>a</code> — so
+        <code>assignHref: 'auto'</code> refuses it and
+        <code>assignHref: true</code> is what makes uiSref drive it. Every link
+        below navigates; only the href differs.
+      </p>
+
+      <div class="row">
+        <sp-link
+          ${ref(assignTrue)}
+          ${uiSref('components', {}, { assignHref: true })}
+          ${uiSrefActive({ activeClasses: ['active'] })}
+          >Components (sp-link)</sp-link
+        >
+        <span class="opt">assignHref: true</span>
+        ${this.readout(assignTrue)}
+      </div>
+
+      <div class="row">
+        <sp-link
+          ${ref(assignAuto)}
+          ${uiSref('tokens', {}, { assignHref: 'auto' })}
+          ${uiSrefActive({ activeClasses: ['active'] })}
+          >Tokens (sp-link)</sp-link
+        >
+        <span class="opt">assignHref: 'auto'</span>
+        ${this.readout(assignAuto)}
+      </div>
+
+      <div class="row">
+        <a
+          ${ref(anchorAuto)}
+          ${uiSref('tokens', {}, { assignHref: 'auto' })}
+          ${uiSrefActive({ activeClasses: ['active'] })}
+          >Tokens (plain a)</a
+        >
+        <span class="opt">assignHref: 'auto'</span>
+        ${this.readout(anchorAuto)}
+      </div>
+
+      <ui-view></ui-view>
+    `;
+  }
+}
+
+const componentsState: LitStateDeclaration = {
+  name: 'components',
+  url: '/components',
+  component: () =>
+    html`<h4>Components</h4>
+      <p>
+        The first link carried a real href here, so hovering it showed the URL
+        and a middle-click would have opened it in a new tab.
+      </p>`,
+};
+
+const tokensState: LitStateDeclaration = {
+  name: 'tokens',
+  url: '/tokens',
+  component: () =>
+    html`<h4>Tokens</h4>
+      <p>
+        Both links to this state navigated on click — the option governs the
+        href attribute only, never the click handler.
+      </p>`,
+};
+
+const router = new UIRouterLit();
+router.plugin(hashLocationPlugin);
+router.stateRegistry.register(componentsState);
+router.stateRegistry.register(tokensState);
+router.urlService.rules.initial({ state: 'components' });
+router.start();
+
+render(
+  html`
+    <sp-theme system="spectrum" color="light" scale="medium">
+      <ui-router .uiRouter=${router}>
+        <app-root></app-root>
+      </ui-router>
+    </sp-theme>
+  `,
+  document.getElementById('root')!,
+);

--- a/examples/design-system-links/tsconfig.json
+++ b/examples/design-system-links/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "experimentalDecorators": true,
+    "useDefineForClassFields": false,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "types": [],
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*", "vite.config.ts"]
+}

--- a/examples/design-system-links/vite.config.ts
+++ b/examples/design-system-links/vite.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  build: {
+    target: 'esnext',
+  },
+});

--- a/examples/hellogalaxy/package-lock.json
+++ b/examples/hellogalaxy/package-lock.json
@@ -12,7 +12,7 @@
         "@uirouter/core": "^6.1.2",
         "@uirouter/visualizer": "^7.2.1",
         "lit": "^3.3.3",
-        "lit-ui-router": "^1.9.0"
+        "lit-ui-router": "^1.10.0"
       },
       "devDependencies": {
         "typescript": "^7.0.2",
@@ -1106,9 +1106,9 @@
       }
     },
     "node_modules/lit-ui-router": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/lit-ui-router/-/lit-ui-router-1.9.0.tgz",
-      "integrity": "sha512-pwnamYE4Hvpogcm1NdqmtwM3oN/Ndf1vj4xlYHqTo0NmmAosTWLrYOxkPQubeSxw48/WDq6gzYLHpacHIkJZnQ==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/lit-ui-router/-/lit-ui-router-1.10.0.tgz",
+      "integrity": "sha512-SjnWTTU0EFMcU/Ce+U2+Dvlm2B72XsEE4ixZHc4fFKJra1YY2IGYx1B8RKl1XPqHsIjBQHaQACAXPVO+v1stxw==",
       "license": "MIT",
       "dependencies": {
         "@oxc-project/runtime": ">=0.50.0"

--- a/examples/hellogalaxy/package.json
+++ b/examples/hellogalaxy/package.json
@@ -13,7 +13,7 @@
     "@uirouter/core": "^6.1.2",
     "@uirouter/visualizer": "^7.2.1",
     "lit": "^3.3.3",
-    "lit-ui-router": "^1.9.0"
+    "lit-ui-router": "^1.10.0"
   },
   "devDependencies": {
     "typescript": "^7.0.2",

--- a/examples/hellosolarsystem/package-lock.json
+++ b/examples/hellosolarsystem/package-lock.json
@@ -11,7 +11,7 @@
         "@uirouter/core": "^6.1.2",
         "@uirouter/visualizer": "^7.2.1",
         "lit": "^3.3.3",
-        "lit-ui-router": "^1.9.0"
+        "lit-ui-router": "^1.10.0"
       },
       "devDependencies": {
         "typescript": "^7.0.2",
@@ -1056,9 +1056,9 @@
       }
     },
     "node_modules/lit-ui-router": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/lit-ui-router/-/lit-ui-router-1.9.0.tgz",
-      "integrity": "sha512-pwnamYE4Hvpogcm1NdqmtwM3oN/Ndf1vj4xlYHqTo0NmmAosTWLrYOxkPQubeSxw48/WDq6gzYLHpacHIkJZnQ==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/lit-ui-router/-/lit-ui-router-1.10.0.tgz",
+      "integrity": "sha512-SjnWTTU0EFMcU/Ce+U2+Dvlm2B72XsEE4ixZHc4fFKJra1YY2IGYx1B8RKl1XPqHsIjBQHaQACAXPVO+v1stxw==",
       "license": "MIT",
       "dependencies": {
         "@oxc-project/runtime": ">=0.50.0"

--- a/examples/hellosolarsystem/package.json
+++ b/examples/hellosolarsystem/package.json
@@ -12,7 +12,7 @@
     "@uirouter/core": "^6.1.2",
     "@uirouter/visualizer": "^7.2.1",
     "lit": "^3.3.3",
-    "lit-ui-router": "^1.9.0"
+    "lit-ui-router": "^1.10.0"
   },
   "devDependencies": {
     "typescript": "^7.0.2",

--- a/examples/helloworld/package-lock.json
+++ b/examples/helloworld/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@uirouter/core": "^6.1.2",
         "lit": "^3.3.3",
-        "lit-ui-router": "^1.9.0"
+        "lit-ui-router": "^1.10.0"
       },
       "devDependencies": {
         "typescript": "^7.0.2",
@@ -1017,9 +1017,9 @@
       }
     },
     "node_modules/lit-ui-router": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/lit-ui-router/-/lit-ui-router-1.9.0.tgz",
-      "integrity": "sha512-pwnamYE4Hvpogcm1NdqmtwM3oN/Ndf1vj4xlYHqTo0NmmAosTWLrYOxkPQubeSxw48/WDq6gzYLHpacHIkJZnQ==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/lit-ui-router/-/lit-ui-router-1.10.0.tgz",
+      "integrity": "sha512-SjnWTTU0EFMcU/Ce+U2+Dvlm2B72XsEE4ixZHc4fFKJra1YY2IGYx1B8RKl1XPqHsIjBQHaQACAXPVO+v1stxw==",
       "license": "MIT",
       "dependencies": {
         "@oxc-project/runtime": ">=0.50.0"

--- a/examples/helloworld/package.json
+++ b/examples/helloworld/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@uirouter/core": "^6.1.2",
     "lit": "^3.3.3",
-    "lit-ui-router": "^1.9.0"
+    "lit-ui-router": "^1.10.0"
   },
   "devDependencies": {
     "typescript": "^7.0.2",

--- a/examples/package.json
+++ b/examples/package.json
@@ -13,7 +13,7 @@
     "format:check": "oxfmt --check \"**/*.{ts,js,json,md,html}\"",
     "postinstall": "concurrently \"npm:example:install:*\"",
     "lint": "oxlint .",
-    "typecheck": "concurrently --names helloworld,hellosolarsystem,hellogalaxy,design-system-links --prefix-colors auto \"pnpm run typecheck:helloworld\" \"pnpm run typecheck:hellosolarsystem\" \"pnpm run typecheck:hellogalaxy\" \"pnpm run typecheck:design-system-links\"",
+    "typecheck": "concurrently --prefix-colors auto \"npm:typecheck:*\"",
     "typecheck:design-system-links": "tsc -p design-system-links",
     "typecheck:hellogalaxy": "tsc -p hellogalaxy",
     "typecheck:hellosolarsystem": "tsc -p hellosolarsystem",

--- a/examples/package.json
+++ b/examples/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "build:embeds": "node build-embeds.ts",
+    "example:install:design-system-links": "npm ci --prefix design-system-links",
     "example:install:hellogalaxy": "npm ci --prefix hellogalaxy",
     "example:install:hellosolarsystem": "npm ci --prefix hellosolarsystem",
     "example:install:helloworld": "npm ci --prefix helloworld",
@@ -12,7 +13,8 @@
     "format:check": "oxfmt --check \"**/*.{ts,js,json,md,html}\"",
     "postinstall": "concurrently \"npm:example:install:*\"",
     "lint": "oxlint .",
-    "typecheck": "concurrently --names helloworld,hellosolarsystem,hellogalaxy --prefix-colors auto \"pnpm run typecheck:helloworld\" \"pnpm run typecheck:hellosolarsystem\" \"pnpm run typecheck:hellogalaxy\"",
+    "typecheck": "concurrently --names helloworld,hellosolarsystem,hellogalaxy,design-system-links --prefix-colors auto \"pnpm run typecheck:helloworld\" \"pnpm run typecheck:hellosolarsystem\" \"pnpm run typecheck:hellogalaxy\" \"pnpm run typecheck:design-system-links\"",
+    "typecheck:design-system-links": "tsc -p design-system-links",
     "typecheck:hellogalaxy": "tsc -p hellogalaxy",
     "typecheck:hellosolarsystem": "tsc -p hellosolarsystem",
     "typecheck:helloworld": "tsc -p helloworld"


### PR DESCRIPTION
Refs #603.

The option #597 keeps for 2.0 is the one nothing in the repo exercises. This adds the missing consumer as a live docs example: `uiSref` driving a **design-system link element** — `<sp-link>` from Spectrum Web Components — with `assignHref: true`.

## What the example demonstrates

`examples/design-system-links/` is a standalone Vite app: two states (`components`, `tokens`), three links, each printing its **own live `href` attribute** read back out of the DOM.

| element | option | rendered `href` |
| --- | --- | --- |
| `<sp-link>` | `assignHref: true` | `href="#/components"` |
| `<sp-link>` | `assignHref: 'auto'` | *no href attribute* |
| `<a>` | `assignHref: 'auto'` | `href="#/tokens"` |

All three navigate on click, so the running app makes the point the prose makes: the option governs the attribute only, `'auto'` scopes it to real `<a>`/`<area>`/SVG `<a>` by tag name, and a link-shaped custom element — `localName` `sp-link`, not `a` — needs `true`. That contrast is the *why* behind the escape hatch surviving the 2.0 flip, staged side by side rather than asserted.

`docs/guides/design-system-links.md` is the page around it: how to pair `uiSref` with a design system's link component, what the `href` actually buys (status bar, middle-click, copy-link, `aria-current` via `uiSrefActive`), a table for choosing between `true` / `'auto'` / `false`, and a note that the dev-build warning still fires on `true` because the directive cannot know your element forwards `href`.

## Design decisions taken — object to any of these

1. **Placement: a new `docs/guides/` page**, not `docs/tutorial/`. The tutorial framing ("Walkthrough: …") does not fit an example with no tutorial behind it. Registered in the sidebar alongside the six existing guides and in `docs/guides/index.md` under a new "Links & Markup" heading. This is the first of the issue's second category — live documentation for one API surface, not a tutorial rung — and `examples/README.md` says so explicitly.
2. **Precedent: the full `<LiveExample>` treatment** (Preview + Edit in StackBlitz), matching `helloworld`/`hellosolarsystem`/`hellogalaxy`. That means all three registry entries kept in sync: `EXAMPLES` in `docs/.vitepress/theme/components/examples.ts`, `EMBEDDED_EXAMPLES` in `docs/.vitepress/vite.config.ts`, and the build list in `examples/build-embeds.ts` — plus `example:install:*` / `typecheck:*` in `examples/package.json`. No new embed component: `ExampleEmbed.vue` and `LiveExample.vue` already compose it.
3. **Dependency: `@spectrum-web-components/link` + `@spectrum-web-components/theme`, npm-installed inside `examples/design-system-links/`** — out of the pnpm lockfile, out of the catalog, matching the StackBlitz consumption path like every other `examples/*` dependency. Note SWC is **not a new vendor here**: `docs` already depends on `@spectrum-web-components/icons-workflow` via the catalog (`ExampleEmbed.vue` imports its icons). Different layer, different install path; only the consumer in `examples/` is new.

## Also here: the release bump the example needed

`assignHref` landed in #590, so this example could not install until it shipped. `lit-ui-router@1.10.0` is now published, and three commits carry that through:

- **All four examples raised to `^1.10.0`** and relocked onto the registry tarball. `design-system-links` resolves what StackBlitz will resolve, not a locally packed stand-in; the lock diff is 4 files × 4 lines with no collateral dependency churn.
- **`examples` `typecheck` now fans out with a script glob**, matching the `postinstall` install step:

  ```json
  "typecheck": "concurrently --prefix-colors auto \"npm:typecheck:*\""
  ```

  `concurrently` derives the prefix names from the wildcard, so adding an example is one `typecheck:<name>` script instead of a third edit to the same enumerated line. The `typecheck:` prefix needs the colon, so it does not recurse into `typecheck` itself.

## Verification

CI is green on this branch against the published `1.10.0` — `build_and_test / run`, the signal gate, `lint_workflows`, `lint_pr_commits`, `lint_pr_title`, CodeRabbit, Workers Builds, and all seven codecov contexts. `lint:templates` and `lint:elements` are inside that run, so the `<sp-link>` markup clears the lit-a11y rules #557 turned on without new suppressions.

Local gates, and the runtime evidence CI does not cover:

- `turbo run lint` — **green**, 45/45, including `lint:templates` (lit-analyzer: 0 problems in 115 files) and `lint:elements`
- `turbo run typecheck` — **green**, 54/54, including the new `typecheck:design-system-links`
- `turbo run build` — **green**, 22/22, including `examples#build:embeds` and the docs build; `docs/dist/examples/design-system-links/` is static-copied and `docs/dist/guides/design-system-links.html` renders with both tabs
- Runtime, driven with Playwright against the built app: the `href` values in the table above are what the DOM actually carries, clicks navigate from both `sp-link`s, `uiSrefActive` toggles the active class on all three, and the console is clean



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a live Design System Links example demonstrating router integration with custom design-system links and native anchors.
  - Showcases `assignHref: true` and `'auto'` behaviors, live link destinations, navigation, and accessibility considerations.
- **Documentation**
  - Added a dedicated guide covering configuration options, navigation behavior, warnings, and setup guidance.
  - Added the example to the documentation sidebar, guides index, examples overview, and embedded examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->