### PR TITLE
feat(lit-ui-router): warn in lit dev mode when no <ui-router> ancestor is found

### DIFF
--- a/packages/lit-ui-router/src/dev-warn.ts
+++ b/packages/lit-ui-router/src/dev-warn.ts
@@ -1,0 +1,54 @@
+import { UIRouterLitElement } from './ui-router.js';
+
+/**
+ * Whether lit resolved to its development build. `enableWarning` is inherited
+ * from `ReactiveElement`, which declares it optional precisely because it
+ * exists only in development — lit's own docs prescribe guarding on it. Same
+ * shape in lit 2 and 3, and typed optional in both builds' `.d.ts`, so this
+ * needs no cast. Read per call, so import order cannot matter.
+ * @internal
+ */
+export function inLitDevMode(): boolean {
+  return typeof UIRouterLitElement.enableWarning === 'function';
+}
+
+/**
+ * Elements already told about a missing `<ui-router>`. One registry across all
+ * the sites, not one per site: a single missing provider trips `uiSref`'s
+ * render and its click on the same element, and a wall of near-identical
+ * messages obscures the one fix.
+ *
+ * @internal
+ */
+const warnedMissingRouter = new WeakSet<Element>();
+
+/**
+ * Warns once per element that a binding found no `<ui-router>` ancestor and has
+ * therefore degraded to a no-op.
+ *
+ * Callers must only reach this **after** the router seek has actually run and
+ * come back empty. Every seek here is deferred past the element's first render,
+ * so a binding legitimately sees no router on its first pass; warning there
+ * would fire on every correctly wired app.
+ *
+ * @param element the element whose binding found nothing
+ * @param subject how to name it in the message, e.g. `<a uiSref="home">`
+ * @param consequence what will not happen, e.g. `will not navigate`
+ *
+ * @internal
+ */
+export function warnMissingRouter(
+  element: Element,
+  subject: string,
+  consequence: string,
+): void {
+  if (!inLitDevMode() || warnedMissingRouter.has(element)) {
+    return;
+  }
+  warnedMissingRouter.add(element);
+  console.warn(
+    `lit-ui-router: ${subject} found no <ui-router> ancestor, so it ${consequence}. ` +
+      'Wrap this subtree in <ui-router>, or pass a router explicitly.',
+    element,
+  );
+}

--- a/packages/lit-ui-router/src/specs/ui-sref-active.spec.ts
+++ b/packages/lit-ui-router/src/specs/ui-sref-active.spec.ts
@@ -986,6 +986,120 @@ describe('uiSrefActive directive', () => {
       await tick(100);
     });
   });
