### PR TITLE
test(lit-ui-router): opt the role="link" aria-current spec into assignHref auto

### DIFF
--- a/packages/lit-ui-router/src/specs/ui-sref-active.spec.ts
+++ b/packages/lit-ui-router/src/specs/ui-sref-active.spec.ts
@@ -616,7 +616,10 @@ describe('uiSrefActive directive', () => {
       const { wrapper } = await setupWithStates(parentChildStates);
 
       render(
-        html`<span role="link" ${uiSref('parent')} ${uiSrefActive({})}
+        html`<span
+          role="link"
+          ${uiSref('parent', {}, { assignHref: 'auto' })}
+          ${uiSrefActive({})}
           >Parent</span
         >`,
         wrapper,
@@ -628,6 +631,9 @@ describe('uiSrefActive directive', () => {
 
       const span = wrapper.querySelector('span')!;
       expect(span.getAttribute('aria-current')).toBe('page');
+      // aria-current follows the role, href follows the tag: under auto the
+      // span takes the first and not the second
+      expect(span.hasAttribute('href')).toBe(false);
     });
 
     it('should default aria-current on for an SVG anchor', async () => {


### PR DESCRIPTION
Follow-up to #633, which silenced the four `<button>` click-guard specs but deliberately left this one warning. On review that reasoning does not hold up.

## Why the nag goes

It was left in place on the theory that `role="link"` is a shape a real consumer would plausibly write, so the deprecation notice firing there demonstrates the library nagging about it. But nothing asserts the warning at that call site — it is stderr, not coverage — and the notice already has five dedicated specs in the `assignHref` describe:

- it fires and names the fix (`{ assignHref: 'auto' }`)
- it fires once per element, not once per render
- it stays silent outside lit dev mode, while still writing the href
- dev lit is actually loaded, so those guards are not vacuous
- `'auto'` writes nothing and says nothing

The warning path keys off `!isNativeLink(element)`, which is element-type agnostic, so a `<span role="link">` exercises nothing the `<button>` specs do not.

## Why `'auto'` is the better demonstration here

`aria-current` defaulting keys off `isNativeLink(element) || element.matches('[role~="link"]')` — independent of `href`. That is the split `ui-sref-active.ts:184` documents: `aria-current` follows the *role*, `href` follows the *tag*, and the overlap is deliberately not exact.

Under the 1.x default the span got both, which blurs exactly the distinction the spec exists to pin down. Under `'auto'` it takes the first and not the second, and the spec now asserts that. So the silenced warning becomes coverage rather than disappearing.

Mutation-checked: drop `'auto'` and `expect(span.hasAttribute('href')).toBe(false)` fails.

## Verification

`vitest run src/specs/ui-sref.spec.ts src/specs/ui-sref-active.spec.ts` — 247 passed, across chromium/firefox/safari. With #633 merged, dev-warning lines across the two spec files go 1 → 0. `turbo run format lint --filter=lit-ui-router` clean.

https://claude.ai/code/session_013HitN8q4QWp8242yw5Ypvj


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accessibility state handling for role-based links.
  * Ensured active navigation elements receive `aria-current="page"` even when they do not have an `href` attribute.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->