### PR TITLE
build(coderabbit): skip review on release PRs

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -21,6 +21,13 @@ reviews:
     # Work here sits in draft for a long time. Review on "ready for review",
     # not on every WIP push; `@coderabbitai review` pulls one in early.
     drafts: false
+    # Release PRs from bump-version.yml are a version bump plus a generated
+    # changelog — nothing to review. `gh pr create --label release` applies the
+    # label in the same call that opens the PR, so one is never briefly
+    # unlabeled. A negative-only filter excludes; it does not opt everything
+    # else out.
+    labels:
+      - '!release'
     base_branches:
       - main
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,9 +77,10 @@ discussion (see the tool README).
 
 [CodeRabbit](https://docs.coderabbit.ai) reviews a PR once it leaves draft, and
 re-reviews each push after that. Drafts are skipped on purpose — comment
-`@coderabbitai review` to pull one in early. It is advisory either way: no
-required status check, nothing it says blocks a merge. `mise run ci` remains the
-gate.
+`@coderabbitai review` to pull one in early. Release PRs are skipped too — the
+`release` label excludes them, since a version bump plus a generated changelog
+has nothing to review. It is advisory either way: no required status check,
+nothing it says blocks a merge. `mise run ci` remains the gate.
 
 Its behaviour lives in [`.coderabbit.yaml`](./.coderabbit.yaml), read from the
 PR's own branch, so a PR may adjust its own review. The static analysers this


### PR DESCRIPTION
Follow-up to #605.

Release PRs from the "Bump version" workflow are a version bump plus a
generated changelog — there is nothing for a reviewer, human or bot, to say
about them. This excludes them from CodeRabbit's automatic review.

### Why the label, not the title

`auto_review.labels` accepts negative matches, and the release workflow already
applies a `release` label whose own description reads *"Release PRs from
bump-version.yml; exempt from semantic PR checks"* — so this reuses the existing
marker for "this PR is machine-generated, skip the usual checks" instead of
inventing a second heuristic.

The alternative, `ignore_title_keywords: ['Release']`, matches case-insensitive
substrings, so it would also silently skip an ordinary PR titled something like
`docs: document the release protocol`.

There is no race: `gh pr create --base … --label release` applies the label in
the same API call that opens the PR (`tools/shared/src/gh.ts`), so a release PR
is never briefly unlabeled and visible to the bot.

A negative-only filter is an exclusion, not an allow-list — every other PR is
still reviewed. Verified against the v2 schema, `oxfmt`, and `rumdl`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contribution guidance to clarify that automated reviews are skipped for pull requests labeled `release`.
  * Reaffirmed that automated reviews are advisory and the standard CI check remains required for merging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->