### PR TITLE
build(deps): bump the pnpm workspace SDK

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,14 +37,14 @@ catalogs:
       specifier: 1101.9.0
       version: 1101.9.0
     '@pnpm/workspace.project-manifest-reader':
-      specifier: 1100.0.23
-      version: 1100.0.23
+      specifier: 1100.0.24
+      version: 1100.0.24
     '@pnpm/workspace.projects-reader':
-      specifier: 1101.0.22
-      version: 1101.0.22
+      specifier: 1101.0.23
+      version: 1101.0.23
     '@pnpm/workspace.workspace-manifest-reader':
-      specifier: 1100.1.5
-      version: 1100.1.5
+      specifier: 1100.1.6
+      version: 1100.1.6
     '@release-it/conventional-changelog':
       specifier: ^12.0.0
       version: 12.0.0
@@ -1264,7 +1264,7 @@ importers:
         version: 1101.9.0
       '@pnpm/workspace.project-manifest-reader':
         specifier: 'catalog:'
-        version: 1100.0.23(@pnpm/logger@1100.0.0)
+        version: 1100.0.24(@pnpm/logger@1100.0.0)
       '@tools/shared':
         specifier: workspace:*
         version: link:../shared
@@ -1324,10 +1324,10 @@ importers:
         version: 1101.9.0
       '@pnpm/workspace.projects-reader':
         specifier: 'catalog:'
-        version: 1101.0.22(@pnpm/logger@1100.0.0)
+        version: 1101.0.23(@pnpm/logger@1100.0.0)
       '@pnpm/workspace.workspace-manifest-reader':
         specifier: 'catalog:'
-        version: 1100.1.5
+        version: 1100.1.6
       '@types/node':
         specifier: 'catalog:'
         version: 24.13.3
@@ -3144,14 +3144,14 @@ packages:
     resolution: {integrity: sha512-XUtk4jElgzD/WnnxqPaPTxRjCE2xC7iyvYwR1eldFgKz9rq1ku3NOHWQ93y6UUXc2wJUTi0s5Qnuvnge7GCzOg==}
     engines: {node: '>=22.13'}
 
-  '@pnpm/cli.utils@1101.0.22':
-    resolution: {integrity: sha512-06o8hcbxbxu5I2bnjYzC2CYt2UWH33HCDtL+ijbpZywbFfTACt2DCZ3R/8m7OAdPQ/e6C8gig5cH1saod9e8Zg==}
+  '@pnpm/cli.utils@1101.0.23':
+    resolution: {integrity: sha512-9LCHYZiE78aMkkK5lkYOVuEr/HjQt1pmEqRCWm4gUg0F3VA2H/zS38l9ZQUhtlqQ87HNRjyXrvIQmhwBbIky7A==}
     engines: {node: '>=22.13'}
     peerDependencies:
       '@pnpm/logger': ^1100.0.0
 
-  '@pnpm/config.package-is-installable@1100.1.2':
-    resolution: {integrity: sha512-eqCp2lqk6I8tcd0C9vuIOY8xuSLNv2PeSMjht8ezsUmy2d2fvufEiNaEXsjUz8GDIKoeuLWtxzI7h3anPILSoA==}
+  '@pnpm/config.package-is-installable@1100.1.3':
+    resolution: {integrity: sha512-nZglvZun7ifvT+6aHlfcQSTe57KTC0xGOgvRlTZDfhYqz9FFmo+65r+6myXivJmKCnwt2BgcovDW9gLzrf0w1Q==}
     engines: {node: '>=22.13'}
     peerDependencies:
       '@pnpm/logger': ^1100.0.0
@@ -3174,8 +3174,8 @@ packages:
     resolution: {integrity: sha512-ywydCrV79h1rrWzINY/yiho0SMIkRMYYrsvsG17KghOSoWiQcq30qGgfRnr+0keed+oxsCNmqlzYO+rz+MI6qg==}
     engines: {node: '>=22.13'}
 
-  '@pnpm/error@1100.1.1':
-    resolution: {integrity: sha512-dqFXd5jTgBkGkwwI6AO9ON/WBXlQ8LIMRyyRysgSshix1XDyYjMmk7+bdPLuY2gjpB95j0Wu9Xq+3l7uuGZToQ==}
+  '@pnpm/error@1100.1.2':
+    resolution: {integrity: sha512-HzeZOy38srT5glZqrlBcdfHd13tec3wrLiVRB5vQnj+ScOswQ2DzZzMJpqMh39gss6zhiTl/MskqKzoY/qT9ew==}
     engines: {node: '>=22.13'}
 
   '@pnpm/fs.graceful-fs@1100.1.1':
