### PR TITLE
docs(guides): note that the embedded example follows the docs theme toggle

### DIFF
--- a/docs/guides/design-system-links.md
+++ b/docs/guides/design-system-links.md
@@ -220,5 +220,13 @@ Chrome around the components reads its colors from Spectrum's own tokens —
 `var(--spectrum-gray-800)` for text, `var(--spectrum-gray-300)` for rules —
 which inherit through the shadow boundary and re-resolve with the theme.
 
+Reading the preference instead of exposing a theme control of its own buys one
+thing worth knowing about: the live example above follows _this page's_
+appearance toggle, not just your OS setting. A page that sets `color-scheme`
+propagates it to a same-origin `<iframe>`, so the embedded document's
+`prefers-color-scheme` flips with the docs theme and the controller re-renders
+on the spot — the dark fragment arriving on the first flip. An app with its own
+bespoke toggle would have needed the embedding page to plumb the scheme in.
+
 Nothing about the pairing is Spectrum-specific: any link-shaped custom element
 takes the same option.


### PR DESCRIPTION
Two-sentence follow-up to #624, capturing a payoff of the media-query approach that is easy to miss.

Because the example reads `prefers-color-scheme` rather than shipping a theme control of its own, the live embed on the guide page follows **this site's** appearance toggle, not just the reader's OS setting: a page that sets `color-scheme` propagates it to a same-origin `<iframe>`, so the embedded document's media query flips with the docs theme and `ColorSchemeController` re-renders on the spot — pulling the dark fragment on the first flip. An app with a bespoke toggle would have needed the embedding page to plumb the scheme in.

## Verification

Confirmed against production (post-#624) with Playwright, toggling `.VPSwitchAppearance` and reading inside the embed frame:

| step | parent | frame `prefers-color-scheme: dark` | `sp-theme[color]` | body |
| --- | --- | --- | --- | --- |
| as loaded (OS dark) | `.dark` | `true` | `dark` | `rgb(29,29,29)` |
| after toggle | light | `false` | `light` | `rgb(255,255,255)` |
| toggled back | `.dark` | `true` | `dark` | `rgb(29,29,29)` |

Worth recording for future testing: this only reproduces with `newContext({ colorScheme: null })`. Playwright emulates `colorScheme: 'light'` by default, and an explicit override pins `prefers-color-scheme` inside iframes — which silently defeats the propagation being tested and produced a confident false negative before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented how live examples follow the embedding page’s light or dark appearance setting.
  * Clarified that independently controlled themes require explicit configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->