### PR TITLE
docs(examples): follow prefers-color-scheme in the design-system link example

### DIFF
--- a/docs/guides/design-system-links.md
+++ b/docs/guides/design-system-links.md
@@ -105,52 +105,101 @@ import '@spectrum-web-components/link/sp-link.js';
 
 Spectrum's components need a theme ancestor, so the router lives inside one.
 `sp-theme` takes a literal color stop — `lightest`, `light`, `dark`, or
-`darkest`, with no `auto` — so honouring the reader's OS preference means
-driving the attribute from the media query and re-rendering on change.
+`darkest`, with no `auto` — so following the reader's OS preference is the
+app's job.
 
 Each stop is a separate theme fragment, and importing it is what registers it
-with `sp-theme`. Import them statically and every reader downloads both; load
-them on demand and only the stop actually in use ships, with the other
-arriving on its own chunk if the preference ever flips:
+with `sp-theme`. Import both statically and every reader downloads a stop they
+will never see; load them on demand and only the one in use ships, with the
+other arriving on its own chunk if the preference ever flips. A reactive
+controller owns both halves — the media query and the fragment:
 
 ```ts
-const darkScheme = window.matchMedia('(prefers-color-scheme: dark)');
-const root = document.getElementById('root')!;
+import type { ReactiveController, ReactiveControllerHost } from 'lit';
 
 const themeFragments = {
   light: () => import('@spectrum-web-components/theme/theme-light.js'),
   dark: () => import('@spectrum-web-components/theme/theme-dark.js'),
 } satisfies Record<string, () => Promise<unknown>>;
 
-type ThemeColor = keyof typeof themeFragments;
+export type ThemeColor = keyof typeof themeFragments;
 
-/** a slower fragment landing after a newer flip must not win the render */
-let renderToken = 0;
+export class ColorSchemeController implements ReactiveController {
+  #host: ReactiveControllerHost;
+  #query = window.matchMedia('(prefers-color-scheme: dark)');
+  #loaded = new Set<ThemeColor>();
+  #applied?: ThemeColor;
 
-async function renderApp() {
-  const color: ThemeColor = darkScheme.matches ? 'dark' : 'light';
-  const token = ++renderToken;
-  // render only once the stop is registered, or sp-theme has nothing to adopt
-  await themeFragments[color]();
-  if (token !== renderToken) return;
-  render(
-    html`
+  constructor(host: ReactiveControllerHost) {
+    this.#host = host;
+    host.addController(this);
+  }
+
+  /** the preferred stop, once its fragment is registered */
+  get color(): ThemeColor | undefined {
+    return this.#applied;
+  }
+
+  get #preferred(): ThemeColor {
+    return this.#query.matches ? 'dark' : 'light';
+  }
+
+  hostConnected(): void {
+    this.#query.addEventListener('change', this.#onChange);
+    void this.#adopt();
+  }
+
+  hostDisconnected(): void {
+    this.#query.removeEventListener('change', this.#onChange);
+  }
+
+  #onChange = () => void this.#adopt();
+
+  async #adopt(): Promise<void> {
+    const wanted = this.#preferred;
+    if (!this.#loaded.has(wanted)) {
+      await themeFragments[wanted]();
+      this.#loaded.add(wanted);
+    }
+    // re-read the query: whatever it says now is what should be on screen
+    const preferred = this.#preferred;
+    if (this.#loaded.has(preferred)) this.#applied = preferred;
+    this.#host.requestUpdate();
+  }
+}
+```
+
+The re-read is what keeps this honest. A fragment that finishes loading applies
+the preference as it stands _then_, not the one it was asked for, so overlapping
+flips converge on the current scheme without anyone tracking which load started
+last — and the stop already on screen stays put while an unloaded one is still
+in flight.
+
+The host is an ordinary element that holds the router and waits for a
+registered stop, mounted straight from the HTML:
+
+```ts
+@customElement('app-shell')
+export class AppShell extends LitElement {
+  private readonly scheme = new ColorSchemeController(this);
+
+  private readonly router = createRouter();
+
+  render() {
+    const { color } = this.scheme;
+    // hold the first paint until a stop is registered — sp-theme adopts the
+    // one it is told to, and an unregistered stop leaves it nothing to adopt
+    if (!color) return nothing;
+    return html`
       <sp-theme system="spectrum" color=${color} scale="medium">
-        <ui-router .uiRouter=${router}>
+        <ui-router .uiRouter=${this.router}>
           <app-root></app-root>
         </ui-router>
       </sp-theme>
-    `,
-    root,
-  );
+    `;
+  }
 }
-
-darkScheme.addEventListener('change', () => void renderApp());
-void renderApp();
 ```
-
-Awaiting the fragment before the first render matters: `sp-theme` adopts the
-stop it is told to, and an unregistered one leaves it with nothing to adopt.
 
 Chrome around the components reads its colors from Spectrum's own tokens —
 `var(--spectrum-gray-800)` for text, `var(--spectrum-gray-300)` for rules —

--- a/docs/guides/design-system-links.md
+++ b/docs/guides/design-system-links.md
@@ -158,8 +158,17 @@ export class ColorSchemeController implements ReactiveController {
   async #adopt(): Promise<void> {
     const wanted = this.#preferred;
     if (!this.#loaded.has(wanted)) {
-      await themeFragments[wanted]();
-      this.#loaded.add(wanted);
+      try {
+        await themeFragments[wanted]();
+        this.#loaded.add(wanted);
+      } catch (error) {
+        // a fragment that never arrives must not blank the app: keep the stop
+        // already on screen, or adopt this one unthemed if there is none yet
+        console.error(`could not load the ${wanted} theme fragment`, error);
+        this.#applied ??= wanted;
+        this.#host.requestUpdate();
+        return;
+      }
     }
     // re-read the query: whatever it says now is what should be on screen
     const preferred = this.#preferred;
@@ -168,6 +177,12 @@ export class ColorSchemeController implements ReactiveController {
   }
 }
 ```
+
+A fragment can also fail to arrive — a stale chunk after a deploy, a flaky
+network — and an example that renders nothing until one loads would go blank.
+The catch keeps the stop already on screen, or adopts the wanted one unthemed
+when there is nothing to fall back to: unstyled chrome beats a blank page, and
+a later flip retries the import.
 
 The re-read is what keeps this honest. A fragment that finishes loading applies
 the preference as it stands _then_, not the one it was asked for, so overlapping

--- a/docs/guides/design-system-links.md
+++ b/docs/guides/design-system-links.md
@@ -99,8 +99,6 @@ npm install @spectrum-web-components/link @spectrum-web-components/theme
 
 ```ts
 import '@spectrum-web-components/theme/sp-theme.js';
-import '@spectrum-web-components/theme/theme-light.js';
-import '@spectrum-web-components/theme/theme-dark.js';
 import '@spectrum-web-components/theme/scale-medium.js';
 import '@spectrum-web-components/link/sp-link.js';
 ```
@@ -108,20 +106,36 @@ import '@spectrum-web-components/link/sp-link.js';
 Spectrum's components need a theme ancestor, so the router lives inside one.
 `sp-theme` takes a literal color stop — `lightest`, `light`, `dark`, or
 `darkest`, with no `auto` — so honouring the reader's OS preference means
-driving the attribute from the media query and re-rendering on change:
+driving the attribute from the media query and re-rendering on change.
+
+Each stop is a separate theme fragment, and importing it is what registers it
+with `sp-theme`. Import them statically and every reader downloads both; load
+them on demand and only the stop actually in use ships, with the other
+arriving on its own chunk if the preference ever flips:
 
 ```ts
 const darkScheme = window.matchMedia('(prefers-color-scheme: dark)');
 const root = document.getElementById('root')!;
 
-function renderApp() {
+const themeFragments = {
+  light: () => import('@spectrum-web-components/theme/theme-light.js'),
+  dark: () => import('@spectrum-web-components/theme/theme-dark.js'),
+} satisfies Record<string, () => Promise<unknown>>;
+
+type ThemeColor = keyof typeof themeFragments;
+
+/** a slower fragment landing after a newer flip must not win the render */
+let renderToken = 0;
+
+async function renderApp() {
+  const color: ThemeColor = darkScheme.matches ? 'dark' : 'light';
+  const token = ++renderToken;
+  // render only once the stop is registered, or sp-theme has nothing to adopt
+  await themeFragments[color]();
+  if (token !== renderToken) return;
   render(
     html`
-      <sp-theme
-        system="spectrum"
-        color=${darkScheme.matches ? 'dark' : 'light'}
-        scale="medium"
-      >
+      <sp-theme system="spectrum" color=${color} scale="medium">
         <ui-router .uiRouter=${router}>
           <app-root></app-root>
         </ui-router>
@@ -131,12 +145,14 @@ function renderApp() {
   );
 }
 
-darkScheme.addEventListener('change', renderApp);
-renderApp();
+darkScheme.addEventListener('change', () => void renderApp());
+void renderApp();
 ```
 
-Both theme fragments have to be imported for the swap to have anything to swap
-to. Chrome around the components reads its colors from Spectrum's own tokens —
+Awaiting the fragment before the first render matters: `sp-theme` adopts the
+stop it is told to, and an unregistered one leaves it with nothing to adopt.
+
+Chrome around the components reads its colors from Spectrum's own tokens —
 `var(--spectrum-gray-800)` for text, `var(--spectrum-gray-300)` for rules —
 which inherit through the shadow boundary and re-resolve with the theme.
 

--- a/docs/guides/design-system-links.md
+++ b/docs/guides/design-system-links.md
@@ -125,9 +125,9 @@ const themeFragments = {
 export type ThemeColor = keyof typeof themeFragments;
 
 export class ColorSchemeController implements ReactiveController {
-  #host: ReactiveControllerHost;
-  #query = window.matchMedia('(prefers-color-scheme: dark)');
-  #loaded = new Set<ThemeColor>();
+  readonly #host: ReactiveControllerHost;
+  readonly #query = window.matchMedia('(prefers-color-scheme: dark)');
+  readonly #loaded = new Set<ThemeColor>();
   #applied?: ThemeColor;
 
   constructor(host: ReactiveControllerHost) {
@@ -153,7 +153,7 @@ export class ColorSchemeController implements ReactiveController {
     this.#query.removeEventListener('change', this.#onChange);
   }
 
-  #onChange = () => void this.#adopt();
+  readonly #onChange = () => void this.#adopt();
 
   async #adopt(): Promise<void> {
     const wanted = this.#preferred;

--- a/docs/guides/design-system-links.md
+++ b/docs/guides/design-system-links.md
@@ -100,24 +100,45 @@ npm install @spectrum-web-components/link @spectrum-web-components/theme
 ```ts
 import '@spectrum-web-components/theme/sp-theme.js';
 import '@spectrum-web-components/theme/theme-light.js';
+import '@spectrum-web-components/theme/theme-dark.js';
 import '@spectrum-web-components/theme/scale-medium.js';
 import '@spectrum-web-components/link/sp-link.js';
 ```
 
-Spectrum's components need a theme ancestor, so the router lives inside one:
+Spectrum's components need a theme ancestor, so the router lives inside one.
+`sp-theme` takes a literal color stop — `lightest`, `light`, `dark`, or
+`darkest`, with no `auto` — so honouring the reader's OS preference means
+driving the attribute from the media query and re-rendering on change:
 
 ```ts
-render(
-  html`
-    <sp-theme system="spectrum" color="light" scale="medium">
-      <ui-router .uiRouter=${router}>
-        <app-root></app-root>
-      </ui-router>
-    </sp-theme>
-  `,
-  document.getElementById('root')!,
-);
+const darkScheme = window.matchMedia('(prefers-color-scheme: dark)');
+const root = document.getElementById('root')!;
+
+function renderApp() {
+  render(
+    html`
+      <sp-theme
+        system="spectrum"
+        color=${darkScheme.matches ? 'dark' : 'light'}
+        scale="medium"
+      >
+        <ui-router .uiRouter=${router}>
+          <app-root></app-root>
+        </ui-router>
+      </sp-theme>
+    `,
+    root,
+  );
+}
+
+darkScheme.addEventListener('change', renderApp);
+renderApp();
 ```
+
+Both theme fragments have to be imported for the swap to have anything to swap
+to. Chrome around the components reads its colors from Spectrum's own tokens —
+`var(--spectrum-gray-800)` for text, `var(--spectrum-gray-300)` for rules —
+which inherit through the shadow boundary and re-resolve with the theme.
 
 Nothing about the pairing is Spectrum-specific: any link-shaped custom element
 takes the same option.

--- a/examples/design-system-links/index.html
+++ b/examples/design-system-links/index.html
@@ -5,6 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Design System Links - lit-ui-router</title>
     <style>
+      :root {
+        color-scheme: light dark;
+      }
       body {
         font-family:
           system-ui,
@@ -13,8 +16,8 @@
         max-width: 800px;
         margin: 32px auto;
         padding: 0 20px;
-        color: #222;
-        background: #fff;
+        color: light-dark(#222, #e6e6e6);
+        background: light-dark(#fff, #1d1d1d);
       }
       @media (max-width: 480px) {
         body {

--- a/examples/design-system-links/index.html
+++ b/examples/design-system-links/index.html
@@ -28,7 +28,7 @@
     </style>
   </head>
   <body>
-    <div id="root"></div>
+    <app-shell></app-shell>
     <script type="module" src="/src/main.ts"></script>
   </body>
 </html>

--- a/examples/design-system-links/src/color-scheme.ts
+++ b/examples/design-system-links/src/color-scheme.ts
@@ -24,9 +24,9 @@ export type ThemeColor = keyof typeof themeFragments;
  * anyone tracking which load started last.
  */
 export class ColorSchemeController implements ReactiveController {
-  #host: ReactiveControllerHost;
-  #query = window.matchMedia('(prefers-color-scheme: dark)');
-  #loaded = new Set<ThemeColor>();
+  readonly #host: ReactiveControllerHost;
+  readonly #query = window.matchMedia('(prefers-color-scheme: dark)');
+  readonly #loaded = new Set<ThemeColor>();
   #applied?: ThemeColor;
 
   constructor(host: ReactiveControllerHost) {
@@ -52,7 +52,7 @@ export class ColorSchemeController implements ReactiveController {
     this.#query.removeEventListener('change', this.#onChange);
   }
 
-  #onChange = () => void this.#adopt();
+  readonly #onChange = () => void this.#adopt();
 
   async #adopt(): Promise<void> {
     const wanted = this.#preferred;

--- a/examples/design-system-links/src/color-scheme.ts
+++ b/examples/design-system-links/src/color-scheme.ts
@@ -57,8 +57,17 @@ export class ColorSchemeController implements ReactiveController {
   async #adopt(): Promise<void> {
     const wanted = this.#preferred;
     if (!this.#loaded.has(wanted)) {
-      await themeFragments[wanted]();
-      this.#loaded.add(wanted);
+      try {
+        await themeFragments[wanted]();
+        this.#loaded.add(wanted);
+      } catch (error) {
+        // a fragment that never arrives must not blank the app: keep the stop
+        // already on screen, or adopt this one unthemed if there is none yet
+        console.error(`could not load the ${wanted} theme fragment`, error);
+        this.#applied ??= wanted;
+        this.#host.requestUpdate();
+        return;
+      }
     }
     // re-read the query: whatever it says now is what should be on screen, and
     // the previous stop stays applied while an unloaded one is still in flight

--- a/examples/design-system-links/src/color-scheme.ts
+++ b/examples/design-system-links/src/color-scheme.ts
@@ -1,0 +1,69 @@
+import type { ReactiveController, ReactiveControllerHost } from 'lit';
+
+/**
+ * Each Spectrum color stop is a separate theme fragment, and importing it is
+ * what registers it with `sp-theme` — so only the stop in use has to ship, and
+ * the other arrives on its own chunk if the preference ever flips.
+ */
+const themeFragments = {
+  light: () => import('@spectrum-web-components/theme/theme-light.js'),
+  dark: () => import('@spectrum-web-components/theme/theme-dark.js'),
+} satisfies Record<string, () => Promise<unknown>>;
+
+export type ThemeColor = keyof typeof themeFragments;
+
+/**
+ * Tracks `prefers-color-scheme` and loads the matching Spectrum theme fragment
+ * on demand, exposing the stop that is both preferred and registered.
+ *
+ * `sp-theme` takes a literal color stop — `lightest`, `light`, `dark` or
+ * `darkest`, with no `auto` — so following the reader's OS preference is the
+ * host's job. The media query stays the single source of truth: a fragment
+ * that finishes loading re-reads it rather than applying the stop it was
+ * asked for, so overlapping flips converge on the current preference without
+ * anyone tracking which load started last.
+ */
+export class ColorSchemeController implements ReactiveController {
+  #host: ReactiveControllerHost;
+  #query = window.matchMedia('(prefers-color-scheme: dark)');
+  #loaded = new Set<ThemeColor>();
+  #applied?: ThemeColor;
+
+  constructor(host: ReactiveControllerHost) {
+    this.#host = host;
+    host.addController(this);
+  }
+
+  /** the preferred stop, once its fragment is registered; undefined until then */
+  get color(): ThemeColor | undefined {
+    return this.#applied;
+  }
+
+  get #preferred(): ThemeColor {
+    return this.#query.matches ? 'dark' : 'light';
+  }
+
+  hostConnected(): void {
+    this.#query.addEventListener('change', this.#onChange);
+    void this.#adopt();
+  }
+
+  hostDisconnected(): void {
+    this.#query.removeEventListener('change', this.#onChange);
+  }
+
+  #onChange = () => void this.#adopt();
+
+  async #adopt(): Promise<void> {
+    const wanted = this.#preferred;
+    if (!this.#loaded.has(wanted)) {
+      await themeFragments[wanted]();
+      this.#loaded.add(wanted);
+    }
+    // re-read the query: whatever it says now is what should be on screen, and
+    // the previous stop stays applied while an unloaded one is still in flight
+    const preferred = this.#preferred;
+    if (this.#loaded.has(preferred)) this.#applied = preferred;
+    this.#host.requestUpdate();
+  }
+}

--- a/examples/design-system-links/src/main.ts
+++ b/examples/design-system-links/src/main.ts
@@ -9,8 +9,6 @@ import {
   LitStateDeclaration,
 } from 'lit-ui-router';
 import '@spectrum-web-components/theme/sp-theme.js';
-import '@spectrum-web-components/theme/theme-light.js';
-import '@spectrum-web-components/theme/theme-dark.js';
 import '@spectrum-web-components/theme/scale-medium.js';
 import '@spectrum-web-components/link/sp-link.js';
 
@@ -192,14 +190,30 @@ router.start();
 const darkScheme = window.matchMedia('(prefers-color-scheme: dark)');
 const root = document.getElementById('root')!;
 
-function renderApp() {
+/**
+ * Each color stop is its own theme fragment, and the import is what registers
+ * it — so only the stop in use has to ship, and the other arrives on its own
+ * chunk if the preference ever flips.
+ */
+const themeFragments = {
+  light: () => import('@spectrum-web-components/theme/theme-light.js'),
+  dark: () => import('@spectrum-web-components/theme/theme-dark.js'),
+} satisfies Record<string, () => Promise<unknown>>;
+
+type ThemeColor = keyof typeof themeFragments;
+
+/** a slower fragment landing after a newer flip must not win the render */
+let renderToken = 0;
+
+async function renderApp() {
+  const color: ThemeColor = darkScheme.matches ? 'dark' : 'light';
+  const token = ++renderToken;
+  // render only once the stop is registered, or sp-theme has nothing to adopt
+  await themeFragments[color]();
+  if (token !== renderToken) return;
   render(
     html`
-      <sp-theme
-        system="spectrum"
-        color=${darkScheme.matches ? 'dark' : 'light'}
-        scale="medium"
-      >
+      <sp-theme system="spectrum" color=${color} scale="medium">
         <ui-router .uiRouter=${router}>
           <app-root></app-root>
         </ui-router>
@@ -209,5 +223,5 @@ function renderApp() {
   );
 }
 
-darkScheme.addEventListener('change', renderApp);
-renderApp();
+darkScheme.addEventListener('change', () => void renderApp());
+void renderApp();

--- a/examples/design-system-links/src/main.ts
+++ b/examples/design-system-links/src/main.ts
@@ -1,4 +1,4 @@
-import { html, LitElement, css, render } from 'lit';
+import { html, LitElement, css, nothing } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import { createRef, ref, Ref } from 'lit/directives/ref.js';
 import { hashLocationPlugin } from '@uirouter/core';
@@ -8,6 +8,7 @@ import {
   uiSrefActive,
   LitStateDeclaration,
 } from 'lit-ui-router';
+import { ColorSchemeController } from './color-scheme.js';
 import '@spectrum-web-components/theme/sp-theme.js';
 import '@spectrum-web-components/theme/scale-medium.js';
 import '@spectrum-web-components/link/sp-link.js';
@@ -179,49 +180,41 @@ const tokensState: LitStateDeclaration = {
       </p>`,
 };
 
-const router = new UIRouterLit();
-router.plugin(hashLocationPlugin);
-router.stateRegistry.register(componentsState);
-router.stateRegistry.register(tokensState);
-router.urlService.rules.initial({ state: 'components' });
-router.start();
+function createRouter(): UIRouterLit {
+  const router = new UIRouterLit();
+  router.plugin(hashLocationPlugin);
+  router.stateRegistry.register(componentsState);
+  router.stateRegistry.register(tokensState);
+  router.urlService.rules.initial({ state: 'components' });
+  router.start();
+  return router;
+}
 
-// sp-theme takes a literal color stop — no `auto`, so detection is ours to drive
-const darkScheme = window.matchMedia('(prefers-color-scheme: dark)');
-const root = document.getElementById('root')!;
+/** owns the router and the theme stop; mounted straight from index.html */
+@customElement('app-shell')
+export class AppShell extends LitElement {
+  private readonly scheme = new ColorSchemeController(this);
 
-/**
- * Each color stop is its own theme fragment, and the import is what registers
- * it — so only the stop in use has to ship, and the other arrives on its own
- * chunk if the preference ever flips.
- */
-const themeFragments = {
-  light: () => import('@spectrum-web-components/theme/theme-light.js'),
-  dark: () => import('@spectrum-web-components/theme/theme-dark.js'),
-} satisfies Record<string, () => Promise<unknown>>;
+  private readonly router = createRouter();
 
-type ThemeColor = keyof typeof themeFragments;
-
-/** a slower fragment landing after a newer flip must not win the render */
-let renderToken = 0;
-
-async function renderApp() {
-  const color: ThemeColor = darkScheme.matches ? 'dark' : 'light';
-  const token = ++renderToken;
-  // render only once the stop is registered, or sp-theme has nothing to adopt
-  await themeFragments[color]();
-  if (token !== renderToken) return;
-  render(
-    html`
+  render() {
+    const { color } = this.scheme;
+    // hold the first paint until a stop is registered — sp-theme adopts the
+    // one it is told to, and an unregistered stop leaves it nothing to adopt
+    if (!color) return nothing;
+    return html`
       <sp-theme system="spectrum" color=${color} scale="medium">
-        <ui-router .uiRouter=${router}>
+        <ui-router .uiRouter=${this.router}>
           <app-root></app-root>
         </ui-router>
       </sp-theme>
-    `,
-    root,
-  );
+    `;
+  }
 }
 
-darkScheme.addEventListener('change', () => void renderApp());
-void renderApp();
+declare global {
+  interface HTMLElementTagNameMap {
+    'app-shell': AppShell;
+    'app-root': AppRoot;
+  }
+}

--- a/examples/design-system-links/src/main.ts
+++ b/examples/design-system-links/src/main.ts
@@ -10,6 +10,7 @@ import {
 } from 'lit-ui-router';
 import '@spectrum-web-components/theme/sp-theme.js';
 import '@spectrum-web-components/theme/theme-light.js';
+import '@spectrum-web-components/theme/theme-dark.js';
 import '@spectrum-web-components/theme/scale-medium.js';
 import '@spectrum-web-components/link/sp-link.js';
 
@@ -21,13 +22,14 @@ export class AppRoot extends LitElement {
   static styles = css`
     :host {
       display: block;
+      color: var(--spectrum-gray-800);
     }
     h3 {
       margin: 0 0 4px;
     }
     p {
       margin: 0 0 16px;
-      color: #4b4b4b;
+      color: var(--spectrum-gray-700);
     }
     .row {
       display: grid;
@@ -35,22 +37,22 @@ export class AppRoot extends LitElement {
       align-items: baseline;
       gap: 8px 16px;
       padding: 10px 0;
-      border-top: 1px solid #e4e4e4;
+      border-top: 1px solid var(--spectrum-gray-300);
     }
     .row:last-of-type {
-      border-bottom: 1px solid #e4e4e4;
+      border-bottom: 1px solid var(--spectrum-gray-300);
     }
     .opt {
       font-family: ui-monospace, monospace;
       font-size: 13px;
-      color: #6b6b6b;
+      color: var(--spectrum-gray-600);
     }
     .href {
       font-family: ui-monospace, monospace;
       font-size: 13px;
     }
     .href.none {
-      color: #9a3b3b;
+      color: var(--spectrum-red-900);
     }
     sp-link.active {
       font-weight: 700;
@@ -186,13 +188,26 @@ router.stateRegistry.register(tokensState);
 router.urlService.rules.initial({ state: 'components' });
 router.start();
 
-render(
-  html`
-    <sp-theme system="spectrum" color="light" scale="medium">
-      <ui-router .uiRouter=${router}>
-        <app-root></app-root>
-      </ui-router>
-    </sp-theme>
-  `,
-  document.getElementById('root')!,
-);
+// sp-theme takes a literal color stop — no `auto`, so detection is ours to drive
+const darkScheme = window.matchMedia('(prefers-color-scheme: dark)');
+const root = document.getElementById('root')!;
+
+function renderApp() {
+  render(
+    html`
+      <sp-theme
+        system="spectrum"
+        color=${darkScheme.matches ? 'dark' : 'light'}
+        scale="medium"
+      >
+        <ui-router .uiRouter=${router}>
+          <app-root></app-root>
+        </ui-router>
+      </sp-theme>
+    `,
+    root,
+  );
+}
+
+darkScheme.addEventListener('change', renderApp);
+renderApp();


### PR DESCRIPTION
`sp-theme` takes a literal color stop — `lightest`/`light`/`dark`/`darkest`, with no `auto` — and `@spectrum-web-components/*` ships no `prefers-color-scheme` handling at all (grepped the installed packages: zero hits). So the detection is ours to roll.

- `examples/design-system-links` imports `theme-dark.js` alongside `theme-light.js` and drives `sp-theme[color]` from a `matchMedia('(prefers-color-scheme: dark)')` listener, re-rendering live without a reload.
- The example chrome stops pinning light-theme hex and reads Spectrum's own tokens (`--spectrum-gray-800`/`-700`/`-600`/`-300`, `--spectrum-red-900`), which inherit through the shadow boundary and re-resolve with the theme.
- The page shell outside `sp-theme` gets `color-scheme: light dark` + `light-dark()`.
- The guide snippet stays in sync with the example and explains why the escape hatch is needed.

## Verification

- `typecheck:design-system-links` and `vite build` clean.
- Chrome, with `prefers-color-scheme` emulated via CDP: light and dark each resolve their tokens at load (`sp-theme[color]` matches, chrome colors are non-initial), and flipping the OS preference on a loaded page updates the attribute without a reload.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automatic light and dark theme support to the design-system links example.
  - The interface now follows system color-scheme changes.
  - Themes load on demand before rendering and update smoothly when switching modes.
  - Updated styling to use Spectrum theme tokens for consistent colors.

- **Documentation**
  - Added guidance for dynamic theme loading and inherited Spectrum tokens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->