@@ -3186,8 +3186,8 @@ packages:
     resolution: {integrity: sha512-A3bRMTIZ5ptDPAE/KsDeY1J5UqqOiyo66+k/mUvaVjx++OJdMbp9If5kisEq9ljAV5r5TRpkxsJbSdrdJ5WtzQ==}
     engines: {node: '>=22.13'}
 
-  '@pnpm/pkg-manifest.utils@1100.3.1':
-    resolution: {integrity: sha512-9gYZ0NFNac2+qYV8suA7KWmZia0eJJNQDeByAhTfFpM1ji3Md7SFoNY9WnqXntpx/p1r9rRTeww4iwou/NEztg==}
+  '@pnpm/pkg-manifest.utils@1100.4.0':
+    resolution: {integrity: sha512-yghZAbJUesFCHs80Gqh9KTHirM8/7Aj2agp1vMQ6j8ZQbG24x9uPxDIy/vzrq97rEOtTHbxk+UNILvMuMq0oEw==}
     engines: {node: '>=22.13'}
     peerDependencies:
       '@pnpm/logger': ^1100.0.0
@@ -3204,8 +3204,8 @@ packages:
     resolution: {integrity: sha512-lB2aSB2h950UX1GX3JW4AZ86xjXD92YJbV92IBSQqHXXZdiemoVKADLA2cDQ4/wKeS7djY8fkITM6X+6iYF62A==}
     engines: {node: '>=22.13'}
 
-  '@pnpm/workspace.project-manifest-reader@1100.0.23':
-    resolution: {integrity: sha512-sIZ9QLZJOVt9nf7qiWd/bUFqyF12T0HrkRhkkkAAzc50NpXEzvbZjRV1V6r9zoWfJwntFx2jzyzYVIn4Zn9Snw==}
+  '@pnpm/workspace.project-manifest-reader@1100.0.24':
+    resolution: {integrity: sha512-RqDb4GI/DxFrpcCtmcKkj1OVEnz9LErYzGMfgXPMh8lJKUBaFfhU9Ys8wjoJCDzhlzn1sEjLWvicxC+hdfoNxg==}
     engines: {node: '>=22.13'}
     peerDependencies:
       '@pnpm/logger': ^1100.0.0
@@ -3214,14 +3214,14 @@ packages:
     resolution: {integrity: sha512-1s+T0xtNHbfQ73LdyE5mEZ8+cXKPQRT0N8qUXp+AZio9Mbgu2R9Qsz2n68vh4tiBrNSndaDc6PlyIb1N/tAEUA==}
     engines: {node: '>=22.13'}
 
-  '@pnpm/workspace.projects-reader@1101.0.22':
-    resolution: {integrity: sha512-rH1MGGvI01+zxFLRS3xqGN9FGNgJ6v4/6AXUEqfzEnUxzMsvilPvwtUBYNsw37Y8Z4lp3OCGMxN7tAOe0MTUlw==}
+  '@pnpm/workspace.projects-reader@1101.0.23':
+    resolution: {integrity: sha512-iKzsrj9DRKsj9uBtgfON6ZJW3Por3IFYqofZ2KjIlzO59mu/iMrwMr7CDqoBR6RyRBvpIZKRB92PqYsBJX8+zg==}
     engines: {node: '>=22.13'}
     peerDependencies:
       '@pnpm/logger': ^1100.0.0
 
-  '@pnpm/workspace.workspace-manifest-reader@1100.1.5':
-    resolution: {integrity: sha512-NMUVtTcyY8vm9xPMmpWRtWaCTdO3JyaHrm1AHdCpTQUhvhemLnULrSp5LG36o6BqUOF/P/cj/i8j97vDOypO5A==}
+  '@pnpm/workspace.workspace-manifest-reader@1100.1.6':
+    resolution: {integrity: sha512-AEz7/8tF9RS8fih3vOoq15mjmnY/QUVVUTv5SYXVan0j8zd87XFmM/lLZm/9czzJV286rlLs9siXwa9s20GtIw==}
     engines: {node: '>=22.13'}
 
   '@polka/url@1.0.0-next.29':
