### PR TITLE
ci: stop the PR lint checks re-running on label churn

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -9,13 +9,16 @@ on:
   # pull_request runs the PR-branch workflow file with no secrets, so
   # checking out and reading the PR's own commits is safe.
   pull_request:
+    # Only the events that can change the PR's COMMITS. The release-label
+    # exemption arrives with the PR (tools/shared/src/gh.ts opens release PRs
+    # with `--label release`), and GitHub delivers TWO `labeled` webhooks per
+    # label, so keeping those types cost four cancelled runs per labelled PR
+    # to cover a case the `opened` payload already carries. Label an open PR
+    # after the fact and re-run the job; it gates nothing.
     types:
       - opened
       - synchronize
       - reopened
-      # labeled/unlabeled: the release-label exemption must re-run the check
-      - labeled
-      - unlabeled
 
 # Re-validate only the latest commits per PR
 concurrency:

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -9,12 +9,6 @@ on:
   # pull_request runs the PR-branch workflow file with no secrets, so
   # checking out and reading the PR's own commits is safe.
   pull_request:
-    # Only the events that can change the PR's COMMITS. The release-label
-    # exemption arrives with the PR (tools/shared/src/gh.ts opens release PRs
-    # with `--label release`), and GitHub delivers TWO `labeled` webhooks per
-    # label, so keeping those types cost four cancelled runs per labelled PR
-    # to cover a case the `opened` payload already carries. Label an open PR
-    # after the fact and re-run the job; it gates nothing.
     types:
       - opened
       - synchronize

--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -10,14 +10,16 @@ on:
     # main-targeting PRs only: a stale branch's old workflow file never runs
     branches:
       - main
+    # Only the events that can change a PR TITLE. A push cannot, and the
+    # release-label exemption arrives with the PR: tools/shared/src/gh.ts
+    # opens release PRs with `--label release`, so `opened` already sees it.
+    # Both cost runs — GitHub delivers TWO `labeled` webhooks per label, so
+    # every labelled PR was spawning four cancelled runs of this check.
+    # Label an open PR after the fact and re-run the job; it gates nothing.
     types:
       - opened
       - edited
-      - synchronize
       - reopened
-      # labeled/unlabeled: the release-label exemption must re-run the check
-      - labeled
-      - unlabeled
 
 permissions:
   pull-requests: read

--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -10,12 +10,6 @@ on:
     # main-targeting PRs only: a stale branch's old workflow file never runs
     branches:
       - main
-    # Only the events that can change a PR TITLE. A push cannot, and the
-    # release-label exemption arrives with the PR: tools/shared/src/gh.ts
-    # opens release PRs with `--label release`, so `opened` already sees it.
-    # Both cost runs — GitHub delivers TWO `labeled` webhooks per label, so
-    # every labelled PR was spawning four cancelled runs of this check.
-    # Label an open PR after the fact and re-run the job; it gates nothing.
     types:
       - opened
       - edited


### PR DESCRIPTION
A labelled PR produces five or six runs of **Semantic PR** and **Commitlint** on one
SHA, all but the last cancelled — and the Checks tab keeps every one.

## Why they don't dedupe

They can't. GitHub has no upsert for workflow runs: `cancel-in-progress` decides how a
superseded run *ends*, not whether it exists, and a cancelled run holds its row forever.
Both workflows already have correct concurrency groups — the rows you're seeing are
proof they fired, not proof they're misconfigured. The only lever is firing fewer events.

## What was firing them

**GitHub delivers two `labeled` webhooks per label.** On #636, four `labeled` events for
two labels, one second apart, same actor. Not a `gh` artefact — dependabot's #628 shows
the identical doubling for `dependencies` and `javascript`. So each label cost two runs
of every workflow listening for it, times three workflows.

**And the case those types existed for is already covered.** The comment on both said
*"the release-label exemption must re-run the check"* — but `tools/shared/src/gh.ts`
opens release PRs with `gh pr create --label release`, so the label is in the `opened`
payload. The types only bought the after-the-fact relabel.

## The change

| Workflow | Types before | After |
| --- | --- | --- |
| Semantic PR | opened, edited, synchronize, reopened, labeled, unlabeled | opened, edited, reopened |
| Commitlint | opened, synchronize, reopened, labeled, unlabeled | opened, synchronize, reopened |

Semantic PR also loses `synchronize` because a push cannot change a PR title.

Measured against #636's event log, this takes it from 6 Semantic PR + 5 Commitlint runs
down to **2 and 1** — the remaining Semantic PR run is CodeRabbit editing the PR body,
which is a real `edited` event we can't filter at `on:`.

## Trade-offs

- Labelling an already-open PR no longer re-runs either check. Neither is required
  (`build_and_test / run` and `Workers Builds: lit-ui-router` are the only required
  contexts), so neither gates anything — re-run the job if you need it restated.
- Semantic PR's result no longer follows the PR to each new SHA. An advisory title lint
  doesn't need restating per commit.

## Left alone

**Deflake e2e** still contributes ~4 skipped rows per labelled PR, and it's the one I
didn't touch: there `labeled` *is* the opt-in trigger, and dropping it would break the
documented sticky mode ("label a wrangler bump, read the check") that the workflow
header spells out. Removing it — sampling only on `synchronize` and `workflow_dispatch`
— would clear those rows, but that's a behaviour change, not a cleanup.

---

*Opened with Claude Code (claude-opus-5).*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Streamlined pull request validation workflows to run on creation, edits, synchronization updates, and reopening.
  * Removed validation triggered solely by pull request label changes.
  * Adjusted release-related validation to no longer recheck pull requests when labels or synchronization status changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->