+
+  describe('missing <ui-router> ancestor', () => {
+    // one template factory, so a re-render reuses the element rather than
+    // producing a fresh one with a fresh directive
+    const link = () =>
+      html`<a ${uiSrefActive({ activeClasses: ['active'], state: 'home' })}
+        >Home</a
+      >`;
+
+    it('should warn once when an update finds no router', async () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      try {
+        render(link(), container);
+        await tick(50);
+
+        expect(warn).toHaveBeenCalledTimes(1);
+        expect(warn.mock.calls[0]?.[0]).toBe(
+          'lit-ui-router: <a uiSrefActive> found no <ui-router> ancestor, ' +
+            'so it will never be marked active. Wrap this subtree in ' +
+            '<ui-router>, or pass a router explicitly.',
+        );
+
+        // the no-op is unchanged: no classes, no throw
+        const anchor = container.querySelector('a')!;
+        expect(anchor.classList.contains('active')).toBe(false);
+
+        // and a re-render does not repeat itself
+        render(link(), container);
+        await tick(50);
+        expect(warn).toHaveBeenCalledTimes(1);
+      } finally {
+        warn.mockRestore();
+      }
+    });
+
+    it('should warn once for an element carrying both directives', async () => {
+      // one missing provider trips uiSref's render and uiSrefActive's update on
+      // the same element; the shared registry keeps that to one message
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      try {
+        render(
+          html`<a
+            ${uiSref('home')}
+            ${uiSrefActive({ activeClasses: ['active'] })}
+            >Home</a
+          >`,
+          container,
+        );
+        await tick(100);
+
+        expect(warn).toHaveBeenCalledTimes(1);
+      } finally {
+        warn.mockRestore();
+      }
+    });
+
+    it('should stay silent outside lit dev mode, but still no-op', async () => {
+      // ReactiveElement.enableWarning exists only in lit's development build,
+      // which is what production consumers resolve away from
+      const enableWarning = UIRouterLitElement.enableWarning;
+      UIRouterLitElement.enableWarning = undefined;
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      try {
+        render(link(), container);
+        await tick(50);
+
+        expect(warn).not.toHaveBeenCalled();
+        // only the warning is gated, never the behaviour
+        expect(container.querySelector('a')!.classList.contains('active')).toBe(
+          false,
+        );
+      } finally {
+        warn.mockRestore();
+        UIRouterLitElement.enableWarning = enableWarning;
+      }
+    });
+
+    it('should confirm the specs run against lit dev mode', () => {
+      // the guard above is only meaningful if the suite sees dev lit; without
+      // this, every warning spec could pass vacuously
+      expect(typeof UIRouterLitElement.enableWarning).toBe('function');
+    });
+
+    it('should not warn when a correctly wired app renders', async () => {
+      // the whole surface at once: provider, view, link and active link
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      try {
+        const { wrapper } = await setupWithStates([
+          { name: 'home', url: '/home' },
+          { name: 'about', url: '/about' },
+        ]);
+
+        wrapper.appendChild(document.createElement('ui-view'));
+        const nav = () =>
+          html`<a
+            ${uiSref('home')}
+            ${uiSrefActive({ activeClasses: ['active'] })}
+            >Home</a
+          >`;
+        render(nav(), wrapper);
+        await tick(50);
+        render(nav(), wrapper);
+        await tick(50);
+
+        await routerGo(router, 'home');
+        await tick(100);
+
+        expect(warn).not.toHaveBeenCalled();
+      } finally {
+        warn.mockRestore();
+      }
+    });
+  });
 });
 
 describe('UiSrefActiveDirective', () => {

--- a/packages/lit-ui-router/src/specs/ui-sref.spec.ts
+++ b/packages/lit-ui-router/src/specs/ui-sref.spec.ts
@@ -5,6 +5,7 @@ import { TargetState } from '@uirouter/core';
 import {
   uiSref,
   UiSrefDirective,
+  UiSrefElement,
   UI_SREF_TARGET_EVENT,
   uiSrefTargetEvent,
   UiSrefTargetEvent,
@@ -105,6 +106,113 @@ describe('uiSref directive', () => {
 
     return wrapper;
   }
+
+  describe('missing <ui-router> ancestor', () => {
+    // one template factory, so a re-render reuses the element rather than
+    // producing a fresh one with a fresh directive
+    const link = () => html`<a ${uiSref('home')}>Home</a>`;
+
+    it('should warn once when a render finds no router', async () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      try {
+        render(link(), container);
+        await tick(50);
+
+        expect(warn).toHaveBeenCalledTimes(1);
+        expect(warn.mock.calls[0]?.[0]).toBe(
+          'lit-ui-router: <a uiSref="home"> found no <ui-router> ancestor, ' +
+            'so it will not navigate. Wrap this subtree in <ui-router>, or ' +
+            'pass a router explicitly.',
+        );
+
+        // the no-op is unchanged: still no href, still no throw
+        const anchor = container.querySelector('a')!;
+        expect(anchor.hasAttribute('href')).toBe(false);
+
+        // and a re-render does not repeat itself
+        render(link(), container);
+        await tick(50);
+        expect(warn).toHaveBeenCalledTimes(1);
+      } finally {
+        warn.mockRestore();
+      }
+    });
+
+    it('should warn once when a click finds no router', () => {
+      // driven directly: on a rendered sref the render above reports first and
+      // the shared once-per-element registry silences this site, so it is the
+      // fallback for a click that arrives with no render report behind it
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      try {
+        const anchor = document.createElement('a');
+        container.appendChild(anchor);
+
+        const srefDirective = new UiSrefDirective({ type: 6 } as any);
+        srefDirective.element = anchor as unknown as UiSrefElement;
+        srefDirective.state = 'home';
+
+        anchor.addEventListener(
+          'click',
+          srefDirective.onClick as EventListener,
+        );
+        clickElement(anchor);
+        clickElement(anchor);
+
+        expect(warn).toHaveBeenCalledTimes(1);
+        expect(warn.mock.calls[0]?.[0]).toContain(
+          '<a uiSref="home"> found no <ui-router> ancestor, so it will not navigate',
+        );
+        // the no-op is unchanged: no target resolved, no href written
+        expect(srefDirective.targetState).toBeNull();
+        expect(anchor.hasAttribute('href')).toBe(false);
+      } finally {
+        warn.mockRestore();
+      }
+    });
+
+    it('should stay silent outside lit dev mode, but still no-op', async () => {
+      // ReactiveElement.enableWarning exists only in lit's development build,
+      // which is what production consumers resolve away from
+      const enableWarning = UIRouterLitElement.enableWarning;
+      UIRouterLitElement.enableWarning = undefined;
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      try {
+        render(link(), container);
+        await tick(50);
+
+        expect(warn).not.toHaveBeenCalled();
+        // only the warning is gated, never the behaviour
+        expect(container.querySelector('a')!.hasAttribute('href')).toBe(false);
+      } finally {
+        warn.mockRestore();
+        UIRouterLitElement.enableWarning = enableWarning;
+      }
+    });
+
+    it('should confirm the specs run against lit dev mode', () => {
+      // the guard above is only meaningful if the suite sees dev lit; without
+      // this, every warning spec could pass vacuously
+      expect(typeof UIRouterLitElement.enableWarning).toBe('function');
+    });
+
+    it('should not warn when a router ancestor is present', async () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      try {
+        const wrapper = await setupWithTemplate(
+          [{ name: 'home', url: '/home' }],
+          link(),
+        );
+
+        expect(wrapper.querySelector('a')!.getAttribute('href')).toContain(
+          '/home',
+        );
+        expect(warn).not.toHaveBeenCalled();
+      } finally {
+        warn.mockRestore();
+      }
+    });
+  });
 
   describe('href generation', () => {
     it('should set href attribute for state with URL', async () => {

--- a/packages/lit-ui-router/src/specs/ui-view.spec.ts
+++ b/packages/lit-ui-router/src/specs/ui-view.spec.ts
@@ -126,11 +126,14 @@ describe('UiView', () => {
     });
 
     it('should render without router context', async () => {
+      // no ancestor provider, so this trips the dev-mode missing-router warning
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
       const uiView = document.createElement('ui-view');
       container.appendChild(uiView);
       await waitForUpdate(uiView);
 
       expect(uiView).toBeInstanceOf(UiView);
+      warn.mockRestore();
     });
 
     it('should seek router from ancestor', async () => {
@@ -547,6 +550,80 @@ describe('UiView', () => {
 
       const parentView = UiView.seekParentView(orphan);
       expect(parentView).toBeNull();
+    });
+  });
+  describe('missing <ui-router> ancestor', () => {
+    it('should warn once when a view updates with no router', async () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      try {
+        const uiView = document.createElement('ui-view');
+        uiView.textContent = 'fallback';
+        container.appendChild(uiView);
+        await waitForUpdate(uiView);
+
+        expect(warn).toHaveBeenCalledTimes(1);
+        expect(warn.mock.calls[0]?.[0]).toBe(
+          'lit-ui-router: <ui-view> found no <ui-router> ancestor, so it ' +
+            'will never render a routed view. Wrap this subtree in ' +
+            '<ui-router>, or pass a router explicitly.',
+        );
+
+        // the no-op is unchanged: still a UiView, still no throw
+        expect(uiView).toBeInstanceOf(UiView);
+
+        // and a further update does not repeat itself
+        uiView.requestUpdate();
+        await waitForUpdate(uiView);
+        expect(warn).toHaveBeenCalledTimes(1);
+      } finally {
+        warn.mockRestore();
+      }
+    });
+
+    it('should stay silent outside lit dev mode', async () => {
+      // ReactiveElement.enableWarning exists only in lit's development build,
+      // which is what production consumers resolve away from
+      const enableWarning = UIRouterLitElement.enableWarning;
+      UIRouterLitElement.enableWarning = undefined;
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      try {
+        const uiView = document.createElement('ui-view');
+        container.appendChild(uiView);
+        await waitForUpdate(uiView);
+
+        expect(warn).not.toHaveBeenCalled();
+        // only the warning is gated, never the behaviour
+        expect(uiView).toBeInstanceOf(UiView);
+      } finally {
+        warn.mockRestore();
+        UIRouterLitElement.enableWarning = enableWarning;
+      }
+    });
+
+    it('should confirm the specs run against lit dev mode', () => {
+      // the guard above is only meaningful if the suite sees dev lit; without
+      // this, every warning spec could pass vacuously
+      expect(typeof UIRouterLitElement.enableWarning).toBe('function');
+    });
+
+    it('should not warn when a router ancestor is present', async () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      try {
+        const { uiView } = await setupRouter([
+          {
+            name: 'home',
+            url: '/home',
+            component: () => html`<div>Home</div>`,
+          },
+        ]);
+        await routerGo(router, 'home');
+
+        expect(uiView.uiRouter).toBe(router);
+        expect(warn).not.toHaveBeenCalled();
+      } finally {
+        warn.mockRestore();
+      }
     });
   });
 });

--- a/packages/lit-ui-router/src/ui-sref-active.ts
+++ b/packages/lit-ui-router/src/ui-sref-active.ts
@@ -20,8 +20,8 @@ import { AsyncDirective } from 'lit/async-directive.js';
 
 import { UIRouterLit } from './core.js';
 import { UIRouterLitElement } from './ui-router.js';
+import { inLitDevMode, warnMissingRouter } from './dev-warn.js';
 import {
-  inLitDevMode,
   isNativeLink,
   UiSrefElement,
   UiSrefTargetEvent,
@@ -542,6 +542,14 @@ export class UiSrefActiveDirective extends AsyncDirective {
 
     if (this.uiRouter && this._firstUpdated) {
       this.doRender();
+    } else if (!this.uiRouter) {
+      // reached only past the awaited `firstUpdated` above, so the seek has
+      // run: the classes this update would have applied are never coming
+      warnMissingRouter(
+        element,
+        `<${element.localName} uiSrefActive>`,
+        'will never be marked active',
+      );
     }
   }
 
@@ -570,13 +578,16 @@ export class UiSrefActiveDirective extends AsyncDirective {
         this.targetStates.add(targetState as TargetState);
       });
     } else if (this.state) {
-      this.targetStates.add(
-        this.uiRouter!.stateService.target(
-          this.state,
-          this.params,
-          this.getOptions(),
-        ),
-      );
+      // no router: no target to resolve, and the update that follows reports it
+      if (this.uiRouter) {
+        this.targetStates.add(
+          this.uiRouter.stateService.target(
+            this.state,
+            this.params,
+            this.getOptions(),
+          ),
+        );
+      }
     } else {
       this.element!.addEventListener(
         UI_SREF_TARGET_EVENT,
@@ -587,12 +598,16 @@ export class UiSrefActiveDirective extends AsyncDirective {
       TRANSITION_STATE_CHANGE_EVENT,
       this.onTransitionStateChange,
     );
-    this._deregisterOnStart = this.uiRouter!.transitionService.onStart(
-      {},
-      this.onTransitionStart,
-    ) as deregisterFn;
-    this._deregisterOnStatesChanged =
-      this.uiRouter!.stateRegistry.onStatesChanged(this.onStatesChanged);
+    // no router: nothing to subscribe to, and `_firstUpdated` still has to be
+    // reached so the next update can report the no-op
+    if (this.uiRouter) {
+      this._deregisterOnStart = this.uiRouter.transitionService.onStart(
+        {},
+        this.onTransitionStart,
+      ) as deregisterFn;
+      this._deregisterOnStatesChanged =
+        this.uiRouter.stateRegistry.onStatesChanged(this.onStatesChanged);
+    }
 
     setTimeout(() => {
       if (this.targetStates.size) {

--- a/packages/lit-ui-router/src/ui-sref.ts
+++ b/packages/lit-ui-router/src/ui-sref.ts
@@ -16,6 +16,7 @@ import { inLitDevMode, warnMissingRouter } from './dev-warn.js';
 import { UIRouterLitElement } from './ui-router.js';
 import { UiView } from './ui-view.js';
 
+// re-export: `inLitDevMode` ships in the public d.ts (#541)
 export { inLitDevMode };
 
 /**

--- a/packages/lit-ui-router/src/ui-sref.ts
+++ b/packages/lit-ui-router/src/ui-sref.ts
@@ -12,8 +12,11 @@ import type { DirectiveResult } from 'lit/directive.js';
 import { AsyncDirective } from 'lit/async-directive.js';
 
 import { UIRouterLit } from './core.js';
+import { inLitDevMode, warnMissingRouter } from './dev-warn.js';
 import { UIRouterLitElement } from './ui-router.js';
 import { UiView } from './ui-view.js';
+
+export { inLitDevMode };
 
 /**
  * Event name dispatched when a uiSref target state changes.
@@ -114,18 +117,6 @@ export type UiSrefTransitionOptions = TransitionOptions & UiSrefOptions;
 const warnedAssignHref = new WeakSet<Element>();
 
 /**
- * Whether lit resolved to its development build. `enableWarning` is inherited
- * from `ReactiveElement`, which declares it optional precisely because it
- * exists only in development — lit's own docs prescribe guarding on it. Same
- * shape in lit 2 and 3, and typed optional in both builds' `.d.ts`, so this
- * needs no cast. Read per call, so import order cannot matter.
- * @internal
- */
-export function inLitDevMode(): boolean {
-  return typeof UIRouterLitElement.enableWarning === 'function';
-}
-
-/**
  * Whether the element navigates on its own. `localName` is lowercase for HTML
  * and SVG alike, so SVG `<a>` needs no namespace check.
  *
@@ -204,6 +195,16 @@ export class UiSrefDirective extends AsyncDirective {
   /** whether the href currently on the element was written by us */
   private _ownsHref = false;
 
+  /**
+   * Whether {@link seekRouter} has run. The seek is deferred a task past the
+   * first render, so `uiRouter` being empty before it means "not looked yet",
+   * not "not there" — only after it may a bail be reported as a missing
+   * provider.
+   *
+   * @internal
+   */
+  private _seekedRouter = false;
+
   /** @internal */
   unsubscribe: (() => void) | undefined;
 
@@ -236,6 +237,9 @@ export class UiSrefDirective extends AsyncDirective {
     const { uiRouter: router } = this;
     const $state = router?.stateService;
     if (!$state) {
+      if (this._seekedRouter) {
+        this.warnMissingRouter(state);
+      }
       return noChange;
     }
 
@@ -304,6 +308,23 @@ export class UiSrefDirective extends AsyncDirective {
   /** @internal */
   seekRouter(): void {
     this.uiRouter = UIRouterLitElement.seekRouter(this.element!);
+    this._seekedRouter = true;
+  }
+
+  /**
+   * Names this sref in the missing-provider warning. Shared by the two sites
+   * that observe the no-op — the render that writes no `href` and the click
+   * that navigates nowhere — so an element that does both still warns once.
+   *
+   * @internal
+   */
+  private warnMissingRouter(state: string): void {
+    const element = this.element!;
+    warnMissingRouter(
+      element,
+      `<${element.localName} uiSref="${state}">`,
+      'will not navigate',
+    );
   }
 
   /** @internal */
@@ -326,6 +347,9 @@ export class UiSrefDirective extends AsyncDirective {
     const options = this.getOptions();
     const $state = router?.stateService;
     if (!$state || !this.element?.isConnected || !state) {
+      if (!$state && state && this.element?.isConnected) {
+        this.warnMissingRouter(state);
+      }
       return;
     }
 
@@ -392,9 +416,13 @@ export class UiSrefDirective extends AsyncDirective {
     this.seekRouter();
     this.seekParentView();
     this.element!.addEventListener('click', this.onClick as EventListener);
-    this.unsubscribe = this.uiRouter!.stateRegistry.onStatesChanged(
-      this.doRender,
-    );
+    // no router: the subscription is the only step that needs one, and
+    // `doRender` still has to run for the no-op to report itself
+    if (this.uiRouter) {
+      this.unsubscribe = this.uiRouter.stateRegistry.onStatesChanged(
+        this.doRender,
+      );
+    }
     this.doRender();
     this._firstUpdated = true;
   }

--- a/packages/lit-ui-router/src/ui-view.ts
+++ b/packages/lit-ui-router/src/ui-view.ts
@@ -1,5 +1,5 @@
 import { LitElement } from 'lit';
-import type { TemplateResult } from 'lit';
+import type { PropertyValues, TemplateResult } from 'lit';
 import { property, state } from 'lit/decorators.js';
 import {
   ActiveUIView,
@@ -27,6 +27,7 @@ import {
   NormalizedLitViewDeclaration,
 } from './interface.js';
 import { LitViewConfig, UIRouterLit } from './core.js';
+import { warnMissingRouter } from './dev-warn.js';
 import { UIRouterLitElement, UiRouterContextEvent } from './ui-router.js';
 
 /** @internal */
@@ -355,6 +356,23 @@ export class UiView extends LitElement {
   /** @internal */
   public get state(): StateDeclaration {
     return (this.viewContext as StateObject).self;
+  }
+
+  /**
+   * Reports a missing provider once this view has actually rendered nothing.
+   *
+   * Deliberately here rather than at the failed seek in `setupUiView`: the seek
+   * runs in `connectedCallback`, and custom-element upgrade order is not
+   * guaranteed, so a correct app can connect a `<ui-view>` before `<ui-router>`
+   * upgrades. By the first completed update the no-op is observable.
+   *
+   * @internal
+   */
+  protected updated(changed: PropertyValues): void {
+    super.updated(changed);
+    if (!this.uiRouter) {
+      warnMissingRouter(this, '<ui-view>', 'will never render a routed view');
+    }
   }
 
   /** @internal */


### PR DESCRIPTION
Closes #599.

## The defect

Every entry point degrades to a no-op when `UIRouterLitElement.seekRouter()` finds no `<ui-router>` ancestor: a link renders, looks right and does nothing; a `<ui-view>` stays empty forever. Nothing in the console connects the symptom to the cause — forgetting the provider, or mounting a subtree outside it.

The no-op is correct and stays. This adds the explanation and nothing else: a `console.warn` behind lit's development build, once per element, worded to name the fix rather than the internal that bailed.

```
lit-ui-router: <a uiSref="home"> found no <ui-router> ancestor, so it will not
navigate. Wrap this subtree in <ui-router>, or pass a router explicitly.
```

The consequence clause is per-site: `will not navigate` for `uiSref`, `will never be marked active` for `uiSrefActive`, `will never render a routed view` for `<ui-view>`. The element itself is passed as the second `console.warn` argument, matching #556's takeover warning, so DevTools can jump straight to it.

## Four sites, not five

| site | warns | when |
| --- | --- | --- |
| `ui-sref.ts` `render()` | yes | the render that writes no `href` |
| `ui-sref.ts` `onClick` | yes | the click that navigates nowhere |
| `ui-sref-active.ts` `update()` | yes | the update that applies no classes |
| `ui-view.ts` | yes | the first completed update that renders nothing |
| `transition-controller.ts` `hostConnected()` | **no** | — |

`TransitionController` accepts an explicit `options.router`, so a consumer wiring it directly is in a different position from someone writing `uiSref` in a template. Its no-op is a documented contract — `transition-controller.spec.ts:98`, *"should be a no-op without a router"* — and warning there would fire on deliberate use.

## Warn on use, not on failed seek

Load-bearing, and it is what decides where the calls go. `seekRouter()` runs at connect time and custom-element upgrade order is not guaranteed, so an app can legitimately connect a `<ui-view>` before `<ui-router>` upgrades. This is the same ordering hazard that got `'href' in element` rejected in #577.

- **`uiSref`** seeks in a `setTimeout(0)` scheduled from `update()`, so its *first* `render()` legitimately sees no router even in a correctly wired app. A `_seekedRouter` flag gates the report: `render()` only reports a bail once the seek has actually run and come back empty. Without that flag, every sref in every app warns — see the mutation table.
- **`uiSrefActive`** seeks inside its `update()`, past an `await`, so the `else` branch that reports is reachable only after the seek. No flag needed, and none added: a `_seekedRouter` here survived every mutation, so it was removed rather than left as untestable ceremony.
- **`<ui-view>`** reports from `updated()`, one full lit update after `connectedCallback` does the seek — not from the `!router` bail in `setupUiView()`, which is the failed seek itself.

## One warning per element

A single missing provider trips several sites at once. One module-level `WeakSet<Element>` is shared across all four call sites, not one per site, so an element that renders *and* is clicked warns once in total, and an element carrying both `uiSref` and `uiSrefActive` warns once rather than twice. Spec'd both ways.

Because `render()` always reports before a click can arrive, the `onClick` site is in practice the deduped fallback for a click with no render report behind it; its spec drives it directly for that reason.

## Reused from #590

`inLitDevMode()` — the `typeof UIRouterLitElement.enableWarning === 'function'` probe — and the once-per-element `WeakSet` shape are both #590's. They were file-local to `ui-sref.ts`, and `ui-view.ts` cannot import from there without a cycle (`ui-sref.ts` already imports `UiView`). So the minimum shared helper was factored out into a new `src/dev-warn.ts`: `inLitDevMode()` moved verbatim, plus `warnMissingRouter(element, subject, consequence)` holding the shared registry.

`ui-sref.ts` re-exports `inLitDevMode` so the public JS surface through `pure.ts`'s `export *` is byte-identical. `ui-sref-active.ts` now imports it from `dev-warn.js` directly. `dev-warn.ts` is not added to `pure.ts` — the helper is internal.

## Bug found: the sref no-op was not actually a no-op

The issue assumes all five sites degrade silently. Three do. The two `uiSref`/`uiSrefActive` sites did **not** — with no router they threw asynchronously, out of reach of any caller:

```
TypeError: Cannot read properties of undefined (reading 'stateRegistry')
  at UiSrefDirective.firstUpdated (ui-sref.ts:395)     # uncaught, from setTimeout
TypeError: Cannot read properties of undefined (reading 'transitionService')
  at UiSrefActiveDirective.firstUpdated (…:590)        # unhandled rejection
```

Both are the same shape: `firstUpdated()` seeks the router and then dereferences `this.uiRouter!` unconditionally to subscribe. Three `if (this.uiRouter)` guards around the subscription calls fix it, and nothing else in either method needs a router. This is in scope rather than a follow-up because it is load-bearing for the feature: `doRender()` sits *after* the throwing line in `uiSref.firstUpdated`, so without the guard the render site never reports, and the acceptance criterion "warns once **and** the existing no-op behaviour is unchanged" cannot hold while the behaviour is an uncaught `TypeError`. It also makes the contract the issue describes actually true.

Out of scope and untouched: the duplicate-registration warnings in `ui-view.register.ts:14` and `ui-router.register.ts:14` stay unconditional and ungated.

## Tests

13 new specs; 240 passing across the package.

- **`ui-sref.spec.ts`** — render finds no router → warns once with the exact message, still no `href`, and a re-render does not repeat (template factory, so the element is reused rather than replaced); click finds no router → warns once, no target resolved; silent outside lit dev mode with the no-op unchanged; a dev-lit guard so the gate spec cannot pass vacuously; a wired router warns zero times.
- **`ui-sref-active.spec.ts`** — update finds no router → warns once with the exact message, no classes applied, re-render silent; **one element carrying both directives warns once, not twice**; dev-mode gate + dev-lit guard; and a **correctly wired app — provider, view, link and active link, rendered twice and navigated — warns zero times**.
- **`ui-view.spec.ts`** — first update with no router → warns once with the exact message, a further `requestUpdate()` silent; dev-mode gate + dev-lit guard; a wired view warns zero times. The pre-existing *"should render without router context"* spec now mocks `console.warn`, since it is a genuine trip of the new warning.

### Mutation tests

Each of the four sites, the gate, the dedupe and the seek gate mutated in turn, full suite run each time. Failure counts are unique spec names across all three browser projects.

| mutation | specs that fail |
| --- | --- |
| drop the `render()` warn | *warn once when a render finds no router* — **1, its own** |
| drop the `onClick` warn | *warn once when a click finds no router* — **1, its own** |
| drop the `uiSrefActive` update warn | *warn once when an update finds no router* — **1, its own** |
| drop the `<ui-view>` warn | *warn once when a view updates with no router* — **1, its own** |
| `inLitDevMode()` → `true` | 5 — all three new *stay silent outside lit dev mode* specs, plus #590's and #556's |
| dedupe `WeakSet` never hits | 5 — every *warns once* spec, including the both-directives one |
| drop `uiSref`'s `_seekedRouter` gate | 8 — every *should not warn* spec in the package, i.e. exactly the false-positive wall the gate exists to prevent |
| drop `uiSrefActive`'s `_seekedRouter` gate | **0** — so the flag was removed from that file rather than shipped untested |

Reverting any of the three `if (this.uiRouter)` subscription guards turns the suite red with the uncaught `TypeError`/unhandled rejection above.

## Verification

```
turbo run test typecheck lint format:check --filter=lit-ui-router
 Tasks:    27 successful, 27 total
 lit-ui-router:test  Test Files 11 passed (11)   Tests 240 passed (240)
 //:lint:templates   ✓ Found 0 problems in 117 files
```

`turbo run format` then `format:check` clean, 30/30.

## Overlap with #627

#627 (`fix/native-link-requires-href`) is open and touches `onClick`'s tier-3 click guard, adding `element.hasAttribute('href') &&`. This branches from `main` and its `onClick` edit is a three-line block inside the *first* guard, well above the tier-3 one, so the two do not overlap textually. Whichever merges second rebases cleanly.

## Semver

Minor. Additive and development-only: no runtime behaviour changes, apart from three no-router paths that raised an uncaught `TypeError` and now reach the no-op they were always documented to reach.

---

*Implemented with Claude Code (claude-opus-5).*
