### PR TITLE
fix(lit-ui-router): require an href before handing a click to the browser

### DIFF
--- a/packages/lit-ui-router/src/specs/ui-sref.spec.ts
+++ b/packages/lit-ui-router/src/specs/ui-sref.spec.ts
@@ -750,6 +750,117 @@ describe('uiSref directive', () => {
     });
   });
 
+  describe('href-less links', () => {
+    // the hand-back guards only make sense when the browser has an href to
+    // act on; without one the click would dead-end
+
+    const home: LitStateDeclaration[] = [{ name: 'home', url: '/home' }];
+
+    it('should ignore a modified click on an anchor with an author href', async () => {
+      const wrapper = await setupWithTemplate(
+        home,
+        html`<a ${uiSref('home', {}, { assignHref: false })} href="/authored"
+          >Link</a
+        >`,
+      );
+
+      const goSpy = vi.spyOn(router!.stateService, 'go');
+      await clickLocatedElement(wrapper.querySelector('a')!, {
+        modifiers: ['Shift'],
+      });
+      await tick();
+
+      expect(goSpy).not.toHaveBeenCalled();
+      expect(suppression.events).toEqual([
+        expect.objectContaining({ type: 'click', defaultPrevented: false }),
+      ]);
+    });
+
+    it('should navigate on a modified click on an anchor with no href', async () => {
+      const wrapper = await setupWithTemplate(
+        home,
+        html`<a ${uiSref('home', {}, { assignHref: false })}>Link</a>`,
+      );
+
+      const anchor = wrapper.querySelector('a')!;
+      expect(anchor.hasAttribute('href')).toBe(false);
+
+      const goSpy = vi.spyOn(router!.stateService, 'go');
+      await clickLocatedElement(anchor, { modifiers: ['Shift'] });
+      await tick();
+
+      expect(goSpy).toHaveBeenCalledWith('home', {}, expect.any(Object));
+      expect(suppression.events).toEqual([
+        expect.objectContaining({ type: 'click', defaultPrevented: true }),
+      ]);
+    });
+
+    it('should navigate on a plain click on an anchor with an author href', async () => {
+      const wrapper = await setupWithTemplate(
+        home,
+        html`<a ${uiSref('home', {}, { assignHref: false })} href="/authored"
+          >Link</a
+        >`,
+      );
+
+      const goSpy = vi.spyOn(router!.stateService, 'go');
+      await clickLocatedElement(wrapper.querySelector('a')!);
+      await tick();
+
+      expect(goSpy).toHaveBeenCalledWith('home', {}, expect.any(Object));
+    });
+
+    it('should navigate on a plain click on an anchor with no href', async () => {
+      const wrapper = await setupWithTemplate(
+        home,
+        html`<a ${uiSref('home', {}, { assignHref: false })}>Link</a>`,
+      );
+
+      const goSpy = vi.spyOn(router!.stateService, 'go');
+      await clickLocatedElement(wrapper.querySelector('a')!);
+      await tick();
+
+      expect(goSpy).toHaveBeenCalledWith('home', {}, expect.any(Object));
+    });
+
+    it('should navigate on a modified click for a state whose navigable has no url', async () => {
+      // core returns null from href(), so no href is written even under the
+      // 1.x default: the dead click needs no unusual configuration
+      const wrapper = await setupWithTemplate(
+        [{ name: 'abstract', abstract: true }],
+        html`<a ${uiSref('abstract')}>Link</a>`,
+      );
+
+      const anchor = wrapper.querySelector('a')!;
+      expect(anchor.hasAttribute('href')).toBe(false);
+
+      const goSpy = vi.spyOn(router!.stateService, 'go');
+      await clickLocatedElement(anchor, { modifiers: ['Shift'] });
+      await tick();
+
+      expect(goSpy).toHaveBeenCalledWith('abstract', {}, expect.any(Object));
+    });
+
+    it('should navigate on a plain click on an href-less anchor with target="_blank"', async () => {
+      // the opensOffApp half of the disjunction dead-ends the same way
+      const wrapper = await setupWithTemplate(
+        home,
+        html`<a ${uiSref('home', {}, { assignHref: false })} target="_blank"
+          >Link</a
+        >`,
+      );
+
+      const goSpy = vi.spyOn(router!.stateService, 'go');
+      await clickLocatedElement(wrapper.querySelector('a')!);
+      await tick();
+
+      expect(goSpy).toHaveBeenCalledWith('home', {}, expect.any(Object));
+      expect(suppression.events).toEqual([
+        expect.objectContaining({ type: 'click', defaultPrevented: true }),
+      ]);
+    });
+  });
+
   describe('descendant clicks (currentTarget)', () => {
     // event.target is the deepest node clicked, so every guard that reads an
     // attribute off it is dead whenever a link wraps its label

--- a/packages/lit-ui-router/src/ui-sref.ts
+++ b/packages/lit-ui-router/src/ui-sref.ts
@@ -336,10 +336,11 @@ export class UiSrefDirective extends AsyncDirective {
       return;
     }
 
-    // scoped to links: these guards hand the click back to the browser, and a
-    // non-link has nothing to hand it back to
+    // scoped to links with an href: these guards hand the click back to the
+    // browser, and without one it has nothing to act on
     if (
       isNativeLink(element) &&
+      element.hasAttribute('href') &&
       (isModifiedClick(event) || opensOffApp(element))
     ) {
       return;


### PR DESCRIPTION
## The defect

`ui-sref.ts`'s tier-3 click guard was tag-only:

```ts
if (isNativeLink(element) && (isModifiedClick(event) || opensOffApp(element))) {
  return;
}
```

An `<a>`/`<area>` with **no `href` attribute** still took the early return, handing the click back to a browser that had nothing to act on — no navigation, no new tab, no `$state.go()`. A dead click.

Two reachable repro paths:

1. `<a uiSref="x" .uiSrefOptions=${{ assignHref: false }}>` with no author-supplied `href`.
2. `<a uiSref="x">` bound to a **url-less state** — `$state.href()` returns `null` for a state whose navigable has no url, so no href is written even under the `assignHref: true` 1.x default. This one needs no unusual configuration.

## The fix

```ts
isNativeLink(element) && element.hasAttribute('href') && (…)
```

Why `hasAttribute('href')` over the alternatives:

- **not `this.href !== null`** — that is keyed on the route, so it misses an **author-supplied** href. `<a href="/docs" uiSref="docs">` under `assignHref: false` must still hand ctrl-click to the browser, and only the attribute check sees that.
- **not `_ownsHref`** — it answers "did *we* write this href?", which is the wrong question. An author href suppresses the fall-through exactly as much as a written one; `_ownsHref` exists to decide what to clean up on an option flip.

`isNativeLink` itself is unchanged, and its **other two call sites keep their tag-only semantics**: `shouldAssignHref()`'s `'auto'` branch and the dev warning. The doc comment's tag-versus-*role* rationale is a different axis and is untouched. Auxclick is out of scope.

## Tests

New `href-less links` describe in `ui-sref.spec.ts` covering all four quadrants plus the two extra cases:

- `<a>` **with** an author href + modified click → hands back (no `go`, default intact) — regression guard
- `<a>` **without** href + modified click → `go` fires, default prevented
- `<a>` with href + plain click → `go`
- `<a>` without href + plain click → `go`
- url-less state, modified click → `go`
- href-less `<a target="_blank">`, plain click → `go` (the `opensOffApp` half of the disjunction)

No existing `<area>` harness, so none invented.

**Mutation test** (per #589): with the source fix reverted and the specs kept, exactly the three fix-dependent specs fail — *modified click with no href*, *url-less state*, *href-less `target="_blank"`* — while the three regression arms pass. Re-applying the fix returns 232/232 green.

## Verification

`turbo run test typecheck lint --filter=lit-ui-router` → 24/24 tasks successful, 232 tests passed. `turbo run format`/`format:check` clean (no files changed).

## Semver

**Minor.** The change only converts dead clicks into navigations; every click that already did something still does the same thing.

Closes #602

*Implemented with Claude Code (claude-opus-5).*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved navigation for links without an `href` when automatic href assignment is disabled.
  * Preserved native browser behavior for modified clicks, external destinations, and new-window links.
  * Ensured navigation is prevented or allowed appropriately based on the link destination and click context.

* **Tests**
  * Added coverage for href-less links, authored and missing hrefs, modifier keys, external targets, new-window links, buttons, and URL-less states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->