### PR TITLE
test(lit-ui-router): opt the button click-guard specs into assignHref auto

### DIFF
--- a/packages/lit-ui-router/src/specs/ui-sref.spec.ts
+++ b/packages/lit-ui-router/src/specs/ui-sref.spec.ts
@@ -524,7 +524,7 @@ describe('uiSref directive', () => {
       // set imperatively: it is invalid markup, which lit-analyzer rejects
       const wrapper = await setupWithTemplate(
         [{ name: 'home', url: '/home' }],
-        html`<button ${uiSref('home')}>Go</button>`,
+        html`<button ${uiSref('home', {}, { assignHref: 'auto' })}>Go</button>`,
       );
       const button = wrapper.querySelector('button')!;
       button.setAttribute('target', '_top');
@@ -830,10 +830,13 @@ describe('uiSref directive', () => {
     // has nothing to defer to, so bailing drops the click instead of
     // handing it back to the browser
 
+    // 'auto' only silences the 1.x href deprecation notice; the guards key off
+    // isNativeLink, not href presence, so it changes nothing these specs assert
+
     it('should navigate on a shift-click on a button', async () => {
       const wrapper = await setupWithTemplate(
         [{ name: 'home', url: '/home' }],
-        html`<button ${uiSref('home')}>Go</button>`,
+        html`<button ${uiSref('home', {}, { assignHref: 'auto' })}>Go</button>`,
       );
 
       const goSpy = vi.spyOn(router!.stateService, 'go');
@@ -848,7 +851,7 @@ describe('uiSref directive', () => {
     it('should navigate on a meta-click on a button', async () => {
       const wrapper = await setupWithTemplate(
         [{ name: 'home', url: '/home' }],
-        html`<button ${uiSref('home')}>Go</button>`,
+        html`<button ${uiSref('home', {}, { assignHref: 'auto' })}>Go</button>`,
       );
 
       const goSpy = vi.spyOn(router!.stateService, 'go');
@@ -863,7 +866,7 @@ describe('uiSref directive', () => {
     it('should still honour defaultPrevented on a button', async () => {
       const wrapper = await setupWithTemplate(
         [{ name: 'home', url: '/home' }],
-        html`<button ${uiSref('home')}>Go</button>`,
+        html`<button ${uiSref('home', {}, { assignHref: 'auto' })}>Go</button>`,
       );
 
       wrapper.addEventListener('click', (event) => event.preventDefault(), {


### PR DESCRIPTION
## What

Pass `{ assignHref: 'auto' }` at the five `uiSref`-on-a-non-link call sites whose subject is something other than `href`: four `<button>` click-guard specs in `ui-sref.spec.ts`, and the `role="link"` `aria-current` spec in `ui-sref-active.spec.ts`.

## Why

The 1.x `assignHref: true` default writes an `href` to whatever element a `uiSref` lands on, and `shouldAssignHref()` warns in dev when that element cannot use one (`ui-sref.ts:296`). These specs put a `uiSref` on a non-link for reasons unrelated to `href`, so every run printed the deprecation notice — 25 stderr lines across the two spec files, none of them asserted.

## Why it is safe

The click guards key off `isNativeLink(element)` (`ui-sref.ts:341`), never off `href` presence, so `'auto'` changes no assertion in the button specs — it only stops the attribute being written. It also points them at what becomes the default in 2.0.

The notice keeps five dedicated specs in the `assignHref` describe: that it fires and names the fix, that it fires once per element rather than once per render, that it stays silent outside lit dev mode while still writing the href, that dev lit is actually loaded so those guards are not vacuous, and that `'auto'` writes nothing and says nothing. The warning path keys off `!isNativeLink(element)`, which is element-type agnostic, so no non-`<button>` case adds coverage.

## The `role="link"` case

`aria-current` defaulting keys off `isNativeLink(element) || element.matches('[role~="link"]')`, independent of `href` — the split `ui-sref-active.ts:184` documents, where `aria-current` follows the role and `href` follows the tag. So `'auto'` is the better demonstration there, and the spec now asserts the span takes the first and not the second. Mutation-checked: without `'auto'` that assertion fails.

## Verification

`vitest run src/specs/ui-sref.spec.ts src/specs/ui-sref-active.spec.ts` — 247 passed before and after, across chromium/firefox/safari. Warning lines 25 → 0. `turbo run format lint --filter=lit-ui-router` clean.

https://claude.ai/code/session_013HitN8q4QWp8242yw5Ypvj
