### PR TITLE
build(coderabbit): add a no-coderabbit opt-out label

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -26,8 +26,12 @@ reviews:
     # label in the same call that opens the PR, so one is never briefly
     # unlabeled. A negative-only filter excludes; it does not opt everything
     # else out.
+    # `no-coderabbit` is the manual escape hatch: label a PR to spend the
+    # review budget elsewhere. `@coderabbitai review` still works on a labelled
+    # PR when you change your mind.
     labels:
       - '!release'
+      - '!no-coderabbit'
     base_branches:
       - main
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,8 +79,9 @@ discussion (see the tool README).
 re-reviews each push after that. Drafts are skipped on purpose — comment
 `@coderabbitai review` to pull one in early. Release PRs are skipped too — the
 `release` label excludes them, since a version bump plus a generated changelog
-has nothing to review. It is advisory either way: no required status check,
-nothing it says blocks a merge. `mise run ci` remains the gate.
+has nothing to review. Label any other PR `no-coderabbit` to opt it out the same
+way. It is advisory either way: no required status check, nothing it says blocks
+a merge. `mise run ci` remains the gate.
 
 Its behaviour lives in [`.coderabbit.yaml`](./.coderabbit.yaml), read from the
 PR's own branch, so a PR may adjust its own review. The static analysers this


### PR DESCRIPTION
Follow-up to #623.

`labels: ['!release']` covers the machine-generated bump PRs. This adds a
manual lever for everything else: label a PR `no-coderabbit` and the automatic
review skips it.

On the free OSS tier a review is a thing worth spending deliberately — a
lockfile refresh, a typo fix, or a branch you already know the shape of doesn't
need one, and skipping it leaves the budget for the PR that does.

### Notes

- The label is new: *"Skip CodeRabbit's automatic review on this PR"*. It says
  what it does, so nobody has to open the config to find out.
- `labels` already held one negative match, so this is a second entry in the
  same exclusion list. It stays an exclusion filter — every unlabelled PR is
  still reviewed automatically.
- The opt-out is not a lock-out: `@coderabbitai review` still pulls in a review
  on a labelled PR when you change your mind, without touching the label.

**This PR wears the label**, so a quiet CodeRabbit here is the change working.
Verified against the v2 schema and `turbo run format`.