@@ -6320,6 +6320,9 @@ packages:
     resolution: {integrity: sha512-AQdy8s4WhNvUZ6P8F6PB21tSPIYKniic+Ogx0AacBMjKP1GUHN2E9URxQHtCusiwxudnCKkdy4GrHXPPJSkCCw==}
     engines: {node: ^14.13.1 || >=16.0.0}
 
+  semver-utils@1.1.4:
+    resolution: {integrity: sha512-EjnoLE5OGmDAVV/8YDoN5KiajNadjzIp9BAHOhYeQHt7j0UWxjmgsx4YD48wp4Ue1Qogq38F1GNUJNqF1kKKxA==}
+
   semver@7.8.5:
     resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
     engines: {node: '>=10'}
@@ -8436,24 +8439,24 @@ snapshots:
       '@pnpm/types': 1101.9.0
       load-json-file: 7.0.1
 
-  '@pnpm/cli.utils@1101.0.22(@pnpm/logger@1100.0.0)':
+  '@pnpm/cli.utils@1101.0.23(@pnpm/logger@1100.0.0)':
     dependencies:
       '@pnpm/cli.meta': 1100.0.14
-      '@pnpm/config.package-is-installable': 1100.1.2(@pnpm/logger@1100.0.0)
-      '@pnpm/error': 1100.1.1
+      '@pnpm/config.package-is-installable': 1100.1.3(@pnpm/logger@1100.0.0)
+      '@pnpm/error': 1100.1.2
       '@pnpm/logger': 1100.0.0
-      '@pnpm/pkg-manifest.utils': 1100.3.1(@pnpm/logger@1100.0.0)
+      '@pnpm/pkg-manifest.utils': 1100.4.0(@pnpm/logger@1100.0.0)
       '@pnpm/types': 1101.9.0
-      '@pnpm/workspace.project-manifest-reader': 1100.0.23(@pnpm/logger@1100.0.0)
+      '@pnpm/workspace.project-manifest-reader': 1100.0.24(@pnpm/logger@1100.0.0)
       chalk: 6.0.0
       load-json-file: 7.0.1
 
-  '@pnpm/config.package-is-installable@1100.1.2(@pnpm/logger@1100.0.0)':
+  '@pnpm/config.package-is-installable@1100.1.3(@pnpm/logger@1100.0.0)':
     dependencies:
       '@pnpm/cli.meta': 1100.0.14
       '@pnpm/core-loggers': 1100.3.2(@pnpm/logger@1100.0.0)
       '@pnpm/engine.runtime.system-version': 1100.0.9
-      '@pnpm/error': 1100.1.1
+      '@pnpm/error': 1100.1.2
       '@pnpm/logger': 1100.0.0
       '@pnpm/types': 1101.9.0
       detect-libc: 2.1.2
@@ -8479,7 +8482,7 @@ snapshots:
       execa: safe-execa@0.3.0
       memoize: 11.0.0
 
-  '@pnpm/error@1100.1.1':
+  '@pnpm/error@1100.1.2':
     dependencies:
       '@pnpm/constants': 1101.0.0
 
@@ -8492,14 +8495,15 @@ snapshots:
       bole: 5.0.29
       split2: 4.2.0
 
-  '@pnpm/pkg-manifest.utils@1100.3.1(@pnpm/logger@1100.0.0)':
+  '@pnpm/pkg-manifest.utils@1100.4.0(@pnpm/logger@1100.0.0)':
     dependencies:
       '@pnpm/core-loggers': 1100.3.2(@pnpm/logger@1100.0.0)
       '@pnpm/deps.peer-range': 1100.1.1
-      '@pnpm/error': 1100.1.1
+      '@pnpm/error': 1100.1.2
       '@pnpm/logger': 1100.0.0
       '@pnpm/types': 1101.9.0
       semver: 7.8.5
+      semver-utils: 1.1.4
 
   '@pnpm/text.comments-parser@1100.0.1':
     dependencies:
@@ -8509,12 +8513,12 @@ snapshots:
 
   '@pnpm/types@1101.9.0': {}
 
-  '@pnpm/workspace.project-manifest-reader@1100.0.23(@pnpm/logger@1100.0.0)':
+  '@pnpm/workspace.project-manifest-reader@1100.0.24(@pnpm/logger@1100.0.0)':
     dependencies:
-      '@pnpm/error': 1100.1.1
+      '@pnpm/error': 1100.1.2
       '@pnpm/fs.graceful-fs': 1100.1.1
       '@pnpm/logger': 1100.0.0
