### PR TITLE
build(deps): retire the last minimum-release-age exclusion

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -153,7 +153,4 @@ patchedDependencies:
   '@vitest/browser': patches/@vitest__browser.patch
   lit-dialog: patches/lit-dialog.patch
 
-minimumReleaseAgeExclude:
-  - vite@8.2.2
-
 minimumReleaseAgeStrict: true


### PR DESCRIPTION
`vite@8.2.2` published 2026-08-20T04:14:39Z and crossed pnpm's 24h `minimumReleaseAge` window at 2026-08-21T04:14:39Z. It was the last entry in the block, so the `minimumReleaseAgeExclude` key goes with it — back to a bare age gate.

Retirement proof (the same procedure used on the publint entries in #631):

| step | result |
| --- | --- |
| `md5 -q pnpm-lock.yaml` before | `898f9aa1685f4db08a628b853bfa0ce8` |
| `pnpm install` after the edit | exit 0, md5 unchanged — byte-identical |
| `pnpm install --frozen-lockfile` | exit 0, no `ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION` |
| `rolldown@` lines in the lock | exactly one, `1.2.4` |

The frozen-lockfile run is the one that matters: it's the path CI takes, and the one that raises the age-gate violation against an existing lockfile rather than at resolution time.

https://claude.ai/code/session_01EHSj4626pcBc2ipMGDmRPX

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package release-age validation settings.
  * Newly released versions are now subject to the standard minimum release-age checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->