-      '@pnpm/pkg-manifest.utils': 1100.3.1(@pnpm/logger@1100.0.0)
+      '@pnpm/pkg-manifest.utils': 1100.4.0(@pnpm/logger@1100.0.0)
       '@pnpm/text.comments-parser': 1100.0.1
       '@pnpm/types': 1101.9.0
       '@pnpm/workspace.project-manifest-writer': 1100.0.14
@@ -8535,21 +8539,21 @@ snapshots:
       write-file-atomic: 7.0.1
       write-yaml-file: 6.0.0
 
-  '@pnpm/workspace.projects-reader@1101.0.22(@pnpm/logger@1100.0.0)':
+  '@pnpm/workspace.projects-reader@1101.0.23(@pnpm/logger@1100.0.0)':
     dependencies:
-      '@pnpm/cli.utils': 1101.0.22(@pnpm/logger@1100.0.0)
+      '@pnpm/cli.utils': 1101.0.23(@pnpm/logger@1100.0.0)
       '@pnpm/constants': 1101.0.0
       '@pnpm/logger': 1100.0.0
       '@pnpm/text.ordinal-comparator': 1100.0.0
       '@pnpm/types': 1101.9.0
-      '@pnpm/workspace.project-manifest-reader': 1100.0.23(@pnpm/logger@1100.0.0)
+      '@pnpm/workspace.project-manifest-reader': 1100.0.24(@pnpm/logger@1100.0.0)
       p-filter: 4.1.0
       tinyglobby: 0.2.17
 
-  '@pnpm/workspace.workspace-manifest-reader@1100.1.5':
+  '@pnpm/workspace.workspace-manifest-reader@1100.1.6':
     dependencies:
       '@pnpm/constants': 1101.0.0
-      '@pnpm/error': 1100.1.1
+      '@pnpm/error': 1100.1.2
       '@pnpm/types': 1101.9.0
       read-yaml-file: 3.0.0
 
@@ -11954,6 +11958,8 @@ snapshots:
   safer-buffer@2.1.2: {}
 
   screenfull@6.0.2: {}
+
+  semver-utils@1.1.4: {}
 
   semver@7.8.5: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -18,9 +18,9 @@ catalog:
   '@custom-elements-manifest/analyzer': ^0.11.0
   '@pnpm/logger': 1100.0.0
   '@pnpm/types': 1101.9.0
-  '@pnpm/workspace.project-manifest-reader': 1100.0.23
-  '@pnpm/workspace.projects-reader': 1101.0.22
-  '@pnpm/workspace.workspace-manifest-reader': 1100.1.5
+  '@pnpm/workspace.project-manifest-reader': 1100.0.24
+  '@pnpm/workspace.projects-reader': 1101.0.23
+  '@pnpm/workspace.workspace-manifest-reader': 1100.1.6
   '@release-it/conventional-changelog': ^12.0.0
   '@spectrum-web-components/icons-workflow': ^1.12.2
   '@types/dom-navigation': ^1.0.7


### PR DESCRIPTION
Slice 2 of 2 from dependabot #628. **Stacked on #629** — review/merge that first.

| package | from | to |
| --- | --- | --- |
| `@pnpm/workspace.project-manifest-reader` | 1100.0.23 | 1100.0.24 |
| `@pnpm/workspace.projects-reader` | 1101.0.22 | 1101.0.23 |
| `@pnpm/workspace.workspace-manifest-reader` | 1100.1.5 | 1100.1.6 |

### Why this is its own PR

These are EXACT pins, and they are what `tools/` uses to read workspace manifests. If one of them regresses, the fix is a revert of these three lines — not an untangle from a nine-package commit. Keeping the slice separate also keeps it independently holdable while the pnpm 12 RC eval is in flight.

### Lockfile review

The delta is confined to the SDK's own transitives (`@pnpm/cli.utils`, `config.package-is-installable`, `error`, `pkg-manifest.utils`). The `@pnpm/logger@1100.0.0` peer key is unchanged on all three and `@pnpm/types` stays `1101.9.0`, so there's no auto-peer re-resolution to audit here.

### Verification

`mise run //:ci` — **158/158 tasks successful**, including all 5 Cypress e2e suites.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workspace package versions to newer releases.
  * Improved compatibility and reliability for workspace project and manifest